### PR TITLE
Only output details of commits that *introduce* HE strings

### DIFF
--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -104,7 +104,7 @@ def find_strings(git_url, printJson=False):
                         continue
                     stringsFound = []
                     lines = blob.diff.decode('utf-8', errors='replace').split("\n")
-                    for line in lines:
+                    for line in [l for l in lines if l.startswith("+")]:
                         for word in line.split():
                             base64_strings = get_strings_of_set(word, BASE64_CHARS)
                             hex_strings = get_strings_of_set(word, HEX_CHARS)


### PR DESCRIPTION
High-entropy strings that appear in the "context" of diffs, or those that are removed by a commit aren't particularly interesting when you're searching a repository's history for secrets. This change means trufflehog only searches diffs for lines that introduce potential secrets, dramatically reducing the amount of noise to search through in trufflehog's output.