### PR TITLE
Add report option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ GitPython==2.1.1
 unittest2==1.1.0
 pytest-cov==2.5.1
 codecov==2.0.15
-truffleHogRegexes==0.0.4
+truffleHogRegexes==0.0.5

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='truffleHog',
-    version='2.0.93',
+    version='2.0.94',
     description='Searches through git repositories for high entropy strings, digging deep into commit history.',
     url='https://github.com/dxa4481/truffleHog',
     author='Dylan Ayrey',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='truffleHog',
-    version='2.0.94',
+    version='2.0.95',
     description='Searches through git repositories for high entropy strings, digging deep into commit history.',
     url='https://github.com/dxa4481/truffleHog',
     author='Dylan Ayrey',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='truffleHog',
-    version='2.0.92',
+    version='2.0.93',
     description='Searches through git repositories for high entropy strings, digging deep into commit history.',
     url='https://github.com/dxa4481/truffleHog',
     author='Dylan Ayrey',

--- a/test_all.py
+++ b/test_all.py
@@ -7,7 +7,7 @@ class TestStringMethods(unittest.TestCase):
 
     def test_shannon(self):
         random_stringB64 = "ZWVTjPQSdhwRgl204Hc51YCsritMIzn8B=/p9UyeX7xu6KkAGqfm3FJ+oObLDNEva"
-        random_stringHex = "b3A0a1FDfe86dcCE945B72" 
+        random_stringHex = "b3A0a1FDfe86dcCE945B72"
         self.assertGreater(truffleHog.shannon_entropy(random_stringB64, truffleHog.BASE64_CHARS), 4.5)
         self.assertGreater(truffleHog.shannon_entropy(random_stringHex, truffleHog.HEX_CHARS), 3)
 
@@ -21,6 +21,71 @@ class TestStringMethods(unittest.TestCase):
             truffleHog.find_strings("https://github.com/dxa4481/tst.git")
         except UnicodeEncodeError:
             self.fail("Unicode print error")
+
+
+    def test_report_with_repeated_findings(self):
+        issues = [{
+            "stringsFound": ["abc", "abc"],
+            "reason": "",
+            "date": "",
+            "commitHash": "",
+            "commitAuthorName": "",
+            "commitAuthorEmail": "",
+            "path": "",
+            "branch": "",
+            "commit": ""
+        }]
+        report_issues = []
+
+        truffleHog.addIssuesToReport(issues, report_issues)
+
+        self.assertEqual(len(report_issues), 1)
+
+
+    def test_report_with_repeated_commit(self):
+        issues = [{
+            "stringsFound": ["abc", "abc"],
+            "reason": "",
+            "date": "",
+            "commitHash": "11111",
+            "commitAuthorName": "",
+            "commitAuthorEmail": "",
+            "path": "",
+            "branch": "",
+            "commit": ""
+        }]
+        report_issues = []
+
+        truffleHog.addIssuesToReport(issues, report_issues)
+
+        commits = report_issues[0]['commits']
+        self.assertEqual(len(commits), 1)
+
+
+    def test_report_high_entropy_issue_has_relevant_lines(self):
+        issues = [{
+            "stringsFound": ["abc", "abc"],
+            "linesFound": ["lorem abc", "ipsum abc amet"],
+            "reason": "",
+            "date": "",
+            "commitHash": "11111",
+            "commitAuthorName": "",
+            "commitAuthorEmail": "",
+            "path": "",
+            "branch": "",
+            "commit": ""
+        }]
+        report_issues = []
+
+        truffleHog.addIssuesToReport(issues, report_issues)
+
+        commit = report_issues[0]['commits'][0]
+        self.assertEqual(len(commit['relevantLines']), 2)
+
+
+    def test_saveReport_without_issues(self):
+        truffleHog.saveReport('/tmp/test.json', [])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -384,7 +384,7 @@ def saveReport(report_path, report_issues):
         return
 
     with open(report_path, 'w') as f:
-        f.write(json.dumps(report_issues, indent=4, separators=(',', ': ')))
+        json.dump(report_issues, f, indent=4, separators=(',', ': '))
 
 
 if __name__ == "__main__":

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -27,7 +27,7 @@ def main():
     parser.add_argument("--entropy", dest="do_entropy", help="Enable entropy checks")
     parser.add_argument("--since_commit", dest="since_commit", help="Only scan from a given commit hash")
     parser.add_argument("--max_depth", dest="max_depth", help="The max commit depth to go back when searching for secrets")
-    parser.add_argument("--report", dest="report_path", help="Path where the report file will be written")
+    parser.add_argument("--report", dest="report_path", type=is_file_path, help="Path where the report file will be written", metavar="FILE_PATH")
     parser.add_argument('git_url', type=str, help='URL for secret searching')
     parser.set_defaults(regex=False)
     parser.set_defaults(rules={})
@@ -63,6 +63,12 @@ def main():
         sys.exit(1)
     else:
         sys.exit(0)
+
+
+def is_file_path(path):
+    if os.path.isdir(path):
+        raise argparse.ArgumentTypeError("{0} is a directory path. It should be a file path instead.".format(path))
+    return path
 
 
 def str2bool(v):
@@ -344,7 +350,6 @@ def addIssuesToReport(issues, report_issues):
                     commit['relevantLines'] = issue['linesFound']
 
                 reported_issue["commits"].append(commit)
-
 
 
 def saveReport(report_path, report_issues):

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -335,8 +335,7 @@ def find_strings(git_url, since_commit=None, max_depth=1000000, printJson=False,
     output["project_path"] = project_path
     output["clone_uri"] = git_url
     output["issues_path"] = output_dir
-    if not repo_path:
-        shutil.rmtree(project_path, onerror=del_rw)
+    output["report_issues"] = report_issues
     return output
 
 

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -28,6 +28,7 @@ def main():
     parser.add_argument("--since_commit", dest="since_commit", help="Only scan from a given commit hash")
     parser.add_argument("--max_depth", dest="max_depth", help="The max commit depth to go back when searching for secrets")
     parser.add_argument("--report", dest="report_path", type=is_file_path, help="Path where the report file will be written", metavar="FILE_PATH")
+    parser.add_argument("--no-output", dest="no_output", help="Disable standard output", action="store_true")
     parser.add_argument("--branch", dest="branch", help="Name of the branch to be scanned")
     parser.add_argument("--repo_path", type=str, dest="repo_path", help="Path to the cloned repo. If provided, git_url will not be used")
     parser.add_argument("--cleanup", dest="cleanup", action="store_true", help="Clean up all temporary result files")
@@ -38,6 +39,7 @@ def main():
     parser.set_defaults(since_commit=None)
     parser.set_defaults(entropy=True)
     parser.set_defaults(report_path=None)
+    parser.set_defaults(no_output=False)
     parser.set_defaults(branch=None)
     parser.set_defaults(repo_path=None)
     parser.set_defaults(cleanup=False)
@@ -58,7 +60,7 @@ def main():
 
     do_report = args.report_path != None
     do_entropy = str2bool(args.do_entropy)
-    output = find_strings(args.git_url, args.since_commit, args.max_depth, args.output_json, args.do_regex, do_entropy, do_report, surpress_output=False, branch=args.branch, repo_path=args.repo_path)
+    output = find_strings(args.git_url, args.since_commit, args.max_depth, args.output_json, args.do_regex, do_entropy, do_report, surpress_output=args.no_output, branch=args.branch, repo_path=args.repo_path)
     project_path = output["project_path"]
 
     if not args.repo_path:

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -60,7 +60,9 @@ def main():
     do_entropy = str2bool(args.do_entropy)
     output = find_strings(args.git_url, args.since_commit, args.max_depth, args.output_json, args.do_regex, do_entropy, do_report, surpress_output=False, branch=args.branch, repo_path=args.repo_path)
     project_path = output["project_path"]
-    shutil.rmtree(project_path, onerror=del_rw)
+
+    if not args.repo_path:
+        shutil.rmtree(project_path, onerror=del_rw)
 
     if do_report:
         saveReport(args.report_path, output['report_issues'])


### PR DESCRIPTION
Hi,

I added an option that generates a report like this: 

```
{
    "finding": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
    "reason": "High Entropy",
    "commits": [
        {
            "date": "2017-04-07 10-47:27",
            "hash": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
            "authorName": "Foo Bar"
            "authorEmail": "foo@bar.com",
            "file": "src/file.go",
            "branch": "origin/master",
            "commitMsg": "Lorem ipsum dolor sit amet",
            "relevantLines": "+ secret = 62cdb7020ff920e5aa642c3d4066950dd1f01f4d"
        },
        {
            "date": "2017-04-07 10-47:27",
            "hash": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
            "author": "foo@bar.com",
            "file": "src/file.py",
            "branch": "origin/master",
            "commitMsg": "Lorem ipsum dolor sit amet",
            "relevantLines": "+ secret = 62cdb7020ff920e5aa642c3d4066950dd1f01f4d"
        }
    ]
}
```

It does a couple of things:

1. It only contains information that is relevant to the secrets instead of the full diffs to reduce noise and make it easy to spot them.
2. The findings are grouped so they appear only once and there's an array of commits where that finding was found.

Cheers