### PR TITLE
Only delete repositories that weren't provided with the repo_path argument.

### DIFF
--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -56,7 +56,8 @@ def main():
     do_entropy = str2bool(args.do_entropy)
     output = find_strings(args.git_url, args.since_commit, args.max_depth, args.output_json, args.do_regex, do_entropy, surpress_output=False, branch=args.branch, repo_path=args.repo_path)
     project_path = output["project_path"]
-    shutil.rmtree(project_path, onerror=del_rw)
+    if not args.repo_path:
+        shutil.rmtree(project_path, onerror=del_rw)
     if args.cleanup:
         clean_up(output)
     if output["foundIssues"]:


### PR DESCRIPTION
This checks if the repo_path argument was passed in before attempting to delete the repository directory after the run. If the user cloned their own repo, they should likely decide when to delete it.