### PR TITLE
Initial take on trimming down output to the essential data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 /truffleHog.egg-info/
 **/__pycache__/
 **/*.pyc
+/.idea
+/pyenv

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ optional arguments:
   -h, --help            show this help message and exit
   --json                Output in JSON
   --regex               Enable high signal regex checks
+  --contextify          Trim the output down to essential information
+                        For the entropy checker shows the line of occurance as well as surrounding words
+                        For the regex checker only outputs the actually found string for now (to be worked on)
   --rules RULES         Ignore default regexes and source from json list file
   --entropy DO_ENTROPY  Enable entropy checks
   --since_commit SINCE_COMMIT

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -183,11 +183,12 @@ def print_results(printJson, issue, contextify):
 
 
 def render_with_context(lines_with_context):
-    # the middle term holds the found entity
-    return "\n\n".join(["Line {}: \n".format(line_with_context[0])
-                        + line_with_context[1][0] + "\n"
+    return "\n\n".join(["Line {}: \n".format(line_with_context[0])  # line number
+                        + line_with_context[1][0] + "\n"  # pre context
+                        # the middle term holds the found entity
                         + bcolors.WARNING + line_with_context[1][1] + bcolors.ENDC + "\n"
-                        + line_with_context[1][2] for line_with_context in lines_with_context])
+                        + line_with_context[1][2]  # post context
+                        for line_with_context in lines_with_context])
 
 
 def process_found_word_with_context(string, line_number, word_number, all_words):


### PR DESCRIPTION
Hey man,
we found our self getting lost in the amount of text we were getting back from the tool. Albeit useful in general, it was a blocker for our massive repo.
Attached version that adds `--contextify` flag  to considerably reduce the amount of output served.
Cheers.