### PR TITLE
With regex, exclude lines from entropy scaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,10 @@ This module will go through the entire commit history of each branch, and check 
 ```
 usage: trufflehog [-h] [--json] [--regex] [--rules RULES]
                   [--entropy DO_ENTROPY] [--since_commit SINCE_COMMIT]
-                  [--max_depth MAX_DEPTH]
+                  [--max_depth MAX_DEPTH] [--branch BRANCH]
+                  [-i INCLUDE_PATHS_FILE] [-x EXCLUDE_PATHS_FILE]
+                  [-e ENTROPY_EXCLUDE_RE_FILE] [--repo_path REPO_PATH]
+                  [--cleanup]
                   git_url
 
 Find secrets hidden in the depths of git.
@@ -105,11 +108,9 @@ optional arguments:
                         comments and are ignored. If empty or not provided
                         (default), no Git object paths are excluded unless
                         effectively excluded via the --include_paths option.
+  -e ENTROPY_EXCLUDE_RE_FILE, --entropy-exclude-regex ENTROPY_EXCLUDE_RE_FILE
+			File with regular expressions (one perline), none of
+			wihch may match a diff line in order for it to be 
+			scanned by entropy checks. If empty or not provided
+			(default), all diff lines are included.
 ```
-
-## Wishlist
-
-- ~~A way to detect and not scan binary diffs~~
-- ~~Don't rescan diffs if already looked at in another branch~~
-- ~~A since commit X feature~~
-- ~~Print the file affected~~

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -318,7 +318,7 @@ def path_included(blob, include_patterns=None, exclude_patterns=None):
 
 
 def find_strings(git_url, since_commit=None, max_depth=1000000, printJson=False, do_regex=False, do_entropy=True, surpress_output=True,
-                custom_regexes={}, branch=None, repo_path=None, path_inclusions=None, path_exclusions=None, entropy_regex_exclusions=None):
+                custom_regexes={}, branch=None, repo_path=None, path_inclusions=None, path_exclusions=None, entropy_regex_exclusions=[]):
     output = {"foundIssues": []}
     if repo_path:
         project_path = repo_path


### PR DESCRIPTION
Add the option --entropy-exclude-regex ENTROPY_EXCLUDE_RE_FILE to exclude some lines from entropy scanning.
It can be an option to Feature request: Ignore false-positives #137