### PR TITLE
TruffleHog TypeError: can only concatenate str (not "tuple") to str

### DIFF
--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -246,7 +246,7 @@ def regex_check(printableDiff, commit_time, branch_name, prev_commit, blob, comm
     for key in secret_regexes:
         found_strings = secret_regexes[key].findall(printableDiff)
         for found_string in found_strings:
-            found_diff = printableDiff.replace(printableDiff, bcolors.WARNING + found_string + bcolors.ENDC)
+            found_diff = printableDiff.replace(printableDiff, bcolors.WARNING + str(found_string) + bcolors.ENDC)
         if found_strings:
             foundRegex = {}
             foundRegex['date'] = commit_time


### PR DESCRIPTION
Hello,

I was looking to write a look ahead negative regex but I always had a ```TypeError: can only concatenate str (not "tuple") to str``` popping.

```python
  File "/usr/local/lib/python3.9/site-packages/truffleHog/truffleHog.py", line 92, in main
    output = find_strings(args.git_url, args.since_commit, args.max_depth, args.output_json, args.do_regex, do_entropy,
  File "/usr/local/lib/python3.9/site-packages/truffleHog/truffleHog.py", line 362, in find_strings
    foundIssues = diff_worker(diff, curr_commit, prev_commit, branch_name, commitHash, custom_regexes, do_entropy, do_regex, printJson, surpress_output, path_inclusions, path_exclusions, allow)
  File "/usr/local/lib/python3.9/site-packages/truffleHog/truffleHog.py", line 281, in diff_worker
    found_regexes = regex_check(printableDiff, commit_time, branch_name, prev_commit, blob, commitHash, custom_regexes)
  File "/usr/local/lib/python3.9/site-packages/truffleHog/truffleHog.py", line 249, in regex_check
    found_diff = printableDiff.replace(printableDiff, bcolors.WARNING + found_string + bcolors.ENDC)
TypeError: can only concatenate str (not "tuple") to str
```

Because *found_string* is a tuple and not a string, we have to convert it correctly!