### PR TITLE
Improve get_strings_of_set() performance

### DIFF
--- a/test_all.py
+++ b/test_all.py
@@ -22,6 +22,12 @@ class TestStringMethods(unittest.TestCase):
         self.assertGreater(truffleHog.shannon_entropy(random_stringB64, truffleHog.BASE64_CHARS), 4.5)
         self.assertGreater(truffleHog.shannon_entropy(random_stringHex, truffleHog.HEX_CHARS), 3)
 
+    def test_get_strings_of_set(self):
+        self.assertEqual(["123456"], truffleHog.get_strings_of_set("1234_123456", truffleHog.BASE64_CHARS, 5))
+        self.assertEqual(["123456"], truffleHog.get_strings_of_set("123456_1234", truffleHog.BASE64_CHARS, 5))
+        self.assertEqual(["123456"], truffleHog.get_strings_of_set("1234_123456_1234", truffleHog.BASE64_CHARS, 5))
+        self.assertEqual(["123456", "1234567", "12345678"], truffleHog.get_strings_of_set("12345_123456_1234567_12345678", truffleHog.BASE64_CHARS, 5))
+
     def test_cloning(self):
         project_path = truffleHog.clone_git_repo("https://github.com/dxa4481/truffleHog.git")
         license_file = os.path.join(project_path, "LICENSE")

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -139,21 +139,10 @@ def shannon_entropy(data, iterator):
 
 
 def get_strings_of_set(word, char_set, threshold=20):
-    count = 0
-    letters = ""
-    strings = []
-    for char in word:
-        if char in char_set:
-            letters += char
-            count += 1
-        else:
-            if count > threshold:
-                strings.append(letters)
-            letters = ""
-            count = 0
-    if count > threshold:
-        strings.append(letters)
-    return strings
+    if len(word) <= threshold:
+         return []
+    # Compiled regexes are cached internally so this only adds overhead on the first call.
+    return re.findall("[{}]{{{},}}".format(char_set, threshold + 1), word)
 
 class bcolors:
     HEADER = '\033[95m'


### PR DESCRIPTION
Add unit tests for `get_strings_of_set()` and then improve its performance. Exit immediately if string length is shorter than threadhold. Use `re.findall` which will compile the regex, `re` caches the regex on first pass to the overhead on subsequent calls of using `re` is low. IMO this also improves readability.
