### PR TITLE
Update truffleHog.py

### DIFF
--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -14,6 +14,7 @@ import os
 import re
 import json
 import stat
+import platform
 from git import Repo
 from git import NULL_TREE
 from truffleHogRegexes.regexChecks import regexes
@@ -120,9 +121,16 @@ def str2bool(v):
 BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
 HEX_CHARS = "1234567890abcdefABCDEF"
 
-def del_rw(action, name, exc):
-    os.chmod(name, stat.S_IWRITE)
-    os.remove(name)
+def del_rw(func, path, exc):
+    """
+    Handles permissions error when trying to remove file
+    Add write permissions, try to remove file again
+    """
+    if platform.system() == "Windows":
+        os.chmod(path, stat.S_IWUSR)
+    else:
+        os.chmod(path, stat.S_IWRITE)
+    func(path)
 
 def shannon_entropy(data, iterator):
     """


### PR DESCRIPTION
In collaboration with @LegiaScouser, who discovered the issue.

## Objective

Enable `truffleHog.searchOrg` to run on Windows.

## Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Performance Tweaks
- [ ] Style Tweaks
- [ ] Code Refactoring
- [ ] Documentation
- [ ] Tests

## Issue

Screenshot of Issue:
![image](https://user-images.githubusercontent.com/45048808/142691470-35e8034e-3304-421f-8717-058de478c2c8.png)

Stack Overflow: 
- https://stackoverflow.com/questions/39566812/python-script-not-deleting-git-files-in-windows
- https://stackoverflow.com/questions/2656322/shutil-rmtree-fails-on-windows-with-access-is-denied

## Work Done

Add case to `shutils.rmtree` error handler `del_rw` for Windows. Adding Windows-specific write permission (previously had only Unix)

https://docs.python.org/3/library/stat.html#stat.S_IWUSR

## Output

`truffleHog.searchOrg` successfully scans repositories without errors.

## Tested

Ran truffleHog.searchOrg on Windows and Mac.