### PR TITLE
Add Information about Exit Codes

### DIFF
--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -10,6 +10,7 @@ import argparse
 import uuid
 import hashlib
 import tempfile
+import textwrap
 import os
 import re
 import json
@@ -21,7 +22,21 @@ from truffleHogRegexes.regexChecks import regexes
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Find secrets hidden in the depths of git.')
+    parser = argparse.ArgumentParser(description='Find secrets hidden in the depths of git.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=textwrap.dedent(
+            '''\
+            ADDITIONAL INFORMATION:\n
+
+                Exit Status Code:\n
+
+                 We return non-zero exit code when a secret is found.\n
+
+                 0  No Secrets Found\n
+
+                 1  Secrets Found\n
+            \n
+            '''))
     parser.add_argument('--json', dest="output_json", action="store_true", help="Output in JSON")
     parser.add_argument("--regex", dest="do_regex", action="store_true", help="Enable high signal regex checks")
     parser.add_argument("--rules", dest="rules", help="Ignore default regexes and source from json file")


### PR DESCRIPTION
In https://github.com/trufflesecurity/truffleHog/issues/267 a
user identified TruffleSecurity returned non-zero exit codes
when secrets were found and a 0 exit code when a secret is not
found. This ticket adds additional information to the CLI.



