### PR TITLE
Fix Error - can only concatenate str (not tuple) to str

### DIFF
--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -246,6 +246,7 @@ def regex_check(printableDiff, commit_time, branch_name, prev_commit, blob, comm
     for key in secret_regexes:
         found_strings = secret_regexes[key].findall(printableDiff)
         for found_string in found_strings:
+            found_string = str(found_string)
             found_diff = printableDiff.replace(printableDiff, bcolors.WARNING + str(found_string) + bcolors.ENDC)
         if found_strings:
             foundRegex = {}


### PR DESCRIPTION
## Issue details:

if the found_strings contains a value that is not strung then the concatenation of fails in `def regex_check` fails and throws the error:

<img width="1087" alt="Screenshot 2022-01-31 at 6 26 19 PM" src="https://user-images.githubusercontent.com/26146246/151801857-18ca70e3-ba23-4626-8f29-c93457b01b3b.png">

## Fix

To fix the issue, I have converted `found_string` to str first and the issue resolved.
