### PR TITLE
Fix regex for Slack API Tokens

### DIFF
--- a/pkg/detectors/slack/slack.go
+++ b/pkg/detectors/slack/slack.go
@@ -20,10 +20,10 @@ var _ detectors.Detector = Scanner{}
 
 var (
 	tokenPats = map[string]*regexp.Regexp{
-		"Slack Bot Token":               regexp.MustCompile(`xoxb\-[0-9]{10,13}\-[0-9]{10,13}[a-z0-9\-]*`),
-		"Slack User Token":              regexp.MustCompile(`xoxp\-[0-9]{10,13}\-[0-9]{10,13}[a-z0-9\-]*`),
-		"Slack Workspace Access Token":  regexp.MustCompile(`xoxa\-[0-9]{10,13}\-[0-9]{10,13}[a-z0-9\-]*`),
-		"Slack Workspace Refresh Token": regexp.MustCompile(`xoxr\-[0-9]{10,13}\-[0-9]{10,13}[a-z0-9\-]*`),
+		"Slack Bot Token":               regexp.MustCompile(`xoxb\-[0-9]{10,13}\-[0-9]{10,13}[a-zA-Z0-9\-]*`),
+		"Slack User Token":              regexp.MustCompile(`xoxp\-[0-9]{10,13}\-[0-9]{10,13}[a-zA-Z0-9\-]*`),
+		"Slack Workspace Access Token":  regexp.MustCompile(`xoxa\-[0-9]{10,13}\-[0-9]{10,13}[a-zA-Z0-9\-]*`),
+		"Slack Workspace Refresh Token": regexp.MustCompile(`xoxr\-[0-9]{10,13}\-[0-9]{10,13}[a-zA-Z0-9\-]*`),
 	}
 	verifyURL = "https://slack.com/api/auth.test"
 )


### PR DESCRIPTION
Fixes regex for Slack API Token to match uppercase letters in token