### PR TITLE
Remove versionFlag in favor of setting the version flag with kingpin

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,8 +32,7 @@ import (
 var (
 	cli            = kingpin.New("TruffleHog", "TruffleHog is a tool for finding credentials.")
 	cmd            string
-	debug          = cli.Flag("debug", "Run in debug mode").Bool()
-	versionFlag    = cli.Flag("version", "Prints trufflehog version.").Bool()
+	debug          = cli.Flag("debug", "Run in debug mode.").Bool()
 	jsonOut        = cli.Flag("json", "Output in JSON format.").Short('j').Bool()
 	jsonLegacy     = cli.Flag("json-legacy", "Use the pre-v3.0 JSON format. Only works with git, gitlab, and github sources.").Bool()
 	concurrency    = cli.Flag("concurrency", "Number of concurrent workers.").Default(strconv.Itoa(runtime.NumCPU())).Int()
@@ -91,6 +90,7 @@ func init() {
 		}
 	}
 
+	cli.Version("trufflehog " + version.BuildVersion)
 	cmd = kingpin.MustParse(cli.Parse(os.Args[1:]))
 
 	if *jsonOut {
@@ -127,11 +127,8 @@ func main() {
 }
 
 func run(state overseer.State) {
-	if *debug || *versionFlag {
+	if *debug {
 		fmt.Println("trufflehog " + version.BuildVersion)
-		if *versionFlag {
-			return
-		}
 	}
 
 	// When setting a base commit, chunks must be scanned in order.


### PR DESCRIPTION
This allows calling `trufflehog --version` without kingpin failing to
parse the arguments.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
