### PR TITLE
[THOG-234] Update security trails detector's regex and keywords.

### DIFF
--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -92,7 +92,7 @@ func CleanResults(results []Result) []Result {
 func PrefixRegex(keywords []string) string {
 	pre := `(?i)(?:`
 	middle := strings.Join(keywords, "|")
-	post := `).{0,40}`
+	post := `).|(?:[\n\r]){0,40}`
 	return pre + middle + post
 }
 

--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -92,7 +92,7 @@ func CleanResults(results []Result) []Result {
 func PrefixRegex(keywords []string) string {
 	pre := `(?i)(?:`
 	middle := strings.Join(keywords, "|")
-	post := `).|(?:[\n\r]){0,40}`
+	post := `)(?:.|[\n\r]){0,40}`
 	return pre + middle + post
 }
 

--- a/pkg/detectors/detectors_test.go
+++ b/pkg/detectors/detectors_test.go
@@ -1,0 +1,36 @@
+package detectors
+
+import "testing"
+
+func TestPrefixRegex(t *testing.T) {
+	tests := []struct {
+		keywords []string
+		expected string
+	}{
+		{
+			keywords: []string{"securitytrails"},
+			expected: `(?i)(?:securitytrails).|(?:[\n\r]){0,40}`,
+		},
+		{
+			keywords: []string{"zipbooks"},
+			expected: `(?i)(?:zipbooks).|(?:[\n\r]){0,40}`,
+		},
+		{
+			keywords: []string{"wrike"},
+			expected: `(?i)(?:wrike).|(?:[\n\r]){0,40}`,
+		},
+	}
+	for _, tt := range tests {
+		got := PrefixRegex(tt.keywords)
+		if got != tt.expected {
+			t.Errorf("PrefixRegex(%v) got: %v want: %v", tt.keywords, got, tt.expected)
+		}
+	}
+}
+
+func BenchmarkPrefixRegex(b *testing.B) {
+	kws := []string{"securitytrails"}
+	for i := 0; i < b.N; i++ {
+		PrefixRegex(kws)
+	}
+}

--- a/pkg/detectors/securitytrails/securitytrails.go
+++ b/pkg/detectors/securitytrails/securitytrails.go
@@ -26,7 +26,7 @@ var (
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"securitytrails"}
+	return []string{"securitytrails", "security trails"}
 }
 
 // FromData will find and optionally verify SecurityTrails secrets in a given set of bytes.

--- a/pkg/detectors/securitytrails/securitytrails_test.go
+++ b/pkg/detectors/securitytrails/securitytrails_test.go
@@ -40,6 +40,22 @@ func TestSecurityTrails_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a securitytrails secret\n %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_SecurityTrails,
+					Verified:     true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "found, verified inline",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a securitytrails secret %s within", secret)),
 				verify: true,
 			},


### PR DESCRIPTION
## What?
Update the security trails' detector's regex and keywords.
## Why?
The old regex was not capturing secrets that followed keywords after a new line.
By default, "." doesn't match newline. If you give the "s" flag, it does
## How?
Update the regex to include the "s" flag properly matches the secrets with keyword.
## Testing?
accompanying unit tests
## Screenshots (optional)
n/a
## Anything Else?
[Issue#424](https://github.com/trufflesecurity/trufflehog/issues/424)
regex validation: https://regex101.com/r/8T83x5/1