### PR TITLE
Ignore safedir when scanning git repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 replace github.com/jpillora/overseer => github.com/trufflesecurity/overseer v1.1.7-custom4
 
-replace github.com/zricethezav/gitleaks/v8 => github.com/trufflesecurity/gitleaks/v8 v8.6.1-custom1
+replace github.com/zricethezav/gitleaks/v8 => github.com/trufflesecurity/gitleaks/v8 v8.6.1-custom3
 
 require (
 	cloud.google.com/go/secretmanager v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -447,8 +447,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tailscale/depaware v0.0.0-20210622194025-720c4b409502 h1:34icjjmqJ2HPjrSuJYEkdZ+0ItmGQAQ75cRHIiftIyE=
 github.com/tailscale/depaware v0.0.0-20210622194025-720c4b409502/go.mod h1:p9lPsd+cx33L3H9nNoecRRxPssFKUwwI50I3pZ0yT+8=
-github.com/trufflesecurity/gitleaks/v8 v8.6.1-custom1 h1:HJPy+ciKU82lFPK0cxXJ4BYvCIANCQp29zhjU2T1UXo=
-github.com/trufflesecurity/gitleaks/v8 v8.6.1-custom1/go.mod h1:TxBuxH8eB/1la8Mc7I6j/ZZYNG/mHGpoi09N2oHx5nQ=
+github.com/trufflesecurity/gitleaks/v8 v8.6.1-custom3 h1:Xc61NkfI7aDHd8eHa0gglK0ZVF5UF54M4u4C5tuAKcw=
+github.com/trufflesecurity/gitleaks/v8 v8.6.1-custom3/go.mod h1:Em2rda83ePrhmaX4ZdvNjnUADRiOJirEAqln0ZtN8og=
 github.com/trufflesecurity/overseer v1.1.7-custom4 h1:5ed5+2+N3ZaW7oc4n7PIjkybGHUZmdCH9iAztB/2+Cc=
 github.com/trufflesecurity/overseer v1.1.7-custom4/go.mod h1:nT9w37AiO1Nop2VhVhNfzAFaPjthvxgpDV3XKsxYkcI=
 github.com/xanzy/go-gitlab v0.60.0 h1:HaIlc14k4t9eJjAhY0Gmq2fBHgKd1MthBn3+vzDtsbA=

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -268,7 +268,15 @@ func (s *Git) ScanCommits(repo *git.Repository, path string, scanOptions *ScanOp
 
 	// Errors returned on errChan aren't blocking, so just ignore them.
 	errChan := make(chan error)
-	fileChan, err := glgo.GitLog(path, scanOptions.HeadHash, errChan)
+	var gitLogArgs []string
+	if scanOptions.HeadHash != "" {
+		gitLogArgs = append(gitLogArgs, scanOptions.HeadHash)
+	}
+	logOpts := glgo.LogOpts{
+		Args:           gitLogArgs,
+		DisableSafeDir: true,
+	}
+	fileChan, err := glgo.GitLog(path, logOpts, errChan)
 	if err != nil {
 		return errors.WrapPrefix(err, "could not open repo path", 0)
 	}


### PR DESCRIPTION
Fixes issue where safedir prevents running `git log` against a mounted docker directory where directory ownership doesn't match. The issue was preventing the trufflehog action from working properly.