### PR TITLE
Detectors that fail verification should still report the unverified secret

### DIFF
--- a/pkg/detectors/dropbox/dropbox.go
+++ b/pkg/detectors/dropbox/dropbox.go
@@ -6,10 +6,9 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
-
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 )
 
 type Scanner struct{}
@@ -53,23 +52,20 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", match[1]))
 			res, err := client.Do(req)
-			if err != nil {
-				return results, err
-			}
-			defer res.Body.Close()
+			if err == nil {
+				res.Body.Close() // The request body is unused.
 
-			// 200 means good key for get current user
-			// 400 is bad (malformed)
-			// 403 bad scope
-			if res.StatusCode == http.StatusOK {
-				s.Verified = true
+				// 200 means good key for get current user
+				// 400 is bad (malformed)
+				// 403 bad scope
+				if res.StatusCode == http.StatusOK {
+					s.Verified = true
+				}
 			}
 		}
 
-		if !s.Verified {
-			if detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
-				continue
-			}
+		if !s.Verified && detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
+			continue
 		}
 
 		results = append(results, s)

--- a/pkg/detectors/elasticemail/elasticemail.go
+++ b/pkg/detectors/elasticemail/elasticemail.go
@@ -2,14 +2,11 @@ package elasticemail
 
 import (
 	"context"
-	// "log"
+	"encoding/json"
+	"io"
+	"net/http"
 	"regexp"
 	"strings"
-
-	// "fmt"
-	"encoding/json"
-	"io/ioutil"
-	"net/http"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -56,35 +53,24 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				continue
 			}
 			res, err := client.Do(req)
-			if err != nil {
-				continue
-			}
-			defer res.Body.Close()
-			var byteData []byte
-			_, err = res.Body.Read(byteData)
-			if err != nil {
-				continue
-			}
-
-			defer res.Body.Close()
-			data, readErr := ioutil.ReadAll(res.Body)
-			if readErr != nil {
-				continue
-			}
-			var ResVar struct {
-				Success bool `json:"success"`
-			}
-			if err := json.Unmarshal(data, &ResVar); err != nil {
-				continue
-			}
-			if ResVar.Success {
-				s1.Verified = true
-			} else {
-
-				if detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
-					continue
+			if err == nil {
+				data, readErr := io.ReadAll(res.Body)
+				res.Body.Close()
+				if readErr == nil {
+					var ResVar struct {
+						Success bool `json:"success"`
+					}
+					if err := json.Unmarshal(data, &ResVar); err == nil {
+						if ResVar.Success {
+							s1.Verified = true
+						}
+					}
 				}
 			}
+		}
+
+		if !s1.Verified && detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
+			continue
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/github/github.go
+++ b/pkg/detectors/github/github.go
@@ -73,23 +73,18 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/json; charset=utf-8")
 			req.Header.Add("Authorization", fmt.Sprintf("token %s", token))
 			res, err := client.Do(req)
-			if err != nil {
-				break
-			}
-			defer res.Body.Close()
-			if res.StatusCode >= 200 && res.StatusCode < 300 {
+			if err == nil {
 				var userResponse userRes
 				err = json.NewDecoder(res.Body).Decode(&userResponse)
+				res.Body.Close()
 				if err == nil {
 					s.Verified = true
 				}
 			}
 		}
 
-		if !s.Verified {
-			if detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
-				continue
-			}
+		if !s.Verified && detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
+			continue
 		}
 
 		results = append(results, s)

--- a/pkg/detectors/github_old/github_old.go
+++ b/pkg/detectors/github_old/github_old.go
@@ -75,21 +75,24 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/json; charset=utf-8")
 			req.Header.Add("Authorization", fmt.Sprintf("token %s", token))
 			res, err := client.Do(req)
-			if err != nil {
-				break
-			}
-			defer res.Body.Close()
-			if res.StatusCode >= 200 && res.StatusCode < 300 {
-				var userResponse userRes
-				err = json.NewDecoder(res.Body).Decode(&userResponse)
-				if err == nil {
-					s.Verified = true
+			if err == nil {
+				if res.StatusCode >= 200 && res.StatusCode < 300 {
+					var userResponse userRes
+					err = json.NewDecoder(res.Body).Decode(&userResponse)
+					res.Body.Close()
+					if err == nil {
+						s.Verified = true
+					}
 				}
 			}
+		}
+
+		if !s.Verified && detectors.IsKnownFalsePositive(token, detectors.DefaultFalsePositives, true) {
+			continue
 		}
 
 		results = append(results, s)
 	}
 
-	return
+	return // Should we add detectors.CleanResults(results), nil ?
 }

--- a/pkg/detectors/github_old/github_old.go
+++ b/pkg/detectors/github_old/github_old.go
@@ -94,5 +94,5 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		results = append(results, s)
 	}
 
-	return // Should we add detectors.CleanResults(results), nil ?
+	return detectors.CleanResults(results), nil
 }

--- a/pkg/detectors/gitlab/gitlab.go
+++ b/pkg/detectors/gitlab/gitlab.go
@@ -6,10 +6,9 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
-
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 )
 
 type Scanner struct{}
@@ -59,27 +58,24 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", match[1]))
 			res, err := client.Do(req)
-			if err != nil {
-				return results, err
-			}
-			defer res.Body.Close()
+			if err == nil {
+				res.Body.Close() // The request body is unused.
 
-			// 200 means good key and has `read_user` scope
-			// 403 means good key but not the right scope
-			// 401 is bad key
-			if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusForbidden {
-				secret.Verified = true
+				// 200 means good key and has `read_user` scope
+				// 403 means good key but not the right scope
+				// 401 is bad key
+				if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusForbidden {
+					secret.Verified = true
+				}
 			}
 		}
 
-		if !secret.Verified {
-			if detectors.IsKnownFalsePositive(string(secret.Raw), detectors.DefaultFalsePositives, true) {
-				continue
-			}
+		if !secret.Verified && detectors.IsKnownFalsePositive(string(secret.Raw), detectors.DefaultFalsePositives, true) {
+			continue
 		}
 
 		results = append(results, secret)
 	}
 
-	return
+	return detectors.CleanResults(results), nil
 }

--- a/pkg/detectors/gitlabv2/gitlab.go
+++ b/pkg/detectors/gitlabv2/gitlab.go
@@ -6,10 +6,9 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
-
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 )
 
 type Scanner struct{}
@@ -59,23 +58,20 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", match[1]))
 			res, err := client.Do(req)
-			if err != nil {
-				return results, err
-			}
-			defer res.Body.Close()
+			if err == nil {
+				res.Body.Close() // The request body is unused.
 
-			// 200 means good key and has `read_user` scope
-			// 403 means good key but not the right scope
-			// 401 is bad key
-			if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusForbidden {
-				secret.Verified = true
+				// 200 means good key and has `read_user` scope
+				// 403 means good key but not the right scope
+				// 401 is bad key
+				if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusForbidden {
+					secret.Verified = true
+				}
 			}
 		}
 
-		if !secret.Verified {
-			if detectors.IsKnownFalsePositive(string(secret.Raw), detectors.DefaultFalsePositives, true) {
-				continue
-			}
+		if !secret.Verified && detectors.IsKnownFalsePositive(string(secret.Raw), detectors.DefaultFalsePositives, true) {
+			continue
 		}
 
 		results = append(results, secret)

--- a/pkg/detectors/jdbc/jdbc.go
+++ b/pkg/detectors/jdbc/jdbc.go
@@ -45,29 +45,26 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			Redacted:     redact,
 		}
 
-		if verify {
-			//TODO can this be verified? Possibly. Could triage verification to other DBMS strings
-			s.Verified = false
-			// client := common.SaneHttpClient()
-			// req, err := http.NewRequestWithContext(ctx, "GET", "https://jdbcci.com/api/v2/me", nil)
-			if err != nil {
-				continue
-			}
-			// req.Header.Add("Accept", "application/json;")
-			// req.Header.Add("Jdbc-Token", token)
-			// res, err := client.Do(req)
-			// if err != nil {
-			// 	break
-			// }
-			// if res.StatusCode >= 200 && res.StatusCode < 300 {
-			// 	s.Verified = true
-			// }
-		}
+		//if verify {
+		//	// TODO: can this be verified? Possibly. Could triage verification to other DBMS strings
+		//	s.Verified = false
+		//	client := common.SaneHttpClient()
+		//	req, err := http.NewRequestWithContext(ctx, "GET", "https://jdbcci.com/api/v2/me", nil)
+		//	if err != nil {
+		//		continue
+		//	}
+		//	req.Header.Add("Accept", "application/json;")
+		//	req.Header.Add("Jdbc-Token", token)
+		//	res, err := client.Do(req)
+		//	if err == nil {
+		//		if res.StatusCode >= 200 && res.StatusCode < 300 {
+		//			s.Verified = true
+		//		}
+		//	}
+		//}
 
-		if !s.Verified {
-			if detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, false) {
-				continue
-			}
+		if !s.Verified && detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, false) {
+			continue
 		}
 
 		results = append(results, s)

--- a/pkg/detectors/mailchimp/mailchimp.go
+++ b/pkg/detectors/mailchimp/mailchimp.go
@@ -54,22 +54,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			req.SetBasicAuth("anystring", match)
 			res, err := client.Do(req)
-			if err != nil {
-				break
-			}
-			defer res.Body.Close()
-			if res.StatusCode == 200 {
-				s.Verified = true
-			} else {
-				s.Verified = false
-			}
+			if err == nil {
+				res.Body.Close() // The request body is unused.
 
+				if res.StatusCode == 200 {
+					s.Verified = true
+				}
+			}
 		}
 
-		if !s.Verified {
-			if detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
-				continue
-			}
+		if !s.Verified && detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
+			continue
 		}
 
 		results = append(results, s)

--- a/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
+++ b/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
@@ -27,7 +27,7 @@ var (
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"microsoft"} // should we instead look for webhook.office.com, or something required to be in the regex above?
+	return []string{"webhook.office.com"}
 }
 
 // FromData will find and optionally verify MicrosoftTeamsWebhook secrets in a given set of bytes.

--- a/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
+++ b/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
@@ -2,7 +2,7 @@ package microsoftteamswebhook
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -27,7 +27,7 @@ var (
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"microsoft"}
+	return []string{"microsoft"} // should we instead look for webhook.office.com, or something required to be in the regex above?
 }
 
 // FromData will find and optionally verify MicrosoftTeamsWebhook secrets in a given set of bytes.
@@ -54,24 +54,19 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
-			if err != nil {
-				continue
-			}
-			defer res.Body.Close()
-
-			body, err := ioutil.ReadAll(res.Body)
-			if err != nil {
-				continue
-			}
-
-			if res.StatusCode >= 200 && string(body) == "1" {
-				s1.Verified = true
-			} else {
-				//This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key
-				if detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, false) {
-					continue
+			if err == nil {
+				body, err := io.ReadAll(res.Body)
+				res.Body.Close()
+				if err == nil {
+					if res.StatusCode >= 200 && string(body) == "1" {
+						s1.Verified = true
+					}
 				}
 			}
+		}
+
+		if !s1.Verified && detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, false) {
+			continue
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/midise/midise.go
+++ b/pkg/detectors/midise/midise.go
@@ -6,10 +6,9 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
-
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 )
 
 type Scanner struct{}
@@ -54,20 +53,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", match))
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
-			if err != nil {
-				return results, err
-			}
-			defer res.Body.Close()
+			if err == nil {
+				res.Body.Close() // The request body is unused.
 
-			if res.StatusCode == http.StatusOK {
-				s.Verified = true
+				if res.StatusCode == http.StatusOK {
+					s.Verified = true
+				}
 			}
 		}
 
-		if !s.Verified {
-			if detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
-				continue
-			}
+		if !s.Verified && detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
+			continue
 		}
 
 		results = append(results, s)

--- a/pkg/detectors/onelogin/onelogin.go
+++ b/pkg/detectors/onelogin/onelogin.go
@@ -63,26 +63,23 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					req.Header.Add("Authorization", fmt.Sprintf("client_id:%s, client_secret:%s", clientID[1], clientSecret[1]))
 					req.Header.Add("Content-Type", "application/json; charset=utf-8")
 					res, err := client.Do(req)
-					if err != nil {
-						return results, err
-					}
-					defer res.Body.Close()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						s.Verified = true
-						break
+					if err == nil {
+						res.Body.Close() // The request body is unused.
+
+						if res.StatusCode >= 200 && res.StatusCode < 300 {
+							s.Verified = true
+						}
 					}
 				}
 			}
 
-			if !s.Verified {
-				if detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
-					continue
-				}
+			if !s.Verified && detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
+				continue
 			}
 
 			results = append(results, s)
 		}
 	}
 
-	return
+	return detectors.CleanResults(results), nil
 }

--- a/pkg/detectors/privatekey/privatekey.go
+++ b/pkg/detectors/privatekey/privatekey.go
@@ -9,10 +9,9 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
-
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 )
 
 type Scanner struct {
@@ -62,13 +61,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 
 		if verify {
 			data, err := lookupFingerprint(fingerprint, s.IncludeExpired)
-			if err != nil {
+			if err == nil {
+				secret.StructuredData = data
+				if data != nil {
+					secret.Verified = true
+				}
+			} else {
 				log.Warn(err)
-				return nil, err
-			}
-			secret.StructuredData = data
-			if data != nil {
-				secret.Verified = true
 			}
 		}
 

--- a/pkg/detectors/sendgrid/sendgrid.go
+++ b/pkg/detectors/sendgrid/sendgrid.go
@@ -60,23 +60,20 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", res))
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
-			if err != nil {
-				return results, err
-			}
-			defer res.Body.Close()
+			if err == nil {
+				res.Body.Close() // The request body is unused.
 
-			// 200 means good key and has `templates` scope
-			// 403 means good key but not the right scope
-			// 401 is bad key
-			if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusForbidden {
-				s.Verified = true
+				// 200 means good key and has `templates` scope
+				// 403 means good key but not the right scope
+				// 401 is bad key
+				if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusForbidden {
+					s.Verified = true
+				}
 			}
 		}
 
-		if !s.Verified {
-			if detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
-				continue
-			}
+		if !s.Verified && detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
+			continue
 		}
 
 		results = append(results, s)

--- a/pkg/detectors/square/square.go
+++ b/pkg/detectors/square/square.go
@@ -67,22 +67,19 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			// unclear if this version needs to be set or matters, seems to work without, but docs want it
 			//req.Header.Add("Square-Version", "2020-08-12")
 			res, err := client.Do(req)
-			if err != nil {
-				return results, err
-			}
-			defer res.Body.Close()
+			if err == nil {
+				res.Body.Close() // The request body is unused.
 
-			// 200 means good key and has `merchants` scope - default allowed by square
-			// 401 is bad key
-			if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusForbidden {
-				s.Verified = true
+				// 200 means good key and has `merchants` scope - default allowed by square
+				// 401 is bad key
+				if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusForbidden {
+					s.Verified = true
+				}
 			}
 		}
 
-		if !s.Verified {
-			if detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
-				continue
-			}
+		if !s.Verified && detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
+			continue
 		}
 
 		results = append(results, s)

--- a/pkg/detectors/squareapp/squareapp.go
+++ b/pkg/detectors/squareapp/squareapp.go
@@ -77,7 +77,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err == nil {
 					res.Body.Close() // The request body is unused.
 
-					// 404 = Correct crentials. The fake access token should not be found
+					// 404 = Correct credentials. The fake access token should not be found.
 					if res.StatusCode == http.StatusNotFound {
 						s.Verified = true
 					}

--- a/pkg/detectors/squareapp/squareapp.go
+++ b/pkg/detectors/squareapp/squareapp.go
@@ -9,10 +9,9 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
-
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 )
 
 type Scanner struct{}
@@ -75,21 +74,18 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				// unclear if this version needs to be set or matters, seems to work without, but docs want it
 				//req.Header.Add("Square-Version", "2020-08-12")
 				res, err := client.Do(req)
-				if err != nil {
-					return results, err
-				}
-				defer res.Body.Close()
+				if err == nil {
+					res.Body.Close() // The request body is unused.
 
-				// 404 = Correct crentials. The fake access token should not be found
-				if res.StatusCode == http.StatusNotFound {
-					s.Verified = true
+					// 404 = Correct crentials. The fake access token should not be found
+					if res.StatusCode == http.StatusNotFound {
+						s.Verified = true
+					}
 				}
 			}
 
-			if !s.Verified {
-				if detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
-					continue
-				}
+			if !s.Verified && detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
+				continue
 			}
 
 			results = append(results, s)

--- a/pkg/detectors/stripe/stripe.go
+++ b/pkg/detectors/stripe/stripe.go
@@ -6,10 +6,9 @@ import (
 	"net/http"
 	"regexp"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
-
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 )
 
 type Scanner struct{}
@@ -56,20 +55,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", match))
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
-			if err != nil {
-				return results, err
-			}
-			defer res.Body.Close()
+			if err == nil {
+				res.Body.Close() // The request body is unused.
 
-			if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusForbidden {
-				s.Verified = true
+				if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusForbidden {
+					s.Verified = true
+				}
 			}
 		}
 
-		if !s.Verified {
-			if detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
-				continue
-			}
+		if !s.Verified && detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, true) {
+			continue
 		}
 
 		results = append(results, s)

--- a/pkg/detectors/uri/uri.go
+++ b/pkg/detectors/uri/uri.go
@@ -4,16 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
-
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 )
 
 type Scanner struct {
@@ -109,34 +108,25 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
-			if err != nil {
-				// log.WithError(err).Warn("Error in http post to SSRF proxy")
-				continue
-			}
-			defer res.Body.Close()
-			result := proxyRes{}
-			body, err := ioutil.ReadAll(res.Body)
-			if len(body) == 0 || err != nil {
-				continue
-			}
-			err = json.Unmarshal(body, &result)
-			if err != nil {
-				// log.WithField("body", string(body)).WithError(err).Debug("Error decoding SSRF proxy response")
-				continue
-			}
-			if result.Verified {
-				s.Verified = true
+			if err == nil {
+				result := proxyRes{}
+				body, err := io.ReadAll(res.Body)
+				res.Body.Close()
+				if len(body) != 0 && err == nil {
+					err = json.Unmarshal(body, &result)
+					if err == nil && result.Verified {
+						s.Verified = true
+					}
+				}
 			}
 		}
 
-		if !s.Verified {
-			if detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, false) {
-				continue
-			}
+		if !s.Verified && detectors.IsKnownFalsePositive(string(s.Raw), detectors.DefaultFalsePositives, false) {
+			continue
 		}
 
 		results = append(results, s)
 	}
 
-	return
+	return detectors.CleanResults(results), nil
 }


### PR DESCRIPTION
A number of detectors would fail to detect a secret if verification is turned on, but the verification request failed. This adjusts them to ensure the secret is still included if the verification request fails.

I do have a couple of questions that are slightly unrelated. I've included comments in the code for them, and will add PR comments on them as well.