### PR TITLE
[THOG-204] Use oauth2 as username when cloning

### DIFF
--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -324,7 +324,13 @@ func (s *Source) scanRepos(ctx context.Context, chunksChan chan *sources.Chunk, 
 				}
 				s.SetProgressComplete(i, len(repos), fmt.Sprintf("Repo: %s", repoURL), "")
 
-				path, repo, err := git.CloneRepoUsingToken(s.token, repoURL.String(), "placeholder")
+				// If a username is not provided we need to use a default one in order to clone a private repo.
+				// Not setting "placeholder" as s.user on purpose in case any downstream services rely on a "" value for s.user.
+				user := s.user
+				if user == "" {
+					user = "placeholder"
+				}
+				path, repo, err := git.CloneRepoUsingToken(s.token, repoURL.String(), user)
 				defer os.RemoveAll(path)
 				if err != nil {
 					errsMut.Lock()

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -324,7 +324,7 @@ func (s *Source) scanRepos(ctx context.Context, chunksChan chan *sources.Chunk, 
 				}
 				s.SetProgressComplete(i, len(repos), fmt.Sprintf("Repo: %s", repoURL), "")
 
-				path, repo, err := git.CloneRepoUsingToken(s.token, repoURL.String(), "oauth2")
+				path, repo, err := git.CloneRepoUsingToken(s.token, repoURL.String(), "placeholder")
 				defer os.RemoveAll(path)
 				if err != nil {
 					errsMut.Lock()

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -324,7 +324,7 @@ func (s *Source) scanRepos(ctx context.Context, chunksChan chan *sources.Chunk, 
 				}
 				s.SetProgressComplete(i, len(repos), fmt.Sprintf("Repo: %s", repoURL), "")
 
-				path, repo, err := git.CloneRepoUsingToken(s.token, repoURL.String(), s.user)
+				path, repo, err := git.CloneRepoUsingToken(s.token, repoURL.String(), "oauth2")
 				defer os.RemoveAll(path)
 				if err != nil {
 					errsMut.Lock()


### PR DESCRIPTION
## What?
Fix error when cloning private gitlab repos.
## Why?
In order to scan repos for secret we need to be able to clone them first.
## How?
Use oauth2 as the username when constructing the url for cloning a repo.
## Testing?
Updated unit tests and they are also now working.
## Screenshots (optional)
## Anything Else?