### PR TITLE
Test Gitlab basic authentication with password and personal access token

### DIFF
--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -377,7 +377,7 @@ func (s *Source) basicAuthSuccessful(apiClient *gitlab.Client) bool {
 	if err != nil {
 		return false
 	}
-	if resp.StatusCode <= 400 {
+	if resp.StatusCode != 200 {
 		return false
 	}
 	if user != nil {


### PR DESCRIPTION
Test coverage for gitlab source is now 76% (previous 68%).