### PR TITLE
[THOG-268] Fix crash when scanning with json-legacy flag on a github repo.

### DIFF
--- a/pkg/output/legacy_json.go
+++ b/pkg/output/legacy_json.go
@@ -32,7 +32,7 @@ func ConvertToLegacyJSON(r *detectors.ResultWithMetadata, repoPath string) *Lega
 	// output format.
 	repo, err := gogit.PlainOpenWithOptions(repoPath, &gogit.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
-		logrus.WithError(err).Fatalf("could open repo: %s", repoPath)
+		logrus.WithError(err).Fatalf("could not open repo: %s", repoPath)
 	}
 
 	fileName := source.GetFile()


### PR DESCRIPTION
## What?
Fix scanning a GIthub repo with the --json-legacy flag.
## Why?
The current scan will crash with the --json-legacy flag set when scanning a github repo.
## How?
Pass the correct repoPath to the `ConvertToLegacyJSON` method so its available when we construct the legacy json response.
## Screenshots (optional)
## Anything Else?
[issue#419](https://github.com/trufflesecurity/trufflehog/issues/419)
