### PR TITLE
fix: regex for hostnames

### DIFF
--- a/pkg/detectors/deputy/deputy.go
+++ b/pkg/detectors/deputy/deputy.go
@@ -22,7 +22,7 @@ var (
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"deputy"}) + `\b([0-9a-z]{32})\b`)
-	urlPat = regexp.MustCompile(`\b([0-9a-z]{1,}.as.deputy.com)\b`)
+	urlPat = regexp.MustCompile(`\b([0-9a-z]{1,}\.as\.deputy\.com)\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/deputy/deputy/deputy.go
+++ b/pkg/detectors/deputy/deputy/deputy.go
@@ -22,7 +22,7 @@ var (
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"deputy"}) + `\b([0-9a-z]{32})\b`)
-	urlPat = regexp.MustCompile(`\b([0-9a-z]{1,}.as.deputy.com)\b`)
+	urlPat = regexp.MustCompile(`\b([0-9a-z]{1,}\.as\.deputy\.com)\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/discordwebhook/discordwebhook.go
+++ b/pkg/detectors/discordwebhook/discordwebhook.go
@@ -20,7 +20,7 @@ var (
 	client = common.SaneHttpClient()
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(`(https:\/\/discord.com\/api\/webhooks\/[0-9]{18}\/[0-9a-zA-Z-]{68})`)
+	keyPat = regexp.MustCompile(`(https:\/\/discord\.com\/api\/webhooks\/[0-9]{18}\/[0-9a-zA-Z-]{68})`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/freshdesk/freshdesk.go
+++ b/pkg/detectors/freshdesk/freshdesk.go
@@ -22,7 +22,7 @@ var (
 	client = common.SaneHttpClient()
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
-	urlPat = regexp.MustCompile(`\b([0-9a-z-]{1,}.freshdesk.com)\b`)
+	urlPat = regexp.MustCompile(`\b([0-9a-z-]{1,}\.freshdesk\.com)\b`)
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"freshdesk"}) + `\b([0-9A-Za-z]{20})\b`)
 )
 

--- a/pkg/detectors/freshdesk/freshdesk/freshdesk.go
+++ b/pkg/detectors/freshdesk/freshdesk/freshdesk.go
@@ -22,7 +22,7 @@ var (
 	client = common.SaneHttpClient()
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
-	urlPat = regexp.MustCompile(`\b([0-9a-z-]{1,}.freshdesk.com)\b`)
+	urlPat = regexp.MustCompile(`\b([0-9a-z-]{1,}\.freshdesk\.com)\b`)
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"freshdesk"}) + `\b([0-9A-Za-z]{20})\b`)
 )
 

--- a/pkg/detectors/invoiceocean/invoiceocean.go
+++ b/pkg/detectors/invoiceocean/invoiceocean.go
@@ -22,7 +22,7 @@ var (
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"invoiceocean"}) + `\b([0-9A-Za-z]{20})\b`)
-	urlPat = regexp.MustCompile(`\b([0-9a-z]{1,}.invoiceocean.com)\b`)
+	urlPat = regexp.MustCompile(`\b([0-9a-z]{1,}\.invoiceocean\.com)\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/invoiceocean/invoiceocean/invoiceocean.go
+++ b/pkg/detectors/invoiceocean/invoiceocean/invoiceocean.go
@@ -22,7 +22,7 @@ var (
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"invoiceocean"}) + `\b([0-9A-Za-z]{20})\b`)
-	urlPat = regexp.MustCompile(`\b([0-9a-z]{1,}.invoiceocean.com)\b`)
+	urlPat = regexp.MustCompile(`\b([0-9a-z]{1,}\.invoiceocean\.com)\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/kanban/kanban/kanban.go
+++ b/pkg/detectors/kanban/kanban/kanban.go
@@ -22,7 +22,7 @@ var (
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"kanban"}) + `\b([0-9A-Z]{12})\b`)
-	urlPat = regexp.MustCompile(`\b([0-9a-z]{1,}.kanbantool.com)\b`)
+	urlPat = regexp.MustCompile(`\b([0-9a-z]{1,}\.kanbantool\.com)\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/signalwire/signalwire.go
+++ b/pkg/detectors/signalwire/signalwire.go
@@ -24,7 +24,7 @@ var (
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"signalwire"}) + `\b([0-9A-Za-z]{50})\b`)
 	idPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"signalwire"}) + `\b([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12})\b`)
-	urlPat = regexp.MustCompile(`\b([0-9a-z-]{3,64}.signalwire.com)\b`)
+	urlPat = regexp.MustCompile(`\b([0-9a-z-]{3,64}\.signalwire\.com)\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/slackwebhook/slackwebhook.go
+++ b/pkg/detectors/slackwebhook/slackwebhook.go
@@ -21,7 +21,7 @@ var (
 	client = common.SaneHttpClient()
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(`(https:\/\/hooks.slack.com\/services\/[A-Za-z0-9+\/]{44,46})`)
+	keyPat = regexp.MustCompile(`(https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9+\/]{44,46})`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/zapierwebhook/zapierwebhook.go
+++ b/pkg/detectors/zapierwebhook/zapierwebhook.go
@@ -20,7 +20,7 @@ var (
 	client = common.SaneHttpClient()
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(`(https:\/\/hooks.zapier.com\/hooks\/catch\/[A-Za-z0-9\/]{16})`)
+	keyPat = regexp.MustCompile(`(https:\/\/hooks\.zapier\.com\/hooks\/catch\/[A-Za-z0-9\/]{16})`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -54,7 +54,7 @@ type Source struct {
 
 // Ensure the Source satisfies the interface at compile time
 var _ sources.Source = (*Source)(nil)
-var endsWithGithub = regexp.MustCompile(`github.com/?$`)
+var endsWithGithub = regexp.MustCompile(`github\.com/?$`)
 
 // Type returns the type of source.
 // It is used for matching source types in configuration and job input.


### PR DESCRIPTION
The current regex for some of the detectors had very minor issues which can lead verification requests to a different domain then intended.
ex- regex for hooks.slack.com will also match hooks1slack.com, hooks2slack.com and so on as "." matches any character (except for line terminators)