### PR TITLE
[THOG-270] Fix scanning crash for git source without TLS.

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -484,7 +484,7 @@ func PrepareRepo(uriString string) (string, bool, error) {
 	switch uri.Scheme {
 	case "file":
 		path = fmt.Sprintf("%s%s", uri.Host, uri.Path)
-	case "https":
+	case "http", "https":
 		remotePath := fmt.Sprintf("%s://%s%s", uri.Scheme, uri.Host, uri.Path)
 		remote = true
 		switch {

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -421,6 +421,12 @@ func TestPrepareRepo(t *testing.T) {
 			err:    nil,
 		},
 		{
+			uri:    "http://github.com/dustin-decker/secretsandstuff.git",
+			path:   true,
+			remote: true,
+			err:    nil,
+		},
+		{
 			uri:    "file:///path/to/file.json",
 			path:   true,
 			remote: false,


### PR DESCRIPTION
## What?
Fix crash when trying to scan a git source without TLS/SSL.
## Why?
Should be able to scan a source without TLS/SSL.
## How?
Update the switch case statement to include `http` as a case in addition to `https`
## Testing?
Updated the unit tests to cover the new scenario.
## Screenshots (optional)
n/a
## Anything Else?