### PR TITLE
Fix link typo in Adding_Detectors_external.md

### DIFF
--- a/hack/docs/Adding_Detectors_external.md
+++ b/hack/docs/Adding_Detectors_external.md
@@ -33,7 +33,7 @@ If you think that something should be included outside of these guidelines, plea
 ### Development Guidelines
 
 - When reasonable, favor using the `net/http` library to make requests instead of bringing in another library.
-- Use the [`common.SaneHttpClient`](pkg/common/http.go) for the `http.Client` whenever possible.
+- Use the [`common.SaneHttpClient`](/pkg/common/http.go) for the `http.Client` whenever possible.
 
 ### Development Dependencies
 


### PR DESCRIPTION
Hi, just a little typo fix.  
The link was missing a `/` and so was leading to https://github.com/trufflesecurity/trufflehog/blob/main/hack/docs/pkg/common/http.go (404) instead of https://github.com/trufflesecurity/trufflehog/blob/main/pkg/common/http.go
