### PR TITLE
[THOG-314] Add new parameter to the Init method for the source interface.

### DIFF
--- a/pkg/engine/filesystem.go
+++ b/pkg/engine/filesystem.go
@@ -23,7 +23,7 @@ func (e *Engine) ScanFileSystem(ctx context.Context, directories []string) error
 	}
 
 	fileSystemSource := filesystem.Source{}
-	err = fileSystemSource.Init(ctx, "trufflehog - filesystem", 0, int64(sourcespb.SourceType_SOURCE_TYPE_FILESYSTEM), true, &conn, runtime.NumCPU())
+	err = fileSystemSource.Init(ctx, "trufflehog - filesystem", 0, int64(sourcespb.SourceType_SOURCE_TYPE_FILESYSTEM), true, &conn, runtime.NumCPU(), nil)
 	if err != nil {
 		return errors.WrapPrefix(err, "could not init filesystem source", 0)
 	}

--- a/pkg/engine/github.go
+++ b/pkg/engine/github.go
@@ -34,7 +34,7 @@ func (e *Engine) ScanGitHub(ctx context.Context, endpoint string, repos, orgs []
 		logrus.WithError(err).Error("failed to marshal github connection")
 		return err
 	}
-	err = source.Init(ctx, "trufflehog - github", 0, 0, false, &conn, concurrency)
+	err = source.Init(ctx, "trufflehog - github", 0, 0, false, &conn, concurrency, nil)
 	if err != nil {
 		logrus.WithError(err).Error("failed to initialize github source")
 		return err

--- a/pkg/engine/gitlab.go
+++ b/pkg/engine/gitlab.go
@@ -40,7 +40,7 @@ func (e *Engine) ScanGitLab(ctx context.Context, endpoint, token string, reposit
 	}
 
 	gitlabSource := gitlab.Source{}
-	err = gitlabSource.Init(ctx, "trufflehog - gitlab", 0, int64(sourcespb.SourceType_SOURCE_TYPE_GITLAB), true, &conn, runtime.NumCPU())
+	err = gitlabSource.Init(ctx, "trufflehog - gitlab", 0, int64(sourcespb.SourceType_SOURCE_TYPE_GITLAB), true, &conn, runtime.NumCPU(), nil)
 	if err != nil {
 		return errors.WrapPrefix(err, "could not init GitLab source", 0)
 	}

--- a/pkg/engine/s3.go
+++ b/pkg/engine/s3.go
@@ -42,7 +42,7 @@ func (e *Engine) ScanS3(ctx context.Context, key, secret string, cloudCred bool,
 	}
 
 	s3Source := s3.Source{}
-	err = s3Source.Init(ctx, "trufflehog - s3", 0, int64(sourcespb.SourceType_SOURCE_TYPE_S3), true, &conn, runtime.NumCPU())
+	err = s3Source.Init(ctx, "trufflehog - s3", 0, int64(sourcespb.SourceType_SOURCE_TYPE_S3), true, &conn, runtime.NumCPU(), nil)
 	if err != nil {
 		return errors.WrapPrefix(err, "failed to init S3 source", 0)
 	}

--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -57,7 +57,7 @@ func (s *Source) JobID() int64 {
 }
 
 // Init returns an initialized Filesystem source.
-func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int, _ interface{}) error {
 	s.log = log.WithField("source", s.Type()).WithField("name", name)
 
 	s.aCtx = aCtx

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -84,7 +84,7 @@ func (s *Source) JobID() int64 {
 }
 
 // Init returns an initialized GitHub source.
-func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int, _ interface{}) error {
 
 	s.aCtx = aCtx
 	s.name = name

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -94,7 +94,7 @@ func (s *Source) Token(ctx context.Context, installationClient *github.Client) (
 }
 
 // Init returns an initialized GitHub source.
-func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int, _ interface{}) error {
 	s.log = log.WithField("source", s.Type()).WithField("name", name)
 
 	s.aCtx = aCtx

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -60,7 +60,7 @@ func (s *Source) JobID() int64 {
 }
 
 // Init returns an initialized Gitlab source.
-func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int, _ interface{}) error {
 
 	s.aCtx = aCtx
 	s.name = name

--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -55,7 +55,7 @@ func (s *Source) JobID() int64 {
 }
 
 // Init returns an initialized AWS source
-func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int, _ interface{}) error {
 	s.log = log.WithField("source", s.Type()).WithField("name", name)
 
 	s.aCtx = aCtx

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -35,7 +35,7 @@ type Source interface {
 	// JobID returns the initialized job ID used for tracking relationships in the DB.
 	JobID() int64
 	// Init initializes the source.
-	Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error
+	Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int, srcClient interface{}) error
 	// Chunks emits data over a channel that is decoded and scanned for secrets.
 	Chunks(ctx context.Context, chunksChan chan *Chunk) error
 	// Completion Percentage for Scanned Source


### PR DESCRIPTION
In order to support the oauth token refresher service we need to be able to pass the source service client as an argument to to the scanner in order to request an oauth token from the gRPC API layer.

Add an interface as an additional param to the source interface.

NOTE: this should ideally be converted to a concrete interface type. This will likely need to have the same signature as the `SourceService` rpc service used for the oauth token refresher service. If we make this it's own service the interface would only need to contain the `GetToken` method to satisfy the interface.