### PR TITLE
Update GitHub action metadata to use ghcr.io image

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ branding:
   color: "green"
 runs:
   using: "docker"
-  image: "Dockerfile"
+  image: "docker://ghcr.io/trufflesecurity/trufflehog:latest"
   args:
     - git
     - file://${{ inputs.path }}


### PR DESCRIPTION
Hi, this PR implements what we discussed on #493. You can see my test results [here](https://github.com/channelbeta/trufflehog/actions/workflows/testpr.yaml).

Runs 1, 2 and 8 were done using the old mode (`Dockerfile`). They took around 3 minutes of runner time just to build the images.

Runs 5, 6 and 7 took around **3 seconds** to pull the prebuilt image from ghcr.io :exploding_head: 

I'm using the `latest` tag, as requested, and it seems to be working fine with regards to action metadata requirements. However, as you can see by the commit history on the `main` branch (and also comparing results from workflow runs 7 and 8), I couldn't get 
the new workflow to find any secrets on the repo.

I'm raising the PR as a draft while I investigate if this is an issue with the metadata change. If there is something I'm overlooking, please leave a comment here.