### PR TITLE
[THOG-327] Resuse the strings builder when writing each fragment.

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -331,8 +331,8 @@ func (s *Git) ScanCommits(repo *git.Repository, path string, scanOptions *ScanOp
 			when = file.PatchHeader.AuthorDate.String()
 		}
 
+		var sb strings.Builder
 		for _, frag := range file.TextFragments {
-			var sb strings.Builder
 			newLineNumber := frag.NewPosition
 			for _, line := range frag.Lines {
 				if line.Op == gitdiff.OpAdd {
@@ -349,6 +349,7 @@ func (s *Git) ScanCommits(repo *git.Repository, path string, scanOptions *ScanOp
 				Data:           []byte(sb.String()),
 				Verify:         s.verify,
 			}
+			sb.Reset()
 		}
 	}
 	return nil


### PR DESCRIPTION
Following up #534 reusing the strings.builder does provide a pretty nice speedup during the gitscan.

Rough test: (as a quick rough estimate using a decent sized repo)
![Screen Shot 2022-05-09 at 7 45 46 PM](https://user-images.githubusercontent.com/21311841/167533291-5c579a12-e788-44eb-985d-6e31e802722a.png)

NOTE: ideally we can get some even better benchmarks, but for now this looks to be quite promising.
