### PR TITLE
Refactor Engine to wait for workers in a Finish method

### DIFF
--- a/pkg/engine/git.go
+++ b/pkg/engine/git.go
@@ -3,9 +3,10 @@ package engine
 import (
 	"context"
 	"fmt"
+	"runtime"
+
 	"github.com/go-errors/errors"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	"runtime"
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -102,12 +103,13 @@ func (e *Engine) ScanGit(ctx context.Context, repoPath, headRef, baseRef string,
 			}
 		})
 
+	e.sourcesWg.Add(1)
 	go func() {
+		defer e.sourcesWg.Done()
 		err := gitSource.ScanRepo(ctx, repo, repoPath, scanOptions, e.ChunksChan())
 		if err != nil {
 			logrus.WithError(err).Fatal("could not scan repo")
 		}
-		close(e.ChunksChan())
 	}()
 	return nil
 }

--- a/pkg/engine/github.go
+++ b/pkg/engine/github.go
@@ -40,12 +40,13 @@ func (e *Engine) ScanGitHub(ctx context.Context, endpoint string, repos, orgs []
 		return err
 	}
 
+	e.sourcesWg.Add(1)
 	go func() {
+		defer e.sourcesWg.Done()
 		err := source.Chunks(ctx, e.ChunksChan())
 		if err != nil {
 			logrus.WithError(err).Fatal("could not scan github")
 		}
-		close(e.ChunksChan())
 	}()
 	return nil
 }

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -1,0 +1,54 @@
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
+)
+
+func PrintJSON(r *detectors.ResultWithMetadata) {
+	v := &struct {
+		// SourceMetadata contains source-specific contextual information.
+		SourceMetadata *source_metadatapb.MetaData
+		// SourceID is the ID of the source that the API uses to map secrets to specific sources.
+		SourceID int64
+		// SourceType is the type of Source.
+		SourceType sourcespb.SourceType
+		// SourceName is the name of the Source.
+		SourceName string
+		// DetectorType is the type of Detector.
+		DetectorType detectorspb.DetectorType
+		// DetectorName is the string name of the DetectorType.
+		DetectorName string
+		Verified     bool
+		// Raw contains the raw secret identifier data. Prefer IDs over secrets since it is used for deduping after hashing.
+		Raw []byte
+		// Redacted contains the redacted version of the raw secret identification data for display purposes.
+		// A secret ID should be used if available.
+		Redacted       string
+		ExtraData      map[string]string
+		StructuredData *detectorspb.StructuredData
+	}{
+		SourceMetadata: r.SourceMetadata,
+		SourceID:       r.SourceID,
+		SourceType:     r.SourceType,
+		SourceName:     r.SourceName,
+		DetectorType:   r.DetectorType,
+		DetectorName:   r.DetectorType.String(),
+		Verified:       r.Verified,
+		Raw:            r.Raw,
+		Redacted:       r.Redacted,
+		ExtraData:      r.ExtraData,
+		StructuredData: r.StructuredData,
+	}
+	out, err := json.Marshal(v)
+	if err != nil {
+		logrus.WithError(err).Fatal("could not marshal result")
+	}
+	fmt.Println(string(out))
+}


### PR DESCRIPTION
This should allow the engine to run multiple concurrent scans if
desired before shutting down.

Additionally, this commit refactors some of the printing logic to the
output package.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
