### PR TITLE
README Total Detectors badge & small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@
 
 ---
 
+<center>
 
 [![CI Status](https://github.com/trufflesecurity/trufflehog/actions/workflows/release.yml/badge.svg)](https://github.com/trufflesecurity/trufflehog/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/trufflesecurity/trufflehog/v3)](https://goreportcard.com/report/github.com/trufflesecurity/trufflehog/v3)
-![License](https://img.shields.io/badge/license-AGPL--3.0-brightgreen)
+[![License](https://img.shields.io/badge/license-AGPL--3.0-brightgreen)](/LICENSE)
 [![Total Detectors](https://shields-staging.herokuapp.com/github/directory-file-count/trufflesecurity/truffleHog/pkg/detectors?label=Total%20Detectors&type=dir)](/pkg/detectors) <!-- Badge must be run from staging, see badges/shields#5967 -->
 
+</center>
 
 ---
 
@@ -157,7 +159,8 @@ docker run -it -v "$PWD:/pwd" trufflesecurity/trufflehog:latest github --org=tru
 
 ### TruffleHog OSS Github Action
 
-```- name: TruffleHog OSS
+```yaml
+- name: TruffleHog OSS
   uses: trufflesecurity/trufflehog@main
   with:
     # Repository path


### PR DESCRIPTION
# Description
[![Total Detectors](https://shields-staging.herokuapp.com/github/directory-file-count/trufflesecurity/truffleHog/pkg/detectors?label=Total%20Detectors&type=dir)](/pkg/detectors)
Add a [shields.io](https://shields.io/) badge to display the total detectors & add YAML highlighting to GH Action example

## General Comments
This badge works by counting the directories in the `pkg/detectors` folder. Weirdly, this functionality is broken on shields production, so the suggestion from [badges/shields#5967](https://github.com/badges/shields/issues/5967) is to use the staging instance.
The LICENSE badge now links directly to the `LICENSE` file instead of an image of the badge.
Additionally, because a newline is missing in the GH Action example, the first line is cut off & the syntax highlighting is broken.