### PR TITLE
added common regex patterns for detectors

### DIFF
--- a/pkg/common/patterns.go
+++ b/pkg/common/patterns.go
@@ -1,0 +1,56 @@
+package common
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const EmailPattern = `\b([a-z0-9]{4,25}@[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,6})\b`
+const SubDomainPattern = `\b([0-9a-zA-Z]{2,40})\b`
+const UUIDPattern = `\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b`
+const UUIDPatternUpperCase = `\b([0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12})\b`
+
+const RegexNumPattern = "0-9"
+const RegexPattern = "0-9a-z"
+const RegexPatternUpperCase = "0-9A-Z"
+const Base64Pattern = "0-9a-zA-Z"
+const HexPattern = "0-9a-f"
+const HexPatternUpperCase = "0-9A-F"
+const HexPatternWithUpperCase = "0-9a-fA-F"
+
+//Custom Regex functions
+func BuildRegex(pattern string, length int) string {
+	return fmt.Sprintf(`\b([%s]{%s})\b`, pattern, strconv.Itoa(length))
+}
+
+func BuildRegexWithChar(pattern, specialChar string, length int) string {
+	return fmt.Sprintf(`\b([%s%s]{%s})\b`, pattern, specialChar, strconv.Itoa(length))
+}
+
+func BuildRegexJWT(firstRange, secondRange, thirdRange string) string {
+	first_range_split := strings.Split(firstRange, ",")
+	first_range_min := strings.TrimSpace(first_range_split[0])
+	first_range_max := strings.TrimSpace(first_range_split[1])
+	if first_range_min >= first_range_max {
+		log.Error("First min value should not be greater than or equal to max")
+	}
+
+	second_range_split := strings.Split(secondRange, ",")
+	second_range_min := strings.TrimSpace(second_range_split[0])
+	second_range_max := strings.TrimSpace(second_range_split[1])
+	if second_range_min >= second_range_max {
+		log.Error("Second min value should not be greater than or equal to max")
+	}
+
+	third_range_split := strings.Split(thirdRange, ",")
+	third_range_min := strings.TrimSpace(third_range_split[0])
+	third_range_max := strings.TrimSpace(third_range_split[1])
+	if third_range_min >= third_range_max {
+		log.Error("Third min value should not be greater than or equal to max")
+	}
+
+	return fmt.Sprintf(`\b(ey[%s]{%s}.ey[%s-\/_]{%s}.[%s-\/_]{%s})\b`, Base64Pattern, firstRange, Base64Pattern, secondRange, Base64Pattern, thirdRange)
+}

--- a/pkg/common/patterns.go
+++ b/pkg/common/patterns.go
@@ -8,8 +8,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const EmailPattern = `\b([a-z0-9]{4,25}@[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,6})\b`
-const SubDomainPattern = `\b([0-9a-zA-Z]{2,40}.[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,6})\b`
+const EmailPattern = `\b(?:[a-z0-9!#$%&'*+/=?^_\x60{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_\x60{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])\b`
+const SubDomainPattern = `\b([A-Za-z0-9](?:(?:[-A-Za-z0-9]){0,61}[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:(?:[-A-Za-z0-9]){0,61}[A-Za-z0-9])?){2,})\b`
 const UUIDPattern = `\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b`
 const UUIDPatternUpperCase = `\b([0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12})\b`
 

--- a/pkg/common/patterns.go
+++ b/pkg/common/patterns.go
@@ -9,24 +9,16 @@ import (
 )
 
 const EmailPattern = `\b([a-z0-9]{4,25}@[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,6})\b`
-const SubDomainPattern = `\b([0-9a-zA-Z]{2,40})\b`
+const SubDomainPattern = `\b([0-9a-zA-Z]{2,40}.[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,6})\b`
 const UUIDPattern = `\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b`
 const UUIDPatternUpperCase = `\b([0-9A-Z]{8}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{4}-[0-9A-Z]{12})\b`
 
-const RegexNumPattern = "0-9"
 const RegexPattern = "0-9a-z"
-const RegexPatternUpperCase = "0-9A-Z"
-const Base64Pattern = "0-9a-zA-Z"
+const AlphaNumPattern = "0-9a-zA-Z"
 const HexPattern = "0-9a-f"
-const HexPatternUpperCase = "0-9A-F"
-const HexPatternWithUpperCase = "0-9a-fA-F"
 
 //Custom Regex functions
-func BuildRegex(pattern string, length int) string {
-	return fmt.Sprintf(`\b([%s]{%s})\b`, pattern, strconv.Itoa(length))
-}
-
-func BuildRegexWithChar(pattern, specialChar string, length int) string {
+func BuildRegex(pattern string, specialChar string, length int) string {
 	return fmt.Sprintf(`\b([%s%s]{%s})\b`, pattern, specialChar, strconv.Itoa(length))
 }
 
@@ -52,5 +44,9 @@ func BuildRegexJWT(firstRange, secondRange, thirdRange string) string {
 		log.Error("Third min value should not be greater than or equal to max")
 	}
 
-	return fmt.Sprintf(`\b(ey[%s]{%s}.ey[%s-\/_]{%s}.[%s-\/_]{%s})\b`, Base64Pattern, firstRange, Base64Pattern, secondRange, Base64Pattern, thirdRange)
+	return fmt.Sprintf(`\b(ey[%s]{%s}.ey[%s-\/_]{%s}.[%s-\/_]{%s})\b`, AlphaNumPattern, firstRange, AlphaNumPattern, secondRange, AlphaNumPattern, thirdRange)
+}
+
+func ToUpperCase(input string) string {
+	return strings.ToUpper(input)
 }

--- a/pkg/common/patterns.go
+++ b/pkg/common/patterns.go
@@ -23,28 +23,17 @@ func BuildRegex(pattern string, specialChar string, length int) string {
 }
 
 func BuildRegexJWT(firstRange, secondRange, thirdRange string) string {
-	first_range_split := strings.Split(firstRange, ",")
-	first_range_min, _ := strconv.ParseInt(strings.TrimSpace(first_range_split[0]), 10, 0)
-	first_range_max, _ := strconv.ParseInt(strings.TrimSpace(first_range_split[1]), 10, 0)
-	if first_range_min >= first_range_max {
-		log.Error("First min value should not be greater than or equal to max")
+	if RangeValidation(firstRange) || RangeValidation(secondRange) || RangeValidation(thirdRange) {
+		log.Error("Min value should not be greater than or equal to max")
 	}
-
-	second_range_split := strings.Split(secondRange, ",")
-	second_range_min, _ := strconv.ParseInt(strings.TrimSpace(second_range_split[0]), 10, 0)
-	second_range_max, _ := strconv.ParseInt(strings.TrimSpace(second_range_split[1]), 10, 0)
-	if second_range_min >= second_range_max {
-		log.Error("Second min value should not be greater than or equal to max")
-	}
-
-	third_range_split := strings.Split(thirdRange, ",")
-	third_range_min, _ := strconv.ParseInt(strings.TrimSpace(third_range_split[0]), 10, 0)
-	third_range_max, _ := strconv.ParseInt(strings.TrimSpace(third_range_split[1]), 10, 0)
-	if third_range_min >= third_range_max {
-		log.Error("Third min value should not be greater than or equal to max")
-	}
-
 	return fmt.Sprintf(`\b(ey[%s]{%s}.ey[%s-\/_]{%s}.[%s-\/_]{%s})\b`, AlphaNumPattern, firstRange, AlphaNumPattern, secondRange, AlphaNumPattern, thirdRange)
+}
+
+func RangeValidation(rangeInput string) bool {
+	range_split := strings.Split(rangeInput, ",")
+	range_min, _ := strconv.ParseInt(strings.TrimSpace(range_split[0]), 10, 0)
+	range_max, _ := strconv.ParseInt(strings.TrimSpace(range_split[1]), 10, 0)
+	return range_min >= range_max
 }
 
 func ToUpperCase(input string) string {

--- a/pkg/common/patterns.go
+++ b/pkg/common/patterns.go
@@ -24,22 +24,22 @@ func BuildRegex(pattern string, specialChar string, length int) string {
 
 func BuildRegexJWT(firstRange, secondRange, thirdRange string) string {
 	first_range_split := strings.Split(firstRange, ",")
-	first_range_min := strings.TrimSpace(first_range_split[0])
-	first_range_max := strings.TrimSpace(first_range_split[1])
+	first_range_min, _ := strconv.ParseInt(strings.TrimSpace(first_range_split[0]), 10, 0)
+	first_range_max, _ := strconv.ParseInt(strings.TrimSpace(first_range_split[1]), 10, 0)
 	if first_range_min >= first_range_max {
 		log.Error("First min value should not be greater than or equal to max")
 	}
 
 	second_range_split := strings.Split(secondRange, ",")
-	second_range_min := strings.TrimSpace(second_range_split[0])
-	second_range_max := strings.TrimSpace(second_range_split[1])
+	second_range_min, _ := strconv.ParseInt(strings.TrimSpace(second_range_split[0]), 10, 0)
+	second_range_max, _ := strconv.ParseInt(strings.TrimSpace(second_range_split[1]), 10, 0)
 	if second_range_min >= second_range_max {
 		log.Error("Second min value should not be greater than or equal to max")
 	}
 
 	third_range_split := strings.Split(thirdRange, ",")
-	third_range_min := strings.TrimSpace(third_range_split[0])
-	third_range_max := strings.TrimSpace(third_range_split[1])
+	third_range_min, _ := strconv.ParseInt(strings.TrimSpace(third_range_split[0]), 10, 0)
+	third_range_max, _ := strconv.ParseInt(strings.TrimSpace(third_range_split[1]), 10, 0)
 	if third_range_min >= third_range_max {
 		log.Error("Third min value should not be greater than or equal to max")
 	}

--- a/pkg/detectors/clicksendsms/clicksendsms.go
+++ b/pkg/detectors/clicksendsms/clicksendsms.go
@@ -44,11 +44,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			continue
 		}
 		resMatch := strings.TrimSpace(match[1])
-		for _, idmatch := range idMatches {
-			if len(idmatch) != 2 {
-				continue
-			}
-			resIdMatch := strings.TrimSpace(idmatch[1])
+		for _, idMatch := range idMatches {
+			resIdMatch := strings.TrimSpace(idMatch[0][strings.LastIndex(idMatch[0], " ")+1:])
 
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_ClickSendsms,

--- a/pkg/detectors/clicksendsms/clicksendsms.go
+++ b/pkg/detectors/clicksendsms/clicksendsms.go
@@ -22,8 +22,8 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(`\b([A-Z0-9]{8}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{12})\b`)
-	idPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"sms"}) + `\b([a-zA-Z0-9]{3,20}@[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,5})\b`)
+	keyPat = regexp.MustCompile(common.UUIDPatternUpperCase)
+	idPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"sms"}) + common.EmailPattern)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/cloudconvert/cloudconvert.go
+++ b/pkg/detectors/cloudconvert/cloudconvert.go
@@ -21,7 +21,7 @@ var (
 	client = common.SaneHttpClient()
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"cloudconvert"}) + `\b(ey[0-9a-zA-Z]{34}.ey[0-9a-zA-Z-_]{200,500}.[0-9a-zA-Z-_]{600,700})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"cloudconvert"}) + common.BuildRegexJWT("30,34", "200,500", "600,700"))
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -35,7 +35,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	dataStr := string(data)
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
-
 	for _, match := range matches {
 		if len(match) != 2 {
 			continue

--- a/pkg/detectors/codemagic/codemagic.go
+++ b/pkg/detectors/codemagic/codemagic.go
@@ -20,7 +20,7 @@ var (
 	client = common.SaneHttpClient()
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"codemagic"}) + common.BuildRegexWithChar(common.Base64Pattern, "_", 43))
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"codemagic"}) + common.BuildRegex(common.AlphaNumPattern, "_", 43))
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/codemagic/codemagic.go
+++ b/pkg/detectors/codemagic/codemagic.go
@@ -20,7 +20,7 @@ var (
 	client = common.SaneHttpClient()
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"codemagic"}) + `\b([a-zA-Z0-9_]{43})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"codemagic"}) + common.BuildRegexWithChar(common.Base64Pattern, "_", 43))
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/databox/databox.go
+++ b/pkg/detectors/databox/databox.go
@@ -2,11 +2,11 @@ package databox
 
 import (
 	"context"
+	b64 "encoding/base64"
 	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
-	b64 "encoding/base64"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -22,7 +22,7 @@ var (
 	client = common.SaneHttpClient()
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"databox"}) + `\b([a-z0-9]{21})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"databox"}) + common.BuildRegex(common.RegexPattern, 21))
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/databox/databox.go
+++ b/pkg/detectors/databox/databox.go
@@ -22,7 +22,7 @@ var (
 	client = common.SaneHttpClient()
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"databox"}) + common.BuildRegex(common.RegexPattern, 21))
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"databox"}) + common.BuildRegex(common.RegexPattern, "", 21))
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/onesignal/onesignal.go
+++ b/pkg/detectors/onesignal/onesignal.go
@@ -2,11 +2,11 @@ package onesignal
 
 import (
 	"context"
+	b64 "encoding/base64"
 	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
-	b64 "encoding/base64"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -22,7 +22,7 @@ var (
 	client = common.SaneHttpClient()
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"onesignal"}) + `\b([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"onesignal"}) + common.UUIDPattern)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/speechtextai/speechtextai.go
+++ b/pkg/detectors/speechtextai/speechtextai.go
@@ -21,7 +21,7 @@ var (
 	client = common.SaneHttpClient()
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"speechtext"}) + common.BuildRegex(common.HexPattern, 32))
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"speechtext"}) + common.BuildRegex(common.HexPattern, "", 32))
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/speechtextai/speechtextai.go
+++ b/pkg/detectors/speechtextai/speechtextai.go
@@ -21,7 +21,7 @@ var (
 	client = common.SaneHttpClient()
 
 	//Make sure that your group is surrounded in boundry characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"speechtext"}) + `\b([0-9a-f]{32})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"speechtext"}) + common.BuildRegex(common.HexPattern, 32))
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/zulipchat/zulipchat.go
+++ b/pkg/detectors/zulipchat/zulipchat.go
@@ -47,11 +47,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
-
-			resIdMatch := strings.TrimSpace(idMatch[1])
+			//getting the last word of the string
+			resIdMatch := strings.TrimSpace(idMatch[0][strings.LastIndex(idMatch[0], " ")+1:])
 
 			for _, domainMatch := range domainMatches {
 				if len(domainMatch) != 2 {
@@ -66,7 +63,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 
 				if verify {
-					req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://%s.zulipchat.com/api/v1/users", resDomainMatch), nil)
+					req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://%s/api/v1/users", resDomainMatch), nil)
 					if err != nil {
 						continue
 					}

--- a/pkg/detectors/zulipchat/zulipchat.go
+++ b/pkg/detectors/zulipchat/zulipchat.go
@@ -21,9 +21,9 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"zulipchat"}) + `\b([0-9a-zA-Z]{32})\b`)
-	idPat     = regexp.MustCompile(detectors.PrefixRegex([]string{"zulipchat"}) + `\b([a-z0-9]{4,25}@[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,6})\b`)
-	domainPat = regexp.MustCompile(detectors.PrefixRegex([]string{"zulipchat", "domain"}) + `\b([0-9a-z]{2,20})\b`)
+	keyPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"zulipchat"}) + common.BuildRegex(common.Base64Pattern, 32))
+	idPat     = regexp.MustCompile(detectors.PrefixRegex([]string{"zulipchat"}) + common.EmailPattern)
+	domainPat = regexp.MustCompile(detectors.PrefixRegex([]string{"zulipchat", "domain"}) + common.SubDomainPattern)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/zulipchat/zulipchat.go
+++ b/pkg/detectors/zulipchat/zulipchat.go
@@ -21,7 +21,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"zulipchat"}) + common.BuildRegex(common.Base64Pattern, 32))
+	keyPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"zulipchat"}) + common.BuildRegex(common.AlphaNumPattern, "", 32))
 	idPat     = regexp.MustCompile(detectors.PrefixRegex([]string{"zulipchat"}) + common.EmailPattern)
 	domainPat = regexp.MustCompile(detectors.PrefixRegex([]string{"zulipchat", "domain"}) + common.SubDomainPattern)
 )

--- a/pkg/detectors/zulipchat/zulipchat_test.go
+++ b/pkg/detectors/zulipchat/zulipchat_test.go
@@ -22,7 +22,7 @@ func TestZulipChat_FromChunk(t *testing.T) {
 	}
 	secret := testSecrets.MustGetField("ZULIPCHAT")
 	id := testSecrets.MustGetField("ZULIPCHAT_ID")
-	domain := testSecrets.MustGetField("ZULIPCHAT_DOMAIN")
+	domain := testSecrets.MustGetField("ZULIPCHAT_DOMAINV2")
 	inactiveSecret := testSecrets.MustGetField("ZULIPCHAT_INACTIVE")
 
 	type args struct {
@@ -42,7 +42,7 @@ func TestZulipChat_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a zulipchat secret %s within zulipchat %s and zulipchat domain %s", secret, id, domain)),
+				data:   []byte(fmt.Sprintf("You can find a zulipchat secret %s within zulipchat %s and zulipchat %s", secret, id, domain)),
 				verify: true,
 			},
 			want: []detectors.Result{
@@ -58,7 +58,7 @@ func TestZulipChat_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a zulipchat secret %s within zulipchat %s and zulipchat domain %s but not valid", inactiveSecret, id, domain)), // the secret would satisfy the regex but not pass validation
+				data:   []byte(fmt.Sprintf("You can find a zulipchat secret %s within zulipchat %s and zulipchat %s but not valid", inactiveSecret, id, domain)), // the secret would satisfy the regex but not pass validation
 				verify: true,
 			},
 			want: []detectors.Result{


### PR DESCRIPTION
Below detectors has the imported function for common regex patterns.

1. ZulipChat
- common.BuildRegex(common.Base64Pattern, ..
- EmailPattern
- SubDomainPattern

2. CloudConvert
- JWT

3. Databox
- common.BuildRegex(common.RegexPattern, ..

4. Onesignal
- UUIDPattern

5. ClickSendSMS
- UUIDPatternUpperCase
- EmailPattern

6. CodeMagic
- BuildRegexWithChar

7: SpeechTextAI
- HexPattern