### PR TITLE
Allow github to resume from encoded resume info

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -328,15 +328,6 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk) err
 	// We must sort the repos so we can resume later if necessary.
 	sort.Strings(s.repos)
 
-	// TODO: Should we keep this randomization? Or make the resumable git an option rather than the default?
-	/*
-		if _, ok := os.LookupEnv("DO_NOT_RANDOMIZE"); !ok {
-			// Randomize channel scan order on each scan
-			rand.Seed(time.Now().UnixNano())
-			rand.Shuffle(len(s.repos), func(i, j int) { s.repos[i], s.repos[j] = s.repos[j], s.repos[i] })
-		}
-	*/
-
 	return s.scan(ctx, installationClient, chunksChan)
 }
 
@@ -795,6 +786,7 @@ func (s *Source) decodeResumeInfo(resumeInfo string) {
 
 // filterReposToResume filters the existing repos down to those that are included in the encoded resume info.
 // It also returns the difference between the original length of the repos and the new length to use for progress reporting.
+// It is required that both the resumeInfo repos and the existing repos in s.repos are sorted.
 func (s *Source) filterReposToResume(resumeInfo string) int {
 	if resumeInfo == "" {
 		return 0

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -812,7 +812,7 @@ func (s *Source) filterReposToResume(resumeInfo string) int {
 	// However, it is possible that a resumed scan does not include all or even any of the repos within the resumeInfo.
 	// In this case, we must ensure we still scan all repos that come after the last found repo in the list.
 	reposToScan := []string{}
-	lastFoundRepoIndex := 0
+	lastFoundRepoIndex := -1
 	resumeRepoIndex := 0
 	for i, repoURL := range s.repos {
 		// If the repoURL is bigger than what we're looking for, move to the next one.

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -3,11 +3,11 @@ package github
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"net/http"
 	"os"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -36,21 +36,23 @@ import (
 )
 
 type Source struct {
-	name       string
-	sourceID   int64
-	jobID      int64
-	verify     bool
-	repos      []string
-	orgs       []string
-	members    []string
-	git        *git.Git
-	httpClient *http.Client
-	aCtx       context.Context
+	name            string
+	sourceID        int64
+	jobID           int64
+	verify          bool
+	repos           []string
+	orgs            []string
+	members         []string
+	git             *git.Git
+	httpClient      *http.Client
+	aCtx            context.Context
+	log             *log.Entry
+	token           string
+	conn            *sourcespb.GitHub
+	jobSem          *semaphore.Weighted
+	resumeInfoSlice []string
+	resumeInfoMutex *sync.Mutex
 	sources.Progress
-	log    *log.Entry
-	token  string
-	conn   *sourcespb.GitHub
-	jobSem *semaphore.Weighted
 }
 
 // Ensure the Source satisfies the interface at compile time
@@ -323,11 +325,17 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk) err
 
 	s.normalizeRepos(ctx, apiClient)
 
-	if _, ok := os.LookupEnv("DO_NOT_RANDOMIZE"); !ok {
-		// Randomize channel scan order on each scan
-		rand.Seed(time.Now().UnixNano())
-		rand.Shuffle(len(s.repos), func(i, j int) { s.repos[i], s.repos[j] = s.repos[j], s.repos[i] })
-	}
+	// We must sort the repos so we can resume later if necessary.
+	sort.Strings(s.repos)
+
+	// TODO: Should we keep this randomization? Or make the resumable git an option rather than the default?
+	/*
+		if _, ok := os.LookupEnv("DO_NOT_RANDOMIZE"); !ok {
+			// Randomize channel scan order on each scan
+			rand.Seed(time.Now().UnixNano())
+			rand.Shuffle(len(s.repos), func(i, j int) { s.repos[i], s.repos[j] = s.repos[j], s.repos[i] })
+		}
+	*/
 
 	return s.scan(ctx, installationClient, chunksChan)
 }
@@ -347,6 +355,9 @@ func (s *Source) scan(ctx context.Context, installationClient *github.Client, ch
 		}
 	}
 
+	// If there is resume information available, limit this scan to only the repos that still need scanning.
+	progressIndexOffset := s.filterReposToResume(s.GetProgress().EncodedResumeInfo)
+
 	for i, repoURL := range s.repos {
 		if err := s.jobSem.Acquire(ctx, 1); err != nil {
 			// Acquire blocks until it can acquire the semaphore or returns an
@@ -360,7 +371,9 @@ func (s *Source) scan(ctx context.Context, installationClient *github.Client, ch
 			defer s.jobSem.Release(1)
 			defer wg.Done()
 
-			s.SetProgressComplete(i, len(s.repos), fmt.Sprintf("Repo: %s", repoURL), "")
+			s.setProgressCompleteWithRepo(i+progressIndexOffset, repoURL)
+			// Ensure the repo is removed from the resume info after being scanned.
+			defer s.removeRepoFromResumeInfo(repoURL)
 
 			if !strings.HasSuffix(repoURL, ".git") {
 				return
@@ -727,4 +740,102 @@ func (s *Source) normalizeRepos(ctx context.Context, apiClient *github.Client) {
 	for key := range normalizedRepos {
 		s.repos = append(s.repos, key)
 	}
+}
+
+// setProgressCompleteWithRepo calls the s.SetProgressComplete after safely setting up the encoded resume info string.
+func (s *Source) setProgressCompleteWithRepo(index int, repoURL string) {
+	s.resumeInfoMutex.Lock()
+	defer s.resumeInfoMutex.Unlock()
+
+	// Add the repoURL to the resume info slice.
+	s.resumeInfoSlice = append(s.resumeInfoSlice, repoURL)
+	sort.Strings(s.resumeInfoSlice)
+
+	// Make the resume info string from the slice.
+	encodedResumeInfo := s.encodeResumeInfo()
+
+	s.SetProgressComplete(index, len(s.repos), fmt.Sprintf("Repo: %s", repoURL), encodedResumeInfo)
+}
+
+// removeRepoFromResumeInfo removes the repoURL from the resume info.
+func (s *Source) removeRepoFromResumeInfo(repoURL string) {
+	s.resumeInfoMutex.Lock()
+	defer s.resumeInfoMutex.Unlock()
+
+	index := -1
+	for i, repo := range s.resumeInfoSlice {
+		if repoURL == repo {
+			index = i
+		}
+	}
+
+	if index == -1 {
+		// We should never be able to be here. But if we are, it means the resume info never had the repo added.
+		// So log the error and do nothing.
+		s.log.Errorf("repoURL (%q) not found in list of encode resume info: %q", repoURL, s.EncodedResumeInfo)
+		return
+	}
+
+	// This removes the element at the given index.
+	s.resumeInfoSlice = append(s.resumeInfoSlice[:index], s.resumeInfoSlice[index+1:]...)
+}
+
+func (s *Source) encodeResumeInfo() string {
+	return strings.Join(s.resumeInfoSlice, "\t")
+}
+
+func (s *Source) decodeResumeInfo(resumeInfo string) {
+	// strings.Split will, for an empty string, return []string{""},
+	// which is an element, where as when there is no resume info we want an empty slice.
+	if resumeInfo == "" {
+		return
+	}
+	s.resumeInfoSlice = strings.Split(resumeInfo, "\t")
+}
+
+// filterReposToResume filters the existing repos down to those that are included in the encoded resume info.
+// It also returns the difference between the original length of the repos and the new length to use for progress reporting.
+func (s *Source) filterReposToResume(resumeInfo string) int {
+	if resumeInfo == "" {
+		return 0
+	}
+
+	s.resumeInfoMutex.Lock()
+	defer s.resumeInfoMutex.Unlock()
+
+	s.decodeResumeInfo(resumeInfo)
+
+	// Because this scanner is multithreaded, it is possible that we have scanned a range of repositories
+	// with some gaps of unlisted but completed repositories in between the ones in resumeInfo.
+	// So we know repositories that have not finished scanning are the ones included in the resumeInfo,
+	// and those that come after the last repository in the resumeInfo.
+	// However, it is possible that a resumed scan does not include all or even any of the repos within the resumeInfo.
+	// In this case, we must ensure we still scan all repos that come after the last found repo in the list.
+	reposToScan := []string{}
+	lastFoundRepoIndex := 0
+	resumeRepoIndex := 0
+	for i, repoURL := range s.repos {
+		// If the repoURL is bigger than what we're looking for, move to the next one.
+		if repoURL > s.resumeInfoSlice[resumeRepoIndex] {
+			resumeRepoIndex++
+		}
+
+		// If we've found all of our repositories end the filter.
+		if resumeRepoIndex == len(s.resumeInfoSlice) {
+			break
+		}
+
+		// If the repoURL is the one we're looking for, add it and update the lastFoundRepoIndex.
+		if repoURL == s.resumeInfoSlice[resumeRepoIndex] {
+			lastFoundRepoIndex = i
+			reposToScan = append(reposToScan, repoURL)
+		}
+	}
+
+	// Append all repos after the last one we've found.
+	reposToScan = append(reposToScan, s.repos[lastFoundRepoIndex+1:]...)
+
+	progressOffsetCount := len(s.repos) - len(reposToScan)
+	s.repos = reposToScan
+	return progressOffsetCount
 }

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -501,6 +501,11 @@ func Test_filterReposToResume(t *testing.T) {
 			wantProgressOffsetCount: 3,
 			wantReposToScan:         []string{"b", "e", "f", "g"},
 		},
+		"no repos found in the repo list": {
+			resumeInfo:              "not\tthere",
+			wantProgressOffsetCount: 0,
+			wantReposToScan:         startingRepos,
+		},
 		"only some repos in the list": {
 			resumeInfo:              "c\tnot\tthere",
 			wantProgressOffsetCount: 2,
@@ -513,6 +518,7 @@ func Test_filterReposToResume(t *testing.T) {
 			repos:           startingRepos,
 			resumeInfoMutex: &sync.Mutex{},
 		}
+
 		gotProgressOffsetCount := s.filterReposToResume(tt.resumeInfo)
 		if gotProgressOffsetCount != tt.wantProgressOffsetCount {
 			t.Errorf("s.filterReposToResume() name: %q got: %d, want: %d", name, gotProgressOffsetCount, tt.wantProgressOffsetCount)


### PR DESCRIPTION
This allows github to be resumed from whatever repos it was last working on.

I'm still working on fixing up a couple of the tests (I think I found a failing test case but am not sure why it is failing). But I wanted to get this out now to answer some questions. Like, this changes the randomization behavior of repo scanning. It would now be sorted. Is that an okay change to the defaults, or should we put it behind a flag?