### PR TITLE
Cleanup individual repositories after scanning

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -136,19 +136,17 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk) err
 			if len(repoURI) == 0 {
 				continue
 			}
-			func(repoURI string) {
+			err := func(repoURI string) error {
 				path, repo, err := CloneRepoUsingToken(token, repoURI, user)
 				defer os.RemoveAll(path)
 				if err != nil {
-					log.WithError(err).Errorf("Unable to clone repo using token: %q", repoURI)
-					return
+					return err
 				}
-				err = s.git.ScanRepo(ctx, repo, path, NewScanOptions(), chunksChan)
-				if err != nil {
-					log.WithError(err).Errorf("Unable to scan repo using token: %q", repoURI)
-					return
-				}
+				return s.git.ScanRepo(ctx, repo, path, NewScanOptions(), chunksChan)
 			}(repoURI)
+			if err != nil {
+				return err
+			}
 		}
 	case *sourcespb.Git_Unauthenticated:
 		for i, repoURI := range s.conn.Repositories {
@@ -156,19 +154,17 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk) err
 			if len(repoURI) == 0 {
 				continue
 			}
-			func(repoURI string) {
+			err := func(repoURI string) error {
 				path, repo, err := CloneRepoUsingUnauthenticated(repoURI)
 				defer os.RemoveAll(path)
 				if err != nil {
-					log.WithError(err).Errorf("Unable to clone repo unauthenticated: %q", repoURI)
-					return
+					return err
 				}
-				err = s.git.ScanRepo(ctx, repo, path, NewScanOptions(), chunksChan)
-				if err != nil {
-					log.WithError(err).Errorf("Unable to scan repo unauthenticated: %q", repoURI)
-					return
-				}
+				return s.git.ScanRepo(ctx, repo, path, NewScanOptions(), chunksChan)
 			}(repoURI)
+			if err != nil {
+				return err
+			}
 		}
 	default:
 		return errors.New("invalid connection type for git source")


### PR DESCRIPTION
The deferred os.RemoveAlls mean that anytime there's a scan of a lot of repositories, they won't be deleted from disk until the entire scan is done. This fixes that.

But it also changes some behavior - currently if there's an error getting or scanning a repo, the scan ends. Should we keep that? I can easily change this to do so. Or should it log the issue and continue scanning, as I've currently implemented it? (Though for directories, the current behavior remains in place)