### PR TITLE
Move aws detector back to ID checking against secrets, make ID the redacted secret

### DIFF
--- a/pkg/detectors/aws/aws_test.go
+++ b/pkg/detectors/aws/aws_test.go
@@ -48,6 +48,7 @@ func TestAWS_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_AWS,
 					Verified:     true,
+					Redacted:     "AKIAWARWQKZNHMZBLY4I",
 				},
 			},
 			wantErr: false,
@@ -64,6 +65,7 @@ func TestAWS_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_AWS,
 					Verified:     false,
+					Redacted:     "AKIAWARWQKZNHMZBLY4I",
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
This fixes the git engine test errors we've been seeing. However, it also resets some aspects of the AWS detector that were changed. Specifically:
* AWS now tries all matched secrets against all IDs, rather than trying IDs against secrets (essentially the outer loop has been switched back)
* The Redacted secret is now back to being the match ID, instead of no longer existing.

It also makes a couple of slight adjustments:
* The AWS response body is immediately closed instead of deferred, as it is never used.
* Anytime a verified secret is found, we skip all remaining secret matches and move on to the next ID. I'm not actually 100% sure that there are no duplicate key IDs, but that's my assumption in making this change.
* Some variables are renamed to make it clear which of them is the ID and which of them is the secret.