### PR TITLE
Properly count the number of repos after a github scan resume

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -370,7 +370,7 @@ func (s *Source) scan(ctx context.Context, installationClient *github.Client, ch
 			defer s.jobSem.Release(1)
 			defer wg.Done()
 
-			s.setProgressCompleteWithRepo(i+progressIndexOffset, repoURL)
+			s.setProgressCompleteWithRepo(i, progressIndexOffset, repoURL)
 			// Ensure the repo is removed from the resume info after being scanned.
 			defer func(s *Source) {
 				s.resumeInfoMutex.Lock()
@@ -794,7 +794,7 @@ func (s *Source) normalizeRepos(ctx context.Context, apiClient *github.Client) {
 }
 
 // setProgressCompleteWithRepo calls the s.SetProgressComplete after safely setting up the encoded resume info string.
-func (s *Source) setProgressCompleteWithRepo(index int, repoURL string) {
+func (s *Source) setProgressCompleteWithRepo(index int, offset int, repoURL string) {
 	s.resumeInfoMutex.Lock()
 	defer s.resumeInfoMutex.Unlock()
 
@@ -805,5 +805,5 @@ func (s *Source) setProgressCompleteWithRepo(index int, repoURL string) {
 	// Make the resume info string from the slice.
 	encodedResumeInfo := sources.EncodeResumeInfo(s.resumeInfoSlice)
 
-	s.SetProgressComplete(index, len(s.repos), fmt.Sprintf("Repo: %s", repoURL), encodedResumeInfo)
+	s.SetProgressComplete(index+offset, len(s.repos)+offset, fmt.Sprintf("Repo: %s", repoURL), encodedResumeInfo)
 }

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -367,7 +367,7 @@ func Test_setProgressCompleteWithRepo(t *testing.T) {
 
 	for _, tt := range tests {
 		s.resumeInfoSlice = tt.startingResumeInfoSlice
-		s.setProgressCompleteWithRepo(0, tt.repoURL)
+		s.setProgressCompleteWithRepo(0, 0, tt.repoURL)
 		if !reflect.DeepEqual(s.resumeInfoSlice, tt.wantResumeInfoSlice) {
 			t.Errorf("s.setProgressCompleteWithRepo() got: %v, want: %v", s.resumeInfoSlice, tt.wantResumeInfoSlice)
 		}


### PR DESCRIPTION
The number of repos was inaccurately reported when a scan was resumed. This fixes that. The fix is also already included in the gitlab resume PR.