### PR TITLE
Add SlackTokens option for slack credentials

### DIFF
--- a/proto/credentials.proto
+++ b/proto/credentials.proto
@@ -59,3 +59,8 @@ message GitHubApp {
   string installation_id = 2;
   string app_id = 3;
 }
+
+message SlackTokens {
+  string app_token = 1;
+  string bot_token = 2;
+}

--- a/proto/sources.proto
+++ b/proto/sources.proto
@@ -189,6 +189,7 @@ message Slack {
   string endpoint = 1 [(validate.rules).string.uri_ref = true];
   oneof credential {
     string token = 2;
+    credentials.SlackTokens tokens = 5;
   }
   repeated string channels = 3;
   repeated string ignoreList = 4;


### PR DESCRIPTION
Is there a way to do this without the `tokens` name, and instead having just `bot_token` and `app_token` be the credential? I don't _think_ so but I am less familiar with protobufs.