### PR TITLE
Add codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,23 @@
+# catch-all
+* @trufflesecurity/product-eng
+
+# teams
+pkg/sources/ @trufflesecurity/backend
+pkg/detectors/ @trufflesecurity/detection
+
+# critical detectors
+pkg/detectors/aws/ @trufflesecurity/backend
+pkg/detectors/gcp/ @trufflesecurity/backend
+pkg/detectors/azure/ @trufflesecurity/backend
+pkg/detectors/okta/ @trufflesecurity/backend
+pkg/detectors/privatekey/ @trufflesecurity/backend
+pkg/detectors/slack/ @trufflesecurity/backend
+pkg/detectors/slackwebhook/ @trufflesecurity/backend
+pkg/detectors/microsoftteamswebhook/ @trufflesecurity/backend
+pkg/detectors/twilio/ @trufflesecurity/backend
+pkg/detectors/sendgrid/ @trufflesecurity/backend
+pkg/detectors/gitlab/ @trufflesecurity/backend
+pkg/detectors/gitlabv2/ @trufflesecurity/backend
+pkg/detectors/github/ @trufflesecurity/backend
+pkg/detectors/github_old/ @trufflesecurity/backend
+pkg/detectors/githubapp/ @trufflesecurity/backend


### PR DESCRIPTION
Adds an initial codeowners file with critical detectors defined [THOG-504]