### PR TITLE
Remove git fragment trace

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -349,7 +349,6 @@ func (s *Git) ScanCommits(repo *git.Repository, path string, scanOptions *ScanOp
 					sb.WriteString(line.Line)
 				}
 			}
-			log.WithField("fragment", sb.String()).Trace("detecting fragment")
 			metadata := s.sourceMetadataFunc(fileName, email, hash, when, urlMetadata, newLineNumber)
 			chunksChan <- &sources.Chunk{
 				SourceName:     s.sourceName,


### PR DESCRIPTION
The fragment trace was a bit too verbose even at the trace level. We may
want to trace the file being chunked or something like that, but not the
entire diff.