### PR TITLE
Add support for Gitlab http repo URLs

### DIFF
--- a/pkg/giturl/giturl.go
+++ b/pkg/giturl/giturl.go
@@ -24,8 +24,8 @@ func NormalizeGithubRepo(repoURL string) (string, error) {
 }
 
 func NormalizeGitlabRepo(repoURL string) (string, error) {
-	if !strings.HasPrefix(repoURL, "https") {
-		return "", errors.New("Gitlab requires https repo urls: e.g. https://gitlab.com/org/repo.git")
+	if !strings.HasPrefix(repoURL, "http:") && !strings.HasPrefix(repoURL, "https:") {
+		return "", errors.New("Gitlab requires http/https repo urls: e.g. https://gitlab.com/org/repo.git")
 	}
 
 	return NormalizeOrgRepoURL("Gitlab", repoURL)


### PR DESCRIPTION
This PR allows TruffleHog to download GitLab repositories that don't support HTTPS connections. 

If there is anything more than I can add for this PR to be accepted, please let me know!

