### PR TITLE
added support for gitlab subgroups

### DIFF
--- a/pkg/giturl/giturl.go
+++ b/pkg/giturl/giturl.go
@@ -72,8 +72,8 @@ func NormalizeOrgRepoURL(provider, repoURL string) (string, error) {
 			return "", errors.Errorf("%s repo appears to be missing the repo name. Org: %q Repo url: %q", provider, org, repoURL)
 		}
 
-	case len(parts) > 3:
-		return "", errors.Errorf("%s repo appears to be too long or contains a trailing slash. Repo url: %q", provider, repoURL)
+	case len(parts) > 3 && strings.HasSuffix(parsed.Path, "/"):
+		return "", errors.Errorf("%s repo contains a trailing slash. Repo url: %q", provider, repoURL)
 	}
 
 	// If we're here it's probably a provider repo without ".git" at the end, so add it and return

--- a/pkg/giturl/giturl_test.go
+++ b/pkg/giturl/giturl_test.go
@@ -22,8 +22,8 @@ func Test_NormalizeOrgRepoURL(t *testing.T) {
 		"org but no repo":            {Provider: "Github", Repo: "https://github.com/org", Out: "", Err: errors.Errorf("Github repo appears to be missing the repo name. Org: %q Repo url: %q", "org", "https://github.com/org")},
 		"org but no repo with slash": {Provider: "Github", Repo: "https://github.com/org/", Out: "", Err: errors.Errorf("Github repo appears to be missing the repo name. Org: %q Repo url: %q", "org", "https://github.com/org/")},
 		"two slashes":                {Provider: "Github", Repo: "https://github.com//", Out: "", Err: errors.Errorf("Github repo appears to be missing the org name. Repo url: %q", "https://github.com//")},
-		"repo with trailing slash":   {Provider: "Github", Repo: "https://github.com/org/repo/", Out: "", Err: errors.Errorf("Github repo appears to be too long or contains a trailing slash. Repo url: %q", "https://github.com/org/repo/")},
-		"too many url path parts":    {Provider: "Github", Repo: "https://github.com/org/repo/unknown/", Out: "", Err: errors.Errorf("Github repo appears to be too long or contains a trailing slash. Repo url: %q", "https://github.com/org/repo/unknown/")},
+		"repo with trailing slash":   {Provider: "Github", Repo: "https://github.com/org/repo/", Out: "", Err: errors.Errorf("Github repo contains a trailing slash. Repo url: %q", "https://github.com/org/repo/")},
+		"too many url path parts":    {Provider: "Github", Repo: "https://github.com/org/repo/unknown/", Out: "", Err: errors.Errorf("Github repo contains a trailing slash. Repo url: %q", "https://github.com/org/repo/unknown/")},
 	}
 
 	for name, tt := range tests {


### PR DESCRIPTION
This change allows the use of subgroups inside GitLab. 

Previously TruffleHog analysed only repos like `https://gitlab-instance.com/org/repo.git`, with this feature it's possible to analyse repos like `https://gitlab-instance.com/my/cool/subgroup/repo.git`.

If there is anything more to change, just let me know!