### PR TITLE
Update github action to support generic cli command input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,6 @@ FROM alpine:3.15
 RUN apk add --no-cache git
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /build/trufflehog /usr/bin/trufflehog
-ENTRYPOINT ["/usr/bin/trufflehog"]
+COPY entrypoint.sh /etc/entrypoint.sh
+RUN chmod +x /etc/entrypoint.sh
+ENTRYPOINT ["/etc/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -3,14 +3,9 @@ description: 'Scan Github Actions with TruffleHog'
 author: Truffle Security Co. <support@trufflesec.com>
 
 inputs:
-  path:
-    description: Repository path
-    required: true
-  base:
-    description: Start scanning from here (usually main branch).
-    required: true
-  head:
-    description: Scan commits until here (usually dev branch).
+  cli_cmd:
+    default: 'git file://./'
+    description: 'cli command to be passed to the trufflehog cli'
     required: false
 branding:
   icon: "shield"
@@ -19,10 +14,4 @@ runs:
   using: "docker"
   image: "docker://ghcr.io/trufflesecurity/trufflehog:latest"
   args:
-    - git
-    - file://${{ inputs.path }}
-    - --since-commit
-    - ${{ inputs.base }}
-    - --branch
-    - ${{ inputs.head }}
-    - --fail
+    - ${{ inputs.cli_cmd }}

--- a/action.yml
+++ b/action.yml
@@ -3,9 +3,18 @@ description: 'Scan Github Actions with TruffleHog'
 author: Truffle Security Co. <support@trufflesec.com>
 
 inputs:
-  cli_cmd:
-    default: 'git file://./'
-    description: 'cli command to be passed to the trufflehog cli'
+  path:
+    description: Repository path
+    required: true
+  base:
+    description: Start scanning from here (usually main branch).
+    required: true
+  head:
+    description: Scan commits until here (usually dev branch).
+    required: false
+  extra_args:
+    default: ''
+    description: Extra args to be passed to the trufflehog cli.
     required: false
 branding:
   icon: "shield"
@@ -14,4 +23,11 @@ runs:
   using: "docker"
   image: "docker://ghcr.io/trufflesecurity/trufflehog:latest"
   args:
-    - ${{ inputs.cli_cmd }}
+    - git
+    - file://${{ inputs.path }}
+    - --since-commit
+    - ${{ inputs.base }}
+    - --branch
+    - ${{ inputs.head }}
+    - --fail
+    - ${{ inputs.extra_args }}

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ branding:
   color: "green"
 runs:
   using: "docker"
-  image: "docker://docker.io/jwenz723/trufflehog:latest"
+  image: "docker://ghcr.io/trufflesecurity/trufflehog:latest"
   args:
     - git
     - file://${{ inputs.path }}

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,7 @@ branding:
   color: "green"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/trufflesecurity/trufflehog:latest"
+  image: "docker://docker.io/jwenz723/trufflehog:latest"
   args:
     - git
     - file://${{ inputs.path }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,5 +2,4 @@
 
 # `$*` expands the `args` supplied in an `array` individually
 # or splits `args` in a string separated by whitespace.
-echo /usr/bin/trufflehog $*
 /usr/bin/trufflehog $*

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
-#! /usr/bin/env bash
+#!/usr/bin/env ash
 
-args=("$@")
-/usr/bin/trufflehog ${args[@]}
+# `$*` expands the `args` supplied in an `array` individually
+# or splits `args` in a string separated by whitespace.
+/usr/bin/trufflehog $*

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,5 @@
 
 # `$*` expands the `args` supplied in an `array` individually
 # or splits `args` in a string separated by whitespace.
+echo /usr/bin/trufflehog $*
 /usr/bin/trufflehog $*


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

This PR partially resolves https://github.com/trufflesecurity/trufflehog/issues/540. Specifically the portion of https://github.com/trufflesecurity/trufflehog/issues/540 regarding adding support for all trufflehog input arguments.

This is one possible way which can generically support passing in all of the available commands and arguments available for the trufflehog cli.
