### PR TITLE
refactor: improved Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM golang:bullseye as builder
+FROM --platform=${BUILDPLATFORM} golang:bullseye as builder
 
 WORKDIR /build
-COPY go.mod go.sum ./
-RUN go mod download
 COPY . . 
-RUN CGO_ENABLED=0 go build -a -o trufflehog main.go
+ENV CGO_ENABLED=0
+ARG TARGETOS TARGETARCH
+RUN  --mount=type=cache,target=/go/pkg/mod \
+     --mount=type=cache,target=/root/.cache/go-build \
+     GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o trufflehog .
 
 FROM alpine:3.15
 RUN apk add --no-cache git
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /build/trufflehog /usr/bin/trufflehog
 ENTRYPOINT ["/usr/bin/trufflehog"]
+


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
* Instead of separating the Go module download, we could remove this and just use a cache mount for ```/go/pkg/mod```
* ```COPY``` will create an extra layer in the container image which slows things down and uses extra disk space. This can be avoided by using ```RUN --mount``` and bind mounting from the build context, from a stage, or an image.
* add a cross compiling targets to the Dockerfile: ```TARGETOS``` & ```TARGETARCH```
* add ```BUILDPLATFORM``` -> matches current machines CPU architecture (eg. linux/amd64)
* go build reduced from 100secs++ to 10secs+++

Useful links:
https://www.docker.com/blog/containerize-your-go-developer-environment-part-1/
https://www.reddit.com/r/golang/comments/q7zppz/docker_cache_for_dependencies/
https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/