### PR TITLE
Fix goreleaser dockerfile

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,6 +13,8 @@ builds:
 dockers:
   - image_templates: ["trufflesecurity/{{ .ProjectName }}:{{ .Version }}-amd64"]
     dockerfile: Dockerfile.goreleaser
+    extra_files:
+    - entrypoint.sh
     use: buildx
     build_flag_templates:
     - --platform=linux/amd64
@@ -26,6 +28,8 @@ dockers:
   - image_templates: ["trufflesecurity/{{ .ProjectName }}:{{ .Version }}-arm64v8"]
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
+    extra_files:
+    - entrypoint.sh
     use: buildx
     build_flag_templates:
     - --platform=linux/arm64/v8
@@ -38,6 +42,8 @@ dockers:
     - --label=org.opencontainers.image.licenses=AGPL-3.0
   - image_templates: ["ghcr.io/trufflesecurity/{{ .ProjectName }}:{{ .Version }}-amd64"]
     dockerfile: Dockerfile.goreleaser
+    extra_files:
+    - entrypoint.sh
     use: buildx
     build_flag_templates:
     - --platform=linux/amd64
@@ -51,6 +57,8 @@ dockers:
   - image_templates: ["ghcr.io/trufflesecurity/{{ .ProjectName }}:{{ .Version }}-arm64v8"]
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
+    extra_files:
+    - entrypoint.sh
     use: buildx
     build_flag_templates:
     - --platform=linux/arm64/v8

--- a/Makefile
+++ b/Makefile
@@ -59,4 +59,4 @@ snifftest:
 	./hack/snifftest/snifftest.sh
 
 test-release:
-	goreleaser release --rm-dist --skip-publish
+	goreleaser release --rm-dist --skip-publish --snapshot

--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,6 @@ release-protos-image:
 
 snifftest:
 	./hack/snifftest/snifftest.sh
+
+test-release:
+	goreleaser release --rm-dist --skip-publish


### PR DESCRIPTION
We need to manually specify files to copy into the goreleaser built docker images that are not the binary. This should fix the automated docker build.