### PR TITLE
Draft: [THOG-371] - Utilize a config struct for engine scan configurations.

### DIFF
--- a/pkg/engine/filesystem.go
+++ b/pkg/engine/filesystem.go
@@ -6,15 +6,18 @@ import (
 
 	"github.com/go-errors/errors"
 	"github.com/sirupsen/logrus"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/filesystem"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/filesystem"
 )
 
-func (e *Engine) ScanFileSystem(ctx context.Context, directories []string) error {
+// ScanFileSystem scans a given file system.
+func (e *Engine) ScanFileSystem(ctx context.Context, c *sources.Config) error {
 	connection := &sourcespb.Filesystem{
-		Directories: directories,
+		Directories: c.Directories,
 	}
 	var conn anypb.Any
 	err := anypb.MarshalFrom(&conn, connection, proto.MarshalOptions{})

--- a/pkg/engine/git.go
+++ b/pkg/engine/git.go
@@ -11,34 +11,36 @@ import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/sirupsen/logrus"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/git"
 )
 
-func (e *Engine) ScanGit(ctx context.Context, repoPath, headRef, baseRef string, maxDepth int, filter *common.Filter) error {
+// ScanGit scans any git source.
+func (e *Engine) ScanGit(ctx context.Context, c *sources.Config) error {
 	logOptions := &gogit.LogOptions{}
 	opts := []git.ScanOption{
-		git.ScanOptionFilter(filter),
+		git.ScanOptionFilter(c.Filter),
 		git.ScanOptionLogOptions(logOptions),
 	}
 
-	repo, err := gogit.PlainOpenWithOptions(repoPath, &gogit.PlainOpenOptions{DetectDotGit: true})
+	repo, err := gogit.PlainOpenWithOptions(c.RepoPath, &gogit.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
-		return fmt.Errorf("could open repo: %s: %w", repoPath, err)
+		return fmt.Errorf("could open repo: %s: %w", c.RepoPath, err)
 	}
 
 	var baseCommit *object.Commit
-	if len(baseRef) > 0 {
-		baseHash := plumbing.NewHash(baseRef)
-		if !plumbing.IsHash(baseRef) {
-			base, err := git.TryAdditionalBaseRefs(repo, baseRef)
+	if len(c.BaseRef) > 0 {
+		baseHash := plumbing.NewHash(c.BaseRef)
+		if !plumbing.IsHash(c.BaseRef) {
+			base, err := git.TryAdditionalBaseRefs(repo, c.BaseRef)
 			if err != nil {
 				return errors.WrapPrefix(err, "unable to resolve base ref", 0)
 			} else {
-				baseRef = base.String()
-				baseCommit, _ = repo.CommitObject(plumbing.NewHash(baseRef))
+				c.BaseRef = base.String()
+				baseCommit, _ = repo.CommitObject(plumbing.NewHash(c.BaseRef))
 			}
 		} else {
 			baseCommit, err = repo.CommitObject(baseHash)
@@ -49,15 +51,15 @@ func (e *Engine) ScanGit(ctx context.Context, repoPath, headRef, baseRef string,
 	}
 
 	var headCommit *object.Commit
-	if len(headRef) > 0 {
-		headHash := plumbing.NewHash(headRef)
-		if !plumbing.IsHash(headRef) {
-			head, err := git.TryAdditionalBaseRefs(repo, headRef)
+	if len(c.HeadRef) > 0 {
+		headHash := plumbing.NewHash(c.HeadRef)
+		if !plumbing.IsHash(c.HeadRef) {
+			head, err := git.TryAdditionalBaseRefs(repo, c.HeadRef)
 			if err != nil {
 				return errors.WrapPrefix(err, "unable to resolve head ref", 0)
 			} else {
-				headRef = head.String()
-				headCommit, _ = repo.CommitObject(plumbing.NewHash(baseRef))
+				c.HeadRef = head.String()
+				headCommit, _ = repo.CommitObject(plumbing.NewHash(c.BaseRef))
 			}
 		} else {
 			headCommit, err = repo.CommitObject(headHash)
@@ -67,23 +69,23 @@ func (e *Engine) ScanGit(ctx context.Context, repoPath, headRef, baseRef string,
 		}
 	}
 
-	// If baseCommit is an ancestor of headCommit, update baseRef to be the common ancestor.
+	// If baseCommit is an ancestor of headCommit, update c.BaseRef to be the common ancestor.
 	if headCommit != nil && baseCommit != nil {
 		mergeBase, err := headCommit.MergeBase(baseCommit)
 		if err != nil || len(mergeBase) < 1 {
 			return errors.WrapPrefix(err, "could not find common base between the given references", 0)
 		}
-		baseRef = mergeBase[0].Hash.String()
+		c.BaseRef = mergeBase[0].Hash.String()
 	}
 
-	if maxDepth != 0 {
-		opts = append(opts, git.ScanOptionMaxDepth(int64(maxDepth)))
+	if c.MaxDepth != 0 {
+		opts = append(opts, git.ScanOptionMaxDepth(int64(c.MaxDepth)))
 	}
-	if baseRef != "" {
-		opts = append(opts, git.ScanOptionBaseHash(baseRef))
+	if c.BaseRef != "" {
+		opts = append(opts, git.ScanOptionBaseHash(c.BaseRef))
 	}
-	if headRef != "" {
-		opts = append(opts, git.ScanOptionHeadCommit(headRef))
+	if c.HeadRef != "" {
+		opts = append(opts, git.ScanOptionHeadCommit(c.HeadRef))
 	}
 	scanOptions := git.NewScanOptions(opts...)
 
@@ -106,7 +108,7 @@ func (e *Engine) ScanGit(ctx context.Context, repoPath, headRef, baseRef string,
 	e.sourcesWg.Add(1)
 	go func() {
 		defer e.sourcesWg.Done()
-		err := gitSource.ScanRepo(ctx, repo, repoPath, scanOptions, e.ChunksChan())
+		err := gitSource.ScanRepo(ctx, repo, c.RepoPath, scanOptions, e.ChunksChan())
 		if err != nil {
 			logrus.WithError(err).Fatal("could not scan repo")
 		}

--- a/pkg/engine/github.go
+++ b/pkg/engine/github.go
@@ -7,34 +7,35 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/github"
 )
 
-func (e *Engine) ScanGitHub(ctx context.Context, endpoint string, repos, orgs []string, token string, includeForks bool, filter *common.Filter, concurrency int, includeMembers bool) error {
+// ScanGitHub scans Github with the provided options.
+func (e *Engine) ScanGitHub(ctx context.Context, c *sources.Config) error {
 	source := github.Source{}
 	connection := sourcespb.GitHub{
-		Endpoint:      endpoint,
-		Organizations: orgs,
-		Repositories:  repos,
-		ScanUsers:     includeMembers,
+		Endpoint:      c.Endpoint,
+		Organizations: c.Orgs,
+		Repositories:  c.Repos,
+		ScanUsers:     c.IncludeMembers,
 	}
-	if len(token) > 0 {
+	if len(c.Token) > 0 {
 		connection.Credential = &sourcespb.GitHub_Token{
-			Token: token,
+			Token: c.Token,
 		}
 	} else {
 		connection.Credential = &sourcespb.GitHub_Unauthenticated{}
 	}
-	connection.IncludeForks = includeForks
+	connection.IncludeForks = c.IncludeForks
 	var conn anypb.Any
 	err := anypb.MarshalFrom(&conn, &connection, proto.MarshalOptions{})
 	if err != nil {
 		logrus.WithError(err).Error("failed to marshal github connection")
 		return err
 	}
-	err = source.Init(ctx, "trufflehog - github", 0, 0, false, &conn, concurrency)
+	err = source.Init(ctx, "trufflehog - github", 0, 0, false, &conn, c.Concurrency)
 	if err != nil {
 		logrus.WithError(err).Error("failed to initialize github source")
 		return err

--- a/pkg/engine/gitlab.go
+++ b/pkg/engine/gitlab.go
@@ -6,31 +6,34 @@ import (
 
 	"github.com/go-errors/errors"
 	"github.com/sirupsen/logrus"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/gitlab"
 	"golang.org/x/net/context"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/gitlab"
 )
 
-func (e *Engine) ScanGitLab(ctx context.Context, endpoint, token string, repositories []string) error {
+// ScanGitLab scans GitLab with the provided configuration.
+func (e *Engine) ScanGitLab(ctx context.Context, c *sources.Config) error {
 	connection := &sourcespb.GitLab{}
 
 	switch {
-	case len(token) > 0:
+	case len(c.Token) > 0:
 		connection.Credential = &sourcespb.GitLab_Token{
-			Token: token,
+			Token: c.Token,
 		}
 	default:
 		return fmt.Errorf("must provide token")
 	}
 
-	if len(endpoint) > 0 {
-		connection.Endpoint = endpoint
+	if len(c.Endpoint) > 0 {
+		connection.Endpoint = c.Endpoint
 	}
 
-	if len(repositories) > 0 {
-		connection.Repositories = repositories
+	if len(c.Repos) > 0 {
+		connection.Repositories = c.Repos
 	}
 
 	var conn anypb.Any

--- a/pkg/engine/syslog.go
+++ b/pkg/engine/syslog.go
@@ -10,24 +10,26 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/syslog"
 )
 
-func (e *Engine) ScanSyslog(ctx context.Context, address, protocol, certPath, keyPath, format string, concurrency int) error {
+// ScanSyslog is a source that scans syslog files.
+func (e *Engine) ScanSyslog(ctx context.Context, c *sources.Config) error {
 	connection := &sourcespb.Syslog{
-		Protocol:      protocol,
-		ListenAddress: address,
-		Format:        format,
+		Protocol:      c.Protocol,
+		ListenAddress: c.Address,
+		Format:        c.Format,
 	}
 
-	if certPath != "" && keyPath != "" {
-		cert, err := os.ReadFile(certPath)
+	if c.CertPath != "" && c.KeyPath != "" {
+		cert, err := os.ReadFile(c.CertPath)
 		if err != nil {
 			return errors.WrapPrefix(err, "could not open TLS cert file", 0)
 		}
 		connection.TlsCert = string(cert)
 
-		key, err := os.ReadFile(keyPath)
+		key, err := os.ReadFile(c.KeyPath)
 		if err != nil {
 			return errors.WrapPrefix(err, "could not open TLS key file", 0)
 		}
@@ -40,7 +42,7 @@ func (e *Engine) ScanSyslog(ctx context.Context, address, protocol, certPath, ke
 		return errors.WrapPrefix(err, "error unmarshalling connection", 0)
 	}
 	source := syslog.Source{}
-	err = source.Init(ctx, "trufflehog - syslog", 0, 0, false, &conn, concurrency)
+	err = source.Init(ctx, "trufflehog - syslog", 0, 0, false, &conn, c.Concurrency)
 	source.InjectConnection(connection)
 	if err != nil {
 		logrus.WithError(err).Error("failed to initialize syslog source")

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"sync"
 
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 // Chunk contains data to be decoded and scanned along with context on where it came from.
@@ -42,6 +44,57 @@ type Source interface {
 	GetProgress() *Progress
 }
 
+// Config defines the optional configuration for a source.
+type Config struct {
+	// Endpoint is the endpoint of the source.
+	Endpoint,
+	// Repo is the repository to scan.
+	Repo,
+	// Token is the token to use to authenticate with the source.
+	Token,
+	// Key is any key to use to authenticate with the source. (ex: S3)
+	Key,
+	// Secret is any secret to use to authenticate with the source. (ex: S3)
+	Secret,
+	// Address used to connect to the source. (ex: syslog)
+	Address,
+	// Protocol used to connect to the source.
+	Protocol,
+	// CertPath is the path to the certificate to use to connect to the source.
+	CertPath,
+	// KeyPath is the path to the key to use to connect to the source.
+	KeyPath,
+	// Format is the format used to connect to the source.
+	Format,
+	// RepoPath is the path to the repository to scan.
+	RepoPath,
+	// HeadRef is the head reference to use to scan from.
+	HeadRef,
+	// BaseRef is the base reference to use to scan from.
+	BaseRef string
+	// Concurrency is the number of concurrent workers to use to scan the source.
+	Concurrency,
+	// MaxDepth is the maximum depth to scan the source.
+	MaxDepth int
+	// IncludeForks indicates whether to include forks in the scan.
+	IncludeForks,
+	// IncludeMembers indicates whether to include members in the scan.
+	IncludeMembers,
+	// CloudCred determines whether to use cloud credentials.
+	// This can NOT be used with a secret.
+	CloudCred bool
+	// Repos is the list of repositories to scan.
+	Repos,
+	// Orgs is the list of organizations to scan.
+	Orgs,
+	// Buckets is the list of buckets to scan.
+	Buckets,
+	// Directories is the list of directories to scan.
+	Directories []string
+	// Filter is the filter to use to scan the source.
+	Filter *common.Filter
+}
+
 // PercentComplete is used to update job completion percentages across sources
 type Progress struct {
 	mut               sync.Mutex
@@ -68,7 +121,7 @@ func (p *Progress) SetProgressComplete(i, scope int, message, encodedResumeInfo 
 	p.PercentComplete = int64((float64(i) / float64(scope)) * 100)
 }
 
-//GetProgressComplete gets job completion percentage for metrics reporting
+// GetProgressComplete gets job completion percentage for metrics reporting
 func (p *Progress) GetProgress() *Progress {
 	p.mut.Lock()
 	defer p.mut.Unlock()


### PR DESCRIPTION
- Define a config struct within sources that encompasses all the configurations used for all the engine scanning integrations.
- Construct each config within main for each source.
- Pass the config as the second argument to each of the engine scan methods.