### PR TITLE
Use re-readable reader and common chunker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	cloud.google.com/go/secretmanager v1.5.0
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.11
 	github.com/aws/aws-sdk-go v1.44.61
+	github.com/bill-rich/disk-buffer-reader v0.1.2
 	github.com/bill-rich/go-syslog v0.0.0-20220413021637-49edb52a574c
 	github.com/bitfinexcom/bitfinex-api-go v0.0.0-20210608095005-9e0b26f200fb
 	github.com/bradleyfalzon/ghinstallation/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -100,6 +100,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/aws/aws-sdk-go v1.44.61 h1:NcpLSS3Z0MiVQIYugx4I40vSIEEAXT0baO684ExNRco=
 github.com/aws/aws-sdk-go v1.44.61/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/bill-rich/disk-buffer-reader v0.1.2 h1:pN9K5JoacTcNWp2SCd3n7mPouSwMP9ouTS66Qa+5IPY=
+github.com/bill-rich/disk-buffer-reader v0.1.2/go.mod h1:VVzzsK1Ac2AnpOfp/5r9JlIFaFkZ9uSf7zisZayCt0Y=
 github.com/bill-rich/go-syslog v0.0.0-20220413021637-49edb52a574c h1:tSME5FDS02qQll3JYodI6RZR/g4EKOHApGv1wMZT+Z0=
 github.com/bill-rich/go-syslog v0.0.0-20220413021637-49edb52a574c/go.mod h1:+sCc6hztur+oZCLOsNk6wCCy+GLrnSNHSRmTnnL+8iQ=
 github.com/bitfinexcom/bitfinex-api-go v0.0.0-20210608095005-9e0b26f200fb h1:9v7Bzlg+1EBYi2IYcUmOwHReBEfqBbYIj3ZCi9cIe1Q=

--- a/pkg/common/chunker.go
+++ b/pkg/common/chunker.go
@@ -23,6 +23,7 @@ func ChunkReader(r io.Reader) chan []byte {
 			n, err := reader.Read(chunk)
 			if err != nil && !errors.Is(err, io.EOF) {
 				log.WithError(err).Error("Error chunking reader.")
+				break
 			}
 			peekData, _ := reader.Peek(PeekSize)
 			chunkChan <- append(chunk[:n], peekData...)

--- a/pkg/common/chunker.go
+++ b/pkg/common/chunker.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"bufio"
+	"errors"
+	"io"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	ChunkSize = 10 * 1024
+	PeekSize  = 3 * 1024
+)
+
+func ChunkReader(r io.Reader) chan []byte {
+	chunkChan := make(chan []byte)
+	go func() {
+		defer close(chunkChan)
+		reader := bufio.NewReaderSize(bufio.NewReader(r), ChunkSize)
+		for {
+			chunk := make([]byte, ChunkSize)
+			n, err := reader.Read(chunk)
+			if err != nil && !errors.Is(err, io.EOF) {
+				log.WithError(err).Error("Error chunking reader.")
+			}
+			peekData, _ := reader.Peek(PeekSize)
+			chunkChan <- append(chunk[:n], peekData...)
+			if errors.Is(err, io.EOF) {
+				break
+			}
+		}
+	}()
+	return chunkChan
+}

--- a/pkg/common/chunker_test.go
+++ b/pkg/common/chunker_test.go
@@ -1,0 +1,75 @@
+package common
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	diskbufferreader "github.com/bill-rich/disk-buffer-reader"
+)
+
+func TestChunker(t *testing.T) {
+	resp, err := http.Get("https://raw.githubusercontent.com/bill-rich/bad-secrets/master/FifteenMB.gz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	reReader, err := diskbufferreader.New(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reReader.Close()
+
+	baseChunkCount := 0
+
+	// Count chunks from looping using chunk size.
+	for {
+		baseChunkCount++
+		tmpChunk := make([]byte, ChunkSize)
+		_, err := reReader.Read(tmpChunk)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Error(err)
+		}
+	}
+	reReader.Reset()
+
+	// Get the first two chunks for comparing later.
+	baseChunkOne := make([]byte, ChunkSize)
+	baseChunkTwo := make([]byte, ChunkSize)
+
+	baseReader := bufio.NewReaderSize(reReader, ChunkSize)
+	baseReader.Read(baseChunkOne)
+	peek, _ := baseReader.Peek(PeekSize)
+	baseChunkOne = append(baseChunkOne, peek...)
+	baseReader.Read(baseChunkTwo)
+	peek, _ = baseReader.Peek(PeekSize)
+	baseChunkTwo = append(baseChunkTwo, peek...)
+
+	// Reset the reader to the beginning and use ChunkReader.
+	reReader.Reset()
+
+	testChunkCount := 0
+	for chunk := range ChunkReader(reReader) {
+		testChunkCount++
+		switch testChunkCount {
+		case 1:
+			if bytes.Compare(baseChunkOne, chunk) != 0 {
+				t.Errorf("First chunk did not match expected. Got: %d bytes, expected: %d bytes", len(chunk), len(baseChunkOne))
+			}
+		case 2:
+			if bytes.Compare(baseChunkTwo, chunk) != 0 {
+				t.Errorf("Second chunk did not match expected. Got: %d bytes, expected: %d bytes; %v", len(chunk), len(baseChunkTwo), baseChunkTwo)
+			}
+		}
+	}
+	if testChunkCount != baseChunkCount {
+		t.Errorf("Wrong number of chunks received. Got %d, expected: %d.", testChunkCount, baseChunkCount)
+	}
+
+}

--- a/pkg/common/chunker_test.go
+++ b/pkg/common/chunker_test.go
@@ -37,34 +37,34 @@ func TestChunker(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	reReader.Reset()
+	_ = reReader.Reset()
 
 	// Get the first two chunks for comparing later.
 	baseChunkOne := make([]byte, ChunkSize)
 	baseChunkTwo := make([]byte, ChunkSize)
 
 	baseReader := bufio.NewReaderSize(reReader, ChunkSize)
-	baseReader.Read(baseChunkOne)
+	_, _ = baseReader.Read(baseChunkOne)
 	peek, _ := baseReader.Peek(PeekSize)
 	baseChunkOne = append(baseChunkOne, peek...)
-	baseReader.Read(baseChunkTwo)
+	_, _ = baseReader.Read(baseChunkTwo)
 	peek, _ = baseReader.Peek(PeekSize)
 	baseChunkTwo = append(baseChunkTwo, peek...)
 
 	// Reset the reader to the beginning and use ChunkReader.
-	reReader.Reset()
+	_ = reReader.Reset()
 
 	testChunkCount := 0
 	for chunk := range ChunkReader(reReader) {
 		testChunkCount++
 		switch testChunkCount {
 		case 1:
-			if bytes.Compare(baseChunkOne, chunk) != 0 {
+			if !bytes.Equal(baseChunkOne, chunk) {
 				t.Errorf("First chunk did not match expected. Got: %d bytes, expected: %d bytes", len(chunk), len(baseChunkOne))
 			}
 		case 2:
-			if bytes.Compare(baseChunkTwo, chunk) != 0 {
-				t.Errorf("Second chunk did not match expected. Got: %d bytes, expected: %d bytes; %v", len(chunk), len(baseChunkTwo), baseChunkTwo)
+			if !bytes.Equal(baseChunkTwo, chunk) {
+				t.Errorf("Second chunk did not match expected. Got: %d bytes, expected: %d bytes", len(chunk), len(baseChunkTwo))
 			}
 		}
 	}

--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -136,7 +136,9 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk) err
 				return nil
 			}
 
-			reReader.Reset()
+			if err := reReader.Reset(); err != nil {
+				return err
+			}
 			reReader.Stop()
 
 			for chunkData := range common.ChunkReader(inputFile) {


### PR DESCRIPTION
This PR has two parts. Adding re-readable readers and adding a common chunking function.

Part 1:
File handlers require that readers be read more than once. Some sources readers are more difficult than others to use efficiently. For example, an HTTP response could be fully read and stored in memory, or two requests could be made, but both have their pitfalls. Using disk-buffer-reader makes it so we can use the same method everywhere. It allows readers to be reset to the beginning by utilizing a tmp file as a buffer.

Part 2:
Each source that deals with files re-implements chunking. A common chunking function gives us consistency and is easier to use.