### PR TITLE
[chore] - Use config struct instead of pointer for engine scans.

### DIFF
--- a/main.go
+++ b/main.go
@@ -200,7 +200,7 @@ func run(state overseer.State) {
 			c.Filter = filter
 		}
 
-		if err = e.ScanGit(ctx, sources.NewConfig(g)); err != nil {
+		if err = e.ScanGit(ctx, *sources.NewConfig(g)); err != nil {
 			logrus.WithError(err).Fatal("Failed to scan Git.")
 		}
 	case githubScan.FullCommand():
@@ -218,7 +218,7 @@ func run(state overseer.State) {
 			c.Concurrency = *concurrency
 		}
 
-		if err = e.ScanGitHub(ctx, sources.NewConfig(github)); err != nil {
+		if err = e.ScanGitHub(ctx, *sources.NewConfig(github)); err != nil {
 			logrus.WithError(err).Fatal("Failed to scan Github.")
 		}
 	case gitlabScan.FullCommand():
@@ -228,7 +228,7 @@ func run(state overseer.State) {
 			c.Repos = *gitlabScanRepos
 		}
 
-		if err = e.ScanGitLab(ctx, sources.NewConfig(gitlab)); err != nil {
+		if err = e.ScanGitLab(ctx, *sources.NewConfig(gitlab)); err != nil {
 			logrus.WithError(err).Fatal("Failed to scan GitLab.")
 		}
 	case filesystemScan.FullCommand():
@@ -236,7 +236,7 @@ func run(state overseer.State) {
 			c.Directories = *filesystemDirectories
 		}
 
-		if err = e.ScanFileSystem(ctx, sources.NewConfig(fs)); err != nil {
+		if err = e.ScanFileSystem(ctx, *sources.NewConfig(fs)); err != nil {
 			logrus.WithError(err).Fatal("Failed to scan filesystem")
 		}
 	case s3Scan.FullCommand():
@@ -246,7 +246,7 @@ func run(state overseer.State) {
 			c.Buckets = *s3ScanBuckets
 		}
 
-		if err = e.ScanS3(ctx, sources.NewConfig(s3)); err != nil {
+		if err = e.ScanS3(ctx, *sources.NewConfig(s3)); err != nil {
 			logrus.WithError(err).Fatal("Failed to scan S3.")
 		}
 	case syslogScan.FullCommand():
@@ -259,7 +259,7 @@ func run(state overseer.State) {
 			c.Concurrency = *concurrency
 		}
 
-		if err = e.ScanSyslog(ctx, sources.NewConfig(syslog)); err != nil {
+		if err = e.ScanSyslog(ctx, *sources.NewConfig(syslog)); err != nil {
 			logrus.WithError(err).Fatal("Failed to scan syslog.")
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -192,7 +192,7 @@ func run(state overseer.State) {
 			defer os.RemoveAll(repoPath)
 		}
 
-		g := func(c *sources.Config) {
+		g := func(c sources.Config) {
 			c.RepoPath = repoPath
 			c.HeadRef = *gitScanBranch
 			c.BaseRef = *gitScanSinceCommit
@@ -200,7 +200,7 @@ func run(state overseer.State) {
 			c.Filter = filter
 		}
 
-		if err = e.ScanGit(ctx, *sources.NewConfig(g)); err != nil {
+		if err = e.ScanGit(ctx, sources.NewConfig(g)); err != nil {
 			logrus.WithError(err).Fatal("Failed to scan Git.")
 		}
 	case githubScan.FullCommand():
@@ -208,7 +208,7 @@ func run(state overseer.State) {
 			log.Fatal("You must specify at least one organization or repository.")
 		}
 
-		github := func(c *sources.Config) {
+		github := func(c sources.Config) {
 			c.Endpoint = *githubScanEndpoint
 			c.Repos = *githubScanRepos
 			c.Orgs = *githubScanOrgs
@@ -218,39 +218,39 @@ func run(state overseer.State) {
 			c.Concurrency = *concurrency
 		}
 
-		if err = e.ScanGitHub(ctx, *sources.NewConfig(github)); err != nil {
+		if err = e.ScanGitHub(ctx, sources.NewConfig(github)); err != nil {
 			logrus.WithError(err).Fatal("Failed to scan Github.")
 		}
 	case gitlabScan.FullCommand():
-		gitlab := func(c *sources.Config) {
+		gitlab := func(c sources.Config) {
 			c.Endpoint = *gitlabScanEndpoint
 			c.Token = *gitlabScanToken
 			c.Repos = *gitlabScanRepos
 		}
 
-		if err = e.ScanGitLab(ctx, *sources.NewConfig(gitlab)); err != nil {
+		if err = e.ScanGitLab(ctx, sources.NewConfig(gitlab)); err != nil {
 			logrus.WithError(err).Fatal("Failed to scan GitLab.")
 		}
 	case filesystemScan.FullCommand():
-		fs := func(c *sources.Config) {
+		fs := func(c sources.Config) {
 			c.Directories = *filesystemDirectories
 		}
 
-		if err = e.ScanFileSystem(ctx, *sources.NewConfig(fs)); err != nil {
+		if err = e.ScanFileSystem(ctx, sources.NewConfig(fs)); err != nil {
 			logrus.WithError(err).Fatal("Failed to scan filesystem")
 		}
 	case s3Scan.FullCommand():
-		s3 := func(c *sources.Config) {
+		s3 := func(c sources.Config) {
 			c.Key = *s3ScanKey
 			c.Secret = *s3ScanSecret
 			c.Buckets = *s3ScanBuckets
 		}
 
-		if err = e.ScanS3(ctx, *sources.NewConfig(s3)); err != nil {
+		if err = e.ScanS3(ctx, sources.NewConfig(s3)); err != nil {
 			logrus.WithError(err).Fatal("Failed to scan S3.")
 		}
 	case syslogScan.FullCommand():
-		syslog := func(c *sources.Config) {
+		syslog := func(c sources.Config) {
 			c.Address = *syslogAddress
 			c.Protocol = *syslogProtocol
 			c.CertPath = *syslogTLSCert
@@ -259,7 +259,7 @@ func run(state overseer.State) {
 			c.Concurrency = *concurrency
 		}
 
-		if err = e.ScanSyslog(ctx, *sources.NewConfig(syslog)); err != nil {
+		if err = e.ScanSyslog(ctx, sources.NewConfig(syslog)); err != nil {
 			logrus.WithError(err).Fatal("Failed to scan syslog.")
 		}
 	}

--- a/pkg/engine/filesystem.go
+++ b/pkg/engine/filesystem.go
@@ -15,11 +15,7 @@ import (
 )
 
 // ScanFileSystem scans a given file system.
-func (e *Engine) ScanFileSystem(ctx context.Context, c *sources.Config) error {
-	if c == nil {
-		return errors.New("nil config provided to ScanFileSystem")
-	}
-
+func (e *Engine) ScanFileSystem(ctx context.Context, c sources.Config) error {
 	connection := &sourcespb.Filesystem{
 		Directories: c.Directories,
 	}

--- a/pkg/engine/git.go
+++ b/pkg/engine/git.go
@@ -18,11 +18,7 @@ import (
 )
 
 // ScanGit scans any git source.
-func (e *Engine) ScanGit(ctx context.Context, c *sources.Config) error {
-	if c == nil {
-		return errors.New("nil config for ScanGit")
-	}
-
+func (e *Engine) ScanGit(ctx context.Context, c sources.Config) error {
 	logOptions := &gogit.LogOptions{}
 	opts := []git.ScanOption{
 		git.ScanOptionFilter(c.Filter),

--- a/pkg/engine/git_test.go
+++ b/pkg/engine/git_test.go
@@ -64,7 +64,7 @@ func TestGitEngine(t *testing.T) {
 			MaxDepth: tTest.maxDepth,
 			Filter:   tTest.filter,
 		}
-		if err := e.ScanGit(ctx, &cfg); err != nil {
+		if err := e.ScanGit(ctx, cfg); err != nil {
 			return
 		}
 		go e.Finish()
@@ -118,7 +118,7 @@ func BenchmarkGitEngine(b *testing.B) {
 			RepoPath: path,
 			Filter:   common.FilterEmpty(),
 		}
-		if err := e.ScanGit(ctx, &cfg); err != nil {
+		if err := e.ScanGit(ctx, cfg); err != nil {
 			return
 		}
 	}

--- a/pkg/engine/github.go
+++ b/pkg/engine/github.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 
-	"github.com/go-errors/errors"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -14,11 +13,7 @@ import (
 )
 
 // ScanGitHub scans Github with the provided options.
-func (e *Engine) ScanGitHub(ctx context.Context, c *sources.Config) error {
-	if c == nil {
-		return errors.New("nil config provided for ScanGitHub")
-	}
-
+func (e *Engine) ScanGitHub(ctx context.Context, c sources.Config) error {
 	source := github.Source{}
 	connection := sourcespb.GitHub{
 		Endpoint:      c.Endpoint,

--- a/pkg/engine/gitlab.go
+++ b/pkg/engine/gitlab.go
@@ -16,11 +16,7 @@ import (
 )
 
 // ScanGitLab scans GitLab with the provided configuration.
-func (e *Engine) ScanGitLab(ctx context.Context, c *sources.Config) error {
-	if c == nil {
-		return errors.New("config is nil for ScanGitlab")
-	}
-
+func (e *Engine) ScanGitLab(ctx context.Context, c sources.Config) error {
 	connection := &sourcespb.GitLab{}
 
 	switch {

--- a/pkg/engine/s3.go
+++ b/pkg/engine/s3.go
@@ -17,11 +17,7 @@ import (
 )
 
 // ScanS3 scans S3 buckets.
-func (e *Engine) ScanS3(ctx context.Context, c *sources.Config) error {
-	if c == nil {
-		return errors.New("nil config provided for ScanS3")
-	}
-
+func (e *Engine) ScanS3(ctx context.Context, c sources.Config) error {
 	connection := &sourcespb.S3{
 		Credential: &sourcespb.S3_Unauthenticated{},
 	}

--- a/pkg/engine/syslog.go
+++ b/pkg/engine/syslog.go
@@ -15,11 +15,7 @@ import (
 )
 
 // ScanSyslog is a source that scans syslog files.
-func (e *Engine) ScanSyslog(ctx context.Context, c *sources.Config) error {
-	if c == nil {
-		return errors.New("nil config provided for ScanSyslog")
-	}
-
+func (e *Engine) ScanSyslog(ctx context.Context, c sources.Config) error {
 	connection := &sourcespb.Syslog{
 		Protocol:      c.Protocol,
 		ListenAddress: c.Address,

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -96,8 +96,8 @@ type Config struct {
 }
 
 // NewConfig returns a new Config with optional values.
-func NewConfig(opts ...func(*Config)) *Config {
-	c := &Config{}
+func NewConfig(opts ...func(Config)) Config {
+	c := Config{}
 	for _, opt := range opts {
 		opt(c)
 	}


### PR DESCRIPTION
Use a config struct instead of pointer when scanning engine sources.
Remove the nil check from each scan.
