### PR TITLE
[Thog-628] update detector results hash v2

### DIFF
--- a/pkg/detectors/adobeio/adobeio.go
+++ b/pkg/detectors/adobeio/adobeio.go
@@ -51,6 +51,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_AdobeIO,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/adzuna/adzuna.go
+++ b/pkg/detectors/adzuna/adzuna.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Adzuna,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/aeroworkflow/aeroworkflow.go
+++ b/pkg/detectors/aeroworkflow/aeroworkflow.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Aeroworkflow,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/agora/agora.go
+++ b/pkg/detectors/agora/agora.go
@@ -53,6 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Agora,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resSecret),
 			}
 
 			if verify {

--- a/pkg/detectors/airbrakeprojectkey/airbrakeprojectkey.go
+++ b/pkg/detectors/airbrakeprojectkey/airbrakeprojectkey.go
@@ -53,6 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_AirbrakeProjectKey,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/airtableapikey/airtableapikey.go
+++ b/pkg/detectors/airtableapikey/airtableapikey.go
@@ -53,6 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detectorspb.DetectorType_AirtableApiKey,
 				Redacted:     appRes,
 				Raw:          []byte(keyRes),
+				RawV2:        []byte(keyRes + appRes),
 			}
 
 			if verify {

--- a/pkg/detectors/alegra/alegra.go
+++ b/pkg/detectors/alegra/alegra.go
@@ -53,6 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Alegra,
 				Raw:          []byte(tokenPatMatch),
+				RawV2:        []byte(tokenPatMatch + userPatMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/algoliaadminkey/algoliaadminkey.go
+++ b/pkg/detectors/algoliaadminkey/algoliaadminkey.go
@@ -51,6 +51,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_AlgoliaAdminKey,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/alibaba/alibaba.go
+++ b/pkg/detectors/alibaba/alibaba.go
@@ -84,6 +84,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Alibaba,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {
@@ -103,7 +104,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				params.Add("Version", "2014-05-26")
 
 				stringToSign := buildStringToSign(req.Method, params.Encode())
-				signature := GetSignature(stringToSign, resMatch+"&") //Get Signature HMAC SHA1
+				signature := GetSignature(stringToSign, resMatch+"&") // Get Signature HMAC SHA1
 				params.Add("Signature", signature)
 				req.URL.RawQuery = params.Encode()
 

--- a/pkg/detectors/amadeus/amadeus.go
+++ b/pkg/detectors/amadeus/amadeus.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Amadeus,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resSecret),
 			}
 
 			if verify {

--- a/pkg/detectors/amplitudeapikey/amplitudeapikey.go
+++ b/pkg/detectors/amplitudeapikey/amplitudeapikey.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_AmplitudeApiKey,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resSecretMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/anypoint/anypoint.go
+++ b/pkg/detectors/anypoint/anypoint.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Anypoint,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + orgRes),
 			}
 
 			if verify {

--- a/pkg/detectors/apideck/apideck.go
+++ b/pkg/detectors/apideck/apideck.go
@@ -53,6 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_ApiDeck,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/apiflash/apiflash.go
+++ b/pkg/detectors/apiflash/apiflash.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Apiflash,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resUrlMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/apimatic/apimatic.go
+++ b/pkg/detectors/apimatic/apimatic.go
@@ -54,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_APIMatic,
 				Raw:          []byte(userPatMatch),
+				RawV2:        []byte(userPatMatch + passPatMatch),
 			}
 			if verify {
 				timeout := 10 * time.Second

--- a/pkg/detectors/appcues/appcues.go
+++ b/pkg/detectors/appcues/appcues.go
@@ -63,6 +63,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1 := detectors.Result{
 					DetectorType: detectorspb.DetectorType_Appcues,
 					Raw:          []byte(resMatch),
+					RawV2:        []byte(resMatch + resUserMatch),
 				}
 				if verify {
 					req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://api.appcues.com/v2/accounts/%s/flows", resIdMatch), nil)

--- a/pkg/detectors/apptivo/apptivo.go
+++ b/pkg/detectors/apptivo/apptivo.go
@@ -53,6 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Apptivo,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/artifactory/artifactory.go
+++ b/pkg/detectors/artifactory/artifactory.go
@@ -54,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_ArtifactoryAccessToken,
 			Raw:          []byte(resMatch),
+			RawV2:        []byte(resMatch + resURLMatch),
 		}
 
 		if verify {

--- a/pkg/detectors/artsy/artsy.go
+++ b/pkg/detectors/artsy/artsy.go
@@ -53,6 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Artsy,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/auth0managementapitoken/auth0managementapitoken.go
+++ b/pkg/detectors/auth0managementapitoken/auth0managementapitoken.go
@@ -58,6 +58,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detectorspb.DetectorType_Auth0ManagementApiToken,
 				Redacted:     domainRes,
 				Raw:          []byte(managementApiTokenRes),
+				RawV2:        []byte(managementApiTokenRes + domainRes),
 			}
 
 			if verify {

--- a/pkg/detectors/auth0oauth/auth0oauth.go
+++ b/pkg/detectors/auth0oauth/auth0oauth.go
@@ -2,14 +2,13 @@ package auth0oauth
 
 import (
 	"context"
+	"io/ioutil"
+	"net/http"
+	"net/url"
 	// "fmt"
 	// "log"
 	"regexp"
 	"strings"
-
-	"io/ioutil"
-	"net/http"
-	"net/url"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -65,6 +64,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					DetectorType: detectorspb.DetectorType_Auth0oauth,
 					Redacted:     clientIdRes,
 					Raw:          []byte(clientSecretRes),
+					RawV2:        []byte(clientIdRes + clientSecretRes),
 				}
 
 				if verify {

--- a/pkg/detectors/auth0oauth/auth0oauth.go
+++ b/pkg/detectors/auth0oauth/auth0oauth.go
@@ -5,8 +5,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	// "fmt"
-	// "log"
 	"regexp"
 	"strings"
 

--- a/pkg/detectors/autodesk/autodesk.go
+++ b/pkg/detectors/autodesk/autodesk.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Autodesk,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resSecret),
 			}
 
 			if verify {

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -81,6 +81,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detectorspb.DetectorType_AWS,
 				Raw:          []byte(resIDMatch),
 				Redacted:     resIDMatch,
+				RawV2:        []byte(resIDMatch + resSecretMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/aylien/aylien.go
+++ b/pkg/detectors/aylien/aylien.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Aylien,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 			if verify {
 				req, err := http.NewRequestWithContext(ctx, "GET", "https://api.aylien.com/news/stories", nil)

--- a/pkg/detectors/billomat/billomat.go
+++ b/pkg/detectors/billomat/billomat.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Billomat,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resId),
 			}
 
 			if verify {

--- a/pkg/detectors/bitmex/bitmex.go
+++ b/pkg/detectors/bitmex/bitmex.go
@@ -58,6 +58,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Bitmex,
 				Raw:          []byte(resSecretMatch),
+				RawV2:        []byte(resMatch + resSecretMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/browserstack/browserstack.go
+++ b/pkg/detectors/browserstack/browserstack.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_BrowserStack,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resUserMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/captaindata/captaindata.go
+++ b/pkg/detectors/captaindata/captaindata.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_CaptainData,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resProjIdMatch + resMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/cashboard/cashboard.go
+++ b/pkg/detectors/cashboard/cashboard.go
@@ -54,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Cashboard,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resUser),
 			}
 
 			if verify {

--- a/pkg/detectors/caspio/caspio.go
+++ b/pkg/detectors/caspio/caspio.go
@@ -63,6 +63,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1 := detectors.Result{
 					DetectorType: detectorspb.DetectorType_Caspio,
 					Raw:          []byte(resMatch),
+					RawV2:        []byte(resMatch + resIdMatch + resDomainMatch),
 				}
 
 				if verify {

--- a/pkg/detectors/censys/censys.go
+++ b/pkg/detectors/censys/censys.go
@@ -51,6 +51,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Censys,
 				Raw:          []byte(tokenPatMatch),
+				RawV2:        []byte(tokenPatMatch + userPatMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/cexio/cexio.go
+++ b/pkg/detectors/cexio/cexio.go
@@ -69,6 +69,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1 := detectors.Result{
 					DetectorType: detectorspb.DetectorType_CexIO,
 					Raw:          []byte(resKeyMatch),
+					RawV2:        []byte(resUserIdMatch + resSecretMatch),
 				}
 
 				if verify {

--- a/pkg/detectors/checkout/checkout.go
+++ b/pkg/detectors/checkout/checkout.go
@@ -20,7 +20,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	//Tokens starting with sk_test are used for the app's sandbox environment while tokens starting with sk only are for production environment
+	// Tokens starting with sk_test are used for the app's sandbox environment while tokens starting with sk only are for production environment
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"checkout"}) + `\b((sk_|sk_test_)[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\b`)
 	idPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"checkout"}) + `\b(cus_[0-9a-zA-Z]{26})\b`)
 )
@@ -53,10 +53,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Checkout,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {
-				//Used the app's sandbox environment for this case since I can't create a live account.
+				// Used the app's sandbox environment for this case since I can't create a live account.
 				req, err := http.NewRequestWithContext(ctx, "GET", "https://api.sandbox.checkout.com/customers/"+resIdMatch, nil)
 				if err != nil {
 					continue

--- a/pkg/detectors/checkvist/checkvist.go
+++ b/pkg/detectors/checkvist/checkvist.go
@@ -53,6 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Checkvist,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resEmailMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/clickhelp/clickhelp.go
+++ b/pkg/detectors/clickhelp/clickhelp.go
@@ -61,6 +61,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1 := detectors.Result{
 					DetectorType: detectorspb.DetectorType_ClickHelp,
 					Raw:          []byte(resServer),
+					RawV2:        []byte(resServer + resEmail),
 				}
 
 				if verify {

--- a/pkg/detectors/clicksendsms/clicksendsms.go
+++ b/pkg/detectors/clicksendsms/clicksendsms.go
@@ -50,6 +50,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_ClickSendsms,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/clockworksms/clockworksms.go
+++ b/pkg/detectors/clockworksms/clockworksms.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_ClockworkSMS,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + tokenRes),
 			}
 
 			if verify {

--- a/pkg/detectors/cloudelements/cloudelements.go
+++ b/pkg/detectors/cloudelements/cloudelements.go
@@ -54,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_CloudElements,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resOrgMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/cloudflareglobalapikey/cloudflareglobalapikey.go
+++ b/pkg/detectors/cloudflareglobalapikey/cloudflareglobalapikey.go
@@ -60,6 +60,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detectorspb.DetectorType_CloudflareGlobalApiKey,
 				Redacted:     emailRes,
 				Raw:          []byte(apiKeyRes),
+				RawV2:        []byte(apiKeyRes + emailRes),
 			}
 
 			if verify {

--- a/pkg/detectors/companyhub/companyhub.go
+++ b/pkg/detectors/companyhub/companyhub.go
@@ -53,6 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_CompanyHub,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/confluent/confluent.go
+++ b/pkg/detectors/confluent/confluent.go
@@ -54,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Confluent,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resSecret),
 			}
 
 			if verify {

--- a/pkg/detectors/copper/copper.go
+++ b/pkg/detectors/copper/copper.go
@@ -51,6 +51,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Copper,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/crossbrowsertesting/crossbrowsertesting.go
+++ b/pkg/detectors/crossbrowsertesting/crossbrowsertesting.go
@@ -51,6 +51,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_CrossBrowserTesting,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/customerguru/customerguru.go
+++ b/pkg/detectors/customerguru/customerguru.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_CustomerGuru,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/customerio/customerio.go
+++ b/pkg/detectors/customerio/customerio.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_CustomerIO,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -29,6 +29,9 @@ type Result struct {
 	Verified     bool
 	// Raw contains the raw secret identifier data. Prefer IDs over secrets since it is used for deduping after hashing.
 	Raw []byte
+	// RawV2 contains the raw secret identifier that is a combination of both the ID and the secret.
+	// This is used for secrets that are multi part and could have the same ID. Ex: AWS credentials
+	RawV2 []byte
 	// Redacted contains the redacted version of the raw secret identification data for display purposes.
 	// A secret ID should be used if available.
 	Redacted       string
@@ -96,9 +99,9 @@ func PrefixRegex(keywords []string) string {
 	return pre + middle + post
 }
 
-//KeyIsRandom is a Low cost check to make sure that 'keys' include a number to reduce FPs.
-//Golang doesnt support regex lookaheads, so must be done in separate calls.
-//TODO improve checks. Shannon entropy did not work well.
+// KeyIsRandom is a Low cost check to make sure that 'keys' include a number to reduce FPs.
+// Golang doesnt support regex lookaheads, so must be done in separate calls.
+// TODO improve checks. Shannon entropy did not work well.
 func KeyIsRandom(key string) bool {
 	for _, ch := range key {
 		if unicode.IsDigit(ch) {

--- a/pkg/detectors/discordbottoken/discordbottoken.go
+++ b/pkg/detectors/discordbottoken/discordbottoken.go
@@ -51,6 +51,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detectorspb.DetectorType_DiscordBotToken,
 				Redacted:     resId,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resId),
 			}
 
 			if verify {

--- a/pkg/detectors/dnscheck/dnscheck.go
+++ b/pkg/detectors/dnscheck/dnscheck.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Dnscheck,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/dwolla/dwolla.go
+++ b/pkg/detectors/dwolla/dwolla.go
@@ -56,6 +56,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Dwolla,
 				Raw:          []byte(idMatch),
+				RawV2:        []byte(idMatch + secretMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/easyinsight/easyinsight.go
+++ b/pkg/detectors/easyinsight/easyinsight.go
@@ -2,12 +2,11 @@ package easyinsight
 
 import (
 	"context"
+	b64 "encoding/base64"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
-
-	b64 "encoding/base64"
-	"net/http"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -55,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_EasyInsight,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/edamam/edamam.go
+++ b/pkg/detectors/edamam/edamam.go
@@ -51,6 +51,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Edamam,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resId),
 			}
 
 			if verify {

--- a/pkg/detectors/eightxeight/eightxeight.go
+++ b/pkg/detectors/eightxeight/eightxeight.go
@@ -55,6 +55,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_EightxEight,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resIdMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/facebookoauth/facebookoauth.go
+++ b/pkg/detectors/facebookoauth/facebookoauth.go
@@ -54,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detectorspb.DetectorType_FacebookOAuth,
 				Redacted:     apiIdRes,
 				Raw:          []byte(apiSecretRes),
+				RawV2:        []byte(apiIdRes + apiSecretRes),
 			}
 
 			if verify {

--- a/pkg/detectors/faceplusplus/faceplusplus.go
+++ b/pkg/detectors/faceplusplus/faceplusplus.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_FacePlusPlus,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resSecret),
 			}
 
 			if verify {

--- a/pkg/detectors/foursquare/foursquare.go
+++ b/pkg/detectors/foursquare/foursquare.go
@@ -51,6 +51,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_FourSquare,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resSecret),
 			}
 
 			if verify {

--- a/pkg/detectors/gengo/gengo.go
+++ b/pkg/detectors/gengo/gengo.go
@@ -61,6 +61,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Gengo,
 				Raw:          []byte(resSecretMatch),
+				RawV2:        []byte(resMatch + resSecretMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/geocodio/geocodio.go
+++ b/pkg/detectors/geocodio/geocodio.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Geocodio,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resSearchMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/kucoin/kucoin.go
+++ b/pkg/detectors/kucoin/kucoin.go
@@ -65,6 +65,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1 := detectors.Result{
 					DetectorType: detectorspb.DetectorType_KuCoin,
 					Raw:          []byte(resKeyMatch),
+					RawV2:        []byte(resKeyMatch + resPassphraseMatch),
 				}
 
 				if verify {

--- a/pkg/detectors/mattermostpersonaltoken/mattermostpersonaltoken.go
+++ b/pkg/detectors/mattermostpersonaltoken/mattermostpersonaltoken.go
@@ -53,6 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_MattermostPersonalToken,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + serverRes),
 			}
 
 			if verify {

--- a/pkg/detectors/mux/mux.go
+++ b/pkg/detectors/mux/mux.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Mux,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resSecretMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/nexmoapikey/nexmoapikey.go
+++ b/pkg/detectors/nexmoapikey/nexmoapikey.go
@@ -51,6 +51,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_NexmoApiKey,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resSecret),
 			}
 
 			if verify {

--- a/pkg/detectors/plivo/plivo.go
+++ b/pkg/detectors/plivo/plivo.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detectorspb.DetectorType_Plivo,
 				Redacted:     id,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + id),
 			}
 			stringResMatch := fmt.Sprintf("%s:%s", id, resMatch)
 			decodeSecret := b64.StdEncoding.EncodeToString([]byte(stringResMatch))

--- a/pkg/detectors/poloniex/poloniex.go
+++ b/pkg/detectors/poloniex/poloniex.go
@@ -58,6 +58,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Poloniex,
 				Raw:          []byte(resSecretMatch),
+				RawV2:        []byte(resMatch + resSecretMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/pusherchannelkey/pusherchannelkey.go
+++ b/pkg/detectors/pusherchannelkey/pusherchannelkey.go
@@ -72,6 +72,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1 := detectors.Result{
 					DetectorType: detectorspb.DetectorType_PusherChannelKey,
 					Raw:          []byte(resappMatch),
+					RawV2:        []byte(resappMatch + reskeyMatch),
 				}
 
 				if verify {

--- a/pkg/detectors/roaring/roaring.go
+++ b/pkg/detectors/roaring/roaring.go
@@ -54,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Roaring,
 				Raw:          []byte(resClient),
+				RawV2:        []byte(resClient + resSecret),
 			}
 
 			if verify {

--- a/pkg/detectors/rownd/rownd.go
+++ b/pkg/detectors/rownd/rownd.go
@@ -61,6 +61,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1 := detectors.Result{
 					DetectorType: detectorspb.DetectorType_Rownd,
 					Raw:          []byte(keyMatch),
+					RawV2:        []byte(keyMatch + secretMatch),
 				}
 
 				if verify {

--- a/pkg/detectors/satismeterprojectkey/satismeterprojectkey.go
+++ b/pkg/detectors/satismeterprojectkey/satismeterprojectkey.go
@@ -62,6 +62,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1 := detectors.Result{
 					DetectorType: detectorspb.DetectorType_SatismeterProjectkey,
 					Raw:          []byte(resMatch),
+					RawV2:        []byte(resMatch + resPassMatch),
 				}
 
 				if verify {

--- a/pkg/detectors/smooch/smooch.go
+++ b/pkg/detectors/smooch/smooch.go
@@ -54,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Smooch,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resSecret),
 			}
 
 			if verify {

--- a/pkg/detectors/strava/strava.go
+++ b/pkg/detectors/strava/strava.go
@@ -60,6 +60,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1 := detectors.Result{
 					DetectorType: detectorspb.DetectorType_Strava,
 					Raw:          []byte(resId),
+					RawV2:        []byte(resId + resSecret),
 				}
 
 				if verify {

--- a/pkg/detectors/textmagic/textmagic.go
+++ b/pkg/detectors/textmagic/textmagic.go
@@ -54,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Textmagic,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resUser),
 			}
 
 			if verify {

--- a/pkg/detectors/tru/tru.go
+++ b/pkg/detectors/tru/tru.go
@@ -53,6 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Tru,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resSecret),
 			}
 
 			if verify {

--- a/pkg/detectors/vouchery/vouchery.go
+++ b/pkg/detectors/vouchery/vouchery.go
@@ -54,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Vouchery,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + subMatch),
 			}
 
 			if verify {


### PR DESCRIPTION
- include RawV2 to all the detectors that require the multi part creds.
- This will prevent collisions if different secrets have the same ID.
