### PR TITLE
Use pointer to config

### DIFF
--- a/main.go
+++ b/main.go
@@ -192,7 +192,7 @@ func run(state overseer.State) {
 			defer os.RemoveAll(repoPath)
 		}
 
-		g := func(c sources.Config) {
+		g := func(c *sources.Config) {
 			c.RepoPath = repoPath
 			c.HeadRef = *gitScanBranch
 			c.BaseRef = *gitScanSinceCommit
@@ -208,7 +208,7 @@ func run(state overseer.State) {
 			log.Fatal("You must specify at least one organization or repository.")
 		}
 
-		github := func(c sources.Config) {
+		github := func(c *sources.Config) {
 			c.Endpoint = *githubScanEndpoint
 			c.Repos = *githubScanRepos
 			c.Orgs = *githubScanOrgs
@@ -222,7 +222,7 @@ func run(state overseer.State) {
 			logrus.WithError(err).Fatal("Failed to scan Github.")
 		}
 	case gitlabScan.FullCommand():
-		gitlab := func(c sources.Config) {
+		gitlab := func(c *sources.Config) {
 			c.Endpoint = *gitlabScanEndpoint
 			c.Token = *gitlabScanToken
 			c.Repos = *gitlabScanRepos
@@ -232,7 +232,7 @@ func run(state overseer.State) {
 			logrus.WithError(err).Fatal("Failed to scan GitLab.")
 		}
 	case filesystemScan.FullCommand():
-		fs := func(c sources.Config) {
+		fs := func(c *sources.Config) {
 			c.Directories = *filesystemDirectories
 		}
 
@@ -240,7 +240,7 @@ func run(state overseer.State) {
 			logrus.WithError(err).Fatal("Failed to scan filesystem")
 		}
 	case s3Scan.FullCommand():
-		s3 := func(c sources.Config) {
+		s3 := func(c *sources.Config) {
 			c.Key = *s3ScanKey
 			c.Secret = *s3ScanSecret
 			c.Buckets = *s3ScanBuckets
@@ -250,7 +250,7 @@ func run(state overseer.State) {
 			logrus.WithError(err).Fatal("Failed to scan S3.")
 		}
 	case syslogScan.FullCommand():
-		syslog := func(c sources.Config) {
+		syslog := func(c *sources.Config) {
 			c.Address = *syslogAddress
 			c.Protocol = *syslogProtocol
 			c.CertPath = *syslogTLSCert

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -96,12 +96,12 @@ type Config struct {
 }
 
 // NewConfig returns a new Config with optional values.
-func NewConfig(opts ...func(Config)) Config {
-	c := Config{}
+func NewConfig(opts ...func(*Config)) Config {
+	c := &Config{}
 	for _, opt := range opts {
 		opt(c)
 	}
-	return c
+	return *c
 }
 
 // PercentComplete is used to update job completion percentages across sources


### PR DESCRIPTION
A pointer is needed for the config maker function otherwise the functions aren't applied to the returned config.