### PR TITLE
[THOG-643] Implement independent log level controls

### DIFF
--- a/pkg/log/core.go
+++ b/pkg/log/core.go
@@ -1,0 +1,41 @@
+package log
+
+import (
+	"go.uber.org/zap/zapcore"
+)
+
+type levelFilterCore struct {
+	core  zapcore.Core
+	level zapcore.LevelEnabler
+}
+
+// NewLevelCore creates a core that can be used to independently control the
+// level of an existing Core. This is essentially a filter that will only log
+// if both the parent and the wrapper cores are enabled.
+func NewLevelCore(core zapcore.Core, level zapcore.LevelEnabler) zapcore.Core {
+	return &levelFilterCore{core, level}
+}
+
+func (c *levelFilterCore) Enabled(lvl zapcore.Level) bool {
+	return c.level.Enabled(lvl)
+}
+
+func (c *levelFilterCore) With(fields []zapcore.Field) zapcore.Core {
+	return &levelFilterCore{c.core.With(fields), c.level}
+}
+
+func (c *levelFilterCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if !c.Enabled(ent.Level) {
+		return ce
+	}
+
+	return c.core.Check(ent, ce)
+}
+
+func (c *levelFilterCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	return c.core.Write(ent, fields)
+}
+
+func (c *levelFilterCore) Sync() error {
+	return c.core.Sync()
+}

--- a/pkg/log/level.go
+++ b/pkg/log/level.go
@@ -15,9 +15,9 @@ var (
 	globalLogLevel levelSetter = zap.NewAtomicLevel()
 
 	// Map of name -> level control for independently setting log levels. A new
-	// control is registered via WithName. This map is never cleaned up and new
-	// entries will overwrite previous values. Currently, this is acceptable
-	// behavior because WithName is used sparingly.
+	// control is registered via WithNamedLevel. This map is never cleaned up
+	// and new entries will overwrite previous values. Currently, this is
+	// acceptable behavior because WithNamedLevel is used sparingly.
 	globalControls map[string]levelSetter = make(map[string]levelSetter, 16)
 	// globalControls is protected (both read and write) by a mutex to make it
 	// thread safe. Access is low frequency, so performance is not a concern.
@@ -80,11 +80,11 @@ func AddLeveler(l logr.Logger, control levelSetter) (logr.Logger, error) {
 	return zapr.NewLogger(zapLogger), nil
 }
 
-// WithName creates a child logger with a new name and independent log level
-// control (see SetLevelFor). NOTE: The child logger does not inherit the
+// WithNamedLevel creates a child logger with a new name and independent log
+// level control (see SetLevelFor). NOTE: The child logger does not inherit the
 // parent's log level, but will maintain the existing level if a control exists
 // for the name.
-func WithName(logger logr.Logger, name string) logr.Logger {
+func WithNamedLevel(logger logr.Logger, name string) logr.Logger {
 	logger = logger.WithName(name)
 	leveler := zap.NewAtomicLevel()
 	newLogger, err := AddLeveler(logger, leveler)

--- a/pkg/log/level.go
+++ b/pkg/log/level.go
@@ -67,16 +67,8 @@ func AddLeveler(l logr.Logger, control levelSetter) (logr.Logger, error) {
 	}
 
 	zapLogger = zapLogger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
-		var newCore zapcore.Core
-		if newCore, err = zapcore.NewIncreaseLevelCore(core, control); err != nil {
-			return core
-		}
-		return newCore
+		return NewLevelCore(core, control)
 	}))
-	// Check err from closure.
-	if err != nil {
-		return l, err
-	}
 	return zapr.NewLogger(zapLogger), nil
 }
 

--- a/pkg/log/level.go
+++ b/pkg/log/level.go
@@ -1,0 +1,101 @@
+package log
+
+import (
+	"sync"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// TODO: Use a struct to make testing easier.
+var (
+	// Global, default log level control.
+	globalLogLevel levelSetter = zap.NewAtomicLevel()
+
+	// Map of name -> level control for independently setting log levels. A new
+	// control is registered via WithName. This map is never cleaned up and new
+	// entries will overwrite previous values. Currently, this is acceptable
+	// behavior because WithName is used sparingly.
+	globalControls map[string]levelSetter = make(map[string]levelSetter, 16)
+	// globalControls is protected (both read and write) by a mutex to make it
+	// thread safe. Access is low frequency, so performance is not a concern.
+	globalControlsLock sync.Mutex
+)
+
+type levelSetter interface {
+	zapcore.LevelEnabler
+	SetLevel(zapcore.Level)
+	Level() zapcore.Level
+}
+
+// SetLevel sets the log level for loggers created with the default level
+// controller.
+func SetLevel(level int8) {
+	SetLevelForControl(globalLogLevel, level)
+}
+
+// SetLevelForControl sets the log level for a given control.
+func SetLevelForControl(control levelSetter, level int8) {
+	// Zap's levels get more verbose as the number gets smaller, as explained
+	// by zapr here: https://github.com/go-logr/zapr#increasing-verbosity
+	// For example setting the level to -2 below, means log.V(2) will be enabled.
+	control.SetLevel(zapcore.Level(-level))
+}
+
+// SetLevelFor sets the log level for a given named control.
+func SetLevelFor(name string, level int8) {
+	globalControlsLock.Lock()
+	defer globalControlsLock.Unlock()
+	if control, ok := globalControls[name]; ok {
+		SetLevelForControl(control, level)
+		return
+	}
+	// Create a new control so registering a control with the same name will
+	// inherit the existing level.
+	newControl := zap.NewAtomicLevel()
+	SetLevelForControl(newControl, level)
+	globalControls[name] = newControl
+}
+
+// AddLeveler adds a log level control to a logr.Logger.
+func AddLeveler(l logr.Logger, control levelSetter) (logr.Logger, error) {
+	zapLogger, err := getZapLogger(l)
+	if err != nil {
+		return l, err
+	}
+
+	zapLogger = zapLogger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+		var newCore zapcore.Core
+		if newCore, err = zapcore.NewIncreaseLevelCore(core, control); err != nil {
+			return core
+		}
+		return newCore
+	}))
+	// Check err from closure.
+	if err != nil {
+		return l, err
+	}
+	return zapr.NewLogger(zapLogger), nil
+}
+
+// WithName creates a child logger with a new name and independent log level
+// control (see SetLevelFor). NOTE: The child logger does not inherit the
+// parent's log level, but will maintain the existing level if a control exists
+// for the name.
+func WithName(logger logr.Logger, name string) logr.Logger {
+	logger = logger.WithName(name)
+	leveler := zap.NewAtomicLevel()
+	newLogger, err := AddLeveler(logger, leveler)
+	if err != nil {
+		return logger
+	}
+	globalControlsLock.Lock()
+	defer globalControlsLock.Unlock()
+	if currentControl, ok := globalControls[name]; ok {
+		leveler.SetLevel(currentControl.Level())
+	}
+	globalControls[name] = leveler
+	return newLogger
+}

--- a/pkg/log/level.go
+++ b/pkg/log/level.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"sort"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -54,9 +55,7 @@ func SetLevelFor(name string, level int8) {
 	}
 	// Create a new control so registering a control with the same name will
 	// inherit the existing level.
-	newControl := zap.NewAtomicLevel()
-	SetLevelForControl(newControl, level)
-	globalControls[name] = newControl
+	globalControls[name] = newAtomicLevelAt(level)
 }
 
 // AddLeveler adds a log level control to a logr.Logger.
@@ -73,21 +72,43 @@ func AddLeveler(l logr.Logger, control levelSetter) (logr.Logger, error) {
 }
 
 // WithNamedLevel creates a child logger with a new name and independent log
-// level control (see SetLevelFor). NOTE: The child logger does not inherit the
-// parent's log level, but will maintain the existing level if a control exists
-// for the name.
+// level control (see SetLevelFor). NOTE: if name already exists, the existing
+// controller will be used, otherwise a new controller is created with level
+// matching the parent's log level.
 func WithNamedLevel(logger logr.Logger, name string) logr.Logger {
 	logger = logger.WithName(name)
-	leveler := zap.NewAtomicLevel()
+
+	globalControlsLock.Lock()
+	defer globalControlsLock.Unlock()
+
+	var leveler levelSetter
+	if currentControl, ok := globalControls[name]; ok {
+		leveler = currentControl
+	} else {
+		leveler = newAtomicLevelAt(findLevel(logger))
+		globalControls[name] = leveler
+	}
 	newLogger, err := AddLeveler(logger, leveler)
 	if err != nil {
 		return logger
 	}
-	globalControlsLock.Lock()
-	defer globalControlsLock.Unlock()
-	if currentControl, ok := globalControls[name]; ok {
-		leveler.SetLevel(currentControl.Level())
-	}
-	globalControls[name] = leveler
 	return newLogger
+}
+
+// newAtomicLevelAt is a helper function to create a zap.AtomicLevel
+// initialized with a level. We cannot use zap.NewAtomicLevelAt here because of
+// a quirk with logr levels (see SetLevelForControl).
+func newAtomicLevelAt(level int8) zap.AtomicLevel {
+	control := zap.NewAtomicLevel()
+	SetLevelForControl(control, level)
+	return control
+}
+
+// findLevel probes a logr.Logger to figure out what level it is at via binary
+// search. We only search [0, 128), so worst case is ~7 checks.
+func findLevel(logger logr.Logger) int8 {
+	sink := logger.GetSink()
+	return int8(sort.Search(128, func(i int) bool {
+		return !sink.Enabled(i)
+	}) - 1)
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -123,7 +123,7 @@ func defaultEncoderConfig() zapcore.EncoderConfig {
 }
 
 // WithCore adds any user supplied zap core to the logger.
-func WithCore(core zapcore.Core) (conf logConfig) {
+func WithCore(core zapcore.Core) logConfig {
 	return logConfig{core: core}
 }
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -99,7 +99,7 @@ func WithJSONSink(sink io.Writer, opts ...func(*sinkConfig)) logConfig {
 }
 
 // WithConsoleSink adds a console-style output to the logger.
-func WithConsoleSink(sink io.Writer, opts ...func(*sinkConfig)) (conf logConfig) {
+func WithConsoleSink(sink io.Writer, opts ...func(*sinkConfig)) logConfig {
 	return newCoreConfig(
 		zapcore.NewConsoleEncoder(defaultEncoderConfig()),
 		zapcore.Lock(zapcore.AddSync(sink)),
@@ -158,8 +158,8 @@ func getZapLogger(l logr.Logger) (*zap.Logger, error) {
 	return nil, errors.New("not a zapr logger")
 }
 
-// WithLeveler sets the sink's level to a static level. This option prevents
-// changing the log level for this sink at runtime.
+// WithLevel sets the sink's level to a static level. This option prevents
+// changing the log level for this sink later on.
 func WithLevel(level int8) func(*sinkConfig) {
 	return WithLeveler(
 		// Zap's levels get more verbose as the number gets smaller, as explained

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -202,7 +202,7 @@ func TestWithLeveler(t *testing.T) {
 	assert.Contains(t, buf2.String(), "line 3")
 }
 
-func TestWithNameMoreVerbose(t *testing.T) {
+func TestWithNamedLevelMoreVerbose(t *testing.T) {
 	var buf bytes.Buffer
 	globalControls = make(map[string]levelSetter, 16)
 
@@ -212,7 +212,7 @@ func TestWithNameMoreVerbose(t *testing.T) {
 		WithConsoleSink(&buf, WithLeveler(l1)),
 	)
 
-	childLogger := WithName(logger, "child")
+	childLogger := WithNamedLevel(logger, "child")
 
 	SetLevelForControl(l1, 1)
 	SetLevelFor("child", 2)
@@ -235,7 +235,7 @@ func TestWithNameMoreVerbose(t *testing.T) {
 	assert.NotContains(t, buf.String(), "service-name.child\tline C")
 }
 
-func TestWithNameLessVerbose(t *testing.T) {
+func TestWithNamedLevelLessVerbose(t *testing.T) {
 	var buf bytes.Buffer
 	globalControls = make(map[string]levelSetter, 16)
 
@@ -245,7 +245,7 @@ func TestWithNameLessVerbose(t *testing.T) {
 		WithConsoleSink(&buf, WithLeveler(l1)),
 	)
 
-	childLogger := WithName(logger, "child")
+	childLogger := WithNamedLevel(logger, "child")
 
 	SetLevelForControl(l1, 1)
 	SetLevelFor("child", 0)
@@ -268,13 +268,13 @@ func TestWithNameLessVerbose(t *testing.T) {
 	assert.NotContains(t, buf.String(), "service-name.child\tline C")
 }
 
-func TestNestedWithName(t *testing.T) {
+func TestNestedWithNamedLevel(t *testing.T) {
 	var buf bytes.Buffer
 	globalControls = make(map[string]levelSetter, 16)
 
 	grandParent, flush := New("grandParent", WithConsoleSink(&buf, WithLevel(1)))
-	parent := WithName(grandParent, "parent")
-	child := WithName(parent, "child")
+	parent := WithNamedLevel(grandParent, "parent")
+	child := WithNamedLevel(parent, "child")
 
 	SetLevelFor("parent", 0)
 	SetLevelFor("child", 2)
@@ -302,13 +302,13 @@ func TestNestedWithName(t *testing.T) {
 	assert.Equal(t, `info-1	grandParent	line 4`, lines[3])
 }
 
-func TestSiblingsWithName(t *testing.T) {
+func TestSiblingsWithNamedLevel(t *testing.T) {
 	var buf bytes.Buffer
 	globalControls = make(map[string]levelSetter, 16)
 
 	parent, flush := New("parent", WithConsoleSink(&buf, WithLevel(1)))
-	alice := WithName(parent, "alice")
-	bob := WithName(parent, "bob")
+	alice := WithNamedLevel(parent, "alice")
+	bob := WithNamedLevel(parent, "bob")
 
 	SetLevelFor("alice", 0)
 	SetLevelFor("bob", 2)
@@ -336,14 +336,14 @@ func TestSiblingsWithName(t *testing.T) {
 	assert.Equal(t, `info-1	parent.bob	line 6`, lines[4])
 }
 
-func TestWithNameConcurrency(t *testing.T) {
+func TestWithNamedLevelConcurrency(t *testing.T) {
 	var buf bytes.Buffer
 	globalControls = make(map[string]levelSetter, 16)
 
 	parent, flush := New("parent", WithConsoleSink(&buf))
 
-	alice := WithName(parent, "alice")
-	bob := WithName(parent, "bob")
+	alice := WithNamedLevel(parent, "alice")
+	bob := WithNamedLevel(parent, "bob")
 
 	var wg sync.WaitGroup
 	f := func(logger logr.Logger) {
@@ -379,7 +379,7 @@ func TestParentLevel(t *testing.T) {
 	parent, flush := New("parent", WithConsoleSink(&buf, WithLevel(2)))
 	parent = parent.WithValues("key", "value")
 	// NOTE: child does not inherit parent's log level, but it does inherit the values
-	child := WithName(parent, "child")
+	child := WithNamedLevel(parent, "child")
 
 	parent.V(2).Info("yay")
 	child.V(2).Info("not logged")
@@ -399,7 +399,7 @@ func TestExistingChildLevel(t *testing.T) {
 
 	SetLevelFor("child", 2)
 	// child should start with a level of 2 due to SetLevelFor above
-	child := WithName(parent, "child")
+	child := WithNamedLevel(parent, "child")
 
 	parent.V(2).Info("yay")
 	child.V(2).Info("yay again")
@@ -409,7 +409,7 @@ func TestExistingChildLevel(t *testing.T) {
 	assert.Contains(t, buf.String(), "info-2\tparent.child\tyay again")
 }
 
-func TestSinkWithName(t *testing.T) {
+func TestSinkWithNamedLevel(t *testing.T) {
 	var buf1, buf2 bytes.Buffer
 	globalControls = make(map[string]levelSetter, 16)
 
@@ -418,7 +418,7 @@ func TestSinkWithName(t *testing.T) {
 		WithConsoleSink(&buf1, WithLevel(0)),
 		WithConsoleSink(&buf2, WithLevel(2)),
 	)
-	child := WithName(parent, "child")
+	child := WithNamedLevel(parent, "child")
 
 	for level := 0; level < 3; level++ {
 		SetLevelFor("child", int8(level))

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -163,7 +163,7 @@ func TestStaticLevelSink(t *testing.T) {
 	logger.Info("line 1")
 	SetLevelForControl(l1, 1)
 	logger.V(1).Info("line 2")
-	flush()
+	assert.Nil(t, flush())
 
 	// buf1 should have both lines
 	assert.Contains(t, buf1.String(), "line 1")
@@ -189,7 +189,7 @@ func TestWithLeveler(t *testing.T) {
 	logger.V(0).Info("line 1")
 	logger.V(1).Info("line 2")
 	logger.V(2).Info("line 3")
-	flush()
+	assert.Nil(t, flush())
 
 	// buf1 should have lines 1 and 2
 	assert.Contains(t, buf1.String(), "line 1")
@@ -223,7 +223,7 @@ func TestWithNamedLevelMoreVerbose(t *testing.T) {
 	childLogger.V(0).Info("line A")
 	childLogger.V(1).Info("line B")
 	childLogger.V(2).Info("line C")
-	flush()
+	assert.Nil(t, flush())
 
 	// parent should log lines 1 and 2
 	// child should log lines A, B, and C
@@ -256,7 +256,7 @@ func TestWithNamedLevelLessVerbose(t *testing.T) {
 	childLogger.V(0).Info("line A")
 	childLogger.V(1).Info("line B")
 	childLogger.V(2).Info("line C")
-	flush()
+	assert.Nil(t, flush())
 
 	// parent should log lines 1 and 2
 	// child should log line A only
@@ -291,7 +291,7 @@ func TestNestedWithNamedLevel(t *testing.T) {
 	parent.V(2).Info("line 8")
 	child.V(2).Info("line 9")
 
-	flush()
+	assert.Nil(t, flush())
 
 	lines := splitLines(buf.String())
 	assert.Equal(t, 4, len(lines))
@@ -325,7 +325,7 @@ func TestSiblingsWithNamedLevel(t *testing.T) {
 	alice.V(2).Info("line 8")
 	bob.V(2).Info("line 9")
 
-	flush()
+	assert.Nil(t, flush())
 	lines := splitLines(buf.String())
 	assert.Equal(t, 5, len(lines))
 
@@ -358,7 +358,7 @@ func TestWithNamedLevelConcurrency(t *testing.T) {
 	go f(bob)
 	wg.Wait()
 
-	flush()
+	assert.Nil(t, flush())
 	logLines := splitLines(buf.String())
 	assert.Equal(t, 300_000, len(logLines))
 	sort.Slice(logLines, func(i, j int) bool {
@@ -384,7 +384,7 @@ func TestParentLevel(t *testing.T) {
 	parent.V(2).Info("yay")
 	child.V(2).Info("not logged")
 	child.Info("yay again")
-	flush()
+	assert.Nil(t, flush())
 
 	assert.Contains(t, buf.String(), `info-2	parent	yay	{"key": "value"}`)
 	assert.NotContains(t, buf.String(), "not logged")
@@ -403,7 +403,7 @@ func TestExistingChildLevel(t *testing.T) {
 
 	parent.V(2).Info("yay")
 	child.V(2).Info("yay again")
-	flush()
+	assert.Nil(t, flush())
 
 	assert.Contains(t, buf.String(), "info-2\tparent\tyay")
 	assert.Contains(t, buf.String(), "info-2\tparent.child\tyay again")
@@ -426,7 +426,7 @@ func TestSinkWithNamedLevel(t *testing.T) {
 		child.V(1).Info("")
 		child.V(2).Info("")
 	}
-	flush()
+	assert.Nil(t, flush())
 
 	// buf1 should get only level 0 logs
 	assert.Equal(t, []string{

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -3,6 +3,7 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"sync"
@@ -446,6 +447,25 @@ func TestSinkWithNamedLevel(t *testing.T) {
 		"info-1\tparent.child",
 		"info-2\tparent.child",
 	}, splitLines(buf2.String()))
+}
+
+func TestAddLeveler(t *testing.T) {
+	l1, l2 := zap.NewAtomicLevel(), zap.NewAtomicLevel()
+	logger, _ := New("parent", WithConsoleSink(io.Discard, WithLeveler(l1)))
+
+	t.Run("child level more verbose", func(t *testing.T) {
+		l1.SetLevel(0)
+		l2.SetLevel(1)
+		_, err := AddLeveler(logger, l2)
+		assert.Nil(t, err)
+	})
+
+	t.Run("child level less verbose", func(t *testing.T) {
+		l1.SetLevel(1)
+		l2.SetLevel(0)
+		_, err := AddLeveler(logger, l2)
+		assert.Nil(t, err)
+	})
 }
 
 func splitLines(s string) []string {


### PR DESCRIPTION
There are two log level controls to mentally distinguish. Log levels
associated with a sink (e.g. stdout and streamed), and log levels
associated with a logger (e.g. a GitHub source).

The level is determined to be the minimum of the two. If a sink is at
level 0, then it will only output level 0 logs regardless of the
logger's level. This is best demonstrated by TestSinkWithNamedLevel.