### PR TITLE
Allow secrets to be passed as env vars

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ var (
 	githubScanEndpoint   = githubScan.Flag("endpoint", "GitHub endpoint.").Default("https://api.github.com").String()
 	githubScanRepos      = githubScan.Flag("repo", `GitHub repository to scan. You can repeat this flag. Example: "https://github.com/dustin-decker/secretsandstuff"`).Strings()
 	githubScanOrgs       = githubScan.Flag("org", `GitHub organization to scan. You can repeat this flag. Example: "trufflesecurity"`).Strings()
-	githubScanToken      = githubScan.Flag("token", "GitHub token.").Envar("TRUFFLEHOG_GITHUB_TOKEN").String()
+	githubScanToken      = githubScan.Flag("token", "GitHub token. Can be provided with environment variable GITHUB_TOKEN.").Envar("GITHUB_TOKEN").String()
 	githubIncludeForks   = githubScan.Flag("include-forks", "Include forks in scan.").Bool()
 	githubIncludeMembers = githubScan.Flag("include-members", "Include organization member repositories in scan.").Bool()
 
@@ -68,7 +68,7 @@ var (
 	// TODO: Add more GitLab options
 	gitlabScanEndpoint = gitlabScan.Flag("endpoint", "GitLab endpoint.").Default("https://gitlab.com").String()
 	gitlabScanRepos    = gitlabScan.Flag("repo", "GitLab repo url. You can repeat this flag. Leave empty to scan all repos accessible with provided credential. Example: https://gitlab.com/org/repo.git").Strings()
-	gitlabScanToken    = gitlabScan.Flag("token", "GitLab token.").Envar("TRUFFLEHOG_GITLAB_TOKEN").Required().String()
+	gitlabScanToken    = gitlabScan.Flag("token", "GitLab token. Can be provided with environment variable GITLAB_TOKEN.").Envar("GITLAB_TOKEN").Required().String()
 
 	filesystemScan        = cli.Command("filesystem", "Find credentials in a filesystem.")
 	filesystemDirectories = filesystemScan.Flag("directory", "Path to directory to scan. You can repeat this flag.").Required().Strings()
@@ -78,8 +78,8 @@ var (
 	// filesystemScanExcludePaths = filesystemScan.Flag("exclude-paths", "Path to file with newline separated regexes for files to exclude in scan.").Short('x').String()
 
 	s3Scan         = cli.Command("s3", "Find credentials in S3 buckets.")
-	s3ScanKey      = s3Scan.Flag("key", "S3 key used to authenticate.").Envar("TRUFFLEHOG_S3_AWS_ACCESS_KEY_ID").String()
-	s3ScanSecret   = s3Scan.Flag("secret", "S3 secret used to authenticate.").Envar("TRUFFLEHOG_S3_AWS_SECRET_ACCESS_KEY").String()
+	s3ScanKey      = s3Scan.Flag("key", "S3 key used to authenticate. Can be provided with environment variable AWS_ACCESS_KEY_ID.").Envar("AWS_ACCESS_KEY_ID").String()
+	s3ScanSecret   = s3Scan.Flag("secret", "S3 secret used to authenticate. Can be provided with environment variable AWS_SECRET_ACCESS_KEY.").Envar("AWS_SECRET_ACCESS_KEY").String()
 	s3ScanCloudEnv = s3Scan.Flag("cloud-environment", "Use IAM credentials in cloud environment.").Bool()
 	s3ScanBuckets  = s3Scan.Flag("bucket", "Name of S3 bucket to scan. You can repeat this flag.").Strings()
 

--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ var (
 	githubScanEndpoint   = githubScan.Flag("endpoint", "GitHub endpoint.").Default("https://api.github.com").String()
 	githubScanRepos      = githubScan.Flag("repo", `GitHub repository to scan. You can repeat this flag. Example: "https://github.com/dustin-decker/secretsandstuff"`).Strings()
 	githubScanOrgs       = githubScan.Flag("org", `GitHub organization to scan. You can repeat this flag. Example: "trufflesecurity"`).Strings()
-	githubScanToken      = githubScan.Flag("token", "GitHub token.").String()
+	githubScanToken      = githubScan.Flag("token", "GitHub token.").Envar("TRUFFLEHOG_GITHUB_TOKEN").String()
 	githubIncludeForks   = githubScan.Flag("include-forks", "Include forks in scan.").Bool()
 	githubIncludeMembers = githubScan.Flag("include-members", "Include organization member repositories in scan.").Bool()
 
@@ -68,7 +68,7 @@ var (
 	// TODO: Add more GitLab options
 	gitlabScanEndpoint = gitlabScan.Flag("endpoint", "GitLab endpoint.").Default("https://gitlab.com").String()
 	gitlabScanRepos    = gitlabScan.Flag("repo", "GitLab repo url. You can repeat this flag. Leave empty to scan all repos accessible with provided credential. Example: https://gitlab.com/org/repo.git").Strings()
-	gitlabScanToken    = gitlabScan.Flag("token", "GitLab token.").Required().String()
+	gitlabScanToken    = gitlabScan.Flag("token", "GitLab token.").Envar("TRUFFLEHOG_GITLAB_TOKEN").Required().String()
 
 	filesystemScan        = cli.Command("filesystem", "Find credentials in a filesystem.")
 	filesystemDirectories = filesystemScan.Flag("directory", "Path to directory to scan. You can repeat this flag.").Required().Strings()
@@ -78,8 +78,8 @@ var (
 	// filesystemScanExcludePaths = filesystemScan.Flag("exclude-paths", "Path to file with newline separated regexes for files to exclude in scan.").Short('x').String()
 
 	s3Scan         = cli.Command("s3", "Find credentials in S3 buckets.")
-	s3ScanKey      = s3Scan.Flag("key", "S3 key used to authenticate.").String()
-	s3ScanSecret   = s3Scan.Flag("secret", "S3 secret used to authenticate.").String()
+	s3ScanKey      = s3Scan.Flag("key", "S3 key used to authenticate.").Envar("TRUFFLEHOG_S3_AWS_ACCESS_KEY_ID").String()
+	s3ScanSecret   = s3Scan.Flag("secret", "S3 secret used to authenticate.").Envar("TRUFFLEHOG_S3_AWS_SECRET_ACCESS_KEY").String()
 	s3ScanCloudEnv = s3Scan.Flag("cloud-environment", "Use IAM credentials in cloud environment.").Bool()
 	s3ScanBuckets  = s3Scan.Flag("bucket", "Name of S3 bucket to scan. You can repeat this flag.").Strings()
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

This change enables the following secrets to be passed as environment variables:
- Github token
- Gitlab token
- AWS access keys for S3 scanning

There are no automated tests for the cli parameters, and I haven't worked on that. I manually tested to see the change working for Github, Gitlab, and S3.

Open to suggestions for the env var names. I tried to make them as descriptive as possible, and used the familiar names for AWS access keys (`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`) as they are the well known env vars for them, although they are still being prefixed to explicitly relate to `trufflehog` S3 scanning.

This PR is related to #735, please refer to it for more context.