### PR TITLE
Fix Honeycomb detector with older key format

### DIFF
--- a/pkg/detectors/honeycomb/honeycomb.go
+++ b/pkg/detectors/honeycomb/honeycomb.go
@@ -20,7 +20,8 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"Honeycomb"}) + `\b([0-9a-zA-Z]{22})\b`)
+	// Older + Newer API key format. See pull#687 for discussion
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"Honeycomb"}) + `\b([0-9a-f]{32}|[0-9a-zA-Z]{22})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
## Description
Add the older HC api key format. See #687 for discussion.
Expanding regex to `\b([0-9a-f]{32}|[0-9a-zA-Z]{22})\b`

![image](https://user-images.githubusercontent.com/73045936/188217564-a5f67102-b3f4-48bb-a8e2-317e596484aa.png)
[Regex visualization](https://www.debuggex.com/r/spDIDRvm-uLZzAqS)
