### PR TITLE
fix regex pattern for confluent detector

### DIFF
--- a/pkg/detectors/confluent/confluent.go
+++ b/pkg/detectors/confluent/confluent.go
@@ -22,8 +22,8 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"confluent"}) + `\b([a-zA-Z-0-9]{16})\b`)
-	secretPat = regexp.MustCompile(detectors.PrefixRegex([]string{"confluent"}) + `\b([a-zA-Z-0-9]{64})\b`)
+	keyPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"confluent"}) + `\b([a-zA-Z0-9]{16})\b`)
+	secretPat = regexp.MustCompile(detectors.PrefixRegex([]string{"confluent"}) + `\b([a-zA-Z0-9\+\/]{64})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -60,7 +60,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if verify {
 				data := fmt.Sprintf("%s:%s", resMatch, resSecret)
 				sEnc := b64.StdEncoding.EncodeToString([]byte(data))
-				req, err := http.NewRequestWithContext(ctx, "GET", "https://api.telemetry.confluent.cloud/v2/metrics/cloud/descriptors/resources", nil)
+				req, err := http.NewRequestWithContext(ctx, "GET", "https://api.confluent.cloud/iam/v2/api-keys/"+resMatch, nil)
 				if err != nil {
 					continue
 				}
@@ -72,7 +72,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						s1.Verified = true
 					} else {
 						// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
-						if detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
+						if detectors.IsKnownFalsePositive(resSecret, detectors.DefaultFalsePositives, true) {
 							continue
 						}
 					}

--- a/pkg/detectors/confluent/confluent.go
+++ b/pkg/detectors/confluent/confluent.go
@@ -54,7 +54,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Confluent,
 				Raw:          []byte(resMatch),
-				RawV2:        []byte(resMatch + resSecret),
 			}
 
 			if verify {

--- a/pkg/detectors/confluent/confluent.go
+++ b/pkg/detectors/confluent/confluent.go
@@ -54,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Confluent,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + resSecret),
 			}
 
 			if verify {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
Closes #770 

Go version : 1.18.0 
OS : macOS 12.5.1

### changes

- Fixed regex for detecting secret and key ID 
- changed validation endpoint
- At L75, changed parameter to secret value instead of key ID 


### Tests (failing) 

- Created `/tmp/.env` file with following content 

```
CONFLUENT_TOKEN=<valid_secret>
CONFLUENT_KEY=<valid_key_id>
CONFLUENT_INACTIVE=<invalid_secret>
```
- Ran `export TEST_SECRET_FILE="/tmp/.env" && go test ./pkg/detectors/confluent -tags=detectors`

- Tests fail with following message : 

```
--- FAIL: TestConfluent_FromChunk (0.93s)
    --- FAIL: TestConfluent_FromChunk/found,_verified (0.77s)
        confluent_test.go:107: Confluent.FromData() found, verified diff: (-got +want)
             [
              {
               DetectorType: 60,
               Verified: true,
               Raw: [
               ],
               RawV2: [
            -   86,
            -   89,
            -   67,
           ...
               ],
               Redacted: "",
               ExtraData: {
               },
               StructuredData: nil,
              },
             ]
```




