### PR TITLE
Add context so to avoid splitting creds.

### DIFF
--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -123,18 +123,18 @@ func TestSingleCommitSingleDiff(t *testing.T) {
 	}
 }
 
-func TestMultiCommitBrokenDiff(t *testing.T) {
-	r := bytes.NewReader([]byte(singleCommitBrokenDiff))
+func TestMultiCommitContextDiff(t *testing.T) {
+	r := bytes.NewReader([]byte(singleCommitContextDiff))
 	commitChan := make(chan Commit)
 	dateOne, _ := time.Parse(DateFormat, "Mon Mar 15 23:27:16 2021 -0700")
 	dateTwo, _ := time.Parse(DateFormat, "Wed Dec 12 18:19:21 2018 -0800")
-	diffOneA := bytes.NewBuffer([]byte(singleCommitBrokenDiffDiffOneA))
-	diffTwoA := bytes.NewBuffer([]byte(singleCommitBrokenDiffDiffTwoA))
-	diffTwoB := bytes.NewBuffer([]byte(singleCommitBrokenDiffDiffTwoB))
+	diffOneA := bytes.NewBuffer([]byte(singleCommitContextDiffDiffOneA))
+	diffTwoA := bytes.NewBuffer([]byte(singleCommitContextDiffDiffTwoA))
+	// diffTwoB := bytes.NewBuffer([]byte(singleCommitContextDiffDiffTwoB))
 	messageOne := strings.Builder{}
-	messageOne.Write([]byte(singleCommitBrokenDiffMessageOne))
+	messageOne.Write([]byte(singleCommitContextDiffMessageOne))
 	messageTwo := strings.Builder{}
-	messageTwo.Write([]byte(singleCommitBrokenDiffMessageTwo))
+	messageTwo.Write([]byte(singleCommitContextDiffMessageTwo))
 	expected := []Commit{
 		{
 			Hash:    "70001020fab32b1fcf2f1f0e5c66424eae649826",
@@ -158,14 +158,8 @@ func TestMultiCommitBrokenDiff(t *testing.T) {
 			Diffs: []Diff{
 				{
 					PathB:     "aws",
-					LineStart: 3,
+					LineStart: 1,
 					Content:   *diffTwoA,
-					IsBinary:  false,
-				},
-				{
-					PathB:     "aws",
-					LineStart: 7,
-					Content:   *diffTwoB,
 					IsBinary:  false,
 				},
 			},
@@ -181,7 +175,7 @@ func TestMultiCommitBrokenDiff(t *testing.T) {
 		}
 
 		if !commit.Equal(&expected[i]) {
-			t.Errorf("Commit does not match. Got: %v, expected: %v", commit, expected)
+			t.Errorf("Commit does not match. Got: %v, expected: %v", commit, expected[i])
 		}
 		i++
 	}
@@ -220,7 +214,7 @@ aws_secret_access_key = Tg0pz8Jii8hkLx4+PnUisM8GmKs3a2DK+9qz/lie
 output = json
 region = us-east-2
 `
-const singleCommitBrokenDiff = `commit 70001020fab32b1fcf2f1f0e5c66424eae649826 (HEAD -> master, origin/master, origin/HEAD)
+const singleCommitContextDiff = `commit 70001020fab32b1fcf2f1f0e5c66424eae649826 (HEAD -> master, origin/master, origin/HEAD)
 Author: Dustin Decker <humanatcomputer@gmail.com>
 Date:   Mon Mar 15 23:27:16 2021 -0700
 
@@ -254,34 +248,37 @@ diff --git a/aws b/aws
 index 239b415..2ee133b 100644
 --- a/aws
 +++ b/aws
-@@ -3 +3,3 @@ blah blaj
+@@ -1,5 +1,7 @@
+ blah blaj
+ 
 -this is the secret: AKIA2E0A8F3B244C9986
 +this is the secret: [Default]
 +Access key Id: AKIAILE3JG6KMS3HZGCA
 +Secret Access Key: 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
-@@ -5 +7 @@ this is the secret: AKIA2E0A8F3B244C9986
+ 
 -okay thank you bye
 \ No newline at end of file
 +okay thank you bye
 `
 
-const singleCommitBrokenDiffMessageOne = `Update aws
+const singleCommitContextDiffMessageOne = `Update aws
 `
 
-const singleCommitBrokenDiffMessageTwo = `Update aws again
+const singleCommitContextDiffMessageTwo = `Update aws again
 `
 
-const singleCommitBrokenDiffDiffOneA = `[default]
+const singleCommitContextDiffDiffOneA = `[default]
 aws_access_key_id = AKIAXYZDQCEN4B6JSJQI
 aws_secret_access_key = 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
 output = json
 region = us-east-2
 `
 
-const singleCommitBrokenDiffDiffTwoA = `this is the secret: [Default]
+const singleCommitContextDiffDiffTwoA = `
+
+this is the secret: [Default]
 Access key Id: AKIAILE3JG6KMS3HZGCA
 Secret Access Key: 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
-`
 
-const singleCommitBrokenDiffDiffTwoB = `okay thank you bye
+okay thank you bye
 `

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -225,18 +225,18 @@ func TestSource_Chunks_Integration(t *testing.T) {
 			},
 			expectedChunkData: map[string]*byteCompare{
 				"70001020fab32b1fcf2f1f0e5c66424eae649826-aws":  {B: []byte("[default]\naws_access_key_id = AKIAXYZDQCEN4B6JSJQI\naws_secret_access_key = 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\noutput = json\nregion = us-east-2\n")},
-				"a6f8aa55736d4a85be31a0048a4607396898647a-bump": {B: []byte("f\n")},
-				"73ab4713057944753f1bdeb80e757380e64c6b5b-bump": {B: []byte(" s \n")},
-				"2f251b8c1e72135a375b659951097ec7749d4af9-bump": {B: []byte(" \n")},
-				"e6c8bbabd8796ea3cd85bfc2e55b27e0a491747f-bump": {B: []byte("oops \n")},
-				"735b52b0eb40610002bb1088e902bd61824eb305-bump": {B: []byte("oops\n")},
+				"a6f8aa55736d4a85be31a0048a4607396898647a-bump": {B: []byte("\n\nf\n")},
+				"73ab4713057944753f1bdeb80e757380e64c6b5b-bump": {B: []byte(" s \n\n")},
+				"2f251b8c1e72135a375b659951097ec7749d4af9-bump": {B: []byte(" \n\n")},
+				"e6c8bbabd8796ea3cd85bfc2e55b27e0a491747f-bump": {B: []byte("\noops \n")},
+				"735b52b0eb40610002bb1088e902bd61824eb305-bump": {B: []byte("\noops\n")},
 				"ce62d79908803153ef6e145e042d3e80488ef747-bump": {B: []byte("\n")},
 				// Normally we might expect to see this commit, and we may in the future.
 				// But at the moment we're ignoring any commit unless it contains at least one non-space character.
-				"27fbead3bf883cdb7de9d7825ed401f28f9398f1-slack": {B: []byte("yup, just did that\n\ngithub_lol: \"ffc7e0f9400fb6300167009e42d2f842cd7956e2\"\n\noh, goodness. there's another one!\n")},
+				"27fbead3bf883cdb7de9d7825ed401f28f9398f1-slack": {B: []byte("\n\n\n\nyup, just did that\n\ngithub_lol: \"ffc7e0f9400fb6300167009e42d2f842cd7956e2\"\n\noh, goodness. there's another one!\n")},
 				"8afb0ecd4998b1179e428db5ebbcdc8221214432-slack": {B: []byte("oops might drop a slack token here\n\ngithub_secret=\"369963c1434c377428ca8531fbc46c0c43d037a0\"\n\nyup, just did that\n"), Multi: true},
 				"8fe6f04ef1839e3fc54b5147e3d0e0b7ab971bd5-aws":   {B: []byte("blah blaj\n\nthis is the secret: AKIA2E0A8F3B244C9986\n\nokay thank you bye\n"), Multi: true},
-				"84e9c75e388ae3e866e121087ea2dd45a71068f2-aws":   {B: []byte("this is the secret: [Default]\nAccess key Id: AKIAILE3JG6KMS3HZGCA\nSecret Access Key: 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\n"), Multi: true},
+				"84e9c75e388ae3e866e121087ea2dd45a71068f2-aws":   {B: []byte("\n\nthis is the secret: [Default]\nAccess key Id: AKIAILE3JG6KMS3HZGCA\nSecret Access Key: 6GKmgiS3EyIBJbeSp7sQ+0PoJrPZjPUg8SF6zYz7\n\nokay thank you bye\n"), Multi: false},
 			},
 		},
 	}


### PR DESCRIPTION
Add context to avoid splitting creds. Replace context with newlines to keep line numbers, but not bog down detectors.

Fixes #702 