### PR TITLE
[OC-101] - Prevent Gitlab detector panic

### DIFF
--- a/pkg/detectors/gitlab/gitlab.go
+++ b/pkg/detectors/gitlab/gitlab.go
@@ -40,7 +40,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		resMatch := strings.TrimSpace(match[1])
 		if strings.Contains(match[0], "glpat") {
 			keyString := strings.Split(match[0], " ")
-			resMatch = keyString[2]
+			resMatch = keyString[len(keyString)-1]
 		}
 
 		secret := detectors.Result{

--- a/pkg/detectors/gitlab/gitlab_test.go
+++ b/pkg/detectors/gitlab/gitlab_test.go
@@ -54,6 +54,22 @@ func TestGitlab_FromChunk(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "found only secret phrase",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("gitlab %s", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Gitlab,
+					Verified:     true,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "found, unverified",
 			s:    Scanner{},
 			args: args{

--- a/pkg/detectors/gitlab/gitlab_test.go
+++ b/pkg/detectors/gitlab/gitlab_test.go
@@ -23,7 +23,7 @@ func TestGitlab_FromChunk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get test secrets from GCP: %s", err)
 	}
-	secret := testSecrets.MustGetField("GITLABV2")
+	secret := testSecrets.MustGetField("GITLAB")
 	secretInactive := testSecrets.MustGetField("GITLAB_INACTIVE")
 	type args struct {
 		ctx    context.Context

--- a/pkg/detectors/gitlab/gitlab_test.go
+++ b/pkg/detectors/gitlab/gitlab_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kylelemons/godebug/pretty"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
@@ -22,7 +23,7 @@ func TestGitlab_FromChunk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get test secrets from GCP: %s", err)
 	}
-	secret := testSecrets.MustGetField("GITLAB")
+	secret := testSecrets.MustGetField("GITLABV2")
 	secretInactive := testSecrets.MustGetField("GITLAB_INACTIVE")
 	type args struct {
 		ctx    context.Context
@@ -41,7 +42,7 @@ func TestGitlab_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a gitlab secret %s within", secret)),
+				data:   []byte(fmt.Sprintf("You can find a gitlab super secret %s within", secret)),
 				verify: true,
 			},
 			want: []detectors.Result{


### PR DESCRIPTION
Use the last index of the result slice to determine secret.
![Screen Shot 2022-09-14 at 4 49 52 PM](https://user-images.githubusercontent.com/21311841/190284420-25021928-e78b-48d7-89a1-36be4625a3b6.png)
