### PR TITLE
Fix improper github org member pagination

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -788,16 +788,15 @@ func (s *Source) addOrgsByUser(ctx context.Context, user string) {
 }
 
 func (s *Source) addMembersByOrg(ctx context.Context, org string) error {
-	opts := &github.ListOptions{
-		PerPage: membersAppPagination,
-	}
-	optsOrg := &github.ListMembersOptions{
-		PublicOnly:  false,
-		ListOptions: *opts,
+	opts := &github.ListMembersOptions{
+		PublicOnly: false,
+		ListOptions: github.ListOptions{
+			PerPage: membersAppPagination,
+		},
 	}
 
 	for {
-		members, res, err := s.apiClient.Organizations.ListMembers(ctx, org, optsOrg)
+		members, res, err := s.apiClient.Organizations.ListMembers(ctx, org, opts)
 		if err == nil {
 			defer res.Body.Close()
 		}


### PR DESCRIPTION
I'm not sure I fully understand why this issue exists. But I think the short version is this: When we attempted to paginate users, we would set a variable's Page value. But that variable appears to not actually be a pointer, despite being added as one. It probably has to do with how struct embedding works. Either way, if we make the overall options variable the whole thing, and update its embedded struct with our page variable, everything works out.