### PR TITLE
Use headref and check empty commits for base

### DIFF
--- a/pkg/engine/git.go
+++ b/pkg/engine/git.go
@@ -59,7 +59,7 @@ func (e *Engine) ScanGit(ctx context.Context, c sources.Config) error {
 				return errors.WrapPrefix(err, "unable to resolve head ref", 0)
 			} else {
 				c.HeadRef = head.String()
-				headCommit, _ = repo.CommitObject(plumbing.NewHash(c.BaseRef))
+				headCommit, _ = repo.CommitObject(plumbing.NewHash(c.HeadRef))
 			}
 		} else {
 			headCommit, err = repo.CommitObject(headHash)


### PR DESCRIPTION
`headCommit` was being set to the base commit, and zero-diff commits were getting skipped in baseRef check.

Fixes #666 