### PR TITLE
Move head and base normalization to source

### DIFF
--- a/pkg/engine/git.go
+++ b/pkg/engine/git.go
@@ -4,10 +4,7 @@ import (
 	"fmt"
 	"runtime"
 
-	"github.com/go-errors/errors"
 	gogit "github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/sirupsen/logrus"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
@@ -29,53 +26,6 @@ func (e *Engine) ScanGit(ctx context.Context, c sources.Config) error {
 	repo, err := gogit.PlainOpenWithOptions(c.RepoPath, &gogit.PlainOpenOptions{DetectDotGit: true})
 	if err != nil {
 		return fmt.Errorf("could open repo: %s: %w", c.RepoPath, err)
-	}
-
-	var baseCommit *object.Commit
-	if len(c.BaseRef) > 0 {
-		baseHash := plumbing.NewHash(c.BaseRef)
-		if !plumbing.IsHash(c.BaseRef) {
-			base, err := git.TryAdditionalBaseRefs(repo, c.BaseRef)
-			if err != nil {
-				return errors.WrapPrefix(err, "unable to resolve base ref", 0)
-			} else {
-				c.BaseRef = base.String()
-				baseCommit, _ = repo.CommitObject(plumbing.NewHash(c.BaseRef))
-			}
-		} else {
-			baseCommit, err = repo.CommitObject(baseHash)
-			if err != nil {
-				return errors.WrapPrefix(err, "unable to resolve base ref", 0)
-			}
-		}
-	}
-
-	var headCommit *object.Commit
-	if len(c.HeadRef) > 0 {
-		headHash := plumbing.NewHash(c.HeadRef)
-		if !plumbing.IsHash(c.HeadRef) {
-			head, err := git.TryAdditionalBaseRefs(repo, c.HeadRef)
-			if err != nil {
-				return errors.WrapPrefix(err, "unable to resolve head ref", 0)
-			} else {
-				c.HeadRef = head.String()
-				headCommit, _ = repo.CommitObject(plumbing.NewHash(c.HeadRef))
-			}
-		} else {
-			headCommit, err = repo.CommitObject(headHash)
-			if err != nil {
-				return errors.WrapPrefix(err, "unable to resolve head ref", 0)
-			}
-		}
-	}
-
-	// If baseCommit is an ancestor of headCommit, update c.BaseRef to be the common ancestor.
-	if headCommit != nil && baseCommit != nil {
-		mergeBase, err := headCommit.MergeBase(baseCommit)
-		if err != nil || len(mergeBase) < 1 {
-			return errors.WrapPrefix(err, "could not find common base between the given references", 0)
-		}
-		c.BaseRef = mergeBase[0].Hash.String()
 	}
 
 	if c.MaxDepth != 0 {


### PR DESCRIPTION
Prevents a bad head or base being used in git source.