### PR TITLE
Fix json output which was previously b64 encoding bytes instead of printing the string

### DIFF
--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -26,8 +26,8 @@ func PrintJSON(r *detectors.ResultWithMetadata) {
 		// DetectorName is the string name of the DetectorType.
 		DetectorName string
 		Verified     bool
-		// Raw contains the raw secret identifier data. Prefer IDs over secrets since it is used for deduping after hashing.
-		Raw []byte
+		// Raw contains the raw secret data.
+		Raw string
 		// Redacted contains the redacted version of the raw secret identification data for display purposes.
 		// A secret ID should be used if available.
 		Redacted       string
@@ -41,7 +41,7 @@ func PrintJSON(r *detectors.ResultWithMetadata) {
 		DetectorType:   r.DetectorType,
 		DetectorName:   r.DetectorType.String(),
 		Verified:       r.Verified,
-		Raw:            r.Raw,
+		Raw:            string(r.Raw),
 		Redacted:       r.Redacted,
 		ExtraData:      r.ExtraData,
 		StructuredData: r.StructuredData,


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
