### PR TITLE
Ignore URIs where the password is redacted

### DIFF
--- a/pkg/detectors/uri/uri.go
+++ b/pkg/detectors/uri/uri.go
@@ -76,6 +76,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			continue
 		}
 
+		// Skip findings where the password only has "*" characters, this is a redacted password
+		if strings.Trim(password, "*") == "" {
+			continue
+		}
+
 		parsedURL, err := url.Parse(urlMatch)
 		if err != nil {
 			continue

--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -111,6 +111,7 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk) err
 				return nil
 			}
 			defer inputFile.Close()
+			log.WithField("file_path", path).Trace("scanning file")
 
 			reReader, err := diskbufferreader.New(inputFile)
 			if err != nil {


### PR DESCRIPTION
Only `*`s in the password is a redacted basic auth URI.

A trace level log statement slipped in for the filesystem scanner but I'd like to merge that too.