### PR TITLE
Buffer commit log processing

### DIFF
--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -104,7 +104,7 @@ func Unstaged(ctx context.Context, source string) (chan Commit, error) {
 
 // executeCommand runs an exec.Cmd, reads stdout and stderr, and waits for the Cmd to complete.
 func executeCommand(ctx context.Context, cmd *exec.Cmd) (chan Commit, error) {
-	commitChan := make(chan Commit)
+	commitChan := make(chan Commit, 64)
 
 	stdOut, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
Some very large commits take a lot of time to process, which we can make progress on while we are scanning the contents of other commits.

Tested with `duckduckgo/tracker-radar`:
* Without buffered channel: 200 minutes
* With buffered channel: 110 minutes
* Speedup: 1.8x

Note: `git log` for the repo took around ~60 minutes which is the theoretical fastest we could scan the repo (via that dependency).
