### PR TITLE
Copy buffer bytes

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -406,7 +406,7 @@ func (s *Git) gitChunk(diff gitparse.Diff, fileName, email, hash, when, urlMetad
 					SourceID:       s.sourceID,
 					SourceType:     s.sourceType,
 					SourceMetadata: metadata,
-					Data:           newChunkBuffer.Bytes(),
+					Data:           append([]byte{}, newChunkBuffer.Bytes()...),
 					Verify:         s.verify,
 				}
 				newChunkBuffer.Reset()
@@ -440,7 +440,7 @@ func (s *Git) gitChunk(diff gitparse.Diff, fileName, email, hash, when, urlMetad
 			SourceID:       s.sourceID,
 			SourceType:     s.sourceType,
 			SourceMetadata: metadata,
-			Data:           newChunkBuffer.Bytes(),
+			Data:           append([]byte{}, newChunkBuffer.Bytes()...),
 			Verify:         s.verify,
 		}
 	}


### PR DESCRIPTION
buffer.Bytes() gives a pointer to the slice that is being reused. Need to copy the slice to avoid weirdness later.
