### PR TITLE
remove updates check from github action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,4 +30,5 @@ runs:
     - --branch
     - ${{ inputs.head }}
     - --fail
+    - --no-update
     - ${{ inputs.extra_args }}


### PR DESCRIPTION
Because action uses the latest image there is no need to check for updates each time

Closes: #882 
