### PR TITLE
Fixed the brew install tap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ Help with setting up this packaging would be appreciated!
 ### 5. Brew
 
 ```bash
-brew tap trufflesecurity/trufflehog
 brew install trufflesecurity/trufflehog/trufflehog
 ```
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Help with setting up this packaging would be appreciated!
 
 ```bash
 brew tap trufflesecurity/trufflehog
-brew install trufflehog
+brew install trufflesecurity/trufflehog/trufflehog
 ```
 
 ## Usage


### PR DESCRIPTION
It seems you need to run the full tap, not just trufflehog.

Signed-off-by: JJ Asghar <awesome@ibm.com>
