### PR TITLE
Add `--exclude-paths` support for gitlab scanning module

### DIFF
--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -41,6 +41,7 @@ type Source struct {
 	repos           []string
 	ignoreRepos     []string
 	git             *git.Git
+	scanOptions     *git.ScanOptions
 	aCtx            context.Context
 	resumeInfoSlice []string
 	resumeInfoMutex sync.Mutex
@@ -325,7 +326,7 @@ func (s *Source) scanRepos(ctx context.Context, chunksChan chan *sources.Chunk) 
 				return
 			}
 			log.Debugf("Starting to scan repo %d/%d: %s", i+1, len(s.repos), repoURL)
-			err = s.git.ScanRepo(ctx, repo, path, git.NewScanOptions(), chunksChan)
+			err = s.git.ScanRepo(ctx, repo, path, s.scanOptions, chunksChan)
 			if err != nil {
 				errsMut.Lock()
 				errs = append(errs, err)
@@ -431,4 +432,8 @@ func (s *Source) setProgressCompleteWithRepo(index int, offset int, repoURL stri
 
 	// Add the offset to both the index and the repos to give the proper place and proper repo count.
 	s.SetProgressComplete(index+offset, len(s.repos)+offset, fmt.Sprintf("Repo: %s", repoURL), encodedResumeInfo)
+}
+
+func (s *Source) WithScanOptions(scanOptions *git.ScanOptions) {
+	s.scanOptions = scanOptions
 }


### PR DESCRIPTION
Closes #918 

Similar to the [PR for adding exclude-paths to the filesystem module](https://github.com/trufflesecurity/trufflehog/pull/881), I:
- in main.go, I added filter creation to the gitlab switchcase
- in the gitlab engine, I created git ScanOptions in the same way that that the git engine does it
- in the gitlab source, instead of having it use git.NewScanOptions(), I have it use the ScanOptions we created using the passed in filter

---
Tests:
As with the filesystem PR, I didn't see any similar tests for exclude-paths in the git source and wasn't sure how to add tests for this PR. 
