### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ TruffleHog has a sub-command for each source of data that you may want to scan:
 - syslog
 - file and stdin (coming soon)
 
-Each subcommand can have options that you can see with the `-h` flag provided to the sub command:
+Each subcommand can have options that you can see with the `--help` flag provided to the sub command:
 
 ```
 $ trufflehog git --help


### PR DESCRIPTION
Fixing help subcommand reference to be `--help`, not `-h`, which does not work:

```
$ trufflehog git -h
trufflehog: error: unknown short flag '-h', try --help
$ trufflehog --version
trufflehog 3.16.4
```

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
