### PR TITLE
Change chunker test source

### DIFF
--- a/pkg/sources/chunker.go
+++ b/pkg/sources/chunker.go
@@ -37,10 +37,12 @@ func Chunker(originalChunk *Chunk) chan *Chunk {
 			}
 			peekData, _ := reader.Peek(PeekSize)
 			chunk.Data = append(chunkBytes[:n], peekData...)
+			if n > 0 {
+				chunkChan <- &chunk
+			}
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			chunkChan <- &chunk
 		}
 	}()
 	return chunkChan

--- a/pkg/sources/chunker.go
+++ b/pkg/sources/chunker.go
@@ -37,10 +37,10 @@ func Chunker(originalChunk *Chunk) chan *Chunk {
 			}
 			peekData, _ := reader.Peek(PeekSize)
 			chunk.Data = append(chunkBytes[:n], peekData...)
-			chunkChan <- &chunk
 			if errors.Is(err, io.EOF) {
 				break
 			}
+			chunkChan <- &chunk
 		}
 	}()
 	return chunkChan

--- a/pkg/sources/chunker_test.go
+++ b/pkg/sources/chunker_test.go
@@ -5,19 +5,14 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"net/http"
 	"testing"
 
 	diskbufferreader "github.com/bill-rich/disk-buffer-reader"
 )
 
 func TestChunker(t *testing.T) {
-	resp, err := http.Get("https://raw.githubusercontent.com/bill-rich/bad-secrets/master/FifteenMB.gz")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-	reReader, err := diskbufferreader.New(resp.Body)
+	byteBuffer := bytes.NewBuffer(make([]byte, ChunkSize*9))
+	reReader, err := diskbufferreader.New(byteBuffer)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Switch to a reader with a predetermined size to limit error sources.
