### PR TITLE
Don't scan the --since-commit target

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,9 +269,9 @@ repos:
     - id: trufflehog
       name: TruffleHog
       description: Detect secrets in your data.
-      entry: bash -c 'trufflehog git file://. --only-verified --fail'
+      entry: bash -c 'trufflehog git file://. --since-commit main --only-verified --fail'
       # For running trufflehog in docker, use the following entry instead:
-      # entry: bash -c 'docker run -v "$(pwd):/workdir" -i --rm trufflesecurity/trufflehog:latest git file:///workdir --only-verified --fail'
+      # entry: bash -c 'docker run -v "$(pwd):/workdir" -i --rm trufflesecurity/trufflehog:latest git file:///workdir --since-commit main --only-verified --fail'
       language: system
       stages: ["commit", "push"]
 ```

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -238,23 +238,11 @@ func TestSource_Chunks_Integration(t *testing.T) {
 			name:    "remote repo, limited",
 			repoURL: "https://github.com/dustin-decker/secretsandstuff.git",
 			expectedChunkData: map[string]*byteCompare{
-				"70001020fab32b1fcf2f1f0e5c66424eae649826-aws":  {B: []byte("[default]\naws_access_key_id = AKIAXYZDQCEN4B6JSJQI\naws_secret_access_key = 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\noutput = json\nregion = us-east-2\n")},
-				"a6f8aa55736d4a85be31a0048a4607396898647a-bump": {B: []byte("\n\nf\n")},
+				"70001020fab32b1fcf2f1f0e5c66424eae649826-aws": {B: []byte("[default]\naws_access_key_id = AKIAXYZDQCEN4B6JSJQI\naws_secret_access_key = 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\noutput = json\nregion = us-east-2\n")},
 			},
 			scanOptions: ScanOptions{
 				HeadHash: "70001020fab32b1fcf2f1f0e5c66424eae649826",
 				BaseHash: "a6f8aa55736d4a85be31a0048a4607396898647a",
-			},
-		},
-		{
-			name:    "remote repo, base ahead of head",
-			repoURL: "https://github.com/dustin-decker/secretsandstuff.git",
-			expectedChunkData: map[string]*byteCompare{
-				"a6f8aa55736d4a85be31a0048a4607396898647a-bump": {B: []byte("\n\nf\n")},
-			},
-			scanOptions: ScanOptions{
-				HeadHash: "a6f8aa55736d4a85be31a0048a4607396898647a",
-				BaseHash: "70001020fab32b1fcf2f1f0e5c66424eae649826",
 			},
 		},
 		{


### PR DESCRIPTION
The commit in `--since-commit` should not be scanned or pre-commit hooks won't work when head of main branch includes a secret.