### PR TITLE
Syncing v2-dev --> v2 branches

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at dxa4481@rit.edu. All
+reported by contacting the project team at dylan@trufflesec.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Searches through git repositories for secrets, digging deep into commit history 
 ## Join The Slack
 Have questions? Feedback? Jump in slack and hang out with me 
 
-https://join.slack.com/t/trufflehog-community/shared_invite/zt-8al1k31h-JlTasbSx4O4mHUxRQ2UgAg
+https://join.slack.com/t/trufflehog-community/shared_invite/zt-pw2qbi43-Aa86hkiimstfdKH9UCpPzQ
 
 ## NEW
 truffleHog previously functioned by running entropy checks on git diffs. This functionality still exists, but high signal regex checks have been added, and the ability to suppress entropy checking has also been added.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Searches through git repositories for secrets, digging deep into commit history 
 ## Join The Slack
 Have questions? Feedback? Jump in slack and hang out with me 
 
-https://join.slack.com/t/trufflehog-community/shared_invite/zt-nzznzf8w-y1Lg4PnnLupzlYuwq_AUHA
+https://join.slack.com/t/trufflehog-community/shared_invite/zt-8al1k31h-JlTasbSx4O4mHUxRQ2UgAg
 
 ## NEW
 truffleHog previously functioned by running entropy checks on git diffs. This functionality still exists, but high signal regex checks have been added, and the ability to suppress entropy checking has also been added.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 
 # truffleHog
-[![codecov](https://codecov.io/gh/dxa4481/truffleHog/branch/master/graph/badge.svg)](https://codecov.io/gh/dxa4481/truffleHog)
+[![codecov](https://codecov.io/gh/trufflesecurity/truffleHog/branch/master/graph/badge.svg)](https://codecov.io/gh/trufflesecurity/truffleHog)
 
 Searches through git repositories for secrets, digging deep into commit history and branches. This is effective at finding secrets accidentally committed.
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='truffleHog',
-    version='2.1.11',
+    version='2.1.13',
     description='Searches through git repositories for high entropy strings, digging deep into commit history.',
     url='https://github.com/dxa4481/truffleHog',
     author='Dylan Ayrey',

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -378,7 +378,7 @@ def find_strings(git_url, since_commit=None, max_depth=1000000, printJson=False,
     output["clone_uri"] = git_url
     output["issues_path"] = output_dir
     if not repo_path:
-	repo.close()
+        repo.close()
         shutil.rmtree(project_path, onerror=del_rw)
     return output
 

--- a/truffleHog/truffleHog.py
+++ b/truffleHog/truffleHog.py
@@ -378,6 +378,7 @@ def find_strings(git_url, since_commit=None, max_depth=1000000, printJson=False,
     output["clone_uri"] = git_url
     output["issues_path"] = output_dir
     if not repo_path:
+	repo.close()
         shutil.rmtree(project_path, onerror=del_rw)
     return output
 


### PR DESCRIPTION
I'm keeping a copy of the latest v2 version. I know it's an unsupported version, but can we sync it with `v2-dev`?

The Entropy scanning functionality is still a valuable feature for a lot of people :)
