### PR TITLE
Use Todoist's REST API v2

### DIFF
--- a/pkg/detectors/todoist/todoist.go
+++ b/pkg/detectors/todoist/todoist.go
@@ -48,7 +48,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.todoist.com/rest/v1/projects", nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.todoist.com/rest/v2/projects", nil)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
v1 was deprecated on December 5, 2022.

The response is unused, but for reference, here's the migration guide: https://developer.todoist.com/rest/v2/#migrating-from-v1