### PR TITLE
Use access-token endpoint for validity check

### DIFF
--- a/pkg/detectors/buildkite/buildkite.go
+++ b/pkg/detectors/buildkite/buildkite.go
@@ -48,7 +48,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.buildkite.com/v2/user", nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.buildkite.com/v2/access-token", nil)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
This PR fixes the issue https://github.com/trufflesecurity/trufflehog/issues/990, it should correctly report keys as valid even if they are missing the user_read scope.