### PR TITLE
Removing Debug version Println to logrus debug - Issue #992

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,7 +150,7 @@ func main() {
 
 func run(state overseer.State) {
 	if *debug {
-		fmt.Println("trufflehog " + version.BuildVersion)
+		logrus.Debugf("trufflehog %s", version.BuildVersion)
 	}
 
 	if *githubScanToken != "" {


### PR DESCRIPTION
Hi,

I created the Issue #992 for this pull request, the problem is that when debug is enabled, we print the trufflehog version in STDOUT instead of STDERR:
```bash
❯ trufflehog filesystem --directory hack 2>/dev/null
❯ trufflehog filesystem --directory hack --debug 2>/dev/null
trufflehog 3.21.0
```

The change is minor and shouldn't required additional testing or have much impact.

Thanks!
