### PR TITLE
Switch to retryableHttpClient for GitHub AuthN API Client + More Logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,29 +173,19 @@ Find credentials in git repositories.
 
 Flags:
       --help                     Show context-sensitive help (also try --help-long and --help-man).
-      --trace                    Run in trace mode
-      --debug                    Run in debug mode
-      --version                  Prints trufflehog version.
+      --debug                    Run in debug mode.
+      --trace                    Run in trace mode.
   -j, --json                     Output in JSON format.
       --json-legacy              Use the pre-v3.0 JSON format. Only works with git, gitlab, and github sources.
-      --concurrency=1            Number of concurrent workers.
+      --concurrency=10           Number of concurrent workers.
       --no-verification          Don't verify the results.
       --only-verified            Only output verified results.
       --filter-unverified        Only output first unverified result per chunk per detector if there are more than one results.
-      --configFilename           Path to configuration file
+      --config=CONFIG            Path to configuration file.
       --print-avg-detector-time  Print the average time spent on each detector.
       --no-update                Don't check for updates.
-  -i, --include-paths=INCLUDE-PATHS
-                                 Path to file with newline separated regexes for files to include in scan.
-  -x, --exclude-paths=EXCLUDE-PATHS
-                                 Path to file with newline separated regexes for files to exclude in scan.
-      --since-commit=SINCE-COMMIT
-                                 Commit to start scan from.
-      --branch=BRANCH            Branch to scan.
-      --max-depth=MAX-DEPTH      Maximum depth of commits to scan.
-      --allow                    No-op flag for backwards compat.
-      --entropy                  No-op flag for backwards compat.
-      --regex                    No-op flag for backwards compat.
+      --fail                     Exit with code 183 if results are found.
+      --version                  Show application version.
 
 Args:
   <uri>  Git repository URL. https://, file://, or ssh:// schema expected.

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Find credentials in git repositories.
 
 Flags:
       --help                     Show context-sensitive help (also try --help-long and --help-man).
+      --trace                    Run in trace mode
       --debug                    Run in debug mode
       --version                  Prints trufflehog version.
   -j, --json                     Output in JSON format.
@@ -180,6 +181,7 @@ Flags:
       --no-verification          Don't verify the results.
       --only-verified            Only output verified results.
       --filter-unverified        Only output first unverified result per chunk per detector if there are more than one results.
+      --configFilename           Path to configuration file
       --print-avg-detector-time  Print the average time spent on each detector.
       --no-update                Don't check for updates.
   -i, --include-paths=INCLUDE-PATHS

--- a/pkg/common/http.go
+++ b/pkg/common/http.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/sirupsen/logrus"
 )
 
 var caCerts = []string{
@@ -93,7 +94,10 @@ func NewCustomTransport(T http.RoundTripper) *CustomTransport {
 
 func PinnedRetryableHttpClient() *http.Client {
 	httpClient := retryablehttp.NewClient()
-	httpClient.Logger = nil
+	httpClient.Logger = logrus.WithFields(logrus.Fields{
+		"name":  "PinnedRetryableHttpClient",
+		"level": logrus.DebugLevel,
+	})
 	httpClient.HTTPClient.Transport = NewCustomTransport(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			RootCAs: PinnedCertPool(),
@@ -115,7 +119,10 @@ func PinnedRetryableHttpClient() *http.Client {
 func RetryableHttpClient() *http.Client {
 	httpClient := retryablehttp.NewClient()
 	httpClient.RetryMax = 3
-	httpClient.Logger = nil
+	httpClient.Logger = logrus.WithFields(logrus.Fields{
+		"name":  "RetryableHttpClient",
+		"level": logrus.DebugLevel,
+	})
 	httpClient.HTTPClient.Timeout = 3 * time.Second
 	httpClient.HTTPClient.Transport = NewCustomTransport(nil)
 	return httpClient.StandardClient()
@@ -124,7 +131,10 @@ func RetryableHttpClient() *http.Client {
 func RetryableHttpClientTimeout(timeOutSeconds int64) *http.Client {
 	httpClient := retryablehttp.NewClient()
 	httpClient.RetryMax = 3
-	httpClient.Logger = nil
+	httpClient.Logger = logrus.WithFields(logrus.Fields{
+		"name":  "RetryableHttpClientTimeout",
+		"level": logrus.DebugLevel,
+	})
 	httpClient.HTTPClient.Timeout = time.Duration(timeOutSeconds) * time.Second
 	httpClient.HTTPClient.Transport = NewCustomTransport(nil)
 	return httpClient.StandardClient()

--- a/pkg/common/http.go
+++ b/pkg/common/http.go
@@ -94,10 +94,7 @@ func NewCustomTransport(T http.RoundTripper) *CustomTransport {
 
 func PinnedRetryableHttpClient() *http.Client {
 	httpClient := retryablehttp.NewClient()
-	httpClient.Logger = logrus.WithFields(logrus.Fields{
-		"name":  "PinnedRetryableHttpClient",
-		"level": logrus.DebugLevel,
-	})
+	httpClient.Logger = logrus.WithField("name", "PinnedRetryableHttpClient").WithField("level", logrus.DebugLevel)
 	httpClient.HTTPClient.Transport = NewCustomTransport(&http.Transport{
 		TLSClientConfig: &tls.Config{
 			RootCAs: PinnedCertPool(),
@@ -119,10 +116,7 @@ func PinnedRetryableHttpClient() *http.Client {
 func RetryableHttpClient() *http.Client {
 	httpClient := retryablehttp.NewClient()
 	httpClient.RetryMax = 3
-	httpClient.Logger = logrus.WithFields(logrus.Fields{
-		"name":  "RetryableHttpClient",
-		"level": logrus.DebugLevel,
-	})
+	httpClient.Logger = logrus.WithField("name", "RetryableHttpClient").WithField("level", logrus.DebugLevel)
 	httpClient.HTTPClient.Timeout = 3 * time.Second
 	httpClient.HTTPClient.Transport = NewCustomTransport(nil)
 	return httpClient.StandardClient()
@@ -131,10 +125,7 @@ func RetryableHttpClient() *http.Client {
 func RetryableHttpClientTimeout(timeOutSeconds int64) *http.Client {
 	httpClient := retryablehttp.NewClient()
 	httpClient.RetryMax = 3
-	httpClient.Logger = logrus.WithFields(logrus.Fields{
-		"name":  "RetryableHttpClientTimeout",
-		"level": logrus.DebugLevel,
-	})
+	httpClient.Logger = logrus.WithField("name", "RetryableHttpClientTimeout").WithField("level", logrus.DebugLevel)
 	httpClient.HTTPClient.Timeout = time.Duration(timeOutSeconds) * time.Second
 	httpClient.HTTPClient.Transport = NewCustomTransport(nil)
 	return httpClient.StandardClient()

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -560,8 +560,16 @@ func (s *Git) ScanRepo(ctx context.Context, repo *git.Repository, repoPath strin
 		ctx.Logger().V(1).Info("error scanning unstaged changes", "error", err)
 	}
 
+	// We're logging time, but the repoPath is usally a dynamically generated folder in /tmp
+	// To make this duration logging useful, we need to log the remote as well
+	remotes, _ := repo.Remotes()
+	repoUrl := "Could not get remote for repo"
+	if len(remotes) != 0 {
+		repoUrl = getSafeRemoteURL(repo, remotes[0].Config().Name)
+	}
+
 	scanTime := time.Now().UnixNano() - start
-	ctx.Logger().V(1).Info("scanning git repo complete", "path", repoPath, "time", scanTime)
+	ctx.Logger().V(1).Info("scanning git repo complete", "Repo", repoUrl, "path", repoPath, "time", scanTime)
 	return nil
 }
 


### PR DESCRIPTION
Hi,

This pull request is meant to fix issue #994 and adds the following:
- Making GitHub authenticated API Client use the `retryableHttpClientTimeout()` by default
- Adding the repo URL to the log 
    - `"scanning git repo complete path: repoPath, time: scanTime"`
    - `"scanning git repo complete Repo: repoUrl path: repoPath, time: scanTime"`
- Adding a logger to all the httpClient supporting one
- Fixing minor documentation issue (missing flags)

This has already helped recover from requests failures as this dev build log output can show:
```json
{
    "level": "debug",
    "msg": "[DEBUG] GET https://api.github.com/repos/ORG/REPO: retrying in 1s (3 left)",
    "name": "RetryableHttpClientTimeout",
    "time": "2023-01-03T10:43:17Z"
}
{
    "level": "debug",
    "msg": "[DEBUG] GET https://api.github.com/orgs/ORG/repos?per_page=100 (status: 502): retrying in 1s (3 left)",
    "name": "RetryableHttpClientTimeout",
    "time": "2023-01-05T07:57:26Z"
}

{
    "level": "debug",
    "msg": "[DEBUG] GET https://keychecker.trufflesecurity.com/fingerprint/<FINGERPRINT> (status: 503): retrying in 0s (3 left)",
    "name": "RetryableHttpClient",
    "time": "2023-01-06T07:44:31Z"
}
```
This comes from the client - https://github.com/hashicorp/go-retryablehttp/blob/master/client.go#L690

-- EDIT: Added correct log output examples