### PR TITLE
fix: do not override base parameter with default in GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
     - git
     - file://${{ inputs.path }}
     - --since-commit
-    - ${{ inputs.base.default }}
+    - ${{ inputs.base }}
     - --branch
     - ${{ inputs.head }}
     - --fail


### PR DESCRIPTION
This reverts #999 which mistakenly makes the `base` parameter for GitHub actions useless because it always sends the default value for `base` into the `--since-commit` flag. Furthermore that default value is  `''` which breaks so `trufflehog` cannot run.

I believe that if `base` is not specified, then the `input.base.default` value will be used automatically when accessing `input.base`. There is no need to add `default`, and doing so only ever gets the default value.

Closes #1002 