### PR TITLE
Full git log when targeting base merge commit

### DIFF
--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -75,9 +75,9 @@ func (c1 *Commit) Equal(c2 *Commit) bool {
 }
 
 // RepoPath parses the output of the `git log` command for the `source` path.
-func RepoPath(ctx context.Context, source string, head string, fullLog bool) (chan Commit, error) {
+func RepoPath(ctx context.Context, source string, head string, abbreviatedLog bool) (chan Commit, error) {
 	args := []string{"-C", source, "log", "-p", "-U5", "--full-history", "--date=format:%a %b %d %H:%M:%S %Y %z"}
-	if !fullLog {
+	if abbreviatedLog {
 		args = append(args, "--diff-filter=AM")
 	}
 	if head != "" {

--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -75,8 +75,11 @@ func (c1 *Commit) Equal(c2 *Commit) bool {
 }
 
 // RepoPath parses the output of the `git log` command for the `source` path.
-func RepoPath(ctx context.Context, source string, head string) (chan Commit, error) {
-	args := []string{"-C", source, "log", "-p", "-U5", "--full-history", "--diff-filter=AM", "--date=format:%a %b %d %H:%M:%S %Y %z"}
+func RepoPath(ctx context.Context, source string, head string, fullLog bool) (chan Commit, error) {
+	args := []string{"-C", source, "log", "-p", "-U5", "--full-history", "--date=format:%a %b %d %H:%M:%S %Y %z"}
+	if !fullLog {
+		args = append(args, "--diff-filter=AM")
+	}
 	if head != "" {
 		args = append(args, head)
 	} else {

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -330,7 +330,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 		return err
 	}
 
-	commitChan, err := gitparse.RepoPath(ctx, path, scanOptions.HeadHash, scanOptions.MergeCommitTarget)
+	commitChan, err := gitparse.RepoPath(ctx, path, scanOptions.HeadHash, scanOptions.BaseHash == "")
 	if err != nil {
 		return err
 	}
@@ -589,11 +589,6 @@ func normalizeConfig(scanOptions *ScanOptions, repo *git.Repository) (err error)
 			if err != nil {
 				return errors.WrapPrefix(err, "unable to resolve base ref", 0)
 			}
-		}
-		// If the commit has more than one parent, it is a merge commit, and the git
-		// log filter cannot be applied.
-		if len(baseCommit.ParentHashes) > 1 {
-			scanOptions.MergeCommitTarget = true
 		}
 	}
 

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -330,7 +330,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 		return err
 	}
 
-	commitChan, err := gitparse.RepoPath(ctx, path, scanOptions.HeadHash)
+	commitChan, err := gitparse.RepoPath(ctx, path, scanOptions.HeadHash, scanOptions.MergeCommitTarget)
 	if err != nil {
 		return err
 	}
@@ -589,6 +589,11 @@ func normalizeConfig(scanOptions *ScanOptions, repo *git.Repository) (err error)
 			if err != nil {
 				return errors.WrapPrefix(err, "unable to resolve base ref", 0)
 			}
+		}
+		// If the commit has more than one parent, it is a merge commit, and the git
+		// log filter cannot be applied.
+		if len(baseCommit.ParentHashes) > 1 {
+			scanOptions.MergeCommitTarget = true
 		}
 	}
 

--- a/pkg/sources/git/scan_options.go
+++ b/pkg/sources/git/scan_options.go
@@ -6,12 +6,11 @@ import (
 )
 
 type ScanOptions struct {
-	Filter            *common.Filter
-	BaseHash          string // When scanning a git.Log, this is the oldest/first commit.
-	HeadHash          string
-	MaxDepth          int64
-	LogOptions        *git.LogOptions
-	MergeCommitTarget bool
+	Filter     *common.Filter
+	BaseHash   string // When scanning a git.Log, this is the oldest/first commit.
+	HeadHash   string
+	MaxDepth   int64
+	LogOptions *git.LogOptions
 }
 
 type ScanOption func(*ScanOptions)

--- a/pkg/sources/git/scan_options.go
+++ b/pkg/sources/git/scan_options.go
@@ -6,11 +6,12 @@ import (
 )
 
 type ScanOptions struct {
-	Filter     *common.Filter
-	BaseHash   string // When scanning a git.Log, this is the oldest/first commit.
-	HeadHash   string
-	MaxDepth   int64
-	LogOptions *git.LogOptions
+	Filter            *common.Filter
+	BaseHash          string // When scanning a git.Log, this is the oldest/first commit.
+	HeadHash          string
+	MaxDepth          int64
+	LogOptions        *git.LogOptions
+	MergeCommitTarget bool
 }
 
 type ScanOption func(*ScanOptions)


### PR DESCRIPTION
Using `--diff-filter` stops `git log` from listing commits that have no changes. This results in merges being skipped. If the specified `base` is a merge commit, the entire history will be scanned.

This change will drop the `--diff-filter` arg if the base commit has multiple parents (is a merge commit).