### PR TITLE
Remove false positive detection for CustomRegex

### DIFF
--- a/pkg/custom_detectors/custom_detectors.go
+++ b/pkg/custom_detectors/custom_detectors.go
@@ -98,9 +98,6 @@ func (c *customRegexWebhook) FromData(ctx context.Context, verify bool, data []b
 			Raw:          []byte(raw),
 		}
 
-		if isKnownFalsePositive(match) {
-			continue
-		}
 		if !verify {
 			results = append(results, result)
 			continue
@@ -210,17 +207,4 @@ func permutateMatches(regexMatches map[string][][]string) []map[string][]string 
 	}
 
 	return matches
-}
-
-// This function will check false positives for common test words, but also it
-// will make sure the key appears 'random' enough to be a real key.
-func isKnownFalsePositive(match map[string][]string) bool {
-	for _, values := range match {
-		for _, value := range values {
-			if detectors.IsKnownFalsePositive(value, detectors.DefaultFalsePositives, true) {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/pkg/custom_detectors/custom_detectors_test.go
+++ b/pkg/custom_detectors/custom_detectors_test.go
@@ -193,6 +193,21 @@ func TestPermutateMatches(t *testing.T) {
 	}
 }
 
+func TestDetector(t *testing.T) {
+	detector, err := NewWebhookCustomRegex(&custom_detectorspb.CustomRegex{
+		Name: "test",
+		// "password" is normally flagged as a false positive, but CustomRegex
+		// should allow the user to decide and report it as a result.
+		Keywords: []string{"password"},
+		Regex:    map[string]string{"regex": "password=.*"},
+	})
+	assert.NoError(t, err)
+	results, err := detector.FromData(context.Background(), false, []byte(`password="123456"`))
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(results))
+	assert.Equal(t, results[0].Raw, []byte(`password="123456"`))
+}
+
 func BenchmarkProductIndices(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		_ = productIndices(3, 2, 6)


### PR DESCRIPTION
Checking for false positives can lead to results being removed before ever getting the opportunity to verify them. Users are already responsible for verification of custom detectors, so let's not interfere with how they choose to use it.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
