### PR TITLE
braintree detector: use production API URL instead of the test sandbo…

### DIFF
--- a/pkg/detectors/braintreepayments/braintreepayments.go
+++ b/pkg/detectors/braintreepayments/braintreepayments.go
@@ -58,7 +58,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			if verify {
 				payload := strings.NewReader(`{"query": "query { ping }"}`)
-				req, err := http.NewRequestWithContext(ctx, "POST", "https://payments.sandbox.braintree-api.com/graphql", payload)
+				req, err := http.NewRequestWithContext(ctx, "POST", "https://payments.braintree-api.com/graphql", payload)
 				if err != nil {
 					continue
 				}


### PR DESCRIPTION
As the credentials required to access Braintree's Sandbox and production environments are distinct, this PR focuses solely on identifying and securing the production keys, similar to the logic employed in the [Stripe key detection](https://github.com/trufflesecurity/trufflehog/blob/26afa76e7c800f29afe7257ce41073d3b83c96cb/pkg/detectors/stripe/stripe.go#LL20C20-L20C20)
