### PR TITLE
Optimize chunker

### DIFF
--- a/pkg/sources/chunker_test.go
+++ b/pkg/sources/chunker_test.go
@@ -103,11 +103,7 @@ func BenchmarkChunker(b *testing.B) {
 
 	baseReader := bufio.NewReaderSize(reReader, ChunkSize)
 	_, _ = baseReader.Read(baseChunkOne)
-	peek, _ := baseReader.Peek(PeekSize)
-	baseChunkOne = append(baseChunkOne, peek...)
 	_, _ = baseReader.Read(baseChunkTwo)
-	peek, _ = baseReader.Peek(PeekSize)
-	baseChunkTwo = append(baseChunkTwo, peek...)
 
 	// Reset the reader to the beginning and use ChunkReader.
 	_ = reReader.Reset()


### PR DESCRIPTION
- Avoid memory allocations by reusing the same slice of bytes for the chunk.
- Remove the calls to bufio.NewReader and bytes.NewReader, as they are not needed.
- Use for instead of for...if...break to avoid checking the error multiple times.

Findings suggest a pretty nice speed up of around 30% for this rather small test case.
![Screenshot 2023-01-30 at 7 01 05 PM](https://user-images.githubusercontent.com/21311841/215652734-00893979-ec97-4dc7-8fcb-eddec58c60d7.png)
![Screenshot 2023-01-30 at 7 03 00 PM](https://user-images.githubusercontent.com/21311841/215652735-f72a21de-6faf-49bd-ad62-d767a36359b2.png)
