### PR TITLE
Make signable detector regex more specifc

### DIFF
--- a/pkg/detectors/signable/signable.go
+++ b/pkg/detectors/signable/signable.go
@@ -28,7 +28,7 @@ var (
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"signable"}
+	return []string{"\bsignable"}
 }
 
 // FromData will find and optionally verify Signable secrets in a given set of bytes.


### PR DESCRIPTION
add \b to the regex to avoid matching ".. assignable: 123456.." 
