### PR TITLE
Revert "Add TruffleHog version input for GitHub action (#1064)"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -3,12 +3,8 @@ description: 'Scan Github Actions with TruffleHog'
 author: Truffle Security Co. <support@trufflesec.com>
 
 inputs:
-  version:
-    description: TruffleHog version.
-    required: false
-    default: latest
   path:
-    description: Repository path.
+    description: Repository path
     required: true
   base:
     description: Start scanning from here (usually main branch).
@@ -26,7 +22,7 @@ branding:
   color: "green"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/trufflesecurity/trufflehog:${{ inputs.version }}"
+  image: "docker://ghcr.io/trufflesecurity/trufflehog:latest"
   args:
     - git
     - file://${{ inputs.path }}


### PR DESCRIPTION
This reverts commit 8dedd08d895220e35cc1f39550e23047c5200cf3.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
