### PR TITLE
Add max commit size

### DIFF
--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -194,97 +194,123 @@ func (c *Parser) fromReader(ctx context.Context, stdOut io.Reader, commitChan ch
 	var currentDiff *Diff
 
 	defer common.RecoverWithExit(ctx)
+	defer close(commitChan)
 	for {
-		line, err := outReader.ReadBytes([]byte("\n")[0])
-		if err != nil && len(line) == 0 {
-			break
-		}
-		switch {
-		case isCommitLine(line):
-			// If there is a currentDiff, add it to currentCommit.
-			if currentDiff != nil && currentDiff.Content.Len() > 0 {
-				currentCommit.Diffs = append(currentCommit.Diffs, *currentDiff)
+		select {
+		case <-ctx.Done():
+			cleanupParse(currentCommit, currentDiff, commitChan)
+			return
+		default:
+			line, err := outReader.ReadBytes([]byte("\n")[0])
+			if err != nil && len(line) == 0 {
+				cleanupParse(currentCommit, currentDiff, commitChan)
+				return
 			}
-			// If there is a currentCommit, send it to the channel.
-			if currentCommit != nil {
-				commitChan <- *currentCommit
-			}
-			// Create a new currentDiff and currentCommit
-			currentDiff = &Diff{}
-			currentCommit = &Commit{
-				Message: strings.Builder{},
-			}
-			// Check that the commit line contains a hash and set it.
-			if len(line) >= 47 {
-				currentCommit.Hash = string(line[7:47])
-			}
-		case isAuthorLine(line):
-			currentCommit.Author = strings.TrimRight(string(line[8:]), "\n")
-		case isDateLine(line):
-			date, err := time.Parse(c.dateFormat, strings.TrimSpace(string(line[6:])))
-			if err != nil {
-				log.WithError(err).Debug("Could not parse date from git stream.")
-			}
-			currentCommit.Date = date
-		case isDiffLine(line):
-			// This should never be nil, but check in case the stdin stream is messed up.
-			if currentCommit == nil {
-				currentCommit = &Commit{}
-			}
-			if currentDiff != nil && currentDiff.Content.Len() > 0 {
-				currentCommit.Diffs = append(currentCommit.Diffs, *currentDiff)
-			}
-			currentDiff = &Diff{}
-		case isModeLine(line):
-			// NoOp
-		case isIndexLine(line):
-			// NoOp
-		case isPlusFileLine(line):
-			currentDiff.PathB = strings.TrimRight(string(line[6:]), "\n")
-		case isMinusFileLine(line):
-			// NoOp
-		case isPlusDiffLine(line):
-			currentDiff.Content.Write(line[1:])
-		case isMinusDiffLine(line):
-			// NoOp. We only care about additions.
-		case isMessageLine(line):
-			currentCommit.Message.Write(line[4:])
-		case isContextDiffLine(line):
-			currentDiff.Content.Write([]byte("\n"))
-		case isBinaryLine(line):
-			currentDiff.IsBinary = true
-			currentDiff.PathB = pathFromBinaryLine(line)
-		case isLineNumberDiffLine(line):
-			if currentDiff != nil && currentDiff.Content.Len() > 0 {
-				currentCommit.Diffs = append(currentCommit.Diffs, *currentDiff)
-			}
-			newDiff := &Diff{
-				PathB: currentDiff.PathB,
-			}
+			switch {
+			case isCommitLine(line):
+				// If there is a currentDiff, add it to currentCommit.
+				if currentDiff != nil && currentDiff.Content.Len() > 0 {
+					currentCommit.Diffs = append(currentCommit.Diffs, *currentDiff)
+				}
+				// If there is a currentCommit, send it to the channel.
+				if currentCommit != nil {
+					commitChan <- *currentCommit
+				}
+				// Create a new currentDiff and currentCommit
+				currentDiff = &Diff{}
+				currentCommit = &Commit{
+					Message: strings.Builder{},
+				}
+				// Check that the commit line contains a hash and set it.
+				if len(line) >= 47 {
+					currentCommit.Hash = string(line[7:47])
+				}
+			case isAuthorLine(line):
+				currentCommit.Author = strings.TrimRight(string(line[8:]), "\n")
+			case isDateLine(line):
+				date, err := time.Parse(c.dateFormat, strings.TrimSpace(string(line[6:])))
+				if err != nil {
+					log.WithError(err).Debug("Could not parse date from git stream.")
+				}
+				currentCommit.Date = date
+			case isDiffLine(line):
+				// This should never be nil, but check in case the stdin stream is messed up.
+				if currentCommit == nil {
+					currentCommit = &Commit{}
+				}
+				if currentDiff != nil && currentDiff.Content.Len() > 0 {
+					currentCommit.Diffs = append(currentCommit.Diffs, *currentDiff)
+					// If the currentDiff is over 1GB, drop it into the channel so it isn't held in memory waiting for more commits.
+					totalSize := 0
+					for _, diff := range currentCommit.Diffs {
+						totalSize += diff.Content.Len()
+					}
+					if totalSize > c.maxCommitSize {
+						commitChan <- *currentCommit
+						currentCommit = &Commit{
+							Hash:    currentCommit.Hash,
+							Author:  currentCommit.Author,
+							Date:    currentCommit.Date,
+							Message: currentCommit.Message,
+							Diffs:   []Diff{},
+						}
+					}
+				}
+				currentDiff = &Diff{}
+			case isModeLine(line):
+				// NoOp
+			case isIndexLine(line):
+				// NoOp
+			case isPlusFileLine(line):
+				currentDiff.PathB = strings.TrimRight(string(line[6:]), "\n")
+			case isMinusFileLine(line):
+				// NoOp
+			case isPlusDiffLine(line):
+				currentDiff.Content.Write(line[1:])
+			case isMinusDiffLine(line):
+				// NoOp. We only care about additions.
+			case isMessageLine(line):
+				currentCommit.Message.Write(line[4:])
+			case isContextDiffLine(line):
+				currentDiff.Content.Write([]byte("\n"))
+			case isBinaryLine(line):
+				currentDiff.IsBinary = true
+				currentDiff.PathB = pathFromBinaryLine(line)
+			case isLineNumberDiffLine(line):
+				if currentDiff != nil && currentDiff.Content.Len() > 0 {
+					currentCommit.Diffs = append(currentCommit.Diffs, *currentDiff)
+				}
+				newDiff := &Diff{
+					PathB: currentDiff.PathB,
+				}
 
-			currentDiff = newDiff
+				currentDiff = newDiff
 
-			words := bytes.Split(line, []byte(" "))
-			if len(words) >= 3 {
-				startSlice := bytes.Split(words[2], []byte(","))
-				lineStart, err := strconv.Atoi(string(startSlice[0]))
-				if err == nil {
-					currentDiff.LineStart = lineStart
+				words := bytes.Split(line, []byte(" "))
+				if len(words) >= 3 {
+					startSlice := bytes.Split(words[2], []byte(","))
+					lineStart, err := strconv.Atoi(string(startSlice[0]))
+					if err == nil {
+						currentDiff.LineStart = lineStart
+					}
 				}
 			}
-		}
-		if currentDiff.Content.Len() > c.maxDiffSize {
-			log.Debugf("Diff for %s exceeded MaxDiffSize(%d)", currentDiff.PathB, c.maxDiffSize)
-			break
+			if currentDiff.Content.Len() > c.maxDiffSize {
+				log.Debugf("Diff for %s exceeded MaxDiffSize(%d)", currentDiff.PathB, c.maxDiffSize)
+				cleanupParse(currentCommit, currentDiff, commitChan)
+				return
+			}
 		}
 	}
+}
+
+func cleanupParse(currentCommit *Commit, currentDiff *Diff, commitChan chan Commit) {
 	if currentDiff != nil && currentDiff.Content.Len() > 0 {
 		currentCommit.Diffs = append(currentCommit.Diffs, *currentDiff)
 	}
 	if currentCommit != nil {
 		commitChan <- *currentCommit
 	}
-	close(commitChan)
 }
 
 // Date:   Tue Aug 10 15:20:40 2021 +0100

--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -196,110 +196,108 @@ func (c *Parser) fromReader(ctx context.Context, stdOut io.Reader, commitChan ch
 	defer common.RecoverWithExit(ctx)
 	defer close(commitChan)
 	for {
-		select {
-		case <-ctx.Done():
+		if common.IsDone(ctx) {
 			cleanupParse(currentCommit, currentDiff, commitChan)
 			return
-		default:
-			line, err := outReader.ReadBytes([]byte("\n")[0])
-			if err != nil && len(line) == 0 {
-				cleanupParse(currentCommit, currentDiff, commitChan)
-				return
+		}
+		line, err := outReader.ReadBytes([]byte("\n")[0])
+		if err != nil && len(line) == 0 {
+			cleanupParse(currentCommit, currentDiff, commitChan)
+			return
+		}
+		switch {
+		case isCommitLine(line):
+			// If there is a currentDiff, add it to currentCommit.
+			if currentDiff != nil && currentDiff.Content.Len() > 0 {
+				currentCommit.Diffs = append(currentCommit.Diffs, *currentDiff)
 			}
-			switch {
-			case isCommitLine(line):
-				// If there is a currentDiff, add it to currentCommit.
-				if currentDiff != nil && currentDiff.Content.Len() > 0 {
-					currentCommit.Diffs = append(currentCommit.Diffs, *currentDiff)
+			// If there is a currentCommit, send it to the channel.
+			if currentCommit != nil {
+				commitChan <- *currentCommit
+			}
+			// Create a new currentDiff and currentCommit
+			currentDiff = &Diff{}
+			currentCommit = &Commit{
+				Message: strings.Builder{},
+			}
+			// Check that the commit line contains a hash and set it.
+			if len(line) >= 47 {
+				currentCommit.Hash = string(line[7:47])
+			}
+		case isAuthorLine(line):
+			currentCommit.Author = strings.TrimRight(string(line[8:]), "\n")
+		case isDateLine(line):
+			date, err := time.Parse(c.dateFormat, strings.TrimSpace(string(line[6:])))
+			if err != nil {
+				log.WithError(err).Debug("Could not parse date from git stream.")
+			}
+			currentCommit.Date = date
+		case isDiffLine(line):
+			// This should never be nil, but check in case the stdin stream is messed up.
+			if currentCommit == nil {
+				currentCommit = &Commit{}
+			}
+			if currentDiff != nil && currentDiff.Content.Len() > 0 {
+				currentCommit.Diffs = append(currentCommit.Diffs, *currentDiff)
+				// If the currentDiff is over 1GB, drop it into the channel so it isn't held in memory waiting for more commits.
+				totalSize := 0
+				for _, diff := range currentCommit.Diffs {
+					totalSize += diff.Content.Len()
 				}
-				// If there is a currentCommit, send it to the channel.
-				if currentCommit != nil {
+				if totalSize > c.maxCommitSize {
 					commitChan <- *currentCommit
-				}
-				// Create a new currentDiff and currentCommit
-				currentDiff = &Diff{}
-				currentCommit = &Commit{
-					Message: strings.Builder{},
-				}
-				// Check that the commit line contains a hash and set it.
-				if len(line) >= 47 {
-					currentCommit.Hash = string(line[7:47])
-				}
-			case isAuthorLine(line):
-				currentCommit.Author = strings.TrimRight(string(line[8:]), "\n")
-			case isDateLine(line):
-				date, err := time.Parse(c.dateFormat, strings.TrimSpace(string(line[6:])))
-				if err != nil {
-					log.WithError(err).Debug("Could not parse date from git stream.")
-				}
-				currentCommit.Date = date
-			case isDiffLine(line):
-				// This should never be nil, but check in case the stdin stream is messed up.
-				if currentCommit == nil {
-					currentCommit = &Commit{}
-				}
-				if currentDiff != nil && currentDiff.Content.Len() > 0 {
-					currentCommit.Diffs = append(currentCommit.Diffs, *currentDiff)
-					// If the currentDiff is over 1GB, drop it into the channel so it isn't held in memory waiting for more commits.
-					totalSize := 0
-					for _, diff := range currentCommit.Diffs {
-						totalSize += diff.Content.Len()
-					}
-					if totalSize > c.maxCommitSize {
-						commitChan <- *currentCommit
-						currentCommit = &Commit{
-							Hash:    currentCommit.Hash,
-							Author:  currentCommit.Author,
-							Date:    currentCommit.Date,
-							Message: currentCommit.Message,
-							Diffs:   []Diff{},
-						}
-					}
-				}
-				currentDiff = &Diff{}
-			case isModeLine(line):
-				// NoOp
-			case isIndexLine(line):
-				// NoOp
-			case isPlusFileLine(line):
-				currentDiff.PathB = strings.TrimRight(string(line[6:]), "\n")
-			case isMinusFileLine(line):
-				// NoOp
-			case isPlusDiffLine(line):
-				currentDiff.Content.Write(line[1:])
-			case isMinusDiffLine(line):
-				// NoOp. We only care about additions.
-			case isMessageLine(line):
-				currentCommit.Message.Write(line[4:])
-			case isContextDiffLine(line):
-				currentDiff.Content.Write([]byte("\n"))
-			case isBinaryLine(line):
-				currentDiff.IsBinary = true
-				currentDiff.PathB = pathFromBinaryLine(line)
-			case isLineNumberDiffLine(line):
-				if currentDiff != nil && currentDiff.Content.Len() > 0 {
-					currentCommit.Diffs = append(currentCommit.Diffs, *currentDiff)
-				}
-				newDiff := &Diff{
-					PathB: currentDiff.PathB,
-				}
-
-				currentDiff = newDiff
-
-				words := bytes.Split(line, []byte(" "))
-				if len(words) >= 3 {
-					startSlice := bytes.Split(words[2], []byte(","))
-					lineStart, err := strconv.Atoi(string(startSlice[0]))
-					if err == nil {
-						currentDiff.LineStart = lineStart
+					currentCommit = &Commit{
+						Hash:    currentCommit.Hash,
+						Author:  currentCommit.Author,
+						Date:    currentCommit.Date,
+						Message: currentCommit.Message,
+						Diffs:   []Diff{},
 					}
 				}
 			}
-			if currentDiff.Content.Len() > c.maxDiffSize {
-				log.Debugf("Diff for %s exceeded MaxDiffSize(%d)", currentDiff.PathB, c.maxDiffSize)
-				cleanupParse(currentCommit, currentDiff, commitChan)
-				return
+			currentDiff = &Diff{}
+		case isModeLine(line):
+			// NoOp
+		case isIndexLine(line):
+			// NoOp
+		case isPlusFileLine(line):
+			currentDiff.PathB = strings.TrimRight(string(line[6:]), "\n")
+		case isMinusFileLine(line):
+			// NoOp
+		case isPlusDiffLine(line):
+			currentDiff.Content.Write(line[1:])
+		case isMinusDiffLine(line):
+			// NoOp. We only care about additions.
+		case isMessageLine(line):
+			currentCommit.Message.Write(line[4:])
+		case isContextDiffLine(line):
+			currentDiff.Content.Write([]byte("\n"))
+		case isBinaryLine(line):
+			currentDiff.IsBinary = true
+			currentDiff.PathB = pathFromBinaryLine(line)
+		case isLineNumberDiffLine(line):
+			if currentDiff != nil && currentDiff.Content.Len() > 0 {
+				currentCommit.Diffs = append(currentCommit.Diffs, *currentDiff)
 			}
+			newDiff := &Diff{
+				PathB: currentDiff.PathB,
+			}
+
+			currentDiff = newDiff
+
+			words := bytes.Split(line, []byte(" "))
+			if len(words) >= 3 {
+				startSlice := bytes.Split(words[2], []byte(","))
+				lineStart, err := strconv.Atoi(string(startSlice[0]))
+				if err == nil {
+					currentDiff.LineStart = lineStart
+				}
+			}
+		}
+		if currentDiff.Content.Len() > c.maxDiffSize {
+			log.Debugf("Diff for %s exceeded MaxDiffSize(%d)", currentDiff.PathB, c.maxDiffSize)
+			cleanupParse(currentCommit, currentDiff, commitChan)
+			return
 		}
 	}
 }

--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -197,13 +197,11 @@ func (c *Parser) fromReader(ctx context.Context, stdOut io.Reader, commitChan ch
 	defer close(commitChan)
 	for {
 		if common.IsDone(ctx) {
-			cleanupParse(currentCommit, currentDiff, commitChan)
-			return
+			break
 		}
 		line, err := outReader.ReadBytes([]byte("\n")[0])
 		if err != nil && len(line) == 0 {
-			cleanupParse(currentCommit, currentDiff, commitChan)
-			return
+			break
 		}
 		switch {
 		case isCommitLine(line):
@@ -296,10 +294,10 @@ func (c *Parser) fromReader(ctx context.Context, stdOut io.Reader, commitChan ch
 		}
 		if currentDiff.Content.Len() > c.maxDiffSize {
 			log.Debugf("Diff for %s exceeded MaxDiffSize(%d)", currentDiff.PathB, c.maxDiffSize)
-			cleanupParse(currentCommit, currentDiff, commitChan)
-			return
+			break
 		}
 	}
+	cleanupParse(currentCommit, currentDiff, commitChan)
 }
 
 func cleanupParse(currentCommit *Commit, currentDiff *Diff, commitChan chan Commit) {


### PR DESCRIPTION
MaxDiffSize was added in a previous PR, but multiple large diffs could still be included in one commit leading to a single commit holding all the diffs in memory while parsing the rest of the commit.

This adds a maximum commit size. If the commit is larger than the max size, it will be dropped into the commitChan and an identical commit (minus existing diffs) will continue to be worked on.
