### PR TITLE
[chore] - Small cleanup

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -71,7 +71,7 @@ func (d *Archive) FromFile(originalCtx context.Context, data io.Reader) chan []b
 }
 
 // openArchive takes a reader and extracts the contents up to the maximum depth.
-func (d *Archive) openArchive(ctx context.Context, depth int, reader io.Reader, archiveChan chan ([]byte)) error {
+func (d *Archive) openArchive(ctx context.Context, depth int, reader io.Reader, archiveChan chan []byte) error {
 	if depth >= maxDepth {
 		return fmt.Errorf("max archive depth reached")
 	}
@@ -110,7 +110,7 @@ func (d *Archive) openArchive(ctx context.Context, depth int, reader io.Reader, 
 		newReader := bytes.NewReader(fileBytes)
 		return d.openArchive(ctx, depth+1, newReader, archiveChan)
 	}
-	return fmt.Errorf("Unknown archive type: %s", format.Name())
+	return fmt.Errorf("unknown archive type: %s", format.Name())
 }
 
 // IsFiletype returns true if the provided reader is an archive.

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/mholt/archiver/v4"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
@@ -51,8 +52,8 @@ func SetArchiveMaxTimeout(timeout time.Duration) {
 }
 
 // FromFile extracts the files from an archive.
-func (d *Archive) FromFile(originalCtx context.Context, data io.Reader) chan ([]byte) {
-	archiveChan := make(chan ([]byte), 512)
+func (d *Archive) FromFile(originalCtx context.Context, data io.Reader) chan []byte {
+	archiveChan := make(chan []byte, 512)
 	go func() {
 		ctx, cancel := context.WithTimeout(originalCtx, maxTimeout)
 		logger := logContext.AddLogger(ctx).Logger()
@@ -113,7 +114,7 @@ func (d *Archive) openArchive(ctx context.Context, depth int, reader io.Reader, 
 }
 
 // IsFiletype returns true if the provided reader is an archive.
-func (d *Archive) IsFiletype(ctx context.Context, reader io.Reader) (io.Reader, bool) {
+func (d *Archive) IsFiletype(_ context.Context, reader io.Reader) (io.Reader, bool) {
 	format, readerB, err := archiver.Identify("", reader)
 	if err != nil {
 		return readerB, false
@@ -128,7 +129,7 @@ func (d *Archive) IsFiletype(ctx context.Context, reader io.Reader) (io.Reader, 
 }
 
 // extractorHandler is applied to each file in an archiver.Extractor file.
-func (d *Archive) extractorHandler(archiveChan chan ([]byte)) func(context.Context, archiver.File) error {
+func (d *Archive) extractorHandler(archiveChan chan []byte) func(context.Context, archiver.File) error {
 	return func(ctx context.Context, f archiver.File) error {
 		logger := logContext.AddLogger(ctx).Logger()
 		logger.V(5).Info("Handling extracted file.", "filename", f.Name())
@@ -168,7 +169,7 @@ func (d *Archive) ReadToMax(ctx context.Context, reader io.Reader) (data []byte,
 			if e, ok := r.(error); ok {
 				err = e
 			} else {
-				err = fmt.Errorf("Panic occurred: %v", r)
+				err = fmt.Errorf("panic occurred: %v", r)
 			}
 			logger.Error(err, "Panic occurred when reading archive")
 		}

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -8,18 +8,28 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
+// DefaultHandlers returns all the default handlers.
 func DefaultHandlers() []Handler {
 	return []Handler{
 		&Archive{},
 	}
 }
 
+// Handler is responsible for extracting data from a file.
 type Handler interface {
+	// FromFile takes in a file and returns a channel of bytes that are
+	// extracted from the file.
 	FromFile(context.Context, io.Reader) chan []byte
+	// IsFiletype takes in a file and returns whether the file is of the
+	// given type.
 	IsFiletype(context.Context, io.Reader) (io.Reader, bool)
+	// New creates a new handler.
 	New()
 }
 
+// HandleFile takes in different file types and extracts the data from them.
+// It sends the chunked data on the chunksChan.
+// It returns true if the file was handled, false otherwise.
 func HandleFile(ctx context.Context, file io.Reader, chunkSkel *sources.Chunk, chunksChan chan *sources.Chunk) bool {
 	// Find a handler for this file.
 	var handler Handler
@@ -44,6 +54,7 @@ func HandleFile(ctx context.Context, file io.Reader, chunkSkel *sources.Chunk, c
 		if common.IsDone(ctx) {
 			return false
 		}
+		// Send data on chunksChan.
 		chunksChan <- &chunk
 	}
 	return true

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
@@ -14,12 +15,12 @@ func DefaultHandlers() []Handler {
 }
 
 type Handler interface {
-	FromFile(context.Context, io.Reader) chan ([]byte)
+	FromFile(context.Context, io.Reader) chan []byte
 	IsFiletype(context.Context, io.Reader) (io.Reader, bool)
 	New()
 }
 
-func HandleFile(ctx context.Context, file io.Reader, chunkSkel *sources.Chunk, chunksChan chan (*sources.Chunk)) bool {
+func HandleFile(ctx context.Context, file io.Reader, chunkSkel *sources.Chunk, chunksChan chan *sources.Chunk) bool {
 	// Find a handler for this file.
 	var handler Handler
 	for _, h := range DefaultHandlers() {
@@ -36,23 +37,14 @@ func HandleFile(ctx context.Context, file io.Reader, chunkSkel *sources.Chunk, c
 
 	// Process the file and read all []byte chunks from handlerChan.
 	handlerChan := handler.FromFile(ctx, file)
-	for {
-		select {
-		case data, open := <-handlerChan:
-			if !open {
-				// We finished reading everything from handlerChan.
-				return true
-			}
-			chunk := *chunkSkel
-			chunk.Data = data
-			// Send data on chunksChan.
-			select {
-			case chunksChan <- &chunk:
-			case <-ctx.Done():
-				return false
-			}
-		case <-ctx.Done():
+	for data := range handlerChan {
+		chunk := *chunkSkel
+		chunk.Data = data
+
+		if common.IsDone(ctx) {
 			return false
 		}
+		chunksChan <- &chunk
 	}
+	return true
 }


### PR DESCRIPTION
- Remove redundant parens.
- Remove select and directly iterate over channel.
- Add commentary to exported methods and struct fields.