### PR TITLE
fixing browserstack regex username detection

### DIFF
--- a/pkg/detectors/browserstack/browserstack.go
+++ b/pkg/detectors/browserstack/browserstack.go
@@ -20,8 +20,8 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"browserstack", "key", "automate", "local"}) + `\b([0-9a-zA-Z_]{20})\b`)
-	userPat = regexp.MustCompile(detectors.PrefixRegex([]string{"browserstack", "user", "automate", "local"}) + `\b([a-zA-Z\d]{3,18}[._-]+[a-zA-Z\d]{6})\b`)
+	keyPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"browserstack", "key", "automate", "local"}) + `\b([0-9a-zA-Z]{20})\b`)
+	userPat = regexp.MustCompile(detectors.PrefixRegex([]string{"browserstack", "user", "automate", "local"}) + `\b([a-zA-Z\d]{3,18}[._-]?[a-zA-Z\d]{6})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
Old pr https://github.com/trufflesecurity/trufflehog/pull/1120 
Correction to detect Old usernames also. Added sample keys below.
The old regex is not detecting browserstack old/new usernames. They are coming in URI detector.

Sample old and new format of credentials are below:
[min,max] length for username is [3,24]
[min,max] length for password is fixed [20]

Old format:
Username = AutumnShikariX
password = Qxx2dz8Q1sy4qqLXkv71
Below in Url format
https://Username:Password@hub-cloud.browserstack.com/wd/hub
http://AutumnShikariX:Qxx2dz8Q1sy4qqLXkv71@hub.browserstack.com/wd/hub
https://rajuRajumdemo1:3iskPrkpEsseiwerAxKB@hub-cloud.browserstack.com/wd/hub
http://Qrchishzhakkar0:698xhfyLX7zieapewH4f@hub-cloud.browserstack.com/wd/hub

New format:
Username = Princetonprinceton_7D2Tbt
Password = XpaGdDCXPrVJ16YUqsHW
Below in Url format
https://Username:Password@hub-cloud.browserstack.com/wd/hub
https://Princetonprinceton_7D2Tbt:XpaGdDCXPrVJ16YUqsHW@hub-cloud.browserstack.com/wd/hub
https://haydenearthXz_bGIqXD:x4dW8YzeF11YCZqwQ6Up@hub-cloud.browserstack.com/wd/hub
http://garybrown4U_bE4JkU:pdssmsj9TXxUef71xdej@hub-cloud.browserstack.com/wd/hub

