### PR TITLE
[chore] Implement String for ScanErrors

### DIFF
--- a/pkg/sources/errors.go
+++ b/pkg/sources/errors.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"fmt"
 	"sync"
 )
 
@@ -28,4 +29,8 @@ func (s *ScanErrors) Count() uint64 {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return uint64(len(s.errors))
+}
+
+func (s *ScanErrors) String() string {
+	return fmt.Sprintf("%v", s.errors)
 }

--- a/pkg/sources/errors_test.go
+++ b/pkg/sources/errors_test.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -145,5 +146,14 @@ func TestScanErrorsCount(t *testing.T) {
 				t.Errorf("got %d, want %d", se.Count(), tc.wantErrCnt)
 			}
 		})
+	}
+}
+
+func TestScanErrorsString(t *testing.T) {
+	se := NewScanErrors()
+	se.Add(nil)
+	want := "[<nil>]"
+	if got := fmt.Sprintf("%v", se); got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
This will concatenate all errors together into a single string. When possible, it would be better to log the actual errors slice to take advantage of structured logging.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
