### PR TITLE
Disable profiler in debug mode and add profile switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Flags:
       --help                     Show context-sensitive help (also try --help-long and --help-man).
       --debug                    Run in debug mode.
       --trace                    Run in trace mode.
+      --profile                  Enables profiling and sets a pprof and fgprof server on :18066.
   -j, --json                     Output in JSON format.
       --json-legacy              Use the pre-v3.0 JSON format. Only works with git, gitlab, and github sources.
       --concurrency=10           Number of concurrent workers.

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ var (
 	cmd              string
 	debug            = cli.Flag("debug", "Run in debug mode.").Bool()
 	trace            = cli.Flag("trace", "Run in trace mode.").Bool()
+	profile          = cli.Flag("profile", "Enables profiling and sets a pprof and fgprof server on :18066.").Bool()
 	jsonOut          = cli.Flag("json", "Output in JSON format.").Short('j').Bool()
 	jsonLegacy       = cli.Flag("json-legacy", "Use the pre-v3.0 JSON format. Only works with git, gitlab, and github sources.").Bool()
 	concurrency      = cli.Flag("concurrency", "Number of concurrent workers.").Default(strconv.Itoa(runtime.NumCPU())).Int()
@@ -183,7 +184,7 @@ func run(state overseer.State) {
 		*concurrency = 1
 	}
 
-	if *debug {
+	if *profile {
 		go func() {
 			router := mux.NewRouter()
 			router.PathPrefix("/debug/pprof").Handler(http.DefaultServeMux)


### PR DESCRIPTION
This fixes issue #1135 

In its current state, trufflehog will configure a profiler fgprog and pprog using the [fgprof](https://github.com/felixge/fgprof) project.

This same project warns about a considerable overhead when using many goroutines:
> The overhead of fgprof increases with the number of active goroutines (including those waiting on I/O, Channels, Locks, etc.) executed by your program. If your program typically has less than 1000 active goroutines, you shouldn't have much to worry about. However, at 10k or more goroutines fgprof might start to cause some noticeable overhead. 

Changes:
- Separate the profiling mode from debug
- `--debug` is still a switch available and allows for debug logging
- `--profile` is  anew switch available and enables the profiling in an opt-in fashion
