### PR TITLE
Add OpenAI API Tokens detector

### DIFF
--- a/pkg/detectors/openai/openai.go
+++ b/pkg/detectors/openai/openai.go
@@ -1,0 +1,113 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strconv"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+)
+
+type Scanner struct{}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	keyPat = regexp.MustCompile(`\b((?:sk)-[a-zA-Z0-9]{48})\b`)
+)
+
+// TODO: Add secret context?? Information about access, ownership etc
+type orgResponse struct {
+	Data []organization `json:"data"`
+}
+
+type organization struct {
+	Id          string `json:"id"`
+	Title       string `json:"title"`
+	User        string `json:"name"`
+	Description string `json:"description"`
+	Personal    bool   `json:"personal"`
+	Default     bool   `json:"is_default"`
+	Role        string `json:"role"`
+}
+
+// Keywords are used for efficiently pre-filtering chunks.
+// Use identifiers in the secret preferably, or the provider name.
+func (s Scanner) Keywords() []string {
+	return []string{"sk-"}
+}
+
+// FromData will find and optionally verify OpenAI secrets in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
+
+	for _, match := range matches {
+		// First match is entire regex, second is the first group.
+		if len(match) != 2 {
+			continue
+		}
+
+		token := match[1]
+
+		s1 := detectors.Result{
+			DetectorType: detectorspb.DetectorType_OpenAI,
+			Redacted:     token[:3] + "..." + token[47:],
+			Raw:          []byte(token),
+		}
+
+		if verify {
+			client := common.SaneHttpClient()
+			// Undocumented API
+			// https://api.openai.com/v1/organizations
+			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.openai.com/v1/organizations", nil)
+			if err != nil {
+				continue
+			}
+			req.Header.Add("Content-Type", "application/json; charset=utf-8")
+			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+			res, err := client.Do(req)
+			if err == nil {
+				if res.StatusCode >= 200 && res.StatusCode < 300 {
+					var orgs orgResponse
+					err = json.NewDecoder(res.Body).Decode(&orgs)
+					res.Body.Close()
+					if err == nil {
+						s1.Verified = true
+						org := orgs.Data[0]
+						s1.ExtraData = map[string]string{
+							"id":          org.Id,
+							"title":       org.Title,
+							"user":        org.User,
+							"description": org.Description,
+							"role":        org.Role,
+							"is_personal": strconv.FormatBool(org.Personal),
+							"is_default":  strconv.FormatBool(org.Default),
+							"total_orgs":  fmt.Sprintf("%d", len(orgs.Data)),
+						}
+					}
+				}
+			}
+		}
+
+		if !s1.Verified && detectors.IsKnownFalsePositive(string(s1.Raw), detectors.DefaultFalsePositives, true) {
+			continue
+		}
+
+		results = append(results, s1)
+	}
+
+	return
+}
+
+func (s Scanner) Type() detectorspb.DetectorType {
+	return detectorspb.DetectorType_OpenAI
+}

--- a/pkg/detectors/openai/openai_test.go
+++ b/pkg/detectors/openai/openai_test.go
@@ -1,0 +1,132 @@
+//go:build detectors
+// +build detectors
+
+package openai
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+func TestOpenAI_FromChunk(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors4")
+	if err != nil {
+		t.Fatalf("could not get test secrets from GCP: %s", err)
+	}
+
+	oaiUnverified := testSecrets.MustGetField("OPENAI_UNVERIFIED")
+	oaiVerified := testSecrets.MustGetField("OPENAI_VERIFIED")
+
+	type args struct {
+		ctx    context.Context
+		data   []byte
+		verify bool
+	}
+
+	tests := []struct {
+		name    string
+		s       Scanner
+		args    args
+		want    []detectors.Result
+		wantErr bool
+	}{
+		{
+			name: "Found, unverified OpenAI token sk-",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a github secret %s within", oaiUnverified)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_OpenAI,
+					Redacted:     "sk-...xxxx",
+					Verified:     false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Found, unverified ghp future length 255",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a github secret %s within", oaiVerified)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_OpenAI,
+					Verified:     true,
+					Redacted:     "sk-...xxxx",
+					ExtraData: map[string]string{
+						"description": "",
+						"id":          "",
+						"is_default":  "",
+						"is_personal": "",
+						"role":        "",
+						"title":       "",
+						"total_orgs":  "",
+						"user":        "",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "not found",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte("You cannot find the secret within"),
+				verify: true,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Scanner{}
+			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("OpenAI.FromData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if len(got[i].Raw) == 0 {
+					t.Fatal("no raw secret present")
+				}
+				got[i].Raw = nil
+			}
+			if diff := pretty.Compare(got, tt.want); diff != "" {
+				t.Errorf("OpenAI.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			}
+		})
+	}
+}
+
+func BenchmarkFromData(benchmark *testing.B) {
+	ctx := context.Background()
+	s := Scanner{}
+	for name, data := range detectors.MustGetBenchmarkData() {
+		benchmark.Run(name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				_, err := s.FromData(ctx, false, data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/detectors/openai/openai_test.go
+++ b/pkg/detectors/openai/openai_test.go
@@ -44,7 +44,7 @@ func TestOpenAI_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a github secret %s within", oaiUnverified)),
+				data:   []byte(fmt.Sprintf("You can find an OpenAI secret %s within", oaiUnverified)),
 				verify: true,
 			},
 			want: []detectors.Result{
@@ -57,11 +57,11 @@ func TestOpenAI_FromChunk(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Found, unverified ghp future length 255",
+			name: "Found, verified OpenAI token sk-",
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a github secret %s within", oaiVerified)),
+				data:   []byte(fmt.Sprintf("You can find an OpenAI secret %s within", oaiVerified)),
 				verify: true,
 			},
 			want: []detectors.Result{

--- a/pkg/engine/defaults.go
+++ b/pkg/engine/defaults.go
@@ -442,6 +442,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/onesignal"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/onwaterio"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/oopspam"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/openai"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/opencagedata"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/opengraphr"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/openuv"
@@ -1166,6 +1167,7 @@ func DefaultDetectors() []detectors.Detector {
 		signupgenius.Scanner{},
 		streak.Scanner{},
 		route4me.Scanner{},
+		openai.Scanner{},
 		opencagedata.Scanner{},
 		positionstack.Scanner{},
 		upcdatabase.Scanner{},


### PR DESCRIPTION
This feature is related to #1140 

This change adds the detection of OpenAI API Tokens in their current form. It also verifies the token (using an endpoint used by the UI of https://platform.openai.com/ but isn't documented in https://platform.openai.com/docs/api-reference/).

The verification pulls extraData for the first organizaton fetched that can help the user understand which organization can be accessed by the token, how many organizations are accessible with the token,...


**IMPORTANT BEFORE MERGING**
Before merging, please add the following secrets
- OPENAI_UNVERIFIED with a value of `sk-xX1xX2xX3xX4xX5xX6xX7xX8xX9xX0xX1xX2xX3xX456xxxx`
- OPENAI_VERIFIED with a valid token
    - Update the wants part of the verified test to match what is returned and part of the extradata) 