### PR TITLE
Remove period from file extension

### DIFF
--- a/pkg/common/vars.go
+++ b/pkg/common/vars.go
@@ -2,16 +2,17 @@ package common
 
 import (
 	"path/filepath"
+	"strings"
 )
 
 var (
 	KB, MB, GB, TB, PB = 1e3, 1e6, 1e9, 1e12, 1e15
-	IGNORED_EXTENSIONS = []string{"mp4", "avi", "mpeg", "mpg", "mov", "wmv", "m4p", "swf", "mp2", "flv", "vob", "webm", "hdv", "3gp", "ogg", "mp3", "wav", "flac", "webp"}
+	IgnoredExtensions  = []string{"mp4", "avi", "mpeg", "mpg", "mov", "wmv", "m4p", "swf", "mp2", "flv", "vob", "webm", "hdv", "3gp", "ogg", "mp3", "wav", "flac", "webp"}
 )
 
 func SkipFile(filename string) bool {
-	for _, ext := range IGNORED_EXTENSIONS {
-		if filepath.Ext(filename) == ext {
+	for _, ext := range IgnoredExtensions {
+		if strings.TrimPrefix(filepath.Ext(filename), ".") == ext {
 			return true
 		}
 	}

--- a/pkg/common/vars_test.go
+++ b/pkg/common/vars_test.go
@@ -8,6 +8,7 @@ func TestSkipFile(t *testing.T) {
 		want bool
 	}
 
+	// Add a test case for each ignored extension.
 	testCases := make([]testCase, 0, len(IgnoredExtensions)+1)
 	for _, ext := range IgnoredExtensions {
 		testCases = append(testCases, testCase{
@@ -15,6 +16,8 @@ func TestSkipFile(t *testing.T) {
 			want: true,
 		})
 	}
+
+	// Add a test case for a file that should not be skipped.
 	testCases = append(testCases, testCase{file: "test.txt", want: false})
 
 	for _, tt := range testCases {

--- a/pkg/common/vars_test.go
+++ b/pkg/common/vars_test.go
@@ -1,0 +1,33 @@
+package common
+
+import "testing"
+
+func TestSkipFile(t *testing.T) {
+	type testCase struct {
+		file string
+		want bool
+	}
+
+	testCases := make([]testCase, 0, len(IgnoredExtensions)+1)
+	for _, ext := range IgnoredExtensions {
+		testCases = append(testCases, testCase{
+			file: "test." + ext,
+			want: true,
+		})
+	}
+	testCases = append(testCases, testCase{file: "test.txt", want: false})
+
+	for _, tt := range testCases {
+		t.Run(tt.file, func(t *testing.T) {
+			if got := SkipFile(tt.file); got != tt.want {
+				t.Errorf("SkipFile(%v) got %v, want %v", tt.file, got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkSkipFile(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		SkipFile("test.mp4")
+	}
+}


### PR DESCRIPTION
- filepath.Ext returns the file extension with a prepended ".". This was resulting in not skipping files that should have been skipped.