### PR TITLE
fixed mesibo detector

### DIFF
--- a/pkg/detectors/mesibo/mesibo.go
+++ b/pkg/detectors/mesibo/mesibo.go
@@ -13,7 +13,6 @@ import (
 )
 
 type Scanner struct{}
-
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 
@@ -61,7 +60,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				body := string(bodyBytes)
 
-				if !strings.Contains(body, "INVALIDTOKEN") {
+				if !strings.Contains(body, "AUTHFAIL") {
 					s1.Verified = true
 				} else {
 					if detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {


### PR DESCRIPTION
fixed the mesibo verification method. the error msg contains AUTHFAIL and not INVALIDTOKEN. was creating false positive.

curl "https://api.mesibo.com/api.php?op=useradd&token=f1ea38be94fe8688787acb6811bb3d911be599d8ef79fbb2984a2bfb2b6e982c"
{"error":"AUTHFAIL","code":401,"cause":"Invalid or expired app token","properties":["token"],"op":"useradd","result":false}
