### PR TITLE
updating browserstack detector user and key PrefixRegex strings

### DIFF
--- a/pkg/detectors/browserstack/browserstack.go
+++ b/pkg/detectors/browserstack/browserstack.go
@@ -20,8 +20,8 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"browserstack", "key", "automate", "local"}) + `\b([0-9a-zA-Z]{20})\b`)
-	userPat = regexp.MustCompile(detectors.PrefixRegex([]string{"browserstack", "user", "automate", "local"}) + `\b([a-zA-Z\d]{3,18}[._-]?[a-zA-Z\d]{6})\b`)
+	keyPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"https://", "http://", "hub-cloud.browserstack.com", "accessKey", "\"access_Key\":", "ACCESS_KEY", "key", "browserstackKey", "BS_AUTHKEY", "BROWSERSTACK_ACCESS_KEY"}) + `\b([0-9a-zA-Z]{20})\b`)
+	userPat = regexp.MustCompile(detectors.PrefixRegex([]string{"https://", "http://", "hub-cloud.browserstack.com", "userName", "\"username\":", "USER_NAME", "user", "browserstackUser", "BS_USERNAME", "BROWSERSTACK_USERNAME"}) + `\b([a-zA-Z\d]{3,18}[._-]+[a-zA-Z\d]{6})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
updating browserstack detector user and key PrefixRegex strings
We have add all the possible strings for user and key from browserstack docs found here - https://www.browserstack.com/docs/
Tested keys detection by browserstack detector by local [go setup](https://github.com/trufflesecurity/trufflehog#1-go) 

Old PR's :  https://github.com/trufflesecurity/trufflehog/pull/1120  https://github.com/trufflesecurity/trufflehog/pull/1123
