### PR TITLE
Fix git commit date string formatting

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -378,7 +378,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 			var email, hash, when string
 			email = commit.Author
 			hash = commit.Hash
-			when = commit.Date.String()
+			when = commit.Date.Format("2006-01-02 15:04:05 -0700")
 
 			// Handle binary files by reading the entire file rather than using the diff.
 			if diff.IsBinary {
@@ -520,7 +520,7 @@ func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string,
 			var email, hash, when string
 			email = commit.Author
 			hash = commit.Hash
-			when = commit.Date.String()
+			when = commit.Date.Format("2006-01-02 15:04:05 -0700")
 
 			// Handle binary files by reading the entire file rather than using the diff.
 			if diff.IsBinary {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
I noticed that the Git dates are formatted with two timezones due to the way `time.Time.String()` is implemented. This change outputs the date in a similar, almost-RFC3339 format, but with the timezone only appearing once.

The way that Go's date formatting works makes me a bit uncomfortable, but it must work well enough given that [all of the built-in date formats use it](https://github.com/golang/go/blob/master/src/time/format.go#L102-L121), so I followed the same pattern. The date used in the implementation is the one used by [Go's `time.RFC3339`](https://github.com/golang/go/blob/master/src/time/format.go#L111) since the string being output is similar.

## Example

```
// Before
2023-03-08 15:55:42 -0500 -0500

// After
2023-03-08 15:55:42 -0500
```

## Resources
- [Related GitHub issue: trufflesecurity/trufflehog#1047](https://github.com/trufflesecurity/trufflehog/issues/1047)
- [Go's `time.Time.String()` documentation](https://pkg.go.dev/time#Time.String)