### PR TITLE
[chore] Add a break statement when iterating through keywords

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -260,6 +260,7 @@ func (e *Engine) detectorWorker(ctx context.Context) {
 						for _, kw := range detector.Keywords() {
 							if _, ok := matchedKeywords[strings.ToLower(kw)]; ok {
 								chunkContainsKeyword = true
+								break
 							}
 						}
 


### PR DESCRIPTION
This PR adds a break statement to exit a loop early once a keyword has been found. This is a _very_ minor optimization but is more consistent with the previous algorithm we were using which will make writing the blog post about aho-corasick easier. 