### PR TITLE
Support for exclude globs at the `git log` level

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ var (
 	gitScanURI          = gitScan.Arg("uri", "Git repository URL. https://, file://, or ssh:// schema expected.").Required().String()
 	gitScanIncludePaths = gitScan.Flag("include-paths", "Path to file with newline separated regexes for files to include in scan.").Short('i').String()
 	gitScanExcludePaths = gitScan.Flag("exclude-paths", "Path to file with newline separated regexes for files to exclude in scan.").Short('x').String()
-	gitScanExcludeGlobs = gitScan.Flag("exclude-globs", "Comma separated list of globs to exclude in scan.").String()
+	gitScanExcludeGlobs = gitScan.Flag("exclude-globs", "Comma separated list of globs to exclude in scan. This option filters at the `git log` level, resulting in faster scans.").String()
 	gitScanSinceCommit  = gitScan.Flag("since-commit", "Commit to start scan from.").String()
 	gitScanBranch       = gitScan.Flag("branch", "Branch to scan.").String()
 	gitScanMaxDepth     = gitScan.Flag("max-depth", "Maximum depth of commits to scan.").Int()

--- a/main.go
+++ b/main.go
@@ -302,7 +302,10 @@ func run(state overseer.State) {
 		if remote {
 			defer os.RemoveAll(repoPath)
 		}
-		excludedGlobs := strings.Split(*gitScanExcludeGlobs, ",")
+		excludedGlobs := []string{}
+		if *gitScanExcludeGlobs != "" {
+			excludedGlobs = strings.Split(*gitScanExcludeGlobs, ",")
+		}
 
 		cfg := sources.GitConfig{
 			RepoPath:     repoPath,

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ var (
 	gitScanURI          = gitScan.Arg("uri", "Git repository URL. https://, file://, or ssh:// schema expected.").Required().String()
 	gitScanIncludePaths = gitScan.Flag("include-paths", "Path to file with newline separated regexes for files to include in scan.").Short('i').String()
 	gitScanExcludePaths = gitScan.Flag("exclude-paths", "Path to file with newline separated regexes for files to exclude in scan.").Short('x').String()
+	gitScanExcludeGlobs = gitScan.Flag("exclude-globs", "Comma separated list of globs to exclude in scan.").String()
 	gitScanSinceCommit  = gitScan.Flag("since-commit", "Commit to start scan from.").String()
 	gitScanBranch       = gitScan.Flag("branch", "Branch to scan.").String()
 	gitScanMaxDepth     = gitScan.Flag("max-depth", "Maximum depth of commits to scan.").Int()
@@ -301,13 +302,15 @@ func run(state overseer.State) {
 		if remote {
 			defer os.RemoveAll(repoPath)
 		}
+		excludedGlobs := strings.Split(*gitScanExcludeGlobs, ",")
 
 		cfg := sources.GitConfig{
-			RepoPath: repoPath,
-			HeadRef:  *gitScanBranch,
-			BaseRef:  *gitScanSinceCommit,
-			MaxDepth: *gitScanMaxDepth,
-			Filter:   filter,
+			RepoPath:     repoPath,
+			HeadRef:      *gitScanBranch,
+			BaseRef:      *gitScanSinceCommit,
+			MaxDepth:     *gitScanMaxDepth,
+			Filter:       filter,
+			ExcludeGlobs: excludedGlobs,
 		}
 		if err = e.ScanGit(ctx, cfg); err != nil {
 			logFatal(err, "Failed to scan Git.")

--- a/pkg/engine/git.go
+++ b/pkg/engine/git.go
@@ -36,6 +36,9 @@ func (e *Engine) ScanGit(ctx context.Context, c sources.GitConfig) error {
 	if c.HeadRef != "" {
 		opts = append(opts, git.ScanOptionHeadCommit(c.HeadRef))
 	}
+	if c.ExcludeGlobs != nil {
+		opts = append(opts, git.ScanOptionExcludeGlobs(c.ExcludeGlobs))
+	}
 	scanOptions := git.NewScanOptions(opts...)
 
 	gitSource := git.NewGit(sourcespb.SourceType_SOURCE_TYPE_GIT, 0, 0, "trufflehog - git", true, runtime.NumCPU(),

--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -126,10 +126,8 @@ func (c *Parser) RepoPath(ctx context.Context, source string, head string, abbre
 	} else {
 		args = append(args, "--all")
 	}
-	if len(excludedGlobs) != 0 {
-		for _, glob := range excludedGlobs {
-			args = append(args, "--", ".", fmt.Sprintf(":(exclude)%s", glob))
-		}
+	for _, glob := range excludedGlobs {
+		args = append(args, "--", ".", fmt.Sprintf(":(exclude)%s", glob))
 	}
 
 	cmd := exec.Command("git", args...)

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -338,7 +338,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 		return err
 	}
 
-	commitChan, err := gitparse.NewParser().RepoPath(ctx, path, scanOptions.HeadHash, scanOptions.BaseHash == "")
+	commitChan, err := gitparse.NewParser().RepoPath(ctx, path, scanOptions.HeadHash, scanOptions.BaseHash == "", scanOptions.ExcludeGlobs)
 	if err != nil {
 		return err
 	}

--- a/pkg/sources/git/scan_options.go
+++ b/pkg/sources/git/scan_options.go
@@ -6,11 +6,12 @@ import (
 )
 
 type ScanOptions struct {
-	Filter     *common.Filter
-	BaseHash   string // When scanning a git.Log, this is the oldest/first commit.
-	HeadHash   string
-	MaxDepth   int64
-	LogOptions *git.LogOptions
+	Filter       *common.Filter
+	BaseHash     string // When scanning a git.Log, this is the oldest/first commit.
+	HeadHash     string
+	MaxDepth     int64
+	ExcludeGlobs []string
+	LogOptions   *git.LogOptions
 }
 
 type ScanOption func(*ScanOptions)
@@ -36,6 +37,12 @@ func ScanOptionHeadCommit(hash string) ScanOption {
 func ScanOptionMaxDepth(maxDepth int64) ScanOption {
 	return func(scanOptions *ScanOptions) {
 		scanOptions.MaxDepth = maxDepth
+	}
+}
+
+func ScanOptionExcludeGlobs(globs []string) ScanOption {
+	return func(scanOptions *ScanOptions) {
+		scanOptions.ExcludeGlobs = globs
 	}
 }
 

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -83,7 +83,8 @@ type GitConfig struct {
 	MaxDepth int
 	// Filter is the filter to use to scan the source.
 	Filter *common.Filter
-	// ExcludedGlobs
+	// ExcludeGlobs is a list of globs to exclude from the scan.
+	// This differs from the Filter exclusions as ExcludeGlobs is applied at the `git log -p` level
 	ExcludeGlobs []string
 }
 

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -83,6 +83,8 @@ type GitConfig struct {
 	MaxDepth int
 	// Filter is the filter to use to scan the source.
 	Filter *common.Filter
+	// ExcludedGlobs
+	ExcludeGlobs []string
 }
 
 // GithubConfig defines the optional configuration for a github source.


### PR DESCRIPTION
### What does this PR do?

Adds a `git` scan mode option to exclude globs at the `git log` level. This is useful if a repo has known files/directories that should be ignored by scans like `/vendor` for Go projects, or `/node_modules ` for node projects.

try it yourself:

```
# This should only report false positives from `go.mod`

git clone -b feature-exclude https://github.com/trufflesecurity/trufflehog.git
cd trufflehog
go build && ./trufflehog  git --no-verification --exclude-globs='**/*.proto,**/*.go' file://$PWD
```
