### PR TITLE
lint on all branches to catch warnings earlier

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - main
   pull_request:
 
 permissions:


### PR DESCRIPTION
This PR adds linting to all branches. Imo the best time to catch lint warnings would be on developmental branches. 