### PR TITLE
Use OAuth2 http client with GCS

### DIFF
--- a/pkg/sources/gcs/gcs.go
+++ b/pkg/sources/gcs/gcs.go
@@ -113,11 +113,11 @@ func configureGCSManager(aCtx context.Context, conn *sourcespb.GCS, concurrency 
 	case *sourcespb.GCS_Unauthenticated:
 		gcsManagerAuthOption = withoutAuthentication()
 	case *sourcespb.GCS_Oauth:
-		oauth2Client, err := oauth2Client(aCtx, conn.GetOauth())
+		client, err := oauth2Client(aCtx, conn.GetOauth())
 		if err != nil {
 			return nil, fmt.Errorf("error creating oauth2 client: %w", err)
 		}
-		gcsManagerAuthOption = withHTTPClient(aCtx, oauth2Client)
+		gcsManagerAuthOption = withHTTPClient(aCtx, client)
 	default:
 		return nil, fmt.Errorf("unknown GCS authentication type: %T", conn.Credential)
 

--- a/pkg/sources/gcs/gcs.go
+++ b/pkg/sources/gcs/gcs.go
@@ -3,18 +3,23 @@ package gcs
 import (
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strconv"
 	"sync"
 
+	"cloud.google.com/go/storage"
 	diskbufferreader "github.com/bill-rich/disk-buffer-reader"
 	"github.com/go-errors/errors"
 	"github.com/go-logr/logr"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/endpoints"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/handlers"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/credentialspb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
@@ -107,6 +112,12 @@ func configureGCSManager(aCtx context.Context, conn *sourcespb.GCS, concurrency 
 		gcsManagerAuthOption = withDefaultADC(aCtx)
 	case *sourcespb.GCS_Unauthenticated:
 		gcsManagerAuthOption = withoutAuthentication()
+	case *sourcespb.GCS_Oauth:
+		oauth2Client, err := oauth2Client(aCtx, conn.GetOauth())
+		if err != nil {
+			return nil, fmt.Errorf("error creating oauth2 client: %w", err)
+		}
+		gcsManagerAuthOption = withHTTPClient(aCtx, oauth2Client)
 	default:
 		return nil, fmt.Errorf("unknown GCS authentication type: %T", conn.Credential)
 
@@ -130,6 +141,31 @@ func configureGCSManager(aCtx context.Context, conn *sourcespb.GCS, concurrency 
 	}
 
 	return gcsManager, nil
+}
+
+func oauth2Client(ctx context.Context, creds *credentialspb.Oauth2) (*http.Client, error) {
+	if creds == nil {
+		return nil, fmt.Errorf("oauth2 credentials are required")
+	}
+	if creds.GetClientId() == "" || creds.GetRefreshToken() == "" || creds.GetAccessToken() == "" {
+		return nil, fmt.Errorf("oauth2 credentials are incomplete, client_id, refresh_token, and access_token are required")
+	}
+
+	conf := &oauth2.Config{
+		ClientID: creds.GetClientId(),
+		Scopes:   []string{storage.ScopeReadOnly},
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  endpoints.Google.AuthURL,
+			TokenURL: endpoints.Google.TokenURL,
+		},
+	}
+
+	tok := &oauth2.Token{
+		AccessToken:  creds.GetAccessToken(),
+		RefreshToken: creds.GetRefreshToken(),
+	}
+
+	return conf.Client(ctx, tok), nil
 }
 
 func setGCSManagerBucketOptions(conn *sourcespb.GCS) gcsManagerOption {

--- a/pkg/sources/gcs/gcs_manager.go
+++ b/pkg/sources/gcs/gcs_manager.go
@@ -4,6 +4,7 @@ import (
 	aCtx "context"
 	"fmt"
 	"io"
+	"net/http"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -118,6 +119,19 @@ func (s *attributes) setBucketCnt(bkt string, cnt uint64) {
 }
 
 type gcsManagerOption func(*gcsManager) error
+
+// withHTTPClient uses the provided HTTP client when creating a new GCS client.
+func withHTTPClient(ctx context.Context, httpClient *http.Client) gcsManagerOption {
+	client, err := storage.NewClient(ctx, option.WithHTTPClient(httpClient), option.WithScopes(storage.ScopeReadOnly))
+	return func(m *gcsManager) error {
+		if err != nil {
+			return err
+		}
+
+		m.client = client
+		return nil
+	}
+}
 
 // withAPIKey uses the provided API key when creating a new GCS client.
 // This can ONLY be used for public buckets.

--- a/pkg/sources/gcs/gcs_manager_test.go
+++ b/pkg/sources/gcs/gcs_manager_test.go
@@ -2,6 +2,7 @@ package gcs
 
 import (
 	"fmt"
+	"net/http"
 	"sort"
 	"testing"
 	"time"
@@ -327,6 +328,12 @@ func TestNewGcsManager(t *testing.T) {
 				concurrency:   defaultConcurrency,
 				maxObjectSize: defaultMaxObjectSize,
 			},
+		},
+		{
+			name:   "new gcs manager, with HTTP client",
+			projID: testProjectID,
+			opts:   []gcsManagerOption{withHTTPClient(ctx, &http.Client{})},
+			want:   &gcsManager{projectID: testProjectID, concurrency: defaultConcurrency, maxObjectSize: defaultMaxObjectSize},
 		},
 	}
 


### PR DESCRIPTION
- Provide a way to create an OAuth HTTP client that can be use by the Google Cloud Storage library. 
