### PR TITLE
Add DetectorName to Result

### DIFF
--- a/pkg/custom_detectors/custom_detectors.go
+++ b/pkg/custom_detectors/custom_detectors.go
@@ -117,6 +117,7 @@ func (c *customRegexWebhook) createResults(ctx context.Context, match map[string
 	}
 	result := detectors.Result{
 		DetectorType: detectorspb.DetectorType_CustomRegex,
+		DetectorName: c.Name,
 		Raw:          []byte(raw),
 	}
 

--- a/pkg/custom_detectors/custom_detectors.go
+++ b/pkg/custom_detectors/custom_detectors.go
@@ -117,7 +117,7 @@ func (c *customRegexWebhook) createResults(ctx context.Context, match map[string
 	}
 	result := detectors.Result{
 		DetectorType: detectorspb.DetectorType_CustomRegex,
-		DetectorName: c.Name,
+		DetectorName: c.GetName(),
 		Raw:          []byte(raw),
 	}
 

--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -34,6 +34,8 @@ type Versioner interface {
 type Result struct {
 	// DetectorType is the type of Detector.
 	DetectorType detectorspb.DetectorType
+	// DetectorName is the name of the Detector. Used for custom detectors.
+	DetectorName string
 	// DecoderType is the type of Decoder.
 	DecoderType detectorspb.DecoderType
 	Verified    bool


### PR DESCRIPTION
Used generic name `DetectorName` so it can potentially be used for other applications in the future.