### PR TITLE
forager requires direct access to gitparse.FromReader

### DIFF
--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -180,7 +180,7 @@ func (c *Parser) executeCommand(ctx context.Context, cmd *exec.Cmd) (chan Commit
 	}()
 
 	go func() {
-		c.fromReader(ctx, stdOut, commitChan)
+		c.FromReader(ctx, stdOut, commitChan)
 		if err := cmd.Wait(); err != nil {
 			ctx.Logger().V(2).Info("Error waiting for git command to complete.", "error", err)
 		}
@@ -189,7 +189,7 @@ func (c *Parser) executeCommand(ctx context.Context, cmd *exec.Cmd) (chan Commit
 	return commitChan, nil
 }
 
-func (c *Parser) fromReader(ctx context.Context, stdOut io.Reader, commitChan chan Commit) {
+func (c *Parser) FromReader(ctx context.Context, stdOut io.Reader, commitChan chan Commit) {
 	outReader := bufio.NewReader(stdOut)
 	var currentCommit *Commit
 	var currentDiff *Diff

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -109,7 +109,7 @@ func TestSingleCommitSingleDiff(t *testing.T) {
 		},
 	}
 	go func() {
-		parser.fromReader(context.TODO(), r, commitChan)
+		parser.FromReader(context.TODO(), r, commitChan)
 	}()
 	i := 0
 	for commit := range commitChan {
@@ -168,7 +168,7 @@ func TestMultiCommitContextDiff(t *testing.T) {
 		},
 	}
 	go func() {
-		NewParser().fromReader(context.TODO(), r, commitChan)
+		NewParser().FromReader(context.TODO(), r, commitChan)
 	}()
 	i := 0
 	for commit := range commitChan {
@@ -198,7 +198,7 @@ func TestMaxDiffSize(t *testing.T) {
 
 	commitChan := make(chan Commit)
 	go func() {
-		parser.fromReader(context.TODO(), bigReader, commitChan)
+		parser.FromReader(context.TODO(), bigReader, commitChan)
 	}()
 
 	commit := <-commitChan
@@ -216,7 +216,7 @@ func TestMaxCommitSize(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(1)*time.Second)
 	defer cancel()
 	go func() {
-		parser.fromReader(ctx, &commitText, commitChan)
+		parser.FromReader(ctx, &commitText, commitChan)
 	}()
 	commitCount := 0
 	for range commitChan {


### PR DESCRIPTION
Exporting the method for forager to use directly