### PR TITLE
Use default endpoints when no custom verifier provided

### DIFF
--- a/pkg/detectors/github/github.go
+++ b/pkg/detectors/github/github.go
@@ -82,6 +82,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
+	if len(s.verifierURLs) == 0 {
+		s.verifierURLs = append(s.verifierURLs, defaultURL)
+	}
+
 	for _, match := range matches {
 		// First match is entire regex, second is the first group.
 		if len(match) != 2 {

--- a/pkg/detectors/gitlab/gitlab.go
+++ b/pkg/detectors/gitlab/gitlab.go
@@ -63,6 +63,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
+	if len(s.verifierURLs) == 0 {
+		s.verifierURLs = append(s.verifierURLs, defaultURL)
+	}
+
 	for _, match := range matches {
 		if len(match) != 2 {
 			continue

--- a/pkg/detectors/gitlabv2/gitlab.go
+++ b/pkg/detectors/gitlabv2/gitlab.go
@@ -62,6 +62,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
+	if len(s.verifierURLs) == 0 {
+		s.verifierURLs = append(s.verifierURLs, defaultURL)
+	}
+
 	for _, match := range matches {
 		if len(match) != 2 {
 			continue


### PR DESCRIPTION
Note: this is likely a temporary solution until we rework the custom verifier logic.
