### PR TITLE
update circle test because workflows expire and need re-running

### DIFF
--- a/pkg/sources/circleci/circleci_test.go
+++ b/pkg/sources/circleci/circleci_test.go
@@ -50,12 +50,10 @@ func TestSource_Scan(t *testing.T) {
 			wantSourceMetadata: &source_metadatapb.MetaData{
 				Data: &source_metadatapb.MetaData_Circleci{
 					Circleci: &source_metadatapb.CircleCI{
-						VcsType:     "github",
-						Username:    "dustin-decker",
-						Repository:  "circle-ci",
-						BuildNumber: 2,
-						BuildStep:   "Spin up environment",
-						Link:        "https://app.circleci.com/pipelines/github/dustin-decker/circle-ci/2",
+						VcsType:    "github",
+						Username:   "dustin-decker",
+						Repository: "circle-ci",
+						BuildStep:  "Spin up environment",
 					},
 				},
 			},
@@ -85,6 +83,8 @@ func TestSource_Scan(t *testing.T) {
 				}
 			}()
 			gotChunk := <-chunksCh
+			gotChunk.SourceMetadata.Data.(*source_metadatapb.MetaData_Circleci).Circleci.BuildNumber = 0 // override this because we need to periodically re-run the builds
+			gotChunk.SourceMetadata.Data.(*source_metadatapb.MetaData_Circleci).Circleci.Link = ""       // override this because we need to periodically re-run the builds
 			if diff := pretty.Compare(gotChunk.SourceMetadata, tt.wantSourceMetadata); diff != "" {
 				t.Errorf("Source.Chunks() %s diff: (-got +want)\n%s", tt.name, diff)
 			}


### PR DESCRIPTION
I re-ran the test and now the build number is 3 so I've updated the test to ignore the build number and link.