### PR TITLE
Remove `toLower` call on decoded chunk

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -247,10 +247,8 @@ func (e *Engine) detectorWorker(ctx context.Context) {
 					continue
 				}
 
-				// dataLower := strings.ToLower(string(decoded.Data))
-				matches := e.prefilter.FindAll(string(decoded.Data))
-
-				for _, m := range matches {
+				// build a map of all keywords that were matched in the chunk
+				for _, m := range e.prefilter.FindAll(string(decoded.Data)) {
 					matchedKeywords[strings.ToLower(string(decoded.Data[m.Start():m.End()]))] = struct{}{}
 				}
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -247,11 +247,11 @@ func (e *Engine) detectorWorker(ctx context.Context) {
 					continue
 				}
 
-				dataLower := strings.ToLower(string(decoded.Data))
-				matches := e.prefilter.FindAll(dataLower)
+				// dataLower := strings.ToLower(string(decoded.Data))
+				matches := e.prefilter.FindAll(string(decoded.Data))
 
 				for _, m := range matches {
-					matchedKeywords[dataLower[m.Start():m.End()]] = struct{}{}
+					matchedKeywords[strings.ToLower(string(decoded.Data[m.Start():m.End()]))] = struct{}{}
 				}
 
 				for verify, detectorsSet := range e.detectors {


### PR DESCRIPTION
### Description
This PR removes a wasteful call to `toLower` on decoded data. The ahocorasick prefilter matches with case insensitivity: https://github.com/trufflesecurity/trufflehog/blob/rm-tolower-prefilter/pkg/engine/engine.go#L145.

### "Testing"

648 results found in both
```
~/code/trufflesecurity/trufflehog (main) gtime ./trufflehog  git --no-update --no-verification  file://$PWD | grep Found | wc -l
^[[A🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

real 4.33s
user 17.80s
sys  1.83s
memory:96936KB
cpu 453%
     648
~/code/trufflesecurity/trufflehog (main) gtime ./trufflehog  git --no-update --no-verification  file://$PWD | grep Found | wc -l
~/code/trufflesecurity/trufflehog (main) git checkout rm-tolower-prefilter
Switched to branch 'rm-tolower-prefilter'
~/code/trufflesecurity/trufflehog (rm-tolower-prefilter) go build
~/code/trufflesecurity/trufflehog (rm-tolower-prefilter) gtime ./trufflehog  git --no-update --no-verification  file://$PWD | grep Found | wc -l
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

real 4.30s
user 17.06s
sys  1.78s
memory:92876KB
cpu 437%
     648
```