### PR TITLE
Only add detectors once

### DIFF
--- a/main.go
+++ b/main.go
@@ -285,7 +285,6 @@ func run(state overseer.State) {
 	e := engine.Start(ctx,
 		engine.WithConcurrency(*concurrency),
 		engine.WithDecoders(decoders.DefaultDecoders()...),
-		engine.WithDetectors(!*noVerification, engine.DefaultDetectors()...),
 		engine.WithDetectors(!*noVerification, engine.CustomDetectors(ctx, urls)...),
 		engine.WithDetectors(!*noVerification, conf.Detectors...),
 		engine.WithFilterDetectors(includeFilter),


### PR DESCRIPTION
`engine.CustomDetectors()` includes `engine.DefaultDetectors()`

@ahrav Can you take a look to confirm both are not needed?