### PR TITLE
optimize base64 decoder

### DIFF
--- a/pkg/decoders/base64_test.go
+++ b/pkg/decoders/base64_test.go
@@ -90,13 +90,29 @@ func TestBase64_FromChunk(t *testing.T) {
 	}
 }
 
-func BenchmarkFromChunk(benchmark *testing.B) {
+func BenchmarkFromChunkSmall(b *testing.B) {
 	d := Base64{}
-	for name, data := range detectors.MustGetBenchmarkData() {
-		benchmark.Run(name, func(b *testing.B) {
-			for n := 0; n < b.N; n++ {
-				d.FromChunk(&sources.Chunk{Data: data})
-			}
-		})
+	data := detectors.MustGetBenchmarkData()["small"]
+
+	for n := 0; n < b.N; n++ {
+		d.FromChunk(&sources.Chunk{Data: data})
+	}
+}
+
+func BenchmarkFromChunkMedium(b *testing.B) {
+	d := Base64{}
+	data := detectors.MustGetBenchmarkData()["medium"]
+
+	for n := 0; n < b.N; n++ {
+		d.FromChunk(&sources.Chunk{Data: data})
+	}
+}
+
+func BenchmarkFromChunkLarge(b *testing.B) {
+	d := Base64{}
+	data := detectors.MustGetBenchmarkData()["big"]
+
+	for n := 0; n < b.N; n++ {
+		d.FromChunk(&sources.Chunk{Data: data})
 	}
 }


### PR DESCRIPTION
- replace the use of strings.Builder w/ bytes.Buffer.

**Small Chunks**
![Screenshot 2023-04-20 at 4 54 46 PM](https://user-images.githubusercontent.com/21311841/233510218-3a4850d2-59e0-4abf-ba65-88a7176bfc6b.png)

**Medium Chunks**
![Screenshot 2023-04-20 at 4 55 12 PM](https://user-images.githubusercontent.com/21311841/233510247-a025bd74-0843-4eee-aa9b-cb21ebfb1a02.png)

**Large Chunks**
![Screenshot 2023-04-20 at 4 55 31 PM](https://user-images.githubusercontent.com/21311841/233510264-3a017aca-55c4-4f9f-87be-15cc4abbe0d3.png)


**NOTE**: separated out the benchmarks in order to properly compare using `benchstat` Additionally I think this could be further optimized, i'm just not smart enough just yet to get it all the way there 😅 