### PR TITLE
WIP: Add Base64URLSafe decoder

### DIFF
--- a/pkg/decoders/base64_test.go
+++ b/pkg/decoders/base64_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestBase64_FromChunk(t *testing.T) {
 	tests := []struct {
-		name  string
 		chunk *sources.Chunk
 		want  *sources.Chunk
+		name  string
 	}{
 		{
 			name: "only b64 chunk",
@@ -114,5 +114,104 @@ func BenchmarkFromChunkLarge(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		d.FromChunk(&sources.Chunk{Data: data})
+	}
+}
+
+func TestBase64URLSafe_FromChunk(t *testing.T) {
+	tests := []struct {
+		chunk *sources.Chunk
+		want  *sources.Chunk
+		name  string
+	}{
+		{
+			name: "only b64 chunk",
+			chunk: &sources.Chunk{
+				Data: []byte(`bG9uZ2VyLWVuY29kZWQtc2VjcmV0LXRlc3Q`),
+			},
+			want: &sources.Chunk{
+				Data: []byte(`longer-encoded-secret-test`),
+			},
+		},
+		{
+			name: "mixed content",
+			chunk: &sources.Chunk{
+				Data: []byte(`token: bG9uZ2VyLWVuY29kZWQtc2VjcmV0LXRlc3Q`),
+			},
+			want: &sources.Chunk{
+				Data: []byte(`token: longer-encoded-secret-test`),
+			},
+		},
+		{
+			name: "no chunk",
+			chunk: &sources.Chunk{
+				Data: []byte(``),
+			},
+			want: nil,
+		},
+		{
+			name: "env var (looks like all b64 decodable but has `=` in the middle)",
+			chunk: &sources.Chunk{
+				Data: []byte(`some-encoded-secret=dGVzdHNlY3JldA`),
+			},
+			want: &sources.Chunk{
+				Data: []byte(`some-encoded-secret=testsecret`),
+			},
+		},
+		{
+			name: "has longer b64 inside",
+			chunk: &sources.Chunk{
+				Data: []byte(`some-encoded-secret="bG9uZ2VyLWVuY29kZWQtc2VjcmV0LXRlc3Q"`),
+			},
+			want: &sources.Chunk{
+				Data: []byte(`some-encoded-secret="longer-encoded-secret-test"`),
+			},
+		},
+		{
+			name: "many possible substrings",
+			chunk: &sources.Chunk{
+				Data: []byte(`Many substrings in this slack message could be base64 decoded
+					but only dGhpcyBlbmNhcHN1bGF0ZWQgc2VjcmV0 should be decoded.`),
+			},
+			want: &sources.Chunk{
+				Data: []byte(`Many substrings in this slack message could be base64 decoded
+					but only this encapsulated secret should be decoded.`),
+			},
+		},
+		{
+			name: "hyphen url b64",
+			chunk: &sources.Chunk{
+				Data: []byte(`dHJ1ZmZsZWhvZz4-ZmluZHMtc2VjcmV0cw`),
+			},
+			want: &sources.Chunk{
+				Data: []byte(`trufflehog>>finds-secrets`),
+			},
+		},
+		{
+			name: "underscore url b64",
+			chunk: &sources.Chunk{
+				Data: []byte(`YjY0dXJsc2FmZS10ZXN0LXNlY3JldC11bmRlcnNjb3Jlcz8_`),
+			},
+			want: &sources.Chunk{
+				Data: []byte(`b64urlsafe-test-secret-underscores??`),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Base64URLSafe{}
+			got := d.FromChunk(tt.chunk)
+			if tt.want != nil {
+				if got == nil {
+					t.Fatal("got nil, did not want nil")
+				}
+				if diff := pretty.Compare(string(got.Data), string(tt.want.Data)); diff != "" {
+					t.Errorf("Base64URLSafeFromChunk() %s diff: (-got +want)\n%s", tt.name, diff)
+				}
+			} else {
+				if got != nil {
+					t.Error("Expected nil chunk")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
* Add decoder that can decode base64 strings with '_' and '-' instead of of '+' and '/'.

Addresses #144.

WIP but looking for early feedback:
* should this functionality be merged into the existing base64 decoder or split into a separate Base64URLSafe decoder? There is a lot of shared code and wanted to see if maintainers have preferences towards making separate decoders (like UTF8/UTF16 decoders) or a single `Base64` decoder before polishing it up, wiring into all the places (detectorspb, decoders, engine, detectors.proto, etc.
