### PR TITLE
double timeout to reduce test failures stemming from timeouts

### DIFF
--- a/pkg/sources/test_helpers.go
+++ b/pkg/sources/test_helpers.go
@@ -22,8 +22,8 @@ func HandleTestChannel(chunksCh chan *Chunk, cf ChunkFunc) error {
 				return err
 			}
 			return nil
-		case <-time.After(10 * time.Second):
-			return fmt.Errorf("no new chunks received after 10 seconds")
+		case <-time.After(20 * time.Second):
+			return fmt.Errorf("no new chunks received after 20 seconds")
 		}
 	}
 }

--- a/pkg/sources/test_helpers.go
+++ b/pkg/sources/test_helpers.go
@@ -10,7 +10,7 @@ type ChunkFunc func(chunk *Chunk) error
 
 var MatchError = errors.New("chunk doesn't match")
 
-func HandleTestChannel(chunksCh chan *Chunk, cf ChunkFunc) error {
+func HandleTestChannel(chunksCh chan *Chunk, cf ChunkFunc, timeout int) error {
 	for {
 		select {
 		case gotChunk := <-chunksCh:
@@ -22,8 +22,8 @@ func HandleTestChannel(chunksCh chan *Chunk, cf ChunkFunc) error {
 				return err
 			}
 			return nil
-		case <-time.After(20 * time.Second):
-			return fmt.Errorf("no new chunks received after 20 seconds")
+		case <-time.After(time.Duration(timeout) * time.Second):
+			return fmt.Errorf("no new chunks received after %d seconds", timeout)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

test failures occuring intermittently due to timeout, doubling timeout to reduce failed CI/CD jobs from timeout issues. 