### PR TITLE
git worktree scanning fix for #827

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,6 @@ go 1.20
 
 replace github.com/jpillora/overseer => github.com/trufflesecurity/overseer v1.1.7-custom5
 
-replace github.com/zricethezav/gitleaks/v8 => github.com/trufflesecurity/gitleaks/v8 v8.6.1-custom10
-
-replace github.com/gitleaks/go-gitdiff => github.com/trufflesecurity/go-gitdiff v0.7.6-zombies2
-
 require (
 	cloud.google.com/go/secretmanager v1.10.0
 	cloud.google.com/go/storage v1.30.1

--- a/pkg/engine/git.go
+++ b/pkg/engine/git.go
@@ -22,7 +22,12 @@ func (e *Engine) ScanGit(ctx context.Context, c sources.GitConfig) error {
 		git.ScanOptionLogOptions(logOptions),
 	}
 
-	repo, err := gogit.PlainOpenWithOptions(c.RepoPath, &gogit.PlainOpenOptions{DetectDotGit: true})
+	options := &gogit.PlainOpenOptions{
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
+	}
+
+	repo, err := gogit.PlainOpenWithOptions(c.RepoPath, options)
 	if err != nil {
 		return fmt.Errorf("could not open repo: %s: %w", c.RepoPath, err)
 	}

--- a/pkg/output/legacy_json.go
+++ b/pkg/output/legacy_json.go
@@ -66,9 +66,14 @@ func ConvertToLegacyJSON(r *detectors.ResultWithMetadata, repoPath string) (*Leg
 		return nil, fmt.Errorf("legacy JSON output can not be used with this source: %s", r.SourceName)
 	}
 
-	// The repo will be needed to gather info needed for the legacy output that isn't included in the new
-	// output format.
-	repo, err := gogit.PlainOpenWithOptions(repoPath, &gogit.PlainOpenOptions{DetectDotGit: true})
+	options := &gogit.PlainOpenOptions{
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
+	}
+
+	// The repo will be needed to gather info needed for the legacy output that
+	// isn't included in the new output format.
+	repo, err := gogit.PlainOpenWithOptions(repoPath, options)
 	if err != nil {
 		return nil, fmt.Errorf("could not open repo %q: %w", repoPath, err)
 	}

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -86,7 +86,6 @@ func (s *Source) JobID() int64 {
 
 // Init returns an initialized GitHub source.
 func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error {
-
 	s.name = name
 	s.sourceId = sourceId
 	s.jobId = jobId
@@ -228,7 +227,11 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk) err
 }
 
 func RepoFromPath(path string) (*git.Repository, error) {
-	return git.PlainOpen(path)
+	options := &git.PlainOpenOptions{
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
+	}
+	return git.PlainOpenWithOptions(path, options)
 }
 
 func CleanOnError(err *error, path string) {
@@ -299,7 +302,11 @@ func CloneRepo(ctx context.Context, userInfo *url.Userinfo, gitUrl string, args 
 		return "", nil, fmt.Errorf("could not clone repo: %s, %w", safeUrl, err)
 	}
 
-	repo, err := git.PlainOpen(clonePath)
+	options := &git.PlainOpenOptions{
+		DetectDotGit:          true,
+		EnableDotGitCommonDir: true,
+	}
+	repo, err := git.PlainOpenWithOptions(clonePath, options)
 	if err != nil {
 		return "", nil, fmt.Errorf("could not open cloned repo: %w", err)
 	}
@@ -486,7 +493,7 @@ func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string,
 	}
 
 	var depth int64
-	var reachedBase = false
+	reachedBase := false
 
 	ctx.Logger().V(1).Info("scanning staged changes", "path", path)
 	for commit := range commitChan {


### PR DESCRIPTION
Fix #827 - Fix worktree scan by setting EnableDotGitCommonDir

Change `PlainOpenOptions` to set `EnableDotGitCommonDir` to true. In every current usage of this function, it is on an already-cloned repository, so it should always be valid to have this set. By doing so, it fixes the worktree commit resolution issue.

Set up worktree:
```bash
git clone https://github.com/trufflesecurity/test_keys
cd test_keys

# Using unpacked objects makes the explanation simpler,
# but same concept applies for packed objects:
mv .git/objects/pack/pack-*.pack .
cat pack-*.pack | git unpack-objects
rm -f pack-*.pack

git worktree add ../tree-test
cd ..
```

```go
go run ./main.go git --since-commit=$(cd tree-test; git merge-base origin/main HEAD) file://tree-test
```

Previously this would fail with a message about not being able to resolve the base ref and after the change will resolve & scan correctly.

To understand how this works:

```
test_keys/
  .git/
    worktrees/
      tree-test/
        commondir (contents):
          ../..
tree-test/
  .git (contents):
    gitdir: /home/user/src/github.com/trufflesecurity/trufflehog/test_keys/.git/worktrees/tree-test
```

Without `EnableDotGitCommonDir` set to true, go-git would try to look for the objects in `test_keys/.git/worktrees/tree-test` directory. In the example I shared above (at this time, could change if there are commits to test_keys), go-git would try to load `test_keys/.git/worktrees/tree-test/objects/77/77b2a3e56973785a52ba4ae4b8dac61d4bac016f`. However, this does not exist, since the files are stored in the `commondir`, and this path will not exist. Instead, it should look at `test_keys/.git/objects/77/77b2a3e56973785a52ba4ae4b8dac61d4bac016f`.

The change to add this seemed to work with all my tests (e.g., ssh, http, filesystem repos passed to trufflehog).
