### PR TITLE
Add extra data and structured data to plain output

### DIFF
--- a/pkg/output/plain.go
+++ b/pkg/output/plain.go
@@ -46,7 +46,35 @@ func PrintPlainOutput(r *detectors.ResultWithMetadata) error {
 	printer.Printf("Decoder Type: %s\n", out.DecoderType)
 	printer.Printf("Raw result: %s\n", whitePrinter.Sprint(out.Raw))
 
-	var aggregateData = make(map[string]interface{})
+	for k, v := range r.Result.ExtraData {
+		printer.Printf(
+			"%s: %v\n",
+			cases.Title(language.AmericanEnglish).String(k),
+			v)
+	}
+
+	for k, v := range r.Result.ExtraData {
+		printer.Printf(
+			"%s: %v\n",
+			cases.Title(language.AmericanEnglish).String(k),
+			v)
+	}
+
+	for idx, v := range r.Result.StructuredData.GithubSshKey {
+		printer.Printf("GithubSshKey %d User: %s\n", idx, v.User)
+
+		if v.PublicKeyFingerprint != "" {
+			printer.Printf("GithubSshKey %d Fingerprint: %s\n", idx, v.PublicKeyFingerprint)
+		}
+	}
+
+	for idx, v := range r.Result.StructuredData.TlsPrivateKey {
+		printer.Printf("TlsPrivateKey %d Fingerprint: %s\n", idx, v.CertificateFingerprint)
+		printer.Printf("TlsPrivateKey %d Verification URL: %s\n", idx, v.VerificationUrl)
+		printer.Printf("TlsPrivateKey %d Expiration: %d\n", idx, v.ExpirationTimestamp)
+	}
+
+	aggregateData := make(map[string]interface{})
 	var aggregateDataKeys []string
 
 	for _, data := range meta {

--- a/pkg/output/plain.go
+++ b/pkg/output/plain.go
@@ -53,13 +53,6 @@ func PrintPlainOutput(r *detectors.ResultWithMetadata) error {
 			v)
 	}
 
-	for k, v := range r.Result.ExtraData {
-		printer.Printf(
-			"%s: %v\n",
-			cases.Title(language.AmericanEnglish).String(k),
-			v)
-	}
-
 	for idx, v := range r.Result.StructuredData.GithubSshKey {
 		printer.Printf("GithubSshKey %d User: %s\n", idx, v.User)
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

While looking into #307, I realized that driftwood output already exists in `StructuredData`, but this is only output with `--json`. This PR adds `ExtraData` and `StructuredData` to the `plain` output.

Example output:

```
go run ./main.go filesystem ./tmp
...
Found verified result 🐷🔑
Detector Type: PrivateKey
Decoder Type: PLAIN
Raw result: -----BEGIN RSA PRIVATE KEY-----
... REDACTED ...
-----END RSA PRIVATE KEY-----
GithubSshKey 0 User: redacted-test-user
File: tmp/private.key
```
