### PR TITLE
Add Data member to ResultsMetadata struct.

### DIFF
--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -68,6 +68,8 @@ type ResultWithMetadata struct {
 	// SourceName is the name of the Source.
 	SourceName string
 	Result
+	// Data from the sources.Chunk which this result was emitted for
+	Data []byte
 }
 
 // CopyMetadata returns a detector result with included metadata from the source chunk.
@@ -78,6 +80,7 @@ func CopyMetadata(chunk *sources.Chunk, result Result) ResultWithMetadata {
 		SourceType:     chunk.SourceType,
 		SourceName:     chunk.SourceName,
 		Result:         result,
+		Data:           chunk.Data,
 	}
 }
 


### PR DESCRIPTION
When a Result is emitted, it should include
the `chunk.Data []byte` so that we can utilize
the blob of data which caused the result.

This makes it so something catching the results
does not have to maintain a collection of chunks
to correlate the two together.

This fixes/implements the proposed feature described
in #1357 
