### PR TITLE
Split files instead of using ReadAll

### DIFF
--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -185,7 +185,6 @@ func (s *Source) scanFile(ctx context.Context, path string, chunksChan chan *sou
 
 	for {
 		chunkBytes := make([]byte, BufferSize)
-		chunk := *chunkSkel
 		reader := bufio.NewReaderSize(reReader, BufferSize)
 		n, err := reader.Read(chunkBytes)
 		if err != nil && !errors.Is(err, io.EOF) {
@@ -193,7 +192,6 @@ func (s *Source) scanFile(ctx context.Context, path string, chunksChan chan *sou
 		}
 		peekData, _ := reader.Peek(PeekSize)
 		if n > 0 {
-			chunksChan <- &chunk
 			chunksChan <- &sources.Chunk{
 				SourceType: s.Type(),
 				SourceName: s.name,

--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -207,6 +207,9 @@ func (s *Source) scanFile(ctx context.Context, path string, chunksChan chan *sou
 				Verify: s.verify,
 			}
 		}
+		if errors.Is(err, io.EOF) {
+			break
+		}
 	}
 	return nil
 }

--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"io/fs"
@@ -181,23 +182,33 @@ func (s *Source) scanFile(ctx context.Context, path string, chunksChan chan *sou
 		return err
 	}
 	reReader.Stop()
-	data, err := io.ReadAll(reReader)
-	if err != nil {
-		return fmt.Errorf("unable to read file: %w", err)
-	}
-	chunksChan <- &sources.Chunk{
-		SourceType: s.Type(),
-		SourceName: s.name,
-		SourceID:   s.SourceID(),
-		Data:       data,
-		SourceMetadata: &source_metadatapb.MetaData{
-			Data: &source_metadatapb.MetaData_Filesystem{
-				Filesystem: &source_metadatapb.Filesystem{
-					File: sanitizer.UTF8(path),
+
+	for {
+		chunkBytes := make([]byte, BufferSize)
+		chunk := *chunkSkel
+		reader := bufio.NewReaderSize(reReader, BufferSize)
+		n, err := reader.Read(chunkBytes)
+		if err != nil && !errors.Is(err, io.EOF) {
+			break
+		}
+		peekData, _ := reader.Peek(PeekSize)
+		if n > 0 {
+			chunksChan <- &chunk
+			chunksChan <- &sources.Chunk{
+				SourceType: s.Type(),
+				SourceName: s.name,
+				SourceID:   s.SourceID(),
+				Data:       append(chunkBytes[:n], peekData...),
+				SourceMetadata: &source_metadatapb.MetaData{
+					Data: &source_metadatapb.MetaData_Filesystem{
+						Filesystem: &source_metadatapb.Filesystem{
+							File: sanitizer.UTF8(path),
+						},
+					},
 				},
-			},
-		},
-		Verify: s.verify,
+				Verify: s.verify,
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Split files into chunks even though chunker would do it later to avoid using huge amounts of memory and causing OOM kill.