### PR TITLE
add a custom detector check for logging duplicate detector

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -165,7 +165,7 @@ func Start(ctx context.Context, options ...EngineOption) *Engine {
 		seenDetectors := make(map[config.DetectorID]struct{}, len(dets))
 		for _, det := range dets {
 			id := config.GetDetectorID(det)
-			if _, ok := seenDetectors[id]; ok {
+			if _, ok := seenDetectors[id]; ok && id.String() != "CustomRegex" {
 				ctx.Logger().Info("possible duplicate detector configured", "detector", id)
 			}
 			seenDetectors[id] = struct{}{}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -165,7 +165,7 @@ func Start(ctx context.Context, options ...EngineOption) *Engine {
 		seenDetectors := make(map[config.DetectorID]struct{}, len(dets))
 		for _, det := range dets {
 			id := config.GetDetectorID(det)
-			if _, ok := seenDetectors[id]; ok && id.String() != "CustomRegex" {
+			if _, ok := seenDetectors[id]; ok && id.ID != detectorspb.DetectorType_CustomRegex {
 				ctx.Logger().Info("possible duplicate detector configured", "detector", id)
 			}
 			seenDetectors[id] = struct{}{}


### PR DESCRIPTION
Takes care of the concern in this issue: https://github.com/trufflesecurity/trufflehog/issues/1392