### PR TITLE
Add Validator interface and example

### DIFF
--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -175,6 +175,12 @@ type Progress struct {
 	SectionsRemaining int32
 }
 
+// Validator is an interface for validating a source. Sources can optionally implement this interface to validate
+// their configuration.
+type Validator interface {
+	Validate() []error
+}
+
 // SetProgressComplete sets job progress information for a running job based on the highest level objects in the source.
 // i is the current iteration in the loop of target scope
 // scope should be the len(scopedItems)

--- a/pkg/sources/syslog/syslog.go
+++ b/pkg/sources/syslog/syslog.go
@@ -59,6 +59,44 @@ func NewSyslog(sourceType sourcespb.SourceType, jobID, sourceID int64, sourceNam
 	}
 }
 
+// Validate validates the configuration of the source.
+func (s *Source) Validate() []error {
+	errors := []error{}
+
+	if s.conn.TlsCert != nilString || s.conn.TlsKey != nilString {
+		if s.conn.TlsCert == nilString || s.conn.TlsKey == nilString {
+			errors = append(errors, fmt.Errorf("tls cert and key must both be set"))
+		}
+		if _, err := tls.LoadX509KeyPair(s.conn.TlsCert, s.conn.TlsKey); err != nil {
+			errors = append(errors, fmt.Errorf("error loading tls cert and key: %s", err))
+		}
+	}
+
+	if s.conn.ListenAddress != nilString {
+		switch s.conn.Protocol {
+		case "tcp":
+			_, err := net.Listen(s.conn.Protocol, s.conn.ListenAddress)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("error listening on tcp socket: %s", err))
+			}
+		case "udp":
+			_, err := net.ListenPacket(s.conn.Protocol, s.conn.ListenAddress)
+			if err != nil {
+				errors = append(errors, fmt.Errorf("error listening on udp socket: %s", err))
+			}
+		default:
+			errors = append(errors, fmt.Errorf("invalid protocol: %s", s.conn.Protocol))
+		}
+	}
+	if s.conn.Protocol != "tcp" && s.conn.Protocol != "udp" {
+		errors = append(errors, fmt.Errorf("invalid protocol: %s", s.conn.Protocol))
+	}
+	if s.conn.Format != "rfc5424" && s.conn.Format != "rfc3164" {
+		errors = append(errors, fmt.Errorf("invalid format: %s", s.conn.Format))
+	}
+	return errors
+}
+
 // Ensure the Source satisfies the interface at compile time.
 var _ sources.Source = (*Source)(nil)
 

--- a/pkg/sources/syslog/syslog.go
+++ b/pkg/sources/syslog/syslog.go
@@ -75,24 +75,26 @@ func (s *Source) Validate() []error {
 	if s.conn.ListenAddress != nilString {
 		switch s.conn.Protocol {
 		case "tcp":
-			_, err := net.Listen(s.conn.Protocol, s.conn.ListenAddress)
+			srv, err := net.Listen(s.conn.Protocol, s.conn.ListenAddress)
 			if err != nil {
 				errors = append(errors, fmt.Errorf("error listening on tcp socket: %s", err))
 			}
+			srv.Close()
 		case "udp":
-			_, err := net.ListenPacket(s.conn.Protocol, s.conn.ListenAddress)
+			srv, err := net.ListenPacket(s.conn.Protocol, s.conn.ListenAddress)
 			if err != nil {
 				errors = append(errors, fmt.Errorf("error listening on udp socket: %s", err))
 			}
+			srv.Close()
 		default:
-			errors = append(errors, fmt.Errorf("invalid protocol: %s", s.conn.Protocol))
+			errors = append(errors, fmt.Errorf("protocol must be 'tcp' or 'udp', got: %s", s.conn.Protocol))
 		}
 	}
 	if s.conn.Protocol != "tcp" && s.conn.Protocol != "udp" {
-		errors = append(errors, fmt.Errorf("invalid protocol: %s", s.conn.Protocol))
+		errors = append(errors, fmt.Errorf("protocol must be 'tcp' or 'udp', got: %s", s.conn.Protocol))
 	}
 	if s.conn.Format != "rfc5424" && s.conn.Format != "rfc3164" {
-		errors = append(errors, fmt.Errorf("invalid format: %s", s.conn.Format))
+		errors = append(errors, fmt.Errorf("format must be 'rfc5424' or 'rfc3164', got: %s", s.conn.Format))
 	}
 	return errors
 }

--- a/pkg/sources/syslog/syslog.go
+++ b/pkg/sources/syslog/syslog.go
@@ -61,7 +61,7 @@ func NewSyslog(sourceType sourcespb.SourceType, jobID, sourceID int64, sourceNam
 
 // Validate validates the configuration of the source.
 func (s *Source) Validate() []error {
-	errors := []error{}
+	var errors []error
 
 	if s.conn.TlsCert != nilString || s.conn.TlsKey != nilString {
 		if s.conn.TlsCert == nilString || s.conn.TlsKey == nilString {

--- a/pkg/sources/syslog/syslog.go
+++ b/pkg/sources/syslog/syslog.go
@@ -86,8 +86,6 @@ func (s *Source) Validate() []error {
 				errors = append(errors, fmt.Errorf("error listening on udp socket: %s", err))
 			}
 			srv.Close()
-		default:
-			errors = append(errors, fmt.Errorf("protocol must be 'tcp' or 'udp', got: %s", s.conn.Protocol))
 		}
 	}
 	if s.conn.Protocol != "tcp" && s.conn.Protocol != "udp" {


### PR DESCRIPTION
Sources can implement the `Validator` interface to test their configuration with error reporting.

Syslog source implements Validator as an example.