### PR TITLE
Add field for verification indeterminate to detector results

### DIFF
--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -74,6 +74,12 @@ func (r Result) IsVerified() bool {
 	return r.Verified && !r.HasVerificationIndeterminate
 }
 
+// IsUnverified checks if a result is guaranteed to be unverified.
+// This is used to differentiate between secrets that are NOT verified and secrets that COULD NOT be verified.
+func (r Result) IsUnverified() bool {
+	return !r.Verified && !r.HasVerificationIndeterminate
+}
+
 type ResultWithMetadata struct {
 	// SourceMetadata contains source-specific contextual information.
 	SourceMetadata *source_metadatapb.MetaData

--- a/pkg/detectors/detectors_test.go
+++ b/pkg/detectors/detectors_test.go
@@ -3,7 +3,9 @@
 
 package detectors
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestPrefixRegex(t *testing.T) {
 	tests := []struct {
@@ -35,5 +37,54 @@ func BenchmarkPrefixRegex(b *testing.B) {
 	kws := []string{"securitytrails"}
 	for i := 0; i < b.N; i++ {
 		PrefixRegex(kws)
+	}
+}
+
+func TestIsVerified(t *testing.T) {
+	tests := []struct {
+		name   string
+		result Result
+		want   bool
+	}{
+		{
+			name: "Verified true, HasVerificationIndeterminate false",
+			result: Result{
+				Verified:                     true,
+				HasVerificationIndeterminate: false,
+			},
+			want: true,
+		},
+		{
+			name: "Verified false, HasVerificationIndeterminate false",
+			result: Result{
+				Verified:                     false,
+				HasVerificationIndeterminate: false,
+			},
+			want: false,
+		},
+		{
+			name: "Verified true, HasVerificationIndeterminate true",
+			result: Result{
+				Verified:                     true,
+				HasVerificationIndeterminate: true,
+			},
+			want: false,
+		},
+		{
+			name: "Verified false, HasVerificationIndeterminate true",
+			result: Result{
+				Verified:                     false,
+				HasVerificationIndeterminate: true,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.result.IsVerified(); got != tt.want {
+				t.Errorf("IsVerified() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/detectors/detectors_test.go
+++ b/pkg/detectors/detectors_test.go
@@ -88,3 +88,52 @@ func TestIsVerified(t *testing.T) {
 		})
 	}
 }
+
+func TestIsUnverified(t *testing.T) {
+	tests := []struct {
+		name   string
+		result Result
+		want   bool
+	}{
+		{
+			name: "Verified true, HasVerificationIndeterminate false",
+			result: Result{
+				Verified:                     true,
+				HasVerificationIndeterminate: false,
+			},
+			want: false,
+		},
+		{
+			name: "Verified false, HasVerificationIndeterminate false",
+			result: Result{
+				Verified:                     false,
+				HasVerificationIndeterminate: false,
+			},
+			want: true,
+		},
+		{
+			name: "Verified true, HasVerificationIndeterminate true",
+			result: Result{
+				Verified:                     true,
+				HasVerificationIndeterminate: true,
+			},
+			want: false,
+		},
+		{
+			name: "Verified false, HasVerificationIndeterminate true",
+			result: Result{
+				Verified:                     false,
+				HasVerificationIndeterminate: true,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.result.IsUnverified(); got != tt.want {
+				t.Errorf("IsUnverified() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- This will be used to distinguish between credentials being unverified, as opposed to some other failure that occurred during the verification process. (ie 429, timeout, etc)
