### PR TITLE
Introduce `trufflehog:ignore` tag feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ trufflehog docker --image trufflesecurity/secrets --only-verified
   + Unauthenticated GitHub scans have rate limits. To improve your rate limits, include the `--token` flag with a personal access token
 + It says a private key was verified, what does that mean?
   + Check out our Driftwood blog post to learn how to do this, in short we've confirmed the key can be used live for SSH or SSL [Blog post](https://trufflesecurity.com/blog/driftwood-know-if-private-keys-are-sensitive/)
++ Is there an easy way to ignore specific secrets?
+  + If the scanned source supports line numbers, then you can add a `trufflehog:ignore` comment on the line containing the secret to ignore that secrets. 
 
 
 # :newspaper: What's new in v3?

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ trufflehog docker --image trufflesecurity/secrets --only-verified
 + It says a private key was verified, what does that mean?
   + Check out our Driftwood blog post to learn how to do this, in short we've confirmed the key can be used live for SSH or SSL [Blog post](https://trufflesecurity.com/blog/driftwood-know-if-private-keys-are-sensitive/)
 + Is there an easy way to ignore specific secrets?
-  + If the scanned source supports line numbers, then you can add a `trufflehog:ignore` comment on the line containing the secret to ignore that secrets. 
+  + If the scanned source [supports line numbers](https://github.com/trufflesecurity/trufflehog/blob/d6375ba92172fd830abb4247cca15e3176448c5d/pkg/engine/engine.go#L358-L365), then you can add a `trufflehog:ignore` comment on the line containing the secret to ignore that secrets. 
 
 
 # :newspaper: What's new in v3?

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1,0 +1,53 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func TestFragmentLineOffset(t *testing.T) {
+	tests := []struct {
+		name         string
+		chunk        *sources.Chunk
+		result       *detectors.Result
+		expectedLine int64
+		expectedBool bool
+	}{
+		{
+			name: "trufflehog:ignore found",
+			chunk: &sources.Chunk{
+				Data: []byte("line1\nline2\ntrufflehog:ignore\nline4"),
+			},
+			result: &detectors.Result{
+				Raw: []byte("trufflehog:ignore"),
+			},
+			expectedLine: 2,
+			expectedBool: true,
+		},
+		{
+			name: "nonexistent string",
+			chunk: &sources.Chunk{
+				Data: []byte("line1\nline2\ntrufflehog:ignore\nline4"),
+			},
+			result: &detectors.Result{
+				Raw: []byte("nonexistent"),
+			},
+			expectedLine: 0,
+			expectedBool: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lineOffset, isIgnored := FragmentLineOffset(tt.chunk, tt.result)
+			if lineOffset != tt.expectedLine {
+				t.Errorf("Expected line offset to be %d, got %d", tt.expectedLine, lineOffset)
+			}
+			if isIgnored != tt.expectedBool {
+				t.Errorf("Expected isIgnored to be %v, got %v", tt.expectedBool, isIgnored)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
This PR adds a feature that allows users to ignore secrets using `trufflehog:ignore`. If a line containing a secret or secrets has `trufflehog:ignore` present then ignore those secrets.

little test script to try it out if curious:
```
#!/bin/bash

git checkout DEVREL-3-ignore-tag
go build

echo "# config.yaml
detectors:
- name: Super custom API detector
  keywords:
  - api
  regex:
    adjective: \"[a-zA-Z0-9]{32}\"
" > config.yaml

echo "NO SECRETS SHOULD BE DETECTED"
echo "api eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee # trufflehog:ignore" > test.md


./trufflehog  filesystem --no-update --config=config.yaml --no-verification test.md

echo "SECRETS SHOULD BE DETECTED"
echo "api eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee" > test.md


./trufflehog  filesystem --no-update --config=config.yaml --no-verification test.md
```