### PR TITLE
remove HEAD from git diff command, rename unstaged to staged

### DIFF
--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -140,10 +140,10 @@ func (c *Parser) RepoPath(ctx context.Context, source string, head string, abbre
 	return c.executeCommand(ctx, cmd)
 }
 
-// Unstaged parses the output of the `git diff` command for the `source` path.
-func (c *Parser) Unstaged(ctx context.Context, source string) (chan Commit, error) {
+// Staged parses the output of the `git diff` command for the `source` path.
+func (c *Parser) Staged(ctx context.Context, source string) (chan Commit, error) {
 	// Provide the --cached flag to diff to get the diff of the staged changes.
-	args := []string{"-C", source, "diff", "-p", "--cached", "--full-history", "--diff-filter=AM", "--date=format:%a %b %d %H:%M:%S %Y %z", "HEAD"}
+	args := []string{"-C", source, "diff", "-p", "--cached", "--full-history", "--diff-filter=AM", "--date=format:%a %b %d %H:%M:%S %Y %z"}
 
 	cmd := exec.Command("git", args...)
 

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -482,7 +482,7 @@ func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string,
 	// Get the URL metadata for reporting (may be empty).
 	urlMetadata := getSafeRemoteURL(repo, "origin")
 
-	commitChan, err := gitparse.NewParser().Unstaged(ctx, path)
+	commitChan, err := gitparse.NewParser().Staged(ctx, path)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR addresses a few things:

1. the function name `Unstaged` should be `Staged` since `--cached` is a synomom for `--staged` according to this [git diff documentation](https://git-scm.com/docs/git-diff):

> git diff [<options>] --cached [--merge-base] [<commit>] [--] [<path>…​]
> This form is to view the changes you staged for the next commit relative to the named <commit>. Typically you would want comparison with the latest commit, so if you do not give <commit>, it defaults to HEAD. If HEAD does not exist (e.g. unborn branches) and <commit> is not given, it shows all staged changes. --staged is a synonym of --cached.
> 

2. Removes `HEAD` from the `git diff -p` arguments since `git diff` will default to `HEAD` if no refs are present. In my testing this change fixes this issue https://github.com/trufflesecurity/trufflehog/issues/1403 

> Typically you would want comparison with the latest commit, so if you do not give <commit>, it defaults to HEAD. If HEAD does not exist (e.g. unborn branches) and <commit> is not given, it shows all staged changes