### PR TITLE
Remove additional apk clean up in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ RUN  --mount=type=cache,target=/go/pkg/mod \
 
 FROM alpine:3.15
 RUN apk add --no-cache bash git openssh-client ca-certificates \
-    && rm -rf /var/cache/apk/* && \
-    update-ca-certificates
+    && update-ca-certificates
 COPY --from=builder /build/trufflehog /usr/bin/trufflehog
 COPY entrypoint.sh /etc/entrypoint.sh
 RUN chmod +x /etc/entrypoint.sh


### PR DESCRIPTION
Because of the `--no-cache` parameter of `apk add`, there won't be additional temporary files to be cleaned up. We can verify that by a single command `docker run -it alpine:3.15 sh -c 'apk add --no-cache bash git openssh-client ca-certificates && ls -al /var/cache/apk/*'`:

```
$ docker run -it alpine:3.15 sh -c 'apk add --no-cache bash git openssh-client ca-certificates && ls -al /var/cache/apk/*'
Unable to find image 'alpine:3.15' locally
3.15: Pulling from library/alpine
0cdfa0c98ed7: Pull complete 
Digest: sha256:3362f865019db5f14ac5154cb0db2c3741ad1cce0416045be422ad4de441b081
Status: Downloaded newer image for alpine:3.15
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
(1/15) Installing ncurses-terminfo-base (6.3_p20211120-r2)
(2/15) Installing ncurses-libs (6.3_p20211120-r2)
(3/15) Installing readline (8.1.1-r0)
(4/15) Installing bash (5.1.16-r0)
Executing bash-5.1.16-r0.post-install
(5/15) Installing ca-certificates (20230506-r0)
(6/15) Installing brotli-libs (1.0.9-r5)
(7/15) Installing nghttp2-libs (1.46.0-r0)
(8/15) Installing libcurl (8.1.2-r0)
(9/15) Installing expat (2.5.0-r0)
(10/15) Installing pcre2 (10.40-r0)
(11/15) Installing git (2.34.8-r0)
(12/15) Installing openssh-keygen (8.8_p1-r1)
(13/15) Installing libedit (20210910.3.1-r0)
(14/15) Installing openssh-client-common (8.8_p1-r1)
(15/15) Installing openssh-client-default (8.8_p1-r1)
Executing busybox-1.34.1-r7.trigger
Executing ca-certificates-20230506-r0.trigger
OK: 25 MiB in 29 packages
ls: /var/cache/apk/*: No such file or directory
```

As we can see at the last line:

> ls: /var/cache/apk/*: No such file or directory

The additional command `rm -rf /var/cache/apk/*` in the Dockerfile can be removed ;)