### PR TITLE
Pass GitHub apiEndpoint for basic or no auth

### DIFF
--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -339,7 +339,8 @@ func TestHandleRateLimit(t *testing.T) {
 func TestEnumerateUnauthenticated(t *testing.T) {
 	defer gock.Off()
 
-	gock.New("https://api.github.com").
+	apiEndpoint := "https://api.github.com"
+	gock.New(apiEndpoint).
 		Get("/orgs/super-secret-org/repos").
 		Reply(200).
 		JSON([]map[string]string{{"clone_url": "https://github.com/super-secret-repo.git", "full_name": "super-secret-repo"}})
@@ -347,7 +348,7 @@ func TestEnumerateUnauthenticated(t *testing.T) {
 	s := initTestSource(nil)
 	s.orgsCache = memory.New()
 	s.orgsCache.Set("super-secret-org", "super-secret-org")
-	s.enumerateUnauthenticated(context.Background())
+	s.enumerateUnauthenticated(context.Background(), apiEndpoint)
 	assert.Equal(t, 1, s.filteredRepoCache.Count())
 	ok := s.filteredRepoCache.Exists("super-secret-repo")
 	assert.True(t, ok)


### PR DESCRIPTION
This is a quick and dirty fix for #1453. 

It may be even easier to just use `github.NewEnterpriseClient` for everything, which is what `enumerateWithApp` seems to do:
https://github.com/trufflesecurity/trufflehog/blob/a99d89d71110b1111bb7f7724067fa8a43a2319e/pkg/sources/github/github.go#L558
