### PR TITLE
Report indeterminacy in AWS verifier

### DIFF
--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -190,9 +190,9 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						// This function will check false positives for common test words, but also it will make sure the key appears "random" enough to be a real key.
 						if detectors.IsKnownFalsePositive(resSecretMatch, detectors.DefaultFalsePositives, true) {
 							continue
-						} else {
-							s1.VerificationError = fmt.Errorf("request to %v returned unexpected status %d", res.Request.URL, res.StatusCode)
 						}
+
+						s1.VerificationError = fmt.Errorf("request to %v returned unexpected status %d", res.Request.URL, res.StatusCode)
 					}
 				} else {
 					s1.VerificationError = err

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -192,6 +192,8 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 							continue
 						}
 					}
+				} else {
+					s1.VerificationError = err
 				}
 			}
 

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -190,6 +190,8 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						// This function will check false positives for common test words, but also it will make sure the key appears "random" enough to be a real key.
 						if detectors.IsKnownFalsePositive(resSecretMatch, detectors.DefaultFalsePositives, true) {
 							continue
+						} else {
+							s1.VerificationError = fmt.Errorf("request to %v returned unexpected status %d", res.Request.URL, res.StatusCode)
 						}
 					}
 				} else {

--- a/pkg/detectors/aws/aws_test.go
+++ b/pkg/detectors/aws/aws_test.go
@@ -55,10 +55,9 @@ func TestAWS_FromChunk(t *testing.T) {
 			},
 			want: []detectors.Result{
 				{
-					DetectorType:      detectorspb.DetectorType_AWS,
-					Verified:          true,
-					VerificationError: nil,
-					Redacted:          "AKIASP2TPHJSQH3FJRUX",
+					DetectorType: detectorspb.DetectorType_AWS,
+					Verified:     true,
+					Redacted:     "AKIASP2TPHJSQH3FJRUX",
 					ExtraData: map[string]string{
 						"account": "171436882533",
 						"arn":     "arn:aws:iam::171436882533:user/canarytokens.com@@4dxkh0pdeop3bzu9zx5wob793",
@@ -78,11 +77,10 @@ func TestAWS_FromChunk(t *testing.T) {
 			},
 			want: []detectors.Result{
 				{
-					DetectorType:      detectorspb.DetectorType_AWS,
-					Verified:          false,
-					VerificationError: nil,
-					Redacted:          "AKIASP2TPHJSQH3FJRUX",
-					ExtraData:         nil,
+					DetectorType: detectorspb.DetectorType_AWS,
+					Verified:     false,
+					Redacted:     "AKIASP2TPHJSQH3FJRUX",
+					ExtraData:    nil,
 				},
 			},
 			wantErr: false,
@@ -108,10 +106,9 @@ func TestAWS_FromChunk(t *testing.T) {
 			},
 			want: []detectors.Result{
 				{
-					DetectorType:      detectorspb.DetectorType_AWS,
-					Verified:          false,
-					VerificationError: nil,
-					Redacted:          "AKIASP2TPHJSQH3FJXYZ",
+					DetectorType: detectorspb.DetectorType_AWS,
+					Verified:     false,
+					Redacted:     "AKIASP2TPHJSQH3FJXYZ",
 				},
 				{
 					DetectorType:      detectorspb.DetectorType_AWS,
@@ -148,10 +145,9 @@ func TestAWS_FromChunk(t *testing.T) {
 			},
 			want: []detectors.Result{
 				{
-					DetectorType:      detectorspb.DetectorType_AWS,
-					Verified:          true,
-					VerificationError: nil,
-					Redacted:          "AKIASP2TPHJSQH3FJRUX",
+					DetectorType: detectorspb.DetectorType_AWS,
+					Verified:     true,
+					Redacted:     "AKIASP2TPHJSQH3FJRUX",
 					ExtraData: map[string]string{
 						"account": "171436882533",
 						"arn":     "arn:aws:iam::171436882533:user/canarytokens.com@@4dxkh0pdeop3bzu9zx5wob793",
@@ -159,10 +155,9 @@ func TestAWS_FromChunk(t *testing.T) {
 					},
 				},
 				{
-					DetectorType:      detectorspb.DetectorType_AWS,
-					Verified:          false,
-					VerificationError: nil,
-					Redacted:          inactiveID,
+					DetectorType: detectorspb.DetectorType_AWS,
+					Verified:     false,
+					Redacted:     inactiveID,
 				},
 			},
 			wantErr: false,
@@ -177,10 +172,9 @@ func TestAWS_FromChunk(t *testing.T) {
 			},
 			want: []detectors.Result{
 				{
-					DetectorType:      detectorspb.DetectorType_AWS,
-					Verified:          false,
-					VerificationError: nil,
-					Redacted:          "AKIASP2TPHJSQH3FJRUX",
+					DetectorType: detectorspb.DetectorType_AWS,
+					Verified:     false,
+					Redacted:     "AKIASP2TPHJSQH3FJRUX",
 				},
 			},
 			wantErr: false,

--- a/pkg/detectors/aws/aws_test.go
+++ b/pkg/detectors/aws/aws_test.go
@@ -111,10 +111,9 @@ func TestAWS_FromChunk(t *testing.T) {
 					Redacted:     "AKIASP2TPHJSQH3FJXYZ",
 				},
 				{
-					DetectorType:      detectorspb.DetectorType_AWS,
-					Verified:          true,
-					VerificationError: nil,
-					Redacted:          "AKIASP2TPHJSQH3FJRUX",
+					DetectorType: detectorspb.DetectorType_AWS,
+					Verified:     true,
+					Redacted:     "AKIASP2TPHJSQH3FJRUX",
 					ExtraData: map[string]string{
 						"account": "171436882533",
 						"arn":     "arn:aws:iam::171436882533:user/canarytokens.com@@4dxkh0pdeop3bzu9zx5wob793",

--- a/pkg/detectors/aws/aws_test.go
+++ b/pkg/detectors/aws/aws_test.go
@@ -54,9 +54,10 @@ func TestAWS_FromChunk(t *testing.T) {
 			},
 			want: []detectors.Result{
 				{
-					DetectorType: detectorspb.DetectorType_AWS,
-					Verified:     true,
-					Redacted:     "AKIASP2TPHJSQH3FJRUX",
+					DetectorType:      detectorspb.DetectorType_AWS,
+					Verified:          true,
+					VerificationError: nil,
+					Redacted:          "AKIASP2TPHJSQH3FJRUX",
 					ExtraData: map[string]string{
 						"account": "171436882533",
 						"arn":     "arn:aws:iam::171436882533:user/canarytokens.com@@4dxkh0pdeop3bzu9zx5wob793",
@@ -76,10 +77,11 @@ func TestAWS_FromChunk(t *testing.T) {
 			},
 			want: []detectors.Result{
 				{
-					DetectorType: detectorspb.DetectorType_AWS,
-					Verified:     false,
-					Redacted:     "AKIASP2TPHJSQH3FJRUX",
-					ExtraData:    nil,
+					DetectorType:      detectorspb.DetectorType_AWS,
+					Verified:          false,
+					VerificationError: nil,
+					Redacted:          "AKIASP2TPHJSQH3FJRUX",
+					ExtraData:         nil,
 				},
 			},
 			wantErr: false,
@@ -105,14 +107,16 @@ func TestAWS_FromChunk(t *testing.T) {
 			},
 			want: []detectors.Result{
 				{
-					DetectorType: detectorspb.DetectorType_AWS,
-					Verified:     false,
-					Redacted:     "AKIASP2TPHJSQH3FJXYZ",
+					DetectorType:      detectorspb.DetectorType_AWS,
+					Verified:          false,
+					VerificationError: nil,
+					Redacted:          "AKIASP2TPHJSQH3FJXYZ",
 				},
 				{
-					DetectorType: detectorspb.DetectorType_AWS,
-					Verified:     true,
-					Redacted:     "AKIASP2TPHJSQH3FJRUX",
+					DetectorType:      detectorspb.DetectorType_AWS,
+					Verified:          true,
+					VerificationError: nil,
+					Redacted:          "AKIASP2TPHJSQH3FJRUX",
 					ExtraData: map[string]string{
 						"account": "171436882533",
 						"arn":     "arn:aws:iam::171436882533:user/canarytokens.com@@4dxkh0pdeop3bzu9zx5wob793",
@@ -143,9 +147,10 @@ func TestAWS_FromChunk(t *testing.T) {
 			},
 			want: []detectors.Result{
 				{
-					DetectorType: detectorspb.DetectorType_AWS,
-					Verified:     true,
-					Redacted:     "AKIASP2TPHJSQH3FJRUX",
+					DetectorType:      detectorspb.DetectorType_AWS,
+					Verified:          true,
+					VerificationError: nil,
+					Redacted:          "AKIASP2TPHJSQH3FJRUX",
 					ExtraData: map[string]string{
 						"account": "171436882533",
 						"arn":     "arn:aws:iam::171436882533:user/canarytokens.com@@4dxkh0pdeop3bzu9zx5wob793",
@@ -153,9 +158,10 @@ func TestAWS_FromChunk(t *testing.T) {
 					},
 				},
 				{
-					DetectorType: detectorspb.DetectorType_AWS,
-					Verified:     false,
-					Redacted:     inactiveID,
+					DetectorType:      detectorspb.DetectorType_AWS,
+					Verified:          false,
+					VerificationError: nil,
+					Redacted:          inactiveID,
 				},
 			},
 			wantErr: false,
@@ -170,9 +176,10 @@ func TestAWS_FromChunk(t *testing.T) {
 			},
 			want: []detectors.Result{
 				{
-					DetectorType: detectorspb.DetectorType_AWS,
-					Verified:     false,
-					Redacted:     "AKIASP2TPHJSQH3FJRUX",
+					DetectorType:      detectorspb.DetectorType_AWS,
+					Verified:          false,
+					VerificationError: nil,
+					Redacted:          "AKIASP2TPHJSQH3FJRUX",
 				},
 			},
 			wantErr: false,

--- a/pkg/pb/detectorspb/detectors.pb.go
+++ b/pkg/pb/detectorspb/detectors.pb.go
@@ -2877,9 +2877,7 @@ type Result struct {
 	HashV2         string            `protobuf:"bytes,8,opt,name=hash_v2,json=hashV2,proto3" json:"hash_v2,omitempty"`
 	DecoderType    DecoderType       `protobuf:"varint,9,opt,name=decoder_type,json=decoderType,proto3,enum=detectors.DecoderType" json:"decoder_type,omitempty"`
 	// This field should only be populated if the verification process itself failed in a way that provides no information
-	// about the verification status of the candidate secret. This is because if this field is set, the application will
-	// ignore the contents of the `verified` field. An example of such a situation is a verification request that timed
-	// out.
+	// about the verification status of the candidate secret, such as if the verification request timed out.
 	VerificationErrorMessage string `protobuf:"bytes,10,opt,name=verification_error_message,json=verificationErrorMessage,proto3" json:"verification_error_message,omitempty"`
 }
 


### PR DESCRIPTION
This is the first (tentative) implementation of verifier indeterminacy. It modifies the AWS verifier to report verification indeterminacy in two cases:
* Something goes wrong with the HTTP request itself (such as a context timeout)
* The returned status code is outside of [200, 300)

Note that this implementation stores the requested URI in the error that is reported. This is for two reasons. The first is that the context timeout err contains this information by default. The second is that I explicitly added it for unexpected status codes for parity with the previous and to aid with debugging. Presumably AWS wouldn't allow you put anything sensitive in a URI (in this case it's the key ID but not the secret) but it's something to keep in mind going forward.

I also updated a generated proto comment that I forgot to do earlier.