### PR TITLE
do not report AWS 403s as indeterminate

### DIFF
--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -192,7 +192,9 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 							continue
 						}
 
-						s1.VerificationError = fmt.Errorf("request to %v returned unexpected status %d", res.Request.URL, res.StatusCode)
+						if res.StatusCode != 403 {
+							s1.VerificationError = fmt.Errorf("request to %v returned unexpected status %d", res.Request.URL, res.StatusCode)
+						}
 					}
 				} else {
 					s1.VerificationError = err


### PR DESCRIPTION
These are quite determinate!

There is _already_ a test that detects this (it's how I noticed it!), I just didn't notice it before merging #1480.