### PR TITLE
Rewrite SourceUnitEnumerator to use UnitReporter instead of a channel

### DIFF
--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -220,10 +220,10 @@ func (s *Source) scanFile(ctx context.Context, path string, chunksChan chan *sou
 // Enumerate implements SourceUnitEnumerator interface. This implementation simply
 // passes the configured paths as the source unit, whether it be a single
 // filepath or a directory.
-func (s *Source) Enumerate(ctx context.Context, units chan<- sources.EnumerationResult) error {
+func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) error {
 	for _, path := range s.paths {
-		item := sources.CommonEnumerationOk(path)
-		if err := common.CancellableWrite(ctx, units, item); err != nil {
+		item := sources.CommonSourceUnit{ID: path}
+		if err := reporter.UnitOk(ctx, item); err != nil {
 			return err
 		}
 	}

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -53,21 +53,22 @@ type SourceUnitUnmarshaller interface {
 // SourceUnitEnumerator defines an optional interface a Source can implement to
 // support enumerating an initialized Source into SourceUnits.
 type SourceUnitEnumerator interface {
-	// Enumerate enumerates the initialized Source, outputting units. This
-	// method is synchronous but can be called in a goroutine to support
-	// concurrent enumeration and chunking. An error should only be
-	// returned from this method in the case of context cancellation. All
-	// other errors related to unit enumeration are tracked in the
-	// EnumerationResult.
-	Enumerate(ctx context.Context, units chan<- EnumerationResult) error
+	// Enumerate creates 0 or more units from an initialized source,
+	// reporting them or any errors to the UnitReporter. This method is
+	// synchronous but can be called in a goroutine to support concurrent
+	// enumeration and chunking. An error should only be returned from this
+	// method in the case of context cancellation, fatal source errors, or
+	// errors returned by the reporter All other errors related to unit
+	// enumeration are tracked by the UnitReporter.
+	Enumerate(ctx context.Context, reporter UnitReporter) error
 }
 
-// EnumerationResult is the result of an enumeration, containing the unit and
-// error if any. Unit and Error are mutually exclusive (only one will be
-// non-nil).
-type EnumerationResult struct {
-	Unit  SourceUnit
-	Error error
+// UnitReporter defines the interface a source will use to report whether a
+// unit was found during enumeration. Either method may be called any number of
+// times. Implementors of this interface should allow for concurrent calls.
+type UnitReporter interface {
+	UnitOk(ctx context.Context, unit SourceUnit) error
+	UnitErr(ctx context.Context, err error) error
 }
 
 // SourceUnit is an object that represents a Source's unit of work. This is
@@ -242,17 +243,4 @@ func (p *Progress) GetProgress() *Progress {
 	p.mut.Lock()
 	defer p.mut.Unlock()
 	return p
-}
-
-// CommonEnumerationOk is a helper function to construct an EnumerationResult
-// using a CommonSourceUnit.
-func CommonEnumerationOk(id string) EnumerationResult {
-	unit := CommonSourceUnit{ID: id}
-	return EnumerationResult{Unit: unit}
-}
-
-// EnumerationErr is a helper function to construct an EnumerationResult from
-// an error.
-func EnumerationErr(err error) EnumerationResult {
-	return EnumerationResult{Error: err}
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
