### PR TITLE
Fix URI detector false positives when the redacted password has been URL encoded

### DIFF
--- a/pkg/detectors/uri/uri.go
+++ b/pkg/detectors/uri/uri.go
@@ -53,7 +53,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		password := match[1]
 
 		// Skip findings where the password only has "*" characters, this is a redacted password
-		if strings.Trim(password, "*") == "" {
+		// Also include the url encoded "*" characters: "%2A"
+		if strings.Trim(password, "*") == "" || strings.Trim(password, "%2A") == "" {
 			continue
 		}
 

--- a/pkg/detectors/uri/uri_test.go
+++ b/pkg/detectors/uri/uri_test.go
@@ -87,6 +87,17 @@ func TestURI_FromChunk(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "nothing found, password was redacted two different ways",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("Both %s and %s have been redacted within", "https://httpwatch::********@www.httpwatch.com/httpgallery/authentication/authenticatedimage/default.aspx?foo=bar", "https://httpwatch::%2A%2A%2A%2A%2A%2A@www.httpwatch.com/httpgallery/authentication/authenticatedimage/default.aspx?foo=bar")),
+				verify: true,
+			},
+			want:    []detectors.Result{},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/detectors/uri/uri_test.go
+++ b/pkg/detectors/uri/uri_test.go
@@ -31,14 +31,14 @@ func TestURI_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a uri secret %s within", "https://user:pass@www.httpwatch.com/httpgallery/authentication/authenticatedimage/default.aspx")),
+				data:   []byte(fmt.Sprintf("You can find a uri secret %s within", "https://user:pass@httpwatch.com/httpgallery/authentication/authenticatedimage/default.aspx")),
 				verify: true,
 			},
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_URI,
 					Verified:     false,
-					Redacted:     "https://user:********@www.httpwatch.com",
+					Redacted:     "https://user:********@httpwatch.com",
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
We occasionally see redacted passwords that have been URL encoded, which means the password is `%2A%2A%2A%2A%2A%2A%2A%2A` instead of `********`. This makes sure those are also not included as findings.