### PR TITLE
tweak jdbc redaction

### DIFF
--- a/pkg/detectors/jdbc/jdbc.go
+++ b/pkg/detectors/jdbc/jdbc.go
@@ -101,13 +101,13 @@ matchLoop:
 }
 
 func tryRedactAnonymousJDBC(conn string) string {
-	if s, ok := tryRedactBasicAuth(conn); ok {
-		return s
-	}
 	if s, ok := tryRedactURLParams(conn); ok {
 		return s
 	}
 	if s, ok := tryRedactODBC(conn); ok {
+		return s
+	}
+	if s, ok := tryRedactBasicAuth(conn); ok {
 		return s
 	}
 	if s, ok := tryRedactRegex(conn); ok {
@@ -158,7 +158,10 @@ func tryRedactODBC(conn string) (string, bool) {
 	var found bool
 	var newParams []string
 	for _, param := range strings.Split(conn, ";") {
-		key, val, _ := strings.Cut(param, "=")
+		key, val, isKvp := strings.Cut(param, "=")
+		if !isKvp {
+			continue
+		}
 		if strings.Contains(strings.ToLower(key), "pass") {
 			newParams = append(newParams, key+"="+strings.Repeat("*", len(val)))
 			found = true

--- a/pkg/detectors/jdbc/jdbc.go
+++ b/pkg/detectors/jdbc/jdbc.go
@@ -159,10 +159,7 @@ func tryRedactODBC(conn string) (string, bool) {
 	var newParams []string
 	for _, param := range strings.Split(conn, ";") {
 		key, val, isKvp := strings.Cut(param, "=")
-		if !isKvp {
-			continue
-		}
-		if strings.Contains(strings.ToLower(key), "pass") {
+		if isKvp && strings.Contains(strings.ToLower(key), "pass") {
 			newParams = append(newParams, key+"="+strings.Repeat("*", len(val)))
 			found = true
 			continue

--- a/pkg/detectors/jdbc/jdbc_test.go
+++ b/pkg/detectors/jdbc/jdbc_test.go
@@ -5,6 +5,7 @@ package jdbc
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
 
@@ -203,6 +204,36 @@ func TestJdbc_FromDataWithIgnorePattern(t *testing.T) {
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Jdbc.FromDataWithConfig() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
+		})
+	}
+}
+
+func TestJdbc_Redact(t *testing.T) {
+	tests := []struct {
+		name string
+		conn string
+		want string
+	}{
+		{
+			name: "username:password@host",
+			conn: "//wrongUser:wrongPass@tcp(127.0.0.1:3306)/",
+			want: "//wrongUser:*********@tcp(127.0.0.1:3306)/",
+		},
+		{
+			name: "url param-style",
+			conn: "jdbc:postgresql://localhost:5432/foo?sslmode=disable&password=p@ssw04d",
+			want: "jdbc:postgresql://localhost:5432/foo?sslmode=disable&password=********",
+		},
+		{
+			name: "odbc-style",
+			conn: "//odbc:server=localhost;user id=sa;database=master;password=p@ssw0rd",
+			want: "//odbc:server=localhost;user id=sa;database=master;password=********",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tryRedactAnonymousJDBC(tt.conn)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/detectors/jdbc/jdbc_test.go
+++ b/pkg/detectors/jdbc/jdbc_test.go
@@ -231,8 +231,8 @@ func TestJdbc_Redact(t *testing.T) {
 		},
 		{
 			name: "odbc-style",
-			conn: "//odbc:server=localhost;user id=sa;database=master;password=p@ssw0rd",
-			want: "//odbc:server=localhost;user id=sa;database=master;password=********",
+			conn: "//odbc:server=localhost;user id=sa;database=master;password=/p?s=sw&rd",
+			want: "//odbc:server=localhost;user id=sa;database=master;password=**********",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/detectors/jdbc/jdbc_test.go
+++ b/pkg/detectors/jdbc/jdbc_test.go
@@ -220,6 +220,11 @@ func TestJdbc_Redact(t *testing.T) {
 			want: "//wrongUser:*********@tcp(127.0.0.1:3306)/",
 		},
 		{
+			name: "username:password@host with unfortunate db name",
+			conn: "//wrongUser:wrongPass@tcp(127.0.0.1:3306)/passwords",
+			want: "//wrongUser:*********@tcp(127.0.0.1:3306)/passwords",
+		},
+		{
 			name: "url param-style",
 			conn: "jdbc:postgresql://localhost:5432/foo?sslmode=disable&password=p@ssw04d",
 			want: "jdbc:postgresql://localhost:5432/foo?sslmode=disable&password=********",

--- a/pkg/detectors/jdbc/jdbc_test.go
+++ b/pkg/detectors/jdbc/jdbc_test.go
@@ -215,12 +215,17 @@ func TestJdbc_Redact(t *testing.T) {
 		want string
 	}{
 		{
-			name: "username:password@host",
+			name: "basic auth'",
+			conn: "//user:secret@tcp(127.0.0.1:3306)/",
+			want: "//user:******@tcp(127.0.0.1:3306)/",
+		},
+		{
+			name: "basic auth including raw string 'pass'",
 			conn: "//wrongUser:wrongPass@tcp(127.0.0.1:3306)/",
 			want: "//wrongUser:*********@tcp(127.0.0.1:3306)/",
 		},
 		{
-			name: "username:password@host with unfortunate db name",
+			name: "basic auth including raw string 'pass' with unfortunate db name",
 			conn: "//wrongUser:wrongPass@tcp(127.0.0.1:3306)/passwords",
 			want: "//wrongUser:*********@tcp(127.0.0.1:3306)/passwords",
 		},
@@ -230,9 +235,14 @@ func TestJdbc_Redact(t *testing.T) {
 			want: "jdbc:postgresql://localhost:5432/foo?sslmode=disable&password=********",
 		},
 		{
-			name: "odbc-style",
+			name: "odbc-style without server",
 			conn: "//odbc:server=localhost;user id=sa;database=master;password=/p?s=sw&rd",
 			want: "//odbc:server=localhost;user id=sa;database=master;password=**********",
+		},
+		{
+			name: "odbc-style with server",
+			conn: "jdbc:sqlserver://a.b.c.net;database=database-name;spring.datasource.password=super-secret-password",
+			want: "jdbc:sqlserver://a.b.c.net;database=database-name;spring.datasource.password=*********************",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
JDBC redaction could fail in some irritating edge cases involving passwords that contain the `@` character. The logic has been tweaked to eliminate these cases and some tests have been added.