### PR TITLE
[chore] - update detector template file

### DIFF
--- a/hack/generate/generate.go
+++ b/hack/generate/generate.go
@@ -34,12 +34,12 @@ func main() {
 	case "detector":
 		mustWriteTemplates([]templateJob{
 			{
-				TemplatePath:  "pkg/detectors/heroku/heroku.go",
+				TemplatePath:  "pkg/detectors/alchemy/alchemy.go",
 				WritePath:     filepath.Join(folderPath(), nameLower+".go"),
 				ReplaceString: []string{"heroku"},
 			},
 			{
-				TemplatePath:  "pkg/detectors/heroku/heroku_test.go",
+				TemplatePath:  "pkg/detectors/alchemy/alchemy_test.go",
 				WritePath:     filepath.Join(folderPath(), nameLower+"_test.go"),
 				ReplaceString: []string{"heroku"},
 			},

--- a/hack/generate/generate.go
+++ b/hack/generate/generate.go
@@ -36,12 +36,12 @@ func main() {
 			{
 				TemplatePath:  "pkg/detectors/alchemy/alchemy.go",
 				WritePath:     filepath.Join(folderPath(), nameLower+".go"),
-				ReplaceString: []string{"heroku"},
+				ReplaceString: []string{"alchemy"},
 			},
 			{
 				TemplatePath:  "pkg/detectors/alchemy/alchemy_test.go",
 				WritePath:     filepath.Join(folderPath(), nameLower+"_test.go"),
-				ReplaceString: []string{"heroku"},
+				ReplaceString: []string{"alchemy"},
 			},
 		})
 		// case "source":


### PR DESCRIPTION
- The detector template file used to generate new detector uses `detectors2` Google Secret. We have reached the limit for the number of items in a single secret file. Use `detectors4` instead.