### PR TITLE
unify JDBC detector ping logic

### DIFF
--- a/pkg/detectors/jdbc/jdbc.go
+++ b/pkg/detectors/jdbc/jdbc.go
@@ -220,11 +220,13 @@ func newJDBC(conn string) (jdbc, error) {
 	return parser(subname)
 }
 
-func ping(ctx context.Context, driverName, conn string) bool {
-	if err := pingErr(ctx, driverName, conn); err != nil {
-		return false
+func ping(ctx context.Context, driverName string, candidateConns ...string) bool {
+	for _, c := range candidateConns {
+		if err := pingErr(ctx, driverName, c); err == nil {
+			return true
+		}
 	}
-	return true
+	return false
 }
 
 func pingErr(ctx context.Context, driverName, conn string) error {

--- a/pkg/detectors/jdbc/jdbc_integration_test.go
+++ b/pkg/detectors/jdbc/jdbc_integration_test.go
@@ -105,6 +105,22 @@ func TestJdbcVerified(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "sql server verified",
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("jdbc:sqlserver://odbc:server=localhost;database=%s;password=%s", sqlServerDatabase, sqlServerPass)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_JDBC,
+					Verified:     true,
+					Redacted:     "jdbc:sqlserver://odbc:server=localhost;database=master;password=**************",
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/detectors/jdbc/mysql.go
+++ b/pkg/detectors/jdbc/mysql.go
@@ -21,14 +21,14 @@ func (s *mysqlJDBC) ping(ctx context.Context) bool {
 		return true
 	}
 	// try building connection string (should be same as s.conn though)
-	if ping(ctx, "mysql", buildConnectionString(s.host, s.database, s.userPass, s.params)) {
+	if ping(ctx, "mysql", buildMySQLConnectionString(s.host, s.database, s.userPass, s.params)) {
 		return true
 	}
 	// try removing database
-	return ping(ctx, "mysql", buildConnectionString(s.host, "", s.userPass, s.params))
+	return ping(ctx, "mysql", buildMySQLConnectionString(s.host, "", s.userPass, s.params))
 }
 
-func buildConnectionString(host, database, userPass, params string) string {
+func buildMySQLConnectionString(host, database, userPass, params string) string {
 	conn := host + "/" + database
 	if userPass != "" {
 		conn = userPass + "@" + conn

--- a/pkg/detectors/jdbc/mysql.go
+++ b/pkg/detectors/jdbc/mysql.go
@@ -21,21 +21,20 @@ func (s *mysqlJDBC) ping(ctx context.Context) bool {
 		return true
 	}
 	// try building connection string (should be same as s.conn though)
-	if ping(ctx, "mysql", s.build()) {
+	if ping(ctx, "mysql", buildConnectionString(s.host, s.database, s.userPass, s.params)) {
 		return true
 	}
 	// try removing database
-	s.database = ""
-	return ping(ctx, "mysql", s.build())
+	return ping(ctx, "mysql", buildConnectionString(s.host, "", s.userPass, s.params))
 }
 
-func (s *mysqlJDBC) build() string {
-	conn := s.host + "/" + s.database
-	if s.userPass != "" {
-		conn = s.userPass + "@" + conn
+func buildConnectionString(host, database, userPass, params string) string {
+	conn := host + "/" + database
+	if userPass != "" {
+		conn = userPass + "@" + conn
 	}
-	if s.params != "" {
-		conn = conn + "?" + s.params
+	if params != "" {
+		conn = conn + "?" + params
 	}
 	return conn
 }

--- a/pkg/detectors/jdbc/mysql.go
+++ b/pkg/detectors/jdbc/mysql.go
@@ -17,15 +17,10 @@ type mysqlJDBC struct {
 }
 
 func (s *mysqlJDBC) ping(ctx context.Context) bool {
-	if ping(ctx, "mysql", s.conn) {
-		return true
-	}
-	// try building connection string (should be same as s.conn though)
-	if ping(ctx, "mysql", buildMySQLConnectionString(s.host, s.database, s.userPass, s.params)) {
-		return true
-	}
-	// try removing database
-	return ping(ctx, "mysql", buildMySQLConnectionString(s.host, "", s.userPass, s.params))
+	return ping(ctx, "mysql",
+		s.conn,
+		buildMySQLConnectionString(s.host, s.database, s.userPass, s.params),
+		buildMySQLConnectionString(s.host, "", s.userPass, s.params))
 }
 
 func buildMySQLConnectionString(host, database, userPass, params string) string {

--- a/pkg/detectors/jdbc/postgres.go
+++ b/pkg/detectors/jdbc/postgres.go
@@ -15,23 +15,11 @@ type postgresJDBC struct {
 }
 
 func (s *postgresJDBC) ping(ctx context.Context) bool {
-	// try the provided connection string directly
-	if ping(ctx, "postgres", s.conn) {
-		return true
-	}
-	// try as a URL
-	if ping(ctx, "postgres", "postgres://"+s.conn) {
-		return true
-	}
-	// build a connection string
-	if ping(ctx, "postgres", buildPostgresConnectionString(s.params, true)) {
-		return true
-	}
-	// ignore the db
-	if ping(ctx, "postgres", buildPostgresConnectionString(s.params, false)) {
-		return true
-	}
-	return false
+	return ping(ctx, "postgres",
+		s.conn,
+		"postgres://"+s.conn,
+		buildPostgresConnectionString(s.params, true),
+		buildPostgresConnectionString(s.params, false))
 }
 
 func joinKeyValues(m map[string]string, sep string) string {

--- a/pkg/detectors/jdbc/sqlserver.go
+++ b/pkg/detectors/jdbc/sqlserver.go
@@ -14,14 +14,10 @@ type sqlServerJDBC struct {
 }
 
 func (s *sqlServerJDBC) ping(ctx context.Context) bool {
-	if ping(ctx, "mssql", s.conn) {
-		return true
-	}
-	if ping(ctx, "mssql", joinKeyValues(s.params, ";")) {
-		return true
-	}
-	// try URL format
-	return ping(ctx, "mssql", "sqlserver://"+s.conn)
+	return ping(ctx, "mssql",
+		s.conn,
+		joinKeyValues(s.params, ";"),
+		"sqlserver://"+s.conn)
 }
 
 func parseSqlServer(subname string) (jdbc, error) {

--- a/pkg/detectors/jdbc/sqlserver_integration_test.go
+++ b/pkg/detectors/jdbc/sqlserver_integration_test.go
@@ -35,7 +35,7 @@ func TestSqlServer(t *testing.T) {
 			wantPing: true,
 		},
 		{
-			input:    "//localhost;database= master;spring.datasource.password=" + sqlServerPass,
+			input:    "//localhost;database=master;spring.datasource.password=" + sqlServerPass,
 			wantPing: true,
 		},
 	}


### PR DESCRIPTION
Previously, the various JDBC detectors would independently try to verify credentials by a process of trying various permutations of candidates one-by-one. The upcoming tri-state verification work will need to add sophistication to this process in the same way for each one, so this PR first combines all of the logic so it can be upgraded in a single spot.