### PR TITLE
JDBC indeterminacy

### DIFF
--- a/pkg/detectors/jdbc/jdbc.go
+++ b/pkg/detectors/jdbc/jdbc.go
@@ -86,7 +86,14 @@ matchLoop:
 			}
 			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
-			s.Verified = j.ping(ctx)
+			pingRes := j.ping(ctx)
+			s.Verified = pingRes.err == nil
+			// If there's a ping error that is marked as "determinate" we throw it away. We do this because this was the
+			// behavior before tri-state verification was introduced and preserving it allows us to gradually migrate
+			// detectors to use tri-state verification.
+			if pingRes.err != nil && pingRes.determinate {
+				s.VerificationError = pingRes.err
+			}
 			// TODO: specialized redaction
 		}
 
@@ -198,8 +205,13 @@ var supportedSubprotocols = map[string]func(string) (jdbc, error){
 	"sqlserver":  parseSqlServer,
 }
 
+type pingResult struct {
+	err         error
+	determinate bool
+}
+
 type jdbc interface {
-	ping(context.Context) bool
+	ping(context.Context) pingResult
 }
 
 func newJDBC(conn string) (jdbc, error) {
@@ -220,13 +232,16 @@ func newJDBC(conn string) (jdbc, error) {
 	return parser(subname)
 }
 
-func ping(ctx context.Context, driverName string, candidateConns ...string) bool {
+func ping(ctx context.Context, driverName string, isDeterminate func(error) bool, candidateConns ...string) pingResult {
+	var indeterminateErrors []error
 	for _, c := range candidateConns {
-		if err := pingErr(ctx, driverName, c); err == nil {
-			return true
+		err := pingErr(ctx, driverName, c)
+		if err == nil || isDeterminate(err) {
+			return pingResult{err, true}
 		}
+		indeterminateErrors = append(indeterminateErrors, err)
 	}
-	return false
+	return pingResult{errors.Join(indeterminateErrors...), false}
 }
 
 func pingErr(ctx context.Context, driverName, conn string) error {

--- a/pkg/detectors/jdbc/jdbc.go
+++ b/pkg/detectors/jdbc/jdbc.go
@@ -91,7 +91,7 @@ matchLoop:
 			// If there's a ping error that is marked as "determinate" we throw it away. We do this because this was the
 			// behavior before tri-state verification was introduced and preserving it allows us to gradually migrate
 			// detectors to use tri-state verification.
-			if pingRes.err != nil && pingRes.determinate {
+			if pingRes.err != nil && !pingRes.determinate {
 				s.VerificationError = pingRes.err
 			}
 			// TODO: specialized redaction

--- a/pkg/detectors/jdbc/mysql.go
+++ b/pkg/detectors/jdbc/mysql.go
@@ -48,11 +48,6 @@ func isMySQLErrorDeterminate(err error) bool {
 		}
 	}
 
-	// For most detectors, if we don't know exactly what the problem is, we should return "determinate" in order to
-	// mimic the two-state verification logic. But the JDBC detector is special: It tries multiple variations on a given
-	// found secret in a waterfall, and returning "true" here terminates the waterfall. Therefore, it is safer to return
-	// false by default so that we don't incorrectly terminate before we find a valid variation. This catch-all also
-	// handles cases like network errors.
 	return false
 }
 

--- a/pkg/detectors/jdbc/mysql.go
+++ b/pkg/detectors/jdbc/mysql.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"github.com/go-sql-driver/mysql"
 	"strings"
-
-	_ "github.com/go-sql-driver/mysql"
 )
 
 type mysqlJDBC struct {

--- a/pkg/detectors/jdbc/mysql.go
+++ b/pkg/detectors/jdbc/mysql.go
@@ -16,8 +16,8 @@ type mysqlJDBC struct {
 	params   string
 }
 
-func (s *mysqlJDBC) ping(ctx context.Context) bool {
-	return ping(ctx, "mysql",
+func (s *mysqlJDBC) ping(ctx context.Context) pingResult {
+	return ping(ctx, "mysql", isMySQLErrorDeterminate,
 		s.conn,
 		buildMySQLConnectionString(s.host, s.database, s.userPass, s.params),
 		buildMySQLConnectionString(s.host, "", s.userPass, s.params))
@@ -32,6 +32,10 @@ func buildMySQLConnectionString(host, database, userPass, params string) string 
 		conn = conn + "?" + params
 	}
 	return conn
+}
+
+func isMySQLErrorDeterminate(err error) bool {
+	return true
 }
 
 func parseMySQL(subname string) (jdbc, error) {

--- a/pkg/detectors/jdbc/mysql_integration_test.go
+++ b/pkg/detectors/jdbc/mysql_integration_test.go
@@ -68,6 +68,8 @@ func TestMySQL(t *testing.T) {
 			pr := j.ping(context.Background())
 			if tt.wantPingErr {
 				assert.Error(t, pr.err)
+			} else {
+				assert.NoError(t, pr.err)
 			}
 			assert.Equal(t, pr.determinate, tt.wantPingDeterminate)
 		})

--- a/pkg/detectors/jdbc/postgres.go
+++ b/pkg/detectors/jdbc/postgres.go
@@ -44,11 +44,6 @@ func isPostgresErrorDeterminate(err error) bool {
 		}
 	}
 
-	// For most detectors, if we don't know exactly what the problem is, we should return "determinate" in order to
-	// mimic the two-state verification logic. But the JDBC detector is special: It tries multiple variations on a given
-	// found secret in a waterfall, and returning "true" here terminates the waterfall. Therefore, it is safer to return
-	// false by default so that we don't incorrectly terminate before we find a valid variation. This catch-all also
-	// handles cases like network errors.
 	return false
 }
 

--- a/pkg/detectors/jdbc/postgres.go
+++ b/pkg/detectors/jdbc/postgres.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"github.com/lib/pq"
 	"strings"
-
-	_ "github.com/lib/pq"
 )
 
 type postgresJDBC struct {

--- a/pkg/detectors/jdbc/postgres.go
+++ b/pkg/detectors/jdbc/postgres.go
@@ -14,12 +14,16 @@ type postgresJDBC struct {
 	params map[string]string
 }
 
-func (s *postgresJDBC) ping(ctx context.Context) bool {
-	return ping(ctx, "postgres",
+func (s *postgresJDBC) ping(ctx context.Context) pingResult {
+	return ping(ctx, "postgres", isPostgresErrorDeterminate,
 		s.conn,
 		"postgres://"+s.conn,
 		buildPostgresConnectionString(s.params, true),
 		buildPostgresConnectionString(s.params, false))
+}
+
+func isPostgresErrorDeterminate(err error) bool {
+	return true
 }
 
 func joinKeyValues(m map[string]string, sep string) string {

--- a/pkg/detectors/jdbc/postgres_integration_test.go
+++ b/pkg/detectors/jdbc/postgres_integration_test.go
@@ -44,7 +44,7 @@ func TestPostgres(t *testing.T) {
 		{
 			input:               "//localhost:5432/foo?password=" + postgresPass,
 			wantPingErr:         true,
-			wantPingDeterminate: true,
+			wantPingDeterminate: false, // No SSL
 		},
 		{
 			input:               "//localhost:5432/foo?sslmode=disable&password=foo",
@@ -55,6 +55,11 @@ func TestPostgres(t *testing.T) {
 			input:               "//localhost:5432/foo?sslmode=disable&user=foo&password=" + postgresPass,
 			wantPingErr:         true,
 			wantPingDeterminate: true,
+		},
+		{
+			input:               "//badhost:5432/foo?sslmode=disable&user=foo&password=" + postgresPass,
+			wantPingErr:         true,
+			wantPingDeterminate: false,
 		},
 		{
 			input:        "invalid",
@@ -72,6 +77,8 @@ func TestPostgres(t *testing.T) {
 			pr := j.ping(context.Background())
 			if tt.wantPingErr {
 				assert.Error(t, pr.err)
+			} else {
+				assert.NoError(t, pr.err)
 			}
 			assert.Equal(t, pr.determinate, tt.wantPingDeterminate)
 		})

--- a/pkg/detectors/jdbc/postgres_integration_test.go
+++ b/pkg/detectors/jdbc/postgres_integration_test.go
@@ -80,7 +80,7 @@ func TestPostgres(t *testing.T) {
 			} else {
 				assert.NoError(t, pr.err)
 			}
-			assert.Equal(t, pr.determinate, tt.wantPingDeterminate)
+			assert.Equal(t, tt.wantPingDeterminate, pr.determinate)
 		})
 	}
 }

--- a/pkg/detectors/jdbc/sqlite.go
+++ b/pkg/detectors/jdbc/sqlite.go
@@ -14,12 +14,18 @@ type sqliteJDBC struct {
 	testing  bool
 }
 
-func (s *sqliteJDBC) ping(ctx context.Context) bool {
+var cannotVerifySqliteError error = errors.New("sqlite credentials cannot be verified")
+
+func (s *sqliteJDBC) ping(ctx context.Context) pingResult {
 	if !s.testing {
 		// sqlite is not a networked database, so we cannot verify
-		return false
+		return pingResult{cannotVerifySqliteError, true}
 	}
-	return ping(ctx, "sqlite3", s.filename)
+	return ping(ctx, "sqlite3", isSqliteErrorDeterminate, s.filename)
+}
+
+func isSqliteErrorDeterminate(err error) bool {
+	return true
 }
 
 func parseSqlite(subname string) (jdbc, error) {

--- a/pkg/detectors/jdbc/sqlite_test.go
+++ b/pkg/detectors/jdbc/sqlite_test.go
@@ -39,7 +39,7 @@ func TestParseSqlite(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.True(t, j.ping(context.Background()))
+				assert.True(t, j.ping(context.Background()).err == nil)
 			}
 		})
 	}

--- a/pkg/detectors/jdbc/sqlserver.go
+++ b/pkg/detectors/jdbc/sqlserver.go
@@ -13,11 +13,15 @@ type sqlServerJDBC struct {
 	params map[string]string
 }
 
-func (s *sqlServerJDBC) ping(ctx context.Context) bool {
-	return ping(ctx, "mssql",
+func (s *sqlServerJDBC) ping(ctx context.Context) pingResult {
+	return ping(ctx, "mssql", isSqlServerErrorDeterminate,
 		s.conn,
 		joinKeyValues(s.params, ";"),
 		"sqlserver://"+s.conn)
+}
+
+func isSqlServerErrorDeterminate(err error) bool {
+	return true
 }
 
 func parseSqlServer(subname string) (jdbc, error) {

--- a/pkg/detectors/jdbc/sqlserver.go
+++ b/pkg/detectors/jdbc/sqlserver.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	mssql "github.com/denisenkom/go-mssqldb"
 	"strings"
-
-	_ "github.com/denisenkom/go-mssqldb"
 )
 
 type sqlServerJDBC struct {

--- a/pkg/detectors/jdbc/sqlserver.go
+++ b/pkg/detectors/jdbc/sqlserver.go
@@ -32,11 +32,6 @@ func isSqlServerErrorDeterminate(err error) bool {
 		}
 	}
 
-	// For most detectors, if we don't know exactly what the problem is, we should return "determinate" in order to
-	// mimic the two-state verification logic. But the JDBC detector is special: It tries multiple variations on a given
-	// found secret in a waterfall, and returning "true" here terminates the waterfall. Therefore, it is safer to return
-	// false by default so that we don't incorrectly terminate before we find a valid variation. This catch-all also
-	// handles cases like network errors.
 	return false
 }
 

--- a/pkg/detectors/jdbc/sqlserver.go
+++ b/pkg/detectors/jdbc/sqlserver.go
@@ -3,6 +3,8 @@ package jdbc
 import (
 	"context"
 	"errors"
+	mssql "github.com/denisenkom/go-mssqldb"
+	"net"
 	"strings"
 
 	_ "github.com/denisenkom/go-mssqldb"
@@ -15,13 +17,32 @@ type sqlServerJDBC struct {
 
 func (s *sqlServerJDBC) ping(ctx context.Context) pingResult {
 	return ping(ctx, "mssql", isSqlServerErrorDeterminate,
-		s.conn,
 		joinKeyValues(s.params, ";"),
+		s.conn,
 		"sqlserver://"+s.conn)
 }
 
 func isSqlServerErrorDeterminate(err error) bool {
-	return true
+	// Could be an invalid host, but it could also be transient
+	if _, isDnsError := err.(*net.DNSError); isDnsError {
+		return false
+	}
+
+	// Error numbers from https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors?view=sql-server-ver16
+	if mssqlError, isMssqlError := err.(mssql.Error); isMssqlError {
+		switch mssqlError.Number {
+		case 18456:
+			// Login failed
+			// This is a determinate failure iff we tried to use a real user
+			return mssqlError.Message != "login error: Login failed for user ''."
+		}
+	}
+
+	// For most detectors, if we don't know exactly what the problem is, we should return "determinate" in order to
+	// mimic the two-state verification logic. But the JDBC detector is special: It tries multiple variations on a given
+	// found secret in a waterfall, and returning "true" here terminates the waterfall. Therefore, it is safer to return
+	// false by default so that we don't incorrectly terminate before we find a valid variation.
+	return false
 }
 
 func parseSqlServer(subname string) (jdbc, error) {

--- a/pkg/detectors/jdbc/sqlserver_integration_test.go
+++ b/pkg/detectors/jdbc/sqlserver_integration_test.go
@@ -32,13 +32,23 @@ func TestSqlServer(t *testing.T) {
 			wantParseErr: true,
 		},
 		{
-			input:               "//odbc:server=localhost;user id=sa;database=master;password=" + sqlServerPass,
+			input:               "//server=localhost;user id=sa;database=master;password=" + sqlServerPass,
 			wantPingErr:         false,
 			wantPingDeterminate: true,
 		},
 		{
+			input:               "//server=badhost;user id=sa;database=master;password=" + sqlServerPass,
+			wantPingErr:         true,
+			wantPingDeterminate: false,
+		},
+		{
 			input:               "//localhost;database=master;spring.datasource.password=" + sqlServerPass,
 			wantPingErr:         false,
+			wantPingDeterminate: true,
+		},
+		{
+			input:               "//localhost;database=master;spring.datasource.password=badpassword",
+			wantPingErr:         true,
 			wantPingDeterminate: true,
 		},
 	}
@@ -56,7 +66,7 @@ func TestSqlServer(t *testing.T) {
 			} else {
 				assert.NoError(t, pr.err)
 			}
-			assert.Equal(t, pr.determinate, tt.wantPingDeterminate)
+			assert.Equal(t, tt.wantPingDeterminate, pr.determinate)
 		})
 	}
 }

--- a/pkg/detectors/jdbc/sqlserver_integration_test.go
+++ b/pkg/detectors/jdbc/sqlserver_integration_test.go
@@ -22,32 +22,39 @@ const (
 
 func TestSqlServer(t *testing.T) {
 	tests := []struct {
-		input    string
-		wantErr  bool
-		wantPing bool
+		input               string
+		wantParseErr        bool
+		wantPingErr         bool
+		wantPingDeterminate bool
 	}{
 		{
-			input:   "",
-			wantErr: true,
+			input:        "",
+			wantParseErr: true,
 		},
 		{
-			input:    "//odbc:server=localhost;user id=sa;database=master;password=" + sqlServerPass,
-			wantPing: true,
+			input:               "//odbc:server=localhost;user id=sa;database=master;password=" + sqlServerPass,
+			wantPingErr:         false,
+			wantPingDeterminate: true,
 		},
 		{
-			input:    "//localhost;database=master;spring.datasource.password=" + sqlServerPass,
-			wantPing: true,
+			input:               "//localhost;database=master;spring.datasource.password=" + sqlServerPass,
+			wantPingErr:         false,
+			wantPingDeterminate: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			j, err := parseSqlServer(tt.input)
-			if tt.wantErr {
+			if tt.wantParseErr {
 				assert.Error(t, err)
 				return
 			}
 			assert.NoError(t, err)
-			assert.Equal(t, tt.wantPing, j.ping(context.Background()))
+			pr := j.ping(context.Background())
+			if tt.wantPingErr {
+				assert.Error(t, pr.err)
+			}
+			assert.Equal(t, pr.determinate, tt.wantPingDeterminate)
 		})
 	}
 }

--- a/pkg/detectors/jdbc/sqlserver_integration_test.go
+++ b/pkg/detectors/jdbc/sqlserver_integration_test.go
@@ -53,6 +53,8 @@ func TestSqlServer(t *testing.T) {
 			pr := j.ping(context.Background())
 			if tt.wantPingErr {
 				assert.Error(t, pr.err)
+			} else {
+				assert.NoError(t, pr.err)
 			}
 			assert.Equal(t, pr.determinate, tt.wantPingDeterminate)
 		})

--- a/pkg/detectors/jdbc/sqlserver_integration_test.go
+++ b/pkg/detectors/jdbc/sqlserver_integration_test.go
@@ -23,7 +23,7 @@ const (
 func TestSqlServer(t *testing.T) {
 	type result struct {
 		parseErr        bool
-		pingErr         bool
+		pingOk          bool
 		pingDeterminate bool
 	}
 	tests := []struct {
@@ -36,31 +36,19 @@ func TestSqlServer(t *testing.T) {
 		},
 		{
 			input: "//server=localhost;user id=sa;database=master;password=" + sqlServerPass,
-			want: result{
-				pingErr:         false,
-				pingDeterminate: true,
-			},
+			want:  result{pingOk: true, pingDeterminate: true},
 		},
 		{
 			input: "//server=badhost;user id=sa;database=master;password=" + sqlServerPass,
-			want: result{
-				pingErr:         true,
-				pingDeterminate: false,
-			},
+			want:  result{pingOk: false, pingDeterminate: false},
 		},
 		{
 			input: "//localhost;database=master;spring.datasource.password=" + sqlServerPass,
-			want: result{
-				pingErr:         false,
-				pingDeterminate: true,
-			},
+			want:  result{pingOk: true, pingDeterminate: true},
 		},
 		{
 			input: "//localhost;database=master;spring.datasource.password=badpassword",
-			want: result{
-				pingErr:         true,
-				pingDeterminate: true,
-			},
+			want:  result{pingOk: false, pingDeterminate: true},
 		},
 	}
 	for _, tt := range tests {
@@ -75,7 +63,7 @@ func TestSqlServer(t *testing.T) {
 
 			pr := j.ping(context.Background())
 
-			got := result{pingErr: pr.err != nil, pingDeterminate: pr.determinate}
+			got := result{pingOk: pr.err == nil, pingDeterminate: pr.determinate}
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
This PR adds an indeterminacy check to the JDBC verifiers. The way they waterfall through various connection variations makes this a non-trivial thing to do. Ultimately, the only way to determinately decide that credentials are unverified is to receive an authentication error. This raises the hypothetical possibility that credentials can be rotated in a way that Trufflehog will not be able to determinately detect: specifically, if credentials are rotated simultaneously with the database or server in question losing connectivity for some other reason. I think this approach is still best because:
* I think the particular scenario is unlikely
* Manual remediation is still possible
* I can't think of another way to do things :(