### PR TITLE
use Go 1.20 for all github workflows

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.18'
+        go-version: '1.20'
 
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.18'
+        go-version: '1.20'
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Smoke


### PR DESCRIPTION
Some of them were updated from 1.18 but not all of them. This PR updates the rest.