### PR TITLE
capture JSON error in AWS detector

### DIFF
--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -184,6 +184,8 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 								"user_id": identityInfo.GetCallerIdentityResponse.GetCallerIdentityResult.UserID,
 								"arn":     identityInfo.GetCallerIdentityResponse.GetCallerIdentityResult.Arn,
 							}
+						} else {
+							s1.VerificationError = err
 						}
 						res.Body.Close()
 					} else {


### PR DESCRIPTION
While documenting the process to migrate a detector to use tri-state verification I discovered a bug in my example detector! Specifically, if the STS response contains a 2xx status code but has an unexpected JSON payload, we report the secrets as determinately unverified rather than indeterminately unverified. This is wrong: A 2xx response means the credentials are probably good and we just don't understand AWS's response.
