### PR TITLE
Support indeterminacy in alchemy and update detector docs

### DIFF
--- a/hack/docs/Adding_Detectors_external.md
+++ b/hack/docs/Adding_Detectors_external.md
@@ -62,14 +62,28 @@ If you think that something should be included outside of these guidelines, plea
    1. Create a [test secrets file, and export the variable](#using-a-test-secret-file)
    2. Update the pattern regex and keywords. Try iterating with [regex101.com](http://regex101.com/).
    3. Update the verifier code to use a non-destructive API call that can determine whether the secret is valid or not.
-   4. Update the tests with these test cases at minimum:
+      * Make sure you understand [verification indeterminacy](#verification-indeterminacy).
+   5. Update the tests with these test cases at minimum:
       1. Found and verified (using a credential loaded from GCP Secrets)
-      2. Found and unverified
-      3. Not found
-      4. Any false positive cases that you come across
+      2. Found and unverified (determinately, i.e. the secret is invalid)
+      3. Found and unverified (indeterminately due to timeout)
+      4. Found and unverified (indeterminately due to an unexpected API response)
+      5. Not found
+      6. Any false positive cases that you come across
    5. Create a pull request for review.
 
 ## Addendum
+
+### Verification indeterminacy
+
+There are two types reasons that secret verification can fail:
+* The candidate secret is not actually a valid secret.
+* Something went wrong in the process unrelated to the candidate secret, such as a transient network error or an unexpected API response.
+
+In Trufflehog parlance, the first type of verification response is called _determinate_ and the second type is called _indeterminate_. Verification code should distinguish between the two by returning an error object in the result struct **only** for indeterminate failures. In general, a verifier should return an error (indicating an indeterminate failure) in all cases that haven't been explicitly identified as determinate failure states. For example, if a verifier makes an HTTP request to a hypothetical authentication endpoint, the response codes could determine what to return:
+* Any `2xx` response would indicate that verification succeeded.
+* A `403` response would indicate that verification failed **determinately** and no error object should be returned.
+* Any other response would indicate that verification failed **indeterminately** and an error object should be returned.
 
 ### Using a test secret file
 

--- a/hack/docs/Adding_Detectors_external.md
+++ b/hack/docs/Adding_Detectors_external.md
@@ -63,7 +63,7 @@ If you think that something should be included outside of these guidelines, plea
    2. Update the pattern regex and keywords. Try iterating with [regex101.com](http://regex101.com/).
    3. Update the verifier code to use a non-destructive API call that can determine whether the secret is valid or not.
       * Make sure you understand [verification indeterminacy](#verification-indeterminacy).
-   5. Update the tests with these test cases at minimum:
+   4. Update the tests with these test cases at minimum:
       1. Found and verified (using a credential loaded from GCP Secrets)
       2. Found and unverified (determinately, i.e. the secret is invalid)
       3. Found and unverified (indeterminately due to timeout)
@@ -80,8 +80,8 @@ There are two types of reasons that secret verification can fail:
 * The candidate secret is not actually a valid secret.
 * Something went wrong in the process unrelated to the candidate secret, such as a transient network error or an unexpected API response.
 
-In Trufflehog parlance, the first type of verification response is called _determinate_ and the second type is called _indeterminate_. Verification code should distinguish between the two by returning an error object in the result struct **only** for indeterminate failures. In general, a verifier should return an error (indicating an indeterminate failure) in all cases that haven't been explicitly identified as determinate failure states. For example, if a verifier makes an HTTP request to a hypothetical authentication endpoint, the response codes could determine what to return:
-* Any `2xx` response would indicate that verification succeeded.
+In Trufflehog parlance, the first type of verification response is called _determinate_ and the second type is called _indeterminate_. Verification code should distinguish between the two by returning an error object in the result struct **only** for indeterminate failures. In general, a verifier should return an error (indicating an indeterminate failure) in all cases that haven't been explicitly identified as determinate failure states. For example, consider a hypothetical authentication endpoint that returns `200 OK` for valid credentials and `403 Forbidden` for invalid credentials. The verifier for this endpoint could make an HTTP request to this endpoint and use the response status code to decide what to return:
+* A `200` response would indicate that verification succeeded. (Or maybe any `2xx` response.)
 * A `403` response would indicate that verification failed **determinately** and no error object should be returned.
 * Any other response would indicate that verification failed **indeterminately** and an error object should be returned.
 

--- a/hack/docs/Adding_Detectors_external.md
+++ b/hack/docs/Adding_Detectors_external.md
@@ -80,7 +80,9 @@ There are two types of reasons that secret verification can fail:
 * The candidate secret is not actually a valid secret.
 * Something went wrong in the process unrelated to the candidate secret, such as a transient network error or an unexpected API response.
 
-In Trufflehog parlance, the first type of verification response is called _determinate_ and the second type is called _indeterminate_. Verification code should distinguish between the two by returning an error object in the result struct **only** for indeterminate failures. In general, a verifier should return an error (indicating an indeterminate failure) in all cases that haven't been explicitly identified as determinate failure states. For example, consider a hypothetical authentication endpoint that returns `200 OK` for valid credentials and `403 Forbidden` for invalid credentials. The verifier for this endpoint could make an HTTP request to this endpoint and use the response status code to decide what to return:
+In Trufflehog parlance, the first type of verification response is called _determinate_ and the second type is called _indeterminate_. Verification code should distinguish between the two by returning an error object in the result struct **only** for indeterminate failures. In general, a verifier should return an error (indicating an indeterminate failure) in all cases that haven't been explicitly identified as determinate failure states.
+
+For example, consider a hypothetical authentication endpoint that returns `200 OK` for valid credentials and `403 Forbidden` for invalid credentials. The verifier for this endpoint could make an HTTP request and use the response status code to decide what to return:
 * A `200` response would indicate that verification succeeded. (Or maybe any `2xx` response.)
 * A `403` response would indicate that verification failed **determinately** and no error object should be returned.
 * Any other response would indicate that verification failed **indeterminately** and an error object should be returned.

--- a/hack/docs/Adding_Detectors_external.md
+++ b/hack/docs/Adding_Detectors_external.md
@@ -76,7 +76,7 @@ If you think that something should be included outside of these guidelines, plea
 
 ### Verification indeterminacy
 
-There are two types reasons that secret verification can fail:
+There are two types of reasons that secret verification can fail:
 * The candidate secret is not actually a valid secret.
 * Something went wrong in the process unrelated to the candidate secret, such as a transient network error or an unexpected API response.
 

--- a/pkg/common/http.go
+++ b/pkg/common/http.go
@@ -75,6 +75,14 @@ func PinnedCertPool() *x509.CertPool {
 	return trustedCerts
 }
 
+type FakeTransport struct {
+	CreateResponse func(req *http.Request) (*http.Response, error)
+}
+
+func (t FakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.CreateResponse(req)
+}
+
 type CustomTransport struct {
 	T http.RoundTripper
 }

--- a/pkg/common/http.go
+++ b/pkg/common/http.go
@@ -3,6 +3,7 @@ package common
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -97,6 +98,21 @@ func NewCustomTransport(T http.RoundTripper) *CustomTransport {
 		T = http.DefaultTransport
 	}
 	return &CustomTransport{T}
+}
+
+func ConstantStatusHttpClient(statusCode int) *http.Client {
+	return &http.Client{
+		Timeout: DefaultResponseTimeout,
+		Transport: FakeTransport{
+			CreateResponse: func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					Request:    req,
+					Body:       io.NopCloser(strings.NewReader("")),
+					StatusCode: statusCode,
+				}, nil
+			},
+		},
+	}
 }
 
 func PinnedRetryableHttpClient() *http.Client {

--- a/pkg/common/http.go
+++ b/pkg/common/http.go
@@ -176,9 +176,9 @@ func SaneHttpClient() *http.Client {
 }
 
 // SaneHttpClientTimeOut adds a custom timeout for some scanners
-func SaneHttpClientTimeOut(timeoutMs int64) *http.Client {
+func SaneHttpClientTimeOut(timeout time.Duration) *http.Client {
 	httpClient := &http.Client{}
-	httpClient.Timeout = time.Millisecond * time.Duration(timeoutMs)
+	httpClient.Timeout = timeout
 	httpClient.Transport = NewCustomTransport(nil)
 	return httpClient
 }

--- a/pkg/common/http.go
+++ b/pkg/common/http.go
@@ -176,9 +176,9 @@ func SaneHttpClient() *http.Client {
 }
 
 // SaneHttpClientTimeOut adds a custom timeout for some scanners
-func SaneHttpClientTimeOut(timeOutSeconds int64) *http.Client {
+func SaneHttpClientTimeOut(timeoutMs int64) *http.Client {
 	httpClient := &http.Client{}
-	httpClient.Timeout = time.Second * time.Duration(timeOutSeconds)
+	httpClient.Timeout = time.Millisecond * time.Duration(timeoutMs)
 	httpClient.Transport = NewCustomTransport(nil)
 	return httpClient
 }

--- a/pkg/detectors/alchemy/alchemy.go
+++ b/pkg/detectors/alchemy/alchemy.go
@@ -20,6 +20,7 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
+	defaultClient = common.SaneHttpClient()
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"alchemy"}) + `\b([0-9a-zA-Z]{23}_[0-9a-zA-Z]{8})\b`)
 )
@@ -50,7 +51,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		if verify {
 			client := s.client
 			if client == nil {
-				client = common.SaneHttpClient()
+				client = defaultClient
 			}
 			req, err := http.NewRequestWithContext(ctx, "GET", "https://eth-mainnet.g.alchemy.com/v2/"+resMatch+"/getNFTs/?owner=vitalik.eth", nil)
 			if err != nil {

--- a/pkg/detectors/alchemy/alchemy.go
+++ b/pkg/detectors/alchemy/alchemy.go
@@ -62,6 +62,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						continue
 					}
 				}
+			} else {
+				s1.VerificationError = err
 			}
 		}
 

--- a/pkg/detectors/alchemy/alchemy.go
+++ b/pkg/detectors/alchemy/alchemy.go
@@ -13,15 +13,13 @@ import (
 )
 
 type Scanner struct {
-	methodOverride string
+	client *http.Client
 }
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClient()
-
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"alchemy"}) + `\b([0-9a-zA-Z]{23}_[0-9a-zA-Z]{8})\b`)
 )
@@ -50,11 +48,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			method := s.methodOverride
-			if method == "" {
-				method = "getNFTs"
+			client := s.client
+			if client == nil {
+				client = common.SaneHttpClient()
 			}
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://eth-mainnet.g.alchemy.com/v2/"+resMatch+"/"+method+"/?owner=vitalik.eth", nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", "https://eth-mainnet.g.alchemy.com/v2/"+resMatch+"/getNFTs/?owner=vitalik.eth", nil)
 			if err != nil {
 				continue
 			}

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -87,7 +87,7 @@ func TestAlchemy_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found, would be verified if not for timeout",
-			s:    Scanner{client: common.SaneHttpClientTimeOut(1)},
+			s:    Scanner{client: common.SaneHttpClientTimeOut(1 * time.Microsecond)},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a alchemy secret %s within", secret)),

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -99,11 +99,27 @@ func TestAlchemy_FromChunk(t *testing.T) {
 			wantErr:               false,
 			wantVerificationError: true,
 		},
+		{
+			name: "found, verified but unexpected api surface",
+			s:    Scanner{methodOverride: "nonexistent"},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a alchemy secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Alchemy,
+					Verified:     false,
+				},
+			},
+			wantErr:               false,
+			wantVerificationError: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := Scanner{}
-			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Alchemy.FromData() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -161,5 +161,7 @@ func BenchmarkFromData(benchmark *testing.B) {
 
 func timeoutContext(timeout time.Duration) context.Context {
 	c, _ := context.WithTimeout(context.Background(), timeout)
+	// The cancellation function is discarded for test ergonomics - this is expected to be used with a short timeout,
+	// and it's test code anyway.
 	return c
 }

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -6,9 +6,6 @@ package alchemy
 import (
 	"context"
 	"fmt"
-	"io"
-	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -107,7 +104,7 @@ func TestAlchemy_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found, verified but unexpected api surface",
-			s:    Scanner{client: constantStatusHttpClient(404)},
+			s:    Scanner{client: common.ConstantStatusHttpClient(404)},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a alchemy secret %s within", secret)),
@@ -159,21 +156,6 @@ func BenchmarkFromData(benchmark *testing.B) {
 				}
 			}
 		})
-	}
-}
-
-func constantStatusHttpClient(statusCode int) *http.Client {
-	return &http.Client{
-		Timeout: common.DefaultResponseTimeout,
-		Transport: common.FakeTransport{
-			CreateResponse: func(req *http.Request) (*http.Response, error) {
-				return &http.Response{
-					Request:    req,
-					Body:       io.NopCloser(strings.NewReader("")),
-					StatusCode: statusCode,
-				}, nil
-			},
-		},
 	}
 }
 

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -87,9 +87,9 @@ func TestAlchemy_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found, would be verified if not for timeout",
-			s:    Scanner{},
+			s:    Scanner{client: common.SaneHttpClientTimeOut(1)},
 			args: args{
-				ctx:    timeoutContext(1 * time.Microsecond),
+				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a alchemy secret %s within", secret)),
 				verify: true,
 			},
@@ -157,11 +157,4 @@ func BenchmarkFromData(benchmark *testing.B) {
 			}
 		})
 	}
-}
-
-func timeoutContext(timeout time.Duration) context.Context {
-	c, _ := context.WithTimeout(context.Background(), timeout)
-	// The cancellation function is discarded for test ergonomics - this is expected to be used with a short timeout,
-	// and it's test code anyway.
-	return c
 }

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -101,7 +101,7 @@ func TestAlchemy_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found, verified but unexpected api surface",
-			s:    Scanner{methodOverride: "nonexistent"},
+			s:    Scanner{methodOverride: "nonexistent-method"},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a alchemy secret %s within", secret)),

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -86,7 +86,7 @@ func TestAlchemy_FromChunk(t *testing.T) {
 			wantVerificationErr: false,
 		},
 		{
-			name: "found, would be verified if not for http timeout",
+			name: "found, would be verified if not for timeout",
 			s:    Scanner{},
 			args: args{
 				ctx:    timeoutContext(1 * time.Microsecond),

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -53,7 +53,8 @@ func TestAlchemy_FromChunk(t *testing.T) {
 					Verified:     true,
 				},
 			},
-			wantErr: false,
+			wantErr:             false,
+			wantVerificationErr: false,
 		},
 		{
 			name: "found, unverified",
@@ -69,7 +70,8 @@ func TestAlchemy_FromChunk(t *testing.T) {
 					Verified:     false,
 				},
 			},
-			wantErr: false,
+			wantErr:             false,
+			wantVerificationErr: false,
 		},
 		{
 			name: "not found",
@@ -79,8 +81,9 @@ func TestAlchemy_FromChunk(t *testing.T) {
 				data:   []byte("You cannot find the secret within"),
 				verify: true,
 			},
-			want:    nil,
-			wantErr: false,
+			want:                nil,
+			wantErr:             false,
+			wantVerificationErr: false,
 		},
 		{
 			name: "found, would be verified if not for http timeout",

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -32,12 +32,12 @@ func TestAlchemy_FromChunk(t *testing.T) {
 		verify bool
 	}
 	tests := []struct {
-		name                  string
-		s                     Scanner
-		args                  args
-		want                  []detectors.Result
-		wantErr               bool
-		wantVerificationError bool
+		name                string
+		s                   Scanner
+		args                args
+		want                []detectors.Result
+		wantErr             bool
+		wantVerificationErr bool
 	}{
 		{
 			name: "found, verified",
@@ -99,8 +99,8 @@ func TestAlchemy_FromChunk(t *testing.T) {
 					Verified:     false,
 				},
 			},
-			wantErr:               false,
-			wantVerificationError: true,
+			wantErr:             false,
+			wantVerificationErr: true,
 		},
 		{
 			name: "found, verified but unexpected api surface",
@@ -116,8 +116,8 @@ func TestAlchemy_FromChunk(t *testing.T) {
 					Verified:     false,
 				},
 			},
-			wantErr:               false,
-			wantVerificationError: true,
+			wantErr:             false,
+			wantVerificationErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -132,8 +132,8 @@ func TestAlchemy_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
-				if (got[i].VerificationError != nil) != tt.wantVerificationError {
-					t.Fatalf("verification error = %v, wantVerificationError %v", got[i].VerificationError, tt.wantVerificationError)
+				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+					t.Fatalf("verification error = %v, wantVerificationError %v", got[i].VerificationError, tt.wantVerificationErr)
 				}
 				got[i].VerificationError = nil
 			}

--- a/pkg/detectors/getemail/getemail.go
+++ b/pkg/detectors/getemail/getemail.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -19,7 +20,7 @@ type Scanner struct{}
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClientTimeOut(5000)
+	client = common.SaneHttpClientTimeOut(5 * time.Second)
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"getemail"}) + `\b([a-zA-Z0-9-]{20})\b`)

--- a/pkg/detectors/getemail/getemail.go
+++ b/pkg/detectors/getemail/getemail.go
@@ -19,7 +19,7 @@ type Scanner struct{}
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClientTimeOut(5)
+	client = common.SaneHttpClientTimeOut(5000)
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"getemail"}) + `\b([a-zA-Z0-9-]{20})\b`)

--- a/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
+++ b/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -18,7 +19,7 @@ type Scanner struct{}
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClientTimeOut(5000)
+	client = common.SaneHttpClientTimeOut(5 * time.Second)
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(`(https:\/\/[a-zA-Z-0-9]+\.webhook\.office\.com\/webhookb2\/[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12}\@[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12}\/IncomingWebhook\/[a-zA-Z-0-9]{32}\/[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12})`)

--- a/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
+++ b/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
@@ -18,7 +18,7 @@ type Scanner struct{}
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClientTimeOut(5)
+	client = common.SaneHttpClientTimeOut(5000)
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(`(https:\/\/[a-zA-Z-0-9]+\.webhook\.office\.com\/webhookb2\/[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12}\@[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12}\/IncomingWebhook\/[a-zA-Z-0-9]{32}\/[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12})`)

--- a/pkg/detectors/scrapersite/scrapersite.go
+++ b/pkg/detectors/scrapersite/scrapersite.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -19,7 +20,7 @@ type Scanner struct{}
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClientTimeOut(10000)
+	client = common.SaneHttpClientTimeOut(10 * time.Second)
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"scrapersite"}) + `\b([a-zA-Z0-9]{45})\b`)

--- a/pkg/detectors/scrapersite/scrapersite.go
+++ b/pkg/detectors/scrapersite/scrapersite.go
@@ -19,7 +19,7 @@ type Scanner struct{}
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClientTimeOut(10)
+	client = common.SaneHttpClientTimeOut(10000)
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"scrapersite"}) + `\b([a-zA-Z0-9]{45})\b`)

--- a/pkg/detectors/screenshotlayer/screenshotlayer.go
+++ b/pkg/detectors/screenshotlayer/screenshotlayer.go
@@ -19,7 +19,7 @@ type Scanner struct{}
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClientTimeOut(10)
+	client = common.SaneHttpClientTimeOut(10000)
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"screenshotlayer"}) + `\b([a-zA-Z0-9_]{32})\b`)

--- a/pkg/detectors/screenshotlayer/screenshotlayer.go
+++ b/pkg/detectors/screenshotlayer/screenshotlayer.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -19,7 +20,7 @@ type Scanner struct{}
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClientTimeOut(10000)
+	client = common.SaneHttpClientTimeOut(10 * time.Second)
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"screenshotlayer"}) + `\b([a-zA-Z0-9_]{32})\b`)

--- a/pkg/detectors/zenserp/zenserp.go
+++ b/pkg/detectors/zenserp/zenserp.go
@@ -18,7 +18,7 @@ type Scanner struct{}
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClientTimeOut(5)
+	client = common.SaneHttpClientTimeOut(5000)
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"zenserp"}) + `\b([0-9a-z-]{36})\b`)

--- a/pkg/detectors/zenserp/zenserp.go
+++ b/pkg/detectors/zenserp/zenserp.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -18,7 +19,7 @@ type Scanner struct{}
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClientTimeOut(5000)
+	client = common.SaneHttpClientTimeOut(5 * time.Second)
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"zenserp"}) + `\b([0-9a-z-]{36})\b`)


### PR DESCRIPTION
This isn't an "important" detector - except that it's the template detector that the detector generator runs on! This PR also:
* Updates the associated documentation
* Changes the method that creates a common testing HTTP client with a timeout to accept a `Duration` directly instead of interpreting a `int64` as a number of seconds
  * Go will silently convert `int64` values to Durations, so we need to be careful when making this change elsewhere