### PR TITLE
[MongoDB] Detect CosmoDB access keys

### DIFF
--- a/pkg/detectors/mongodb/mongodb.go
+++ b/pkg/detectors/mongodb/mongodb.go
@@ -21,7 +21,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 
 var (
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(`\b(mongodb(\+srv)?://[\S]{3,50}:([\S]{3,50})@[-.%\w\/:]+)\b`)
+	keyPat = regexp.MustCompile(`\b(mongodb(\+srv)?://[\S]{3,50}:([\S]{3,88})@[-.%\w\/:]+)\b`)
 	// TODO: Add support for sharded cluster, replica set and Atlas Deployment.
 )
 


### PR DESCRIPTION
The current pattern does not detect [Azure CosmoDB Access Keys](https://learn.microsoft.com/en-us/microsoft-365/compliance/sit-defn-azure-cosmos-db-account-access-key?view=o365-worldwide), which are 88 characters long.

Random example pulled from GitHub:
https://github.com/MichelliBrito/agendalive/blob/e74b7d74cc28140f77e22af1ba372a813dc99aa4/src/main/resources/application.properties#L2

I would recommend generating a live secret and adding that to the test bank, if possible.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
