### PR TITLE
Refactor git source to allow ScanOptions and use source in engine

### DIFF
--- a/pkg/engine/git.go
+++ b/pkg/engine/git.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"runtime"
 
+	"github.com/go-errors/errors"
 	gogit "github.com/go-git/go-git/v5"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/git"
@@ -20,16 +22,6 @@ func (e *Engine) ScanGit(ctx context.Context, c sources.GitConfig) error {
 	opts := []git.ScanOption{
 		git.ScanOptionFilter(c.Filter),
 		git.ScanOptionLogOptions(logOptions),
-	}
-
-	options := &gogit.PlainOpenOptions{
-		DetectDotGit:          true,
-		EnableDotGitCommonDir: true,
-	}
-
-	repo, err := gogit.PlainOpenWithOptions(c.RepoPath, options)
-	if err != nil {
-		return fmt.Errorf("could not open repo: %s: %w", c.RepoPath, err)
 	}
 
 	if c.MaxDepth != 0 {
@@ -46,21 +38,25 @@ func (e *Engine) ScanGit(ctx context.Context, c sources.GitConfig) error {
 	}
 	scanOptions := git.NewScanOptions(opts...)
 
-	gitSource := git.NewGit(sourcespb.SourceType_SOURCE_TYPE_GIT, 0, 0, "trufflehog - git", true, runtime.NumCPU(),
-		func(file, email, commit, timestamp, repository string, line int64) *source_metadatapb.MetaData {
-			return &source_metadatapb.MetaData{
-				Data: &source_metadatapb.MetaData_Git{
-					Git: &source_metadatapb.Git{
-						Commit:     commit,
-						File:       file,
-						Email:      email,
-						Repository: repository,
-						Timestamp:  timestamp,
-						Line:       line,
-					},
-				},
-			}
-		})
+	connection := &sourcespb.Git{
+		// Using Directories here allows us to not pass any
+		// authentication. Also by this point, the c.RepoPath should
+		// still have been prepared and downloaded to a temporary
+		// directory if it was a URL.
+		Directories: []string{c.RepoPath},
+	}
+	var conn anypb.Any
+	err := anypb.MarshalFrom(&conn, connection, proto.MarshalOptions{})
+	if err != nil {
+		ctx.Logger().Error(err, "failed to marshal git connection")
+		return err
+	}
+
+	gitSource := git.Source{}
+	if err := gitSource.Init(ctx, "trufflehog - git", 0, 0, true, &conn, runtime.NumCPU()); err != nil {
+		return errors.WrapPrefix(err, "could not init git source", 0)
+	}
+	gitSource.WithScanOptions(scanOptions)
 
 	ctx = context.WithValues(ctx,
 		"source_type", sourcespb.SourceType_SOURCE_TYPE_GIT.String(),
@@ -68,7 +64,7 @@ func (e *Engine) ScanGit(ctx context.Context, c sources.GitConfig) error {
 	)
 	e.sourcesWg.Go(func() error {
 		defer common.RecoverWithExit(ctx)
-		err := gitSource.ScanRepo(ctx, repo, c.RepoPath, scanOptions, e.ChunksChan())
+		err := gitSource.Chunks(ctx, e.ChunksChan())
 		if err != nil {
 			return fmt.Errorf("could not scan repo: %w", err)
 		}

--- a/pkg/engine/git.go
+++ b/pkg/engine/git.go
@@ -57,6 +57,9 @@ func (e *Engine) ScanGit(ctx context.Context, c sources.GitConfig) error {
 		return errors.WrapPrefix(err, "could not init git source", 0)
 	}
 	gitSource.WithScanOptions(scanOptions)
+	// Don't try to clean up the provided directory. That's handled by the
+	// caller of ScanGit.
+	gitSource.WithPreserveTempDirs(true)
 
 	ctx = context.WithValues(ctx,
 		"source_type", sourcespb.SourceType_SOURCE_TYPE_GIT.String(),


### PR DESCRIPTION
Refactor the Chunks method of the git Source to call out to two helper methods: scanRepos and scanDirs which scans s.conn.Repositories and s.conn.Directories respectively. The only notable change in behavior is that a credential is no longer necessary if there are no s.conn.Repositories to scan.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
