### PR TITLE
Revert "[chore] Remove parent setting / getting in Context wrapper (#…

### DIFF
--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -18,11 +18,22 @@ var (
 type Context interface {
 	context.Context
 	Logger() logr.Logger
+	Parent() context.Context
+	SetParent(ctx context.Context) Context
 }
 
-// CancelFunc is a type alias to context.CancelFunc to allow use as if they are
-// the same types.
-type CancelFunc = context.CancelFunc
+// Parent returns the parent context.
+func (l logCtx) Parent() context.Context {
+	return l.Context
+}
+
+// SetParent sets the parent context on the context.
+func (l logCtx) SetParent(ctx context.Context) Context {
+	l.Context = ctx
+	return l
+}
+
+type CancelFunc context.CancelFunc
 
 // logCtx implements Context.
 type logCtx struct {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -130,7 +130,7 @@ func Start(ctx context.Context, options ...EngineOption) *Engine {
 	sourcesWg, egCtx := errgroup.WithContext(ctx)
 	sourcesWg.SetLimit(e.concurrency)
 	e.sourcesWg = sourcesWg
-	ctx = context.WithLogger(egCtx, ctx.Logger())
+	ctx.SetParent(egCtx)
 
 	if len(e.decoders) == 0 {
 		e.decoders = decoders.DefaultDecoders()


### PR DESCRIPTION
…1516)"

This reverts commit 8ec5e4916c911144aab39e0602dfa930d3aa2d09. This commit is somehow causing AWS verification (and possibly others) to not work.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
