### PR TITLE
Change port 22 to 3389 for shodankey verification due false positive

### DIFF
--- a/pkg/detectors/shodankey/shodankey.go
+++ b/pkg/detectors/shodankey/shodankey.go
@@ -48,7 +48,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.shodan.io/shodan/host/count?key="+resMatch+"&query=port:22&facets=org,os", nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.shodan.io/shodan/host/count?key="+resMatch+"&query=port:3389&facets=org,os", nil)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
Updated port 22 to 3389 for the shodankey verification as the port 22 verification check works with an invalid key or anonymously. 

By changing the port to 3389 it actually performs the verification. 

To verify, try this command
`curl -X GET "https://api.shodan.io/shodan/host/count?query=port:22&facets=org,os"` and observe the 200 response with data returned.

Now try the same request with port 3389 without a key and observe the 401 Unauthorized response code `curl -X GET "https://api.shodan.io/shodan/host/count?query=port:3389&f:22=org,os"`

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
