### PR TITLE
[chore] - optimize chunker

### DIFF
--- a/pkg/sources/chunker.go
+++ b/pkg/sources/chunker.go
@@ -12,6 +12,8 @@ const (
 	ChunkSize = 10 * 1024
 	// PeekSize is the size of the peek into the previous chunk.
 	PeekSize = 3 * 1024
+	// TotalChunkSize is the total size of a chunk with peek data.
+	TotalChunkSize = ChunkSize + PeekSize
 )
 
 // Chunker takes a chunk and splits it into chunks of ChunkSize.
@@ -19,14 +21,14 @@ func Chunker(originalChunk *Chunk) chan *Chunk {
 	chunkChan := make(chan *Chunk)
 	go func() {
 		defer close(chunkChan)
-		if len(originalChunk.Data) <= ChunkSize+PeekSize {
+		if len(originalChunk.Data) <= TotalChunkSize {
 			chunkChan <- originalChunk
 			return
 		}
 		r := bytes.NewReader(originalChunk.Data)
 		reader := bufio.NewReaderSize(bufio.NewReader(r), ChunkSize)
 		for {
-			chunkBytes := make([]byte, ChunkSize+PeekSize)
+			chunkBytes := make([]byte, TotalChunkSize)
 			chunk := *originalChunk
 			chunkBytes = chunkBytes[:ChunkSize]
 			n, err := reader.Read(chunkBytes)

--- a/pkg/sources/chunker.go
+++ b/pkg/sources/chunker.go
@@ -37,7 +37,7 @@ func Chunker(originalChunk *Chunk) chan *Chunk {
 				if errors.Is(err, io.EOF) {
 					break
 				}
-				break
+				continue
 			}
 			peekData, _ := reader.Peek(PeekSize)
 			copy(chunkBytes[n:], peekData)

--- a/pkg/sources/chunker_test.go
+++ b/pkg/sources/chunker_test.go
@@ -72,3 +72,15 @@ func TestChunker(t *testing.T) {
 	}
 
 }
+
+func BenchmarkChunker(b *testing.B) {
+	data := bytes.Repeat([]byte("a"), ChunkSize*100)
+	chunk := &Chunk{
+		Data: data,
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _ = range Chunker(chunk) {
+		}
+	}
+}

--- a/pkg/sources/chunker_test.go
+++ b/pkg/sources/chunker_test.go
@@ -80,7 +80,7 @@ func BenchmarkChunker(b *testing.B) {
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for _ = range Chunker(chunk) {
+		for range Chunker(chunk) {
 		}
 	}
 }


### PR DESCRIPTION
-  Given the PeekSize is a constant and we are always appending it to the chunkBytes, we can make chunkBytes large enough to hold both ChunkSize and PeekSize from the start. This way, we can eliminate the append call altogether.

![Screenshot 2023-07-24 at 11 37 38 AM](https://github.com/trufflesecurity/trufflehog/assets/21311841/457458ea-5140-4479-b03e-08b895d70a1a)
