### PR TITLE
Make Ahocorasick matching case insensitive

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -145,10 +145,14 @@ func Start(ctx context.Context, options ...EngineOption) *Engine {
 	// on keywords
 	keywords := []string{}
 	for _, d := range e.detectors[false] {
-		keywords = append(keywords, d.Keywords()...)
+		for _, kw := range d.Keywords() {
+			keywords = append(keywords, strings.ToLower(kw))
+		}
 	}
 	for _, d := range e.detectors[true] {
-		keywords = append(keywords, d.Keywords()...)
+		for _, kw := range d.Keywords() {
+			keywords = append(keywords, strings.ToLower(kw))
+		}
 	}
 	e.prefilter = *ahocorasick.NewTrieBuilder().AddStrings(keywords).Build()
 
@@ -291,7 +295,7 @@ func (e *Engine) detectorWorker(ctx context.Context) {
 				}
 
 				// build a map of all keywords that were matched in the chunk
-				for _, m := range e.prefilter.MatchString(string(decoded.Data)) {
+				for _, m := range e.prefilter.MatchString(strings.ToLower(string(decoded.Data))) {
 					matchedKeywords[strings.ToLower(m.MatchString())] = struct{}{}
 				}
 


### PR DESCRIPTION
This PR fixes a bug that prevents secrets from being detected if the keyword or chunk data case varies. 

`strings.ToLower` doesn't seem to have a huge effect on performance either.

```
Benchmark git scan on the rails/rails repo

### NEW
real 27.18s
user 58.14s 
sys  5.47s 
memory:753328KB 
cpu 234%
      62

### OLD
real 27.45s
user 56.43s 
sys  5.50s 
memory:750160KB 
cpu 225%
      62
```

To demonstrate this bug fix, try finding a private key