### PR TITLE
Add support for storing handler metadata

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -349,8 +349,15 @@ func (e *Engine) detectorWorker(ctx context.Context) {
 								continue
 							}
 							result.DecoderType = decoderType
+							if result.ExtraData == nil && chunk.HandleMetadata != nil {
+								result.ExtraData = chunk.HandleMetadata
+							} else {
+								for k, v := range chunk.HandleMetadata {
+									// TODO: Check key collisions.
+									result.ExtraData[k] = v
+								}
+							}
 							chunkResults = append(chunkResults, detectors.CopyMetadata(resultChunk, result))
-
 						}
 						if len(results) > 0 {
 							elapsed := time.Since(start)

--- a/pkg/output/plain.go
+++ b/pkg/output/plain.go
@@ -96,9 +96,9 @@ func structToMap(obj interface{}) (m map[string]map[string]interface{}, err erro
 }
 
 type outputFormat struct {
-	DetectorType,
-	DecoderType string
-	Verified bool
-	Raw      string
+	DetectorType string
+	DecoderType  string
+	Verified     bool
+	Raw          string
 	*source_metadatapb.MetaData
 }

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -21,7 +21,8 @@ type Chunk struct {
 	SourceType sourcespb.SourceType
 	// SourceMetadata holds the context of where the Chunk was found.
 	SourceMetadata *source_metadatapb.MetaData
-
+	// HandleMetadata holds the metadata from a handler if one was used.
+	HandleMetadata map[string]string
 	// Data is the data to decode and scan.
 	Data []byte
 	// Verify specifies whether any secrets in the Chunk should be verified.


### PR DESCRIPTION
Currently it's a unstructured map[string]string that gets copied into a Result.ExtraData after detection, but we might want to revisit this decision when we get more handlers.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->
