### PR TITLE
Improve log message when scanning GitHub comments

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -957,7 +957,7 @@ func (s *Source) setProgressCompleteWithRepo(index int, offset int, repoURL stri
 }
 
 func (s *Source) scanComments(ctx context.Context, repoPath string, chunksChan chan *sources.Chunk) error {
-	s.log.Info("scanning comments")
+	s.log.Info("scanning comments", "repository", repoPath)
 
 	// Support ssh and https URLs
 	repoURL, err := git.GitURLParse(repoPath)


### PR DESCRIPTION
This is a small quality-of-life improvement.

TruffleHog currently logs a bunch of "scanning comments" messages without any context.
```sh
$ trufflehog github --org="example" --token=ghp_xxx
2023-07-26T10:20:21-04:00	info-0	trufflehog	loaded decoders	{"count": 3}
2023-07-26T10:20:21-04:00	info-0	trufflehog	loaded detectors	{"total": 1, "verification_enabled": 0, "verification_disabled": 1}
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

2023-07-26T10:20:26-04:00	info-0	trufflehog	Completed enumeration	{"source_type": "SOURCE_TYPE_GITHUB", "source_name": "github", "num_repos": 323, "num_orgs": 1, "num_members": 0}
2023-07-26T10:20:29-04:00	info-0	trufflehog	scanning comments	{"source_type": "SOURCE_TYPE_GITHUB", "source_name": "github"}
...
```

This adds the repository to the log metadata:
```
2023-07-26T10:25:04-04:00	info-0	trufflehog	loaded decoders	{"count": 3}
2023-07-26T10:25:04-04:00	info-0	trufflehog	loaded detectors	{"total": 1, "verification_enabled": 0, "verification_disabled": 1}
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

2023-07-26T10:25:09-04:00	info-0	trufflehog	Completed enumeration	{"source_type": "SOURCE_TYPE_GITHUB", "source_name": "github", "num_repos": 323, "num_orgs": 1, "num_members": 0}
2023-07-26T10:25:18-04:00	info-0	trufflehog	scanning comments	{"source_type": "SOURCE_TYPE_GITHUB", "source_name": "github", "repository": "https://github.com/example/hello-world.git"}
...
```