### PR TITLE
Identify transient AWS verification failures

### DIFF
--- a/pkg/common/http.go
+++ b/pkg/common/http.go
@@ -100,14 +100,14 @@ func NewCustomTransport(T http.RoundTripper) *CustomTransport {
 	return &CustomTransport{T}
 }
 
-func ConstantStatusHttpClient(statusCode int) *http.Client {
+func ConstantResponseHttpClient(statusCode int, body string) *http.Client {
 	return &http.Client{
 		Timeout: DefaultResponseTimeout,
 		Transport: FakeTransport{
 			CreateResponse: func(req *http.Request) (*http.Response, error) {
 				return &http.Response{
 					Request:    req,
-					Body:       io.NopCloser(strings.NewReader("")),
+					Body:       io.NopCloser(strings.NewReader(body)),
 					StatusCode: statusCode,
 				}, nil
 			},

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -104,7 +104,7 @@ func TestAlchemy_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found, verified but unexpected api surface",
-			s:    Scanner{client: common.ConstantStatusHttpClient(404)},
+			s:    Scanner{client: common.ConstantResponseHttpClient(404, "")},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a alchemy secret %s within", secret)),

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -7,9 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"net/http"
 	"regexp"
 	"strings"
@@ -19,15 +16,6 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
-
-type awsError struct {
-	Code    string
-	Message string
-}
-
-type awsErrorResponseBody struct {
-	Error awsError
-}
 
 type scanner struct {
 	skipIDs map[string]struct{}
@@ -229,6 +217,8 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 								if body.Error.Code == "InvalidClientTokenId" {
 									// determinate failure - nothing to do
 								} else {
+									// We see a surprising number of signature mismatch errors here
+									// (The official SDK somehow elicits even more than just making the request ourselves)
 									s1.VerificationError = fmt.Errorf("request to %v returned status %d with an unexpected reason (%s: %s)", res.Request.URL, res.StatusCode, body.Error.Code, body.Error.Message)
 								}
 							} else {
@@ -237,17 +227,6 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						} else {
 							s1.VerificationError = fmt.Errorf("request to %v returned unexpected status %d", res.Request.URL, res.StatusCode)
 						}
-
-						//bytes, err := io.ReadAll(res.Body)
-						//res.Body.Close()
-						//if err != nil {
-						//	panic(err)
-						//}
-						//s1.VerificationError = fmt.Errorf("%d (%s)", res.StatusCode, string(bytes))
-
-						//if res.StatusCode != 403 {
-						//	s1.VerificationError = fmt.Errorf("request to %v returned unexpected status %d", res.Request.URL, res.StatusCode)
-						//}
 					}
 				} else {
 					s1.VerificationError = err
@@ -296,6 +275,15 @@ func awsCustomCleanResults(results []detectors.Result) []detectors.Result {
 	return out
 }
 
+type awsError struct {
+	Code    string
+	Message string
+}
+
+type awsErrorResponseBody struct {
+	Error awsError
+}
+
 type identityRes struct {
 	GetCallerIdentityResponse struct {
 		GetCallerIdentityResult struct {
@@ -311,80 +299,4 @@ type identityRes struct {
 
 func (s scanner) Type() detectorspb.DetectorType {
 	return detectorspb.DetectorType_AWS
-}
-
-func buildRequest(ctx context.Context, resIDMatch, resSecretMatch string) *http.Request {
-	method := "GET"
-	service := "sts"
-	host := "sts.amazonaws.com"
-	region := "us-east-1"
-	endpoint := "https://sts.amazonaws.com"
-	datestamp := time.Now().UTC().Format("20060102")
-	amzDate := time.Now().UTC().Format("20060102T150405Z0700")
-
-	req, err := http.NewRequestWithContext(ctx, method, endpoint, nil)
-	if err != nil {
-		panic(err)
-	}
-	req.Header.Set("Accept", "application/json")
-
-	// TASK 1: CREATE A CANONICAL REQUEST.
-	// http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
-	canonicalURI := "/"
-	canonicalHeaders := "host:" + host + "\n"
-	signedHeaders := "host"
-	algorithm := "AWS4-HMAC-SHA256"
-	credentialScope := fmt.Sprintf("%s/%s/%s/aws4_request", datestamp, region, service)
-
-	params := req.URL.Query()
-	params.Add("Action", "GetCallerIdentity")
-	params.Add("Version", "2011-06-15")
-	params.Add("X-Amz-Algorithm", algorithm)
-	params.Add("X-Amz-Credential", resIDMatch+"/"+credentialScope)
-	params.Add("X-Amz-Date", amzDate)
-	params.Add("X-Amz-Expires", "30")
-	params.Add("X-Amz-SignedHeaders", signedHeaders)
-
-	canonicalQuerystring := params.Encode()
-	payloadHash := GetHash("") // empty payload
-	canonicalRequest := method + "\n" + canonicalURI + "\n" + canonicalQuerystring + "\n" + canonicalHeaders + "\n" + signedHeaders + "\n" + payloadHash
-
-	// TASK 2: CREATE THE STRING TO SIGN.
-	stringToSign := algorithm + "\n" + amzDate + "\n" + credentialScope + "\n" + GetHash(canonicalRequest)
-
-	// TASK 3: CALCULATE THE SIGNATURE.
-	// https://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
-	hash := GetHMAC([]byte(fmt.Sprintf("AWS4%s", resSecretMatch)), []byte(datestamp))
-	hash = GetHMAC(hash, []byte(region))
-	hash = GetHMAC(hash, []byte(service))
-	hash = GetHMAC(hash, []byte("aws4_request"))
-
-	signature2 := GetHMAC(hash, []byte(stringToSign)) // Get Signature HMAC SHA256
-	signature := hex.EncodeToString(signature2)
-
-	// TASK 4: ADD SIGNING INFORMATION TO THE REQUEST.
-	params.Add("X-Amz-Signature", signature)
-	req.Header.Add("Content-type", "application/x-www-form-urlencoded; charset=utf-8")
-	req.URL.RawQuery = params.Encode()
-
-	return req
-}
-
-func verifyWithSts(keyId, secret string) (*sts.GetCallerIdentityOutput, error) {
-	//cfg := aws.NewConfig().WithCredentials(credentials.NewStaticCredentials(keyId, secret, ""))
-	//cfg := &aws.Config{
-	//	Credentials: credentials.NewStaticCredentials(keyId, secret, ""),
-	//}
-	s, err := session.NewSession()
-	s.Config.Credentials = credentials.NewStaticCredentials(keyId, secret, "")
-	if err != nil {
-		return nil, err
-	}
-	svc := sts.New(s)
-	input := &sts.GetCallerIdentityInput{}
-	output, err := svc.GetCallerIdentity(input)
-	if err == nil {
-		return output, err
-	}
-	return nil, err
 }

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -208,7 +208,7 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 								if body.Error.Code == "InvalidClientTokenId" {
 									// determinate failure - nothing to do
 								} else {
-									// We see a surprising number of signature mismatch errors here
+									// We see a surprising number of false-negative signature mismatch errors here
 									// (The official SDK somehow elicits even more than just making the request ourselves)
 									s1.VerificationError = fmt.Errorf("request to %v returned status %d with an unexpected reason (%s: %s)", res.Request.URL, res.StatusCode, body.Error.Code, body.Error.Message)
 								}

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -126,7 +126,7 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				endpoint := "https://sts.amazonaws.com"
 				now := time.Now().UTC()
 				datestamp := now.Format("20060102")
-				amzDate := now.Format("20060102T150405Z")
+				amzDate := now.Format("20060102T150405Z0700")
 
 				req, err := http.NewRequestWithContext(ctx, method, endpoint, nil)
 				if err != nil {

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -205,11 +205,14 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 							err = json.NewDecoder(res.Body).Decode(&body)
 							res.Body.Close()
 							if err == nil {
-								if body.Error.Code == "InvalidClientTokenId" {
+								// All instances of the code I've seen in the wild are PascalCased but this check is
+								// case-insensitive out of an abundance of caution
+								if strings.EqualFold(body.Error.Code, "InvalidClientTokenId") {
 									// determinate failure - nothing to do
 								} else {
 									// We see a surprising number of false-negative signature mismatch errors here
-									// (The official SDK somehow elicits even more than just making the request ourselves)
+									// (The official SDK somehow elicits even more than just making the request
+									// ourselves)
 									s1.VerificationError = fmt.Errorf("request to %v returned status %d with an unexpected reason (%s: %s)", res.Request.URL, res.StatusCode, body.Error.Code, body.Error.Message)
 								}
 							} else {
@@ -267,12 +270,12 @@ func awsCustomCleanResults(results []detectors.Result) []detectors.Result {
 }
 
 type awsError struct {
-	Code    string
-	Message string
+	Code    string `json:"Code"`
+	Message string `json:"Message"`
 }
 
 type awsErrorResponseBody struct {
-	Error awsError
+	Error awsError `json:"Error"`
 }
 
 type identityRes struct {

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -117,19 +117,6 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				//info, err := verifyWithSts(resIDMatch, resSecretMatch)
-				//
-				//s1.Verified = info != nil
-				//s1.VerificationError = err
-				//
-				//if info != nil {
-				//	s1.ExtraData = map[string]string{
-				//		"account": *info.Account,
-				//		"user_id": *info.UserId,
-				//		"arn":     *info.Arn,
-				//	}
-				//}
-
 				// REQUEST VALUES.
 				method := "GET"
 				service := "sts"
@@ -198,7 +185,6 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 								"user_id": identityInfo.GetCallerIdentityResponse.GetCallerIdentityResult.UserID,
 								"arn":     identityInfo.GetCallerIdentityResponse.GetCallerIdentityResult.Arn,
 							}
-							s1.VerificationError = fmt.Errorf("%d", res.StatusCode)
 						} else {
 							s1.VerificationError = err
 						}

--- a/pkg/detectors/aws/aws_test.go
+++ b/pkg/detectors/aws/aws_test.go
@@ -194,9 +194,9 @@ func TestAWS_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found, would be verified if not for http timeout",
-			s:    scanner{},
+			s:    scanner{verificationClient: common.SaneHttpClientTimeOut(1 * time.Microsecond)},
 			args: args{
-				ctx:    timeoutContext(1 * time.Microsecond),
+				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a aws secret %s within aws %s", secret, id)),
 				verify: true,
 			},

--- a/pkg/detectors/aws/aws_test.go
+++ b/pkg/detectors/aws/aws_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
+var unverifiedSecretClient = common.ConstantResponseHttpClient(403, `{"Error": {"Code": "InvalidClientTokenId"} }`)
+
 func TestAWS_FromChunk(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
@@ -69,7 +71,7 @@ func TestAWS_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found, unverified",
-			s:    scanner{},
+			s:    scanner{verificationClient: unverifiedSecretClient},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a aws secret %s within aws %s but not valid", inactiveSecret, id)), // the secret would satisfy the regex but not pass validation
@@ -163,7 +165,7 @@ func TestAWS_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found, unverified, with leading +",
-			s:    scanner{},
+			s:    scanner{verificationClient: unverifiedSecretClient},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a aws secret %s within aws %s but not valid", "+HaNv9cTwheDKGJaws/+BMF2GgybQgBWdhcOOdfF", id)), // the secret would satisfy the regex but not pass validation

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -11,6 +11,11 @@ import (
 )
 
 func PrintJSON(r *detectors.ResultWithMetadata) error {
+	var ve string
+	if r.VerificationError != nil {
+		ve = r.VerificationError.Error()
+	}
+
 	v := &struct {
 		// SourceMetadata contains source-specific contextual information.
 		SourceMetadata *source_metadatapb.MetaData
@@ -37,20 +42,23 @@ func PrintJSON(r *detectors.ResultWithMetadata) error {
 		Redacted       string
 		ExtraData      map[string]string
 		StructuredData *detectorspb.StructuredData
+
+		VerificationErrorMessage string
 	}{
-		SourceMetadata: r.SourceMetadata,
-		SourceID:       r.SourceID,
-		SourceType:     r.SourceType,
-		SourceName:     r.SourceName,
-		DetectorType:   r.DetectorType,
-		DetectorName:   r.DetectorType.String(),
-		DecoderName:    r.DecoderType.String(),
-		Verified:       r.Verified,
-		Raw:            string(r.Raw),
-		RawV2:          string(r.RawV2),
-		Redacted:       r.Redacted,
-		ExtraData:      r.ExtraData,
-		StructuredData: r.StructuredData,
+		SourceMetadata:           r.SourceMetadata,
+		SourceID:                 r.SourceID,
+		SourceType:               r.SourceType,
+		SourceName:               r.SourceName,
+		DetectorType:             r.DetectorType,
+		DetectorName:             r.DetectorType.String(),
+		DecoderName:              r.DecoderType.String(),
+		Verified:                 r.Verified,
+		Raw:                      string(r.Raw),
+		RawV2:                    string(r.RawV2),
+		Redacted:                 r.Redacted,
+		ExtraData:                r.ExtraData,
+		StructuredData:           r.StructuredData,
+		VerificationErrorMessage: ve,
 	}
 	out, err := json.Marshal(v)
 	if err != nil {

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -11,11 +11,6 @@ import (
 )
 
 func PrintJSON(r *detectors.ResultWithMetadata) error {
-	var ve string
-	if r.VerificationError != nil {
-		ve = r.VerificationError.Error()
-	}
-
 	v := &struct {
 		// SourceMetadata contains source-specific contextual information.
 		SourceMetadata *source_metadatapb.MetaData
@@ -42,23 +37,20 @@ func PrintJSON(r *detectors.ResultWithMetadata) error {
 		Redacted       string
 		ExtraData      map[string]string
 		StructuredData *detectorspb.StructuredData
-
-		VerificationErrorMessage string
 	}{
-		SourceMetadata:           r.SourceMetadata,
-		SourceID:                 r.SourceID,
-		SourceType:               r.SourceType,
-		SourceName:               r.SourceName,
-		DetectorType:             r.DetectorType,
-		DetectorName:             r.DetectorType.String(),
-		DecoderName:              r.DecoderType.String(),
-		Verified:                 r.Verified,
-		Raw:                      string(r.Raw),
-		RawV2:                    string(r.RawV2),
-		Redacted:                 r.Redacted,
-		ExtraData:                r.ExtraData,
-		StructuredData:           r.StructuredData,
-		VerificationErrorMessage: ve,
+		SourceMetadata: r.SourceMetadata,
+		SourceID:       r.SourceID,
+		SourceType:     r.SourceType,
+		SourceName:     r.SourceName,
+		DetectorType:   r.DetectorType,
+		DetectorName:   r.DetectorType.String(),
+		DecoderName:    r.DecoderType.String(),
+		Verified:       r.Verified,
+		Raw:            string(r.Raw),
+		RawV2:          string(r.RawV2),
+		Redacted:       r.Redacted,
+		ExtraData:      r.ExtraData,
+		StructuredData: r.StructuredData,
 	}
 	out, err := json.Marshal(v)
 	if err != nil {


### PR DESCRIPTION
It turns out that `GetCallerIdentity` returns a surprising quantity of transient, false-negative 403 responses that carry the `SignatureDoesNotMatch` error reason. I don't know why this is happening, but their transient nature makes them indeterminate verification failures and they should be flagged as such. The AWS detector has therefore been modified to specifically look for the `InvalidClientTokenId` error reason in 403 responses and mark all other responses as indeterminate.

In addition to the functional changes this PR contains some updates to the test code that allow us to test them.