### PR TITLE
Do not nest transports for Github installation client

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -565,6 +565,7 @@ func (s *Source) enumerateWithApp(ctx context.Context, apiEndpoint string, app *
 	}
 	itr.BaseURL = apiEndpoint
 
+	originalTransport := s.httpClient.Transport
 	s.httpClient.Transport = itr
 	s.apiClient, err = github.NewEnterpriseClient(apiEndpoint, apiEndpoint, s.httpClient)
 	if err != nil {
@@ -574,7 +575,7 @@ func (s *Source) enumerateWithApp(ctx context.Context, apiEndpoint string, app *
 	// This client is required to create installation tokens for cloning.
 	// Otherwise, the required JWT is not in the request for the token :/
 	appItr, err := ghinstallation.NewAppsTransport(
-		s.httpClient.Transport,
+		originalTransport,
 		appID,
 		[]byte(app.PrivateKey))
 	if err != nil {


### PR DESCRIPTION
#1454 modified one of the Github enumeration code paths in a way that broke an integration test by causing one client's transport to be used for the construction of a different client, causing authentication failures. This saves the original transport for use, fixing the test.