### PR TITLE
implement indeterminate LDAP verification

### DIFF
--- a/pkg/detectors/ldap/ldap.go
+++ b/pkg/detectors/ldap/ldap.go
@@ -95,10 +95,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			err := verifyLDAP(username, password, ldapURL)
-			s1.Verified = err == nil
-			if !isErrDeterminate(err) {
-				s1.VerificationError = err
+			verificationError := verifyLDAP(username, password, ldapURL)
+
+			s1.Verified = verificationError == nil
+			if !isErrDeterminate(verificationError) {
+				s1.VerificationError = verificationError
 			}
 		}
 

--- a/pkg/detectors/ldap/ldap.go
+++ b/pkg/detectors/ldap/ldap.go
@@ -65,10 +65,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 
 				if verify {
-					err := verifyLDAP(username[1], password[1], ldapURL)
-					s1.Verified = err == nil
-					if !isErrDeterminate(err) {
-						s1.VerificationError = err
+					verificationErr := verifyLDAP(username[1], password[1], ldapURL)
+					s1.Verified = verificationErr == nil
+					if !isErrDeterminate(verificationErr) {
+						s1.VerificationError = verificationErr
 					}
 				}
 

--- a/pkg/detectors/ldap/ldap.go
+++ b/pkg/detectors/ldap/ldap.go
@@ -131,35 +131,32 @@ func verifyLDAP(ctx context.Context, username, password string, ldapURL *url.URL
 	case "ldap":
 		// Non-TLS dial
 		l, err := ldap.DialURL(uri)
-		if err == nil {
-			defer l.Close()
-			// Non-TLS verify
-			err = l.Bind(username, password)
-			if err == nil {
-				return nil
-			}
-
-			// STARTTLS
-			err = l.StartTLS(&tls.Config{InsecureSkipVerify: true})
-			if err == nil {
-				// STARTTLS verify
-				return l.Bind(username, password)
-			} else {
-				return err
-			}
-		} else {
+		if err != nil {
 			return err
 		}
+		defer l.Close()
+		// Non-TLS verify
+		err = l.Bind(username, password)
+		if err == nil {
+			return nil
+		}
+
+		// STARTTLS
+		err = l.StartTLS(&tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		// STARTTLS verify
+		return l.Bind(username, password)
 	case "ldaps":
 		// TLS dial
 		l, err := ldap.DialTLS("tcp", uri, &tls.Config{InsecureSkipVerify: true})
-		if err == nil {
-			defer l.Close()
-			// TLS verify
-			return l.Bind(username, password)
-		} else {
+		if err != nil {
 			return err
 		}
+		defer l.Close()
+		// TLS verify
+		return l.Bind(username, password)
 	}
 
 	return fmt.Errorf("unknown ldap scheme %q", ldapURL.Scheme)

--- a/pkg/detectors/ldap/ldap.go
+++ b/pkg/detectors/ldap/ldap.go
@@ -65,7 +65,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 
 				if verify {
-					err := verifyLDAP(ctx, username[1], password[1], ldapURL)
+					err := verifyLDAP(username[1], password[1], ldapURL)
 					s1.Verified = err == nil
 					if !isErrDeterminate(err) {
 						s1.VerificationError = err
@@ -95,7 +95,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			err := verifyLDAP(ctx, username, password, ldapURL)
+			err := verifyLDAP(username, password, ldapURL)
 			s1.Verified = err == nil
 			if !isErrDeterminate(err) {
 				s1.VerificationError = err
@@ -120,7 +120,7 @@ func isErrDeterminate(err error) bool {
 	return true
 }
 
-func verifyLDAP(ctx context.Context, username, password string, ldapURL *url.URL) error {
+func verifyLDAP(username, password string, ldapURL *url.URL) error {
 	// Tests with non-TLS, TLS, and STARTTLS
 
 	ldap.DefaultTimeout = 5 * time.Second

--- a/pkg/detectors/ldap/ldap_integration_test.go
+++ b/pkg/detectors/ldap/ldap_integration_test.go
@@ -7,13 +7,14 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/kylelemons/godebug/pretty"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
@@ -176,9 +177,9 @@ func TestLdap_Integration_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				got[i].Raw = nil
 			}
-			if diff := pretty.Compare(got, tt.want); diff != "" {
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw")
+			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Ldap.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
 		})

--- a/pkg/detectors/ldap/ldap_integration_test.go
+++ b/pkg/detectors/ldap/ldap_integration_test.go
@@ -230,7 +230,7 @@ func startOpenLDAP() error {
 		return nil
 	case <-time.After(30 * time.Second):
 		stopOpenLDAP()
-		return errors.New("timeout waiting for postgres database to be ready")
+		return errors.New("timeout waiting for ldap service to be ready")
 	}
 }
 


### PR DESCRIPTION
This PR implements tri-state verification for the LDAP detector. This implementation looks for network errors to explicitly flag as indeterminate, rather than authentication errors to explicitly flag as determinate; this is because the error that occurs from authentication failures doesn't appear to have its own type and I didn't want to have to match on the error message text.