### PR TITLE
[bug] - fix data races

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -90,7 +90,7 @@ func (s *Source) setScanOptions(base, head string) {
 	s.scanOptMu.Lock()
 	defer s.scanOptMu.Unlock()
 	s.scanOptions.BaseHash = base
-	s.scanOptions.BaseHash = head
+	s.scanOptions.HeadHash = head
 }
 
 // Ensure the Source satisfies the interfaces at compile time

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -44,30 +44,38 @@ const (
 )
 
 type Source struct {
-	name                 string
-	githubUser           string
-	githubToken          string
-	sourceID             int64
-	jobID                int64
-	verify               bool
-	repos                []string
-	members              []string
-	orgsCache            cache.Cache
-	filteredRepoCache    *filteredRepoCache
-	memberCache          map[string]struct{}
-	repoSizes            repoSize
-	totalRepoSize        int // total size in bytes of all repos
-	git                  *git.Git
-	scanOptions          *git.ScanOptions
-	httpClient           *http.Client
-	log                  logr.Logger
-	conn                 *sourcespb.GitHub
-	jobPool              *errgroup.Group
-	resumeInfoMutex      sync.Mutex
-	resumeInfoSlice      []string
-	apiClient            *github.Client
-	mu                   sync.Mutex
-	publicMap            map[string]source_metadatapb.Visibility
+	name string
+	// Protects the user and token.
+	userMu      sync.Mutex
+	githubUser  string
+	githubToken string
+
+	sourceID          int64
+	jobID             int64
+	verify            bool
+	repos             []string
+	members           []string
+	orgsCache         cache.Cache
+	filteredRepoCache *filteredRepoCache
+	memberCache       map[string]struct{}
+	repoSizes         repoSize
+	totalRepoSize     int // total size in bytes of all repos
+	git               *git.Git
+
+	scanOptMu   sync.Mutex // protects the scanOptions
+	scanOptions *git.ScanOptions
+
+	httpClient      *http.Client
+	log             logr.Logger
+	conn            *sourcespb.GitHub
+	jobPool         *errgroup.Group
+	resumeInfoMutex sync.Mutex
+	resumeInfoSlice []string
+	apiClient       *github.Client
+
+	mu        sync.Mutex // protects the visibility maps
+	publicMap map[string]source_metadatapb.Visibility
+
 	includePRComments    bool
 	includeIssueComments bool
 	sources.Progress
@@ -76,6 +84,13 @@ type Source struct {
 
 func (s *Source) WithScanOptions(scanOptions *git.ScanOptions) {
 	s.scanOptions = scanOptions
+}
+
+func (s *Source) setScanOptions(base, head string) {
+	s.scanOptMu.Lock()
+	defer s.scanOptMu.Unlock()
+	s.scanOptions.BaseHash = base
+	s.scanOptions.BaseHash = head
 }
 
 // Ensure the Source satisfies the interfaces at compile time
@@ -678,6 +693,7 @@ func (s *Source) scan(ctx context.Context, installationClient *github.Client, ch
 			path, repo, err = s.cloneRepo(ctx, repoURL, installationClient)
 			if err != nil {
 				scanErrs.Add(err)
+				return nil
 			}
 
 			defer os.RemoveAll(path)
@@ -686,8 +702,7 @@ func (s *Source) scan(ctx context.Context, installationClient *github.Client, ch
 				return nil
 			}
 
-			s.scanOptions.BaseHash = s.conn.Base
-			s.scanOptions.HeadHash = s.conn.Head
+			s.setScanOptions(s.conn.Base, s.conn.Head)
 
 			repoSize := s.repoSizes.getRepo(repoURL)
 			logger.V(2).Info(fmt.Sprintf("scanning repo %d/%d", i, len(s.repos)), "repo_size", repoSize)

--- a/pkg/sources/github/repo.go
+++ b/pkg/sources/github/repo.go
@@ -50,12 +50,15 @@ func (s *Source) cloneRepo(
 
 	case *sourcespb.GitHub_Token:
 		// We never refresh user provided tokens, so if we already have them, we never need to try and fetch them again.
+		s.userMu.Lock()
 		if s.githubUser == "" || s.githubToken == "" {
 			s.githubUser, s.githubToken, err = s.userAndToken(ctx, installationClient)
 			if err != nil {
+				s.userMu.Unlock()
 				return "", nil, fmt.Errorf("error getting token for repo %s: %w", repoURL, err)
 			}
 		}
+		s.userMu.Unlock()
 		path, repo, err = git.CloneRepoUsingToken(ctx, s.githubToken, repoURL, s.githubUser)
 		if err != nil {
 			return "", nil, fmt.Errorf("error cloning repo %s: %w", repoURL, err)

--- a/pkg/sources/github/repo.go
+++ b/pkg/sources/github/repo.go
@@ -49,16 +49,9 @@ func (s *Source) cloneRepo(
 		}
 
 	case *sourcespb.GitHub_Token:
-		// We never refresh user provided tokens, so if we already have them, we never need to try and fetch them again.
-		s.userMu.Lock()
-		if s.githubUser == "" || s.githubToken == "" {
-			s.githubUser, s.githubToken, err = s.userAndToken(ctx, installationClient)
-			if err != nil {
-				s.userMu.Unlock()
-				return "", nil, fmt.Errorf("error getting token for repo %s: %w", repoURL, err)
-			}
+		if err := s.getUserAndToken(ctx, repoURL, installationClient); err != nil {
+			return "", nil, fmt.Errorf("error getting token for repo %s: %w", repoURL, err)
 		}
-		s.userMu.Unlock()
 		path, repo, err = git.CloneRepoUsingToken(ctx, s.githubToken, repoURL, s.githubUser)
 		if err != nil {
 			return "", nil, fmt.Errorf("error cloning repo %s: %w", repoURL, err)
@@ -67,6 +60,20 @@ func (s *Source) cloneRepo(
 		return "", nil, fmt.Errorf("unhandled credential type for repo %s", repoURL)
 	}
 	return path, repo, nil
+}
+
+func (s *Source) getUserAndToken(ctx context.Context, repoURL string, installationClient *github.Client) error {
+	// We never refresh user provided tokens, so if we already have them, we never need to try and fetch them again.
+	s.userMu.Lock()
+	defer s.mu.Unlock()
+	if s.githubUser == "" || s.githubToken == "" {
+		var err error
+		s.githubUser, s.githubToken, err = s.userAndToken(ctx, installationClient)
+		if err != nil {
+			return fmt.Errorf("error getting token for repo %s: %w", repoURL, err)
+		}
+	}
+	return nil
 }
 
 func (s *Source) userAndToken(ctx context.Context, installationClient *github.Client) (string, string, error) {


### PR DESCRIPTION
- Add test to catch all the data races below
- Multiple repos can concurrently use the git source, therefore we need to make the metrics counter atomic.
NOTE: We should probably look for a less hacky solution for the long term. This is just to temporarily fix the issues.

![Screenshot 2023-07-29 at 3 08 18 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/9d36abec-0f69-42b0-9ba9-8c1ccddaead2)

- Modifying the user and token also needs to be protected
![Screenshot 2023-07-29 at 7 16 45 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/715996dd-71ac-4c50-926d-ca4959d1e8bd)

- Modifying the scanOptions also need protection
![Screenshot 2023-07-29 at 7 29 19 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/1cbd0076-c7c6-497f-9113-57f1bd99cb11)

