### PR TITLE
[chore] - Do not skip scanning commits if scanning comments errors

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -699,7 +699,6 @@ func (s *Source) scan(ctx context.Context, installationClient *github.Client, ch
 
 			if err = s.scanComments(ctx, repoURL, chunksChan); err != nil {
 				scanErrs.Add(fmt.Errorf("error scanning comments in repo %s: %w", repoURL, err))
-				return nil
 			}
 
 			if err = s.git.ScanRepo(ctx, repo, path, s.scanOptions, chunksChan); err != nil {


### PR DESCRIPTION
- An error while scanning comments should not prevent us from scanning the repo. We should simply log the error and try to scan the repo.
