### PR TITLE
Concurrent detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/google/go-github/v42 v42.0.0
 	github.com/googleapis/gax-go/v2 v2.12.0
 	github.com/hashicorp/go-retryablehttp v0.7.4
+	github.com/hashicorp/golang-lru v0.5.1
 	github.com/jlaffaye/ftp v0.2.0
 	github.com/joho/godotenv v1.5.1
 	github.com/jpillora/overseer v1.1.6
@@ -126,6 +127,7 @@ require (
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/golang-lru/v2 v2.0.4 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -301,7 +301,10 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
 github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+dAcgU=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru/v2 v2.0.4 h1:7GHuZcgid37q8o5i3QI9KMT4nCWQQ3Kx3Ov6bb9MfK0=
+github.com/hashicorp/golang-lru/v2 v2.0.4/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=

--- a/main.go
+++ b/main.go
@@ -339,6 +339,7 @@ func run(state overseer.State) {
 		engine.WithFilterDetectors(endpointCustomizer),
 		engine.WithFilterUnverified(*filterUnverified),
 		engine.WithOnlyVerified(*onlyVerified),
+		engine.WithPrintAvgDetectorTime(*printAvgDetectorTime),
 		engine.WithPrinter(printer),
 	)
 
@@ -498,11 +499,12 @@ func run(state overseer.State) {
 	// Wait for all workers to finish.
 	e.Finish(ctx, logFatal)
 
+	// Print results.
 	logger.Info("finished scanning",
 		"chunks", e.ChunksScanned(),
 		"bytes", e.BytesScanned(),
-		"verified-secrets", e.Metrics.VerifiedSecretsFound,
-		"unverified-secrets", e.Metrics.UnverifiedSecretsFound,
+		"verified-secrets", e.VerifiedResults(),
+		"unverified-secrets", e.UnverifiedResults(),
 	)
 
 	if *printAvgDetectorTime {

--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/felixge/fgprof"
-	"github.com/go-logr/logr"
 	"github.com/jpillora/overseer"
 	"google.golang.org/protobuf/types/known/anypb"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -163,7 +162,7 @@ func main() {
 	// make it the default logger for contexts
 	context.SetDefaultLogger(logger)
 	defer func() { _ = sync() }()
-	logFatal := logFatalFunc(logger)
+	logFatal := common.LogFatalFunc(logger)
 
 	updateCfg := overseer.Config{
 		Program:       run,
@@ -189,7 +188,7 @@ func main() {
 func run(state overseer.State) {
 	ctx := context.Background()
 	logger := ctx.Logger()
-	logFatal := logFatalFunc(logger)
+	logFatal := common.LogFatalFunc(logger)
 
 	logger.V(2).Info(fmt.Sprintf("trufflehog %s", version.BuildVersion))
 
@@ -540,19 +539,6 @@ func printAverageDetectorTime(e *engine.Engine) {
 		}
 		avgDuration := total / time.Duration(len(durations))
 		fmt.Fprintf(os.Stderr, "%s: %s\n", detectorName, avgDuration)
-	}
-}
-
-// logFatalFunc returns a log.Fatal style function. Calling the returned
-// function will terminate the program without cleanup.
-func logFatalFunc(logger logr.Logger) func(error, string, ...any) {
-	return func(err error, message string, keyAndVals ...any) {
-		logger.Error(err, message, keyAndVals...)
-		if err != nil {
-			os.Exit(1)
-			return
-		}
-		os.Exit(0)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -499,7 +499,9 @@ func run(state overseer.State) {
 	}
 
 	// Wait for all workers to finish.
-	e.Finish(ctx, logFatal)
+	if err = e.Finish(ctx); err != nil {
+		logFatal(err, "engine failed to finish execution")
+	}
 
 	metrics := e.GetMetrics()
 	// Print results.

--- a/main.go
+++ b/main.go
@@ -329,7 +329,7 @@ func run(state overseer.State) {
 	}
 
 	e := engine.Start(ctx,
-		engine.WithConcurrency(*concurrency),
+		engine.WithConcurrency(uint8(*concurrency)),
 		engine.WithDecoders(decoders.DefaultDecoders()...),
 		engine.WithDetectors(!*noVerification, engine.DefaultDetectors()...),
 		engine.WithDetectors(!*noVerification, conf.Detectors...),

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -3,7 +3,9 @@ package common
 import (
 	"bufio"
 	"bytes"
+	"crypto/rand"
 	"io"
+	"math/big"
 	"strings"
 )
 
@@ -48,4 +50,17 @@ func ResponseContainsSubstring(reader io.ReadCloser, target string) (bool, error
 		return false, err
 	}
 	return false, nil
+}
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+// RandomID returns a random string of the given length.
+func RandomID(length int) string {
+	b := make([]rune, length)
+	for i := range b {
+		randInt, _ := rand.Int(rand.Reader, big.NewInt(int64(len(letters))))
+		b[i] = letters[randInt.Int64()]
+	}
+
+	return string(b)
 }

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -6,7 +6,10 @@ import (
 	"crypto/rand"
 	"io"
 	"math/big"
+	"os"
 	"strings"
+
+	"github.com/go-logr/logr"
 )
 
 func AddStringSliceItem(item string, slice *[]string) {
@@ -63,4 +66,17 @@ func RandomID(length int) string {
 	}
 
 	return string(b)
+}
+
+// LogFatalFunc returns a log.Fatal style function. Calling the returned
+// function will terminate the program without cleanup.
+func LogFatalFunc(logger logr.Logger) func(error, string, ...any) {
+	return func(err error, message string, keyAndVals ...any) {
+		logger.Error(err, message, keyAndVals...)
+		if err != nil {
+			os.Exit(1)
+			return
+		}
+		os.Exit(0)
+	}
 }

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -6,10 +6,7 @@ import (
 	"crypto/rand"
 	"io"
 	"math/big"
-	"os"
 	"strings"
-
-	"github.com/go-logr/logr"
 )
 
 func AddStringSliceItem(item string, slice *[]string) {
@@ -66,17 +63,4 @@ func RandomID(length int) string {
 	}
 
 	return string(b)
-}
-
-// LogFatalFunc returns a log.Fatal style function. Calling the returned
-// function will terminate the program without cleanup.
-func LogFatalFunc(logger logr.Logger) func(error, string, ...any) {
-	return func(err error, message string, keyAndVals ...any) {
-		logger.Error(err, message, keyAndVals...)
-		if err != nil {
-			os.Exit(1)
-			return
-		}
-		os.Exit(0)
-	}
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -187,14 +187,14 @@ func (e *Engine) GetScanMetrics() runtimeMetrics {
 	}
 }
 
-const (
-	defaultChannelBuffer = 1
-	// TODO (ahrav): Determine the optimal cache size.
-	cacheSize = 512 // number of entries in the LRU cache
-)
-
 // Start the engine with options.
 func Start(ctx context.Context, options ...EngineOption) *Engine {
+	const (
+		defaultChannelBuffer = 1
+		// TODO (ahrav): Determine the optimal cache size.
+		cacheSize = 512 // number of entries in the LRU cache
+	)
+
 	cache, err := lru.New(cacheSize)
 	if err != nil {
 		common.LogFatalFunc(ctx.Logger())

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -192,10 +192,11 @@ const (
 	cacheSize            = 1000
 )
 
+// Start the engine with options.
 func Start(ctx context.Context, options ...EngineOption) *Engine {
 	cache, err := lru.New(cacheSize)
 	if err != nil {
-		panic(err)
+		common.LogFatalFunc(ctx.Logger())
 	}
 
 	e := &Engine{
@@ -460,64 +461,9 @@ func (e *Engine) detectorWorker(ctx context.Context) {
 							decoder:  decoderType,
 							wgDoneFn: wgDetect.Done,
 						}
-
-						// start := time.Now()
-						//
-						// results, err := func() ([]detectors.Result, error) {
-						// 	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-						// 	defer cancel()
-						// 	defer common.Recover(ctx)
-						// 	return detector.FromData(ctx, verify, decoded.Data)
-						// }()
-						// if err != nil {
-						// 	ctx.Logger().Error(err, "could not scan chunk",
-						// 		"source_type", decoded.SourceType.String(),
-						// 		"metadata", decoded.SourceMetadata,
-						// 	)
-						// 	continue
-						// }
-						//
-						// if e.filterUnverified {
-						// 	results = detectors.CleanResults(results)
-						// }
-						// for _, result := range results {
-						// 	resultChunk := chunk
-						// 	ignoreLinePresent := false
-						// 	if SupportsLineNumbers(chunk.SourceType) {
-						// 		copyChunk := *chunk
-						// 		copyMetaDataClone := proto.Clone(chunk.SourceMetadata)
-						// 		if copyMetaData, ok := copyMetaDataClone.(*source_metadatapb.MetaData); ok {
-						// 			copyChunk.SourceMetadata = copyMetaData
-						// 		}
-						// 		fragStart, mdLine := FragmentFirstLine(&copyChunk)
-						// 		ignoreLinePresent = SetResultLineNumber(&copyChunk, &result, fragStart, mdLine)
-						// 		resultChunk = &copyChunk
-						// 	}
-						// 	if ignoreLinePresent {
-						// 		continue
-						// 	}
-						// 	result.DecoderType = decoderType
-						// 	chunkResults = append(chunkResults, detectors.CopyMetadata(resultChunk, result))
-						//
-						// }
-						// if len(results) > 0 {
-						// 	elapsed := time.Since(start)
-						// 	detectorName := results[0].DetectorType.String()
-						// 	avgTimeI, ok := e.detectorAvgTime.Load(detectorName)
-						// 	var avgTime []time.Duration
-						// 	if ok {
-						// 		avgTime, ok = avgTimeI.([]time.Duration)
-						// 		if !ok {
-						// 			continue
-						// 		}
-						// 	}
-						// 	avgTime = append(avgTime, elapsed)
-						// 	e.detectorAvgTime.Store(detectorName, avgTime)
-						// }
 					}
 				}
 			}
-			// e.dedupeAndSend(chunkResults)
 		}
 		atomic.AddUint64(&e.metrics.chunksScanned, 1)
 	}
@@ -609,7 +555,7 @@ func (e *Engine) notifyResults(ctx context.Context) {
 		}
 
 		if err := e.printer.Print(ctx, &r); err != nil {
-			// logFatal(err, "error printing results")
+			common.LogFatalFunc(ctx.Logger())
 		}
 	}
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -563,7 +563,7 @@ func (e *Engine) notifyResults(ctx context.Context) {
 		}
 
 		if err := e.printer.Print(ctx, &r); err != nil {
-			// common.LogFatalFunc(ctx.Logger())
+			ctx.Logger().Error(err, "error printing result")
 		}
 	}
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -203,7 +203,7 @@ func Start(ctx context.Context, options ...EngineOption) *Engine {
 	e := &Engine{
 		chunks:               make(chan *sources.Chunk, defaultChannelBuffer),
 		detectableChunksChan: make(chan detectableChunk, defaultChannelBuffer),
-		results:              make(chan detectors.ResultWithMetadata),
+		results:              make(chan detectors.ResultWithMetadata, defaultChannelBuffer),
 		sourcesWg:            &errgroup.Group{},
 		wgDetectorWorkers:    sync.WaitGroup{},
 		WgNotifier:           sync.WaitGroup{},

--- a/pkg/engine/gcs_test.go
+++ b/pkg/engine/gcs_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/decoders"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
@@ -59,11 +61,13 @@ func TestScanGCS(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
 
-			e := Start(ctx,
+			e, err := Start(ctx,
 				WithConcurrency(1),
 				WithDecoders(decoders.DefaultDecoders()...),
 				WithDetectors(false, DefaultDetectors()...),
 			)
+			assert.Nil(t, err)
+
 			go func() {
 				resultCount := 0
 				for range e.ResultsChan() {
@@ -71,15 +75,12 @@ func TestScanGCS(t *testing.T) {
 				}
 			}()
 
-			err := e.ScanGCS(ctx, test.gcsConfig)
+			err = e.ScanGCS(ctx, test.gcsConfig)
 			if err != nil && !test.wantErr && !strings.Contains(err.Error(), "googleapi: Error 400: Bad Request") {
 				t.Errorf("ScanGCS() got: %v, want: %v", err, nil)
 				return
 			}
-			logFatalFunc := func(_ error, _ string, _ ...any) {
-				t.Fatalf("error logging function should not have been called")
-			}
-			e.Finish(ctx, logFatalFunc)
+			assert.Nil(t, e.Finish(ctx))
 
 			if err == nil && test.wantErr {
 				t.Errorf("ScanGCS() got: %v, want: %v", err, "error")

--- a/pkg/engine/git_test.go
+++ b/pkg/engine/git_test.go
@@ -65,12 +65,13 @@ func TestGitEngine(t *testing.T) {
 		},
 	} {
 		t.Run(tName, func(t *testing.T) {
-			e := Start(ctx,
+			e, err := Start(ctx,
 				WithConcurrency(1),
 				WithDecoders(decoders.DefaultDecoders()...),
 				WithDetectors(true, DefaultDetectors()...),
 				WithPrinter(new(discardPrinter)),
 			)
+			assert.Nil(t, err)
 
 			cfg := sources.GitConfig{
 				RepoPath: path,
@@ -120,11 +121,13 @@ func BenchmarkGitEngine(b *testing.B) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	e := Start(ctx,
+	e, err := Start(ctx,
 		WithConcurrency(1),
 		WithDecoders(decoders.DefaultDecoders()...),
 		WithDetectors(false, DefaultDetectors()...),
 	)
+	assert.Nil(b, err)
+
 	go func() {
 		resultCount := 0
 		for range e.ResultsChan() {

--- a/pkg/engine/git_test.go
+++ b/pkg/engine/git_test.go
@@ -85,7 +85,7 @@ func TestGitEngine(t *testing.T) {
 			}
 
 			// Wait for all the chunks to be processed.
-			e.Finish(ctx)
+			assert.Nil(t, e.Finish(ctx))
 			for result := range e.ResultsChan() {
 				switch meta := result.SourceMetadata.GetData().(type) {
 				case *source_metadatapb.MetaData_Git:

--- a/pkg/engine/git_test.go
+++ b/pkg/engine/git_test.go
@@ -84,11 +84,8 @@ func TestGitEngine(t *testing.T) {
 				return
 			}
 
-			logFatalFunc := func(_ error, _ string, _ ...any) {
-				t.Fatalf("error logging function should not have been called")
-			}
 			// Wait for all the chunks to be processed.
-			e.Finish(ctx, logFatalFunc)
+			e.Finish(ctx)
 			for result := range e.ResultsChan() {
 				switch meta := result.SourceMetadata.GetData().(type) {
 				case *source_metadatapb.MetaData_Git:
@@ -104,7 +101,8 @@ func TestGitEngine(t *testing.T) {
 				}
 
 			}
-			assert.Equal(t, len(tTest.expected), int(e.VerifiedResults())+int(e.UnverifiedResults()))
+			metrics := e.GetMetrics()
+			assert.Equal(t, len(tTest.expected), int(metrics.VerifiedSecretsFound)+int(metrics.UnverifiedSecretsFound))
 		})
 	}
 }
@@ -146,8 +144,5 @@ func BenchmarkGitEngine(b *testing.B) {
 			return
 		}
 	}
-	logFatalFunc := func(_ error, _ string, _ ...any) {
-		b.Fatalf("error logging function should not have been called")
-	}
-	e.Finish(ctx, logFatalFunc)
+	assert.Nil(b, e.Finish(ctx))
 }

--- a/pkg/output/github_actions.go
+++ b/pkg/output/github_actions.go
@@ -5,13 +5,17 @@ import (
 	"encoding/hex"
 	"fmt"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
 var dedupeCache = make(map[string]struct{})
 
-func PrintGitHubActionsOutput(r *detectors.ResultWithMetadata) error {
+// GitHubActionsPrinter is a printer that prints results in GitHub Actions format.
+type GitHubActionsPrinter struct{}
+
+func (p *GitHubActionsPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) error {
 	out := gitHubActionsOutputFormat{
 		DetectorType: r.Result.DetectorType.String(),
 		DecoderType:  r.Result.DecoderType.String(),

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -4,13 +4,17 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 )
 
-func PrintJSON(r *detectors.ResultWithMetadata) error {
+// JSONPrinter is a printer that prints results in JSON format.
+type JSONPrinter struct{}
+
+func (p *JSONPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) error {
 	v := &struct {
 		// SourceMetadata contains source-specific contextual information.
 		SourceMetadata *source_metadatapb.MetaData

--- a/pkg/output/legacy_json.go
+++ b/pkg/output/legacy_json.go
@@ -19,7 +19,10 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/git"
 )
 
-func PrintLegacyJSON(ctx context.Context, r *detectors.ResultWithMetadata) error {
+// LegacyJSONPrinter is a printer that prints results in legacy JSON format for backwards compatibility.
+type LegacyJSONPrinter struct{}
+
+func (p *LegacyJSONPrinter) Print(ctx context.Context, r *detectors.ResultWithMetadata) error {
 	var repo string
 	switch r.SourceType {
 	case sourcespb.SourceType_SOURCE_TYPE_GIT:
@@ -41,7 +44,7 @@ func PrintLegacyJSON(ctx context.Context, r *detectors.ResultWithMetadata) error
 		defer os.RemoveAll(repoPath)
 	}
 
-	legacy, err := ConvertToLegacyJSON(r, repoPath)
+	legacy, err := convertToLegacyJSON(r, repoPath)
 	if err != nil {
 		return fmt.Errorf("could not convert to legacy JSON: %w", err)
 	}
@@ -53,7 +56,7 @@ func PrintLegacyJSON(ctx context.Context, r *detectors.ResultWithMetadata) error
 	return nil
 }
 
-func ConvertToLegacyJSON(r *detectors.ResultWithMetadata, repoPath string) (*LegacyJSONOutput, error) {
+func convertToLegacyJSON(r *detectors.ResultWithMetadata, repoPath string) (*LegacyJSONOutput, error) {
 	var source LegacyJSONCompatibleSource
 	switch r.SourceType {
 	case sourcespb.SourceType_SOURCE_TYPE_GIT:

--- a/pkg/output/plain.go
+++ b/pkg/output/plain.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 )
@@ -20,7 +21,10 @@ var (
 	whitePrinter  = color.New(color.FgWhite)
 )
 
-func PrintPlainOutput(r *detectors.ResultWithMetadata) error {
+// PlainPrinter is a printer that prints results in plain text format.
+type PlainPrinter struct{}
+
+func (p *PlainPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) error {
 	out := outputFormat{
 		DetectorType: r.Result.DetectorType.String(),
 		DecoderType:  r.Result.DecoderType.String(),


### PR DESCRIPTION
- Handle detection concurrently instead of serially.
- Introduce an intermediate channel (detectableChunksChan) and detection workers.

Some rough benchmarks running it against a handful of repos. Notice the speedup is dramatic for repos that have a lot of chunks that require detection. (ie pass the keyword and regex matches)

## trufflehog
| Status | Chunks | Bytes    | Time    |
|--------|--------|----------|---------|
| Old    | 20604  | 10716577 | 41.202s |
| New    | 20604  | 10716577 | 15.323s |
## thog
| Status | Chunks  | Bytes     | Time     |
|--------|---------|-----------|----------|
| Old    | 143843  | 237138121 | 2:15.20m |
| New    | 143843  | 237138121 | 34.784s  |
## vscode
| Status | Chunks   | Bytes     | Time     |
|--------|----------|-----------|----------|
| Old    | 1002624  | 400679800 | 2:23.19m |
| New    | 1002624  | 400679800 | 2:11.92m |
## golang
| Status | Chunks  | Bytes     | Time     |
|--------|---------|-----------|----------|
| Old    | 660366  | 298301554 | 1:12.96m |
| New    | 660366  | 298301554 | 1:13.95m |
## gitlab
| Status | Chunks   | Bytes      | Time      |
|--------|----------|------------|-----------|
| Old    | 3964241  | 1206921559 | 54:24.73m |
| New    | 3964245  | 1206924001 | 10:43.01m |

High level architecture:
![concurrent-verification drawio (3)](https://github.com/trufflesecurity/trufflehog/assets/21311841/81da8239-9436-4620-9d42-3293cd974e20)



@zricethezav Given the use of channels i'm not entirely sure if i got the `dedupeAndSend` functionality correctly implemented. Since we can no longer collect all the result chunks across all the detectors for a single chunk, I had to use a LRU cache to try and get something similar. Could you take a look and see if I totally botched it, Thanks.