### PR TITLE
create hidden debug flag to disable overseer

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ var (
 	debug               = cli.Flag("debug", "Run in debug mode.").Bool()
 	trace               = cli.Flag("trace", "Run in trace mode.").Bool()
 	profile             = cli.Flag("profile", "Enables profiling and sets a pprof and fgprof server on :18066.").Bool()
+	LocalDev            = cli.Flag("local-dev", "Hidden feature to disable overseer for local dev.").Hidden().Bool()
 	jsonOut             = cli.Flag("json", "Output in JSON format.").Short('j').Bool()
 	jsonLegacy          = cli.Flag("json-legacy", "Use the pre-v3.0 JSON format. Only works with git, gitlab, and github sources.").Bool()
 	gitHubActionsFormat = cli.Flag("github-actions", "Output in GitHub Actions format.").Bool()
@@ -162,6 +163,12 @@ func main() {
 	logger, sync := log.New("trufflehog", logFormat(os.Stderr))
 	// make it the default logger for contexts
 	context.SetDefaultLogger(logger)
+
+	if *LocalDev {
+		run(overseer.State{})
+		os.Exit(0)
+	}
+
 	defer func() { _ = sync() }()
 	logFatal := logFatalFunc(logger)
 

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ var (
 	debug               = cli.Flag("debug", "Run in debug mode.").Bool()
 	trace               = cli.Flag("trace", "Run in trace mode.").Bool()
 	profile             = cli.Flag("profile", "Enables profiling and sets a pprof and fgprof server on :18066.").Bool()
-	LocalDev            = cli.Flag("local-dev", "Hidden feature to disable overseer for local dev.").Hidden().Bool()
+	localDev            = cli.Flag("local-dev", "Hidden feature to disable overseer for local dev.").Hidden().Bool()
 	jsonOut             = cli.Flag("json", "Output in JSON format.").Short('j').Bool()
 	jsonLegacy          = cli.Flag("json-legacy", "Use the pre-v3.0 JSON format. Only works with git, gitlab, and github sources.").Bool()
 	gitHubActionsFormat = cli.Flag("github-actions", "Output in GitHub Actions format.").Bool()
@@ -163,7 +163,7 @@ func main() {
 	// make it the default logger for contexts
 	context.SetDefaultLogger(logger)
 
-	if *LocalDev {
+	if *localDev {
 		run(overseer.State{})
 		os.Exit(0)
 	}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

support users to attach a debugger to a local trufflehog scanner