### PR TITLE
updating github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,11 +6,12 @@ labels: bug, needs triage
 assignees: trufflesecurity/product-eng
 ---
 
-### Community Note
-
-* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
-* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
-* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+Please Review the [Community Note](../community_note.md) before submitting
+<!--  -->
+<!-- * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request -->
+<!-- * Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request -->
+<!-- * If you are interested in working on this issue or have submitted a pull request, please leave a comment -->
+<!--  -->
 
 ### TruffleHog Version
 <!--- Please run `trufflehog --version` to show the version. If you are not running the latest version, please upgrade because your issue may have already been fixed. --->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,11 +7,6 @@ assignees: trufflesecurity/product-eng
 ---
 
 Please Review the [Community Note](../community_note.md) before submitting
-<!--  -->
-<!-- * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request -->
-<!-- * Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request -->
-<!-- * If you are interested in working on this issue or have submitted a pull request, please leave a comment -->
-<!--  -->
 
 ### TruffleHog Version
 <!--- Please run `trufflehog --version` to show the version. If you are not running the latest version, please upgrade because your issue may have already been fixed. --->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,28 +6,26 @@ labels: enhancement, needs triage
 assignees: trufflesecurity/product-eng
 ---
 
-### Community Note
 
-* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
-* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request
-* If you are interested in working on this issue or have submitted a pull request, please leave a comment
+Please Review the [Community Note](../community_note.md) before submitting
+<!-- ### Community Note -->
+<!--  -->
+<!-- * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request -->
+<!-- * Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request -->
+<!-- * If you are interested in working on this issue or have submitted a pull request, please leave a comment -->
 
-### Description
-
+## Description
 <!--- Please leave a helpful description of the feature request here. --->
 
-## Problem to be Addressed
-<!--- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] --->
-
-## Description of the Preferred Solution
-<!--- A clear and concise description of what you want to happen. What 
-information may be required and what would be the preferred way to provide it? 
+### Preferred Solution
+<!--- A clear and concise description of what you want to happen. What
+information may be required and what would be the preferred way to provide it?
 What should the output include? --->
 
-## Additional Context
+### Additional Context
 <!--- Add any other context or screenshots about the feature request here. --->
 
-### References
+#### References
 
 <!---
 Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
@@ -36,3 +34,4 @@ Are there any other GitHub issues (open or closed) or pull requests that should 
 --->
 
 * #0000
+

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -31,7 +31,8 @@ What should the output include? --->
 Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests
 
 Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation? For example:
---->
 
 * #0000
+--->
+
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,13 +6,7 @@ labels: enhancement, needs triage
 assignees: trufflesecurity/product-eng
 ---
 
-
 Please Review the [Community Note](../community_note.md) before submitting
-<!-- ### Community Note -->
-<!--  -->
-<!-- * Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request -->
-<!-- * Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request -->
-<!-- * If you are interested in working on this issue or have submitted a pull request, please leave a comment -->
 
 ## Description
 <!--- Please leave a helpful description of the feature request here. --->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,3 +2,11 @@
 Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
 If possible try to keep PRs scoped to one feature, and add tests for new features.
 -->
+
+### Description:
+Explain the purpose of the PR.
+
+### Checklist:
+* [ ] Does your PR pass tests (`make test-community`)?
+* [ ] Have you lint your code locally prior to submission (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,6 @@ If possible try to keep PRs scoped to one feature, and add tests for new feature
 Explain the purpose of the PR.
 
 ### Checklist:
-* [ ] Does your PR pass tests (`make test-community`)?
-* [ ] Have you lint your code locally prior to submission (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?
+* [ ] Tests passing (`make test-community`)?
+* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?
 

--- a/.github/community_note.md
+++ b/.github/community_note.md
@@ -1,0 +1,7 @@
+## Community Note
+
+Please vote on this issue by adding a 👍 reaction to the original issue to help the community and maintainers prioritize this request.
+
+Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for issue followers and do not help prioritize the request.
+
+If you are interested in working on this issue or have submitted a pull request, please leave a comment.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,8 +52,8 @@ jobs:
         service_account: 'github-ci-external@trufflehog-testing.iam.gserviceaccount.com'
     - name: Test
       run: make test-detectors
-      continue-on-error: true  
-  test-fork:
+      continue-on-error: true
+  test-community:
     if: ${{ github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     permissions:
@@ -67,4 +67,4 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Test
-      run: make test-forks
+      run: make test-community

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test-race:
 test-detectors:
 	CGO_ENABLED=0 go test -tags=detectors -timeout=5m $(shell go list ./... | grep pkg/detectors)
 
-test-forks:
+test-community:
 	CGO_ENABLED=0 go test -timeout=5m $(shell go list ./... | grep -v /vendor/ | grep -v pkg/detectors | grep -v pkg/sources)
 
 bench:


### PR DESCRIPTION
### Description:
This PR updates some of the `.github` templates to make issue content a little more concise and adds a PR template. It also changes `test-forks` to `test-community` so contributors are encouraged to run `make test-community` locally -- sounds a little better than running `make test-forks` locally.

Open to suggestions on any/all of this

### Checklist:
* [x] Does your PR pass tests (`make test-community`)?
* [x] Have you lint your code locally prior to submission (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?