### PR TITLE
Remove CI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 <div align="center">
 
-[![CI Status](https://github.com/trufflesecurity/trufflehog/actions/workflows/release.yml/badge.svg)](https://github.com/trufflesecurity/trufflehog/actions)
 [![Go Report Card](https://goreportcard.com/badge/github.com/trufflesecurity/trufflehog/v3)](https://goreportcard.com/report/github.com/trufflesecurity/trufflehog/v3)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-brightgreen)](/LICENSE)
 [![Total Detectors](https://img.shields.io/github/directory-file-count/trufflesecurity/truffleHog/pkg/detectors?label=Total%20Detectors&type=dir)](/pkg/detectors)


### PR DESCRIPTION
Remove CI badge from the README since we don't release from branches but rather tags. The CI badge system only allows for specifying a branch. 

![Screenshot 2023-08-01 at 12 22 49 PM](https://github.com/trufflesecurity/trufflehog/assets/15034943/9c77701b-67f8-4878-a6e8-b784910ebd93)

FWIW the failing status is pulling from these workflows https://github.com/trufflesecurity/trufflehog/actions/workflows/release.yml?query=branch%3Amain

For more reference: https://github.com/orgs/community/discussions/24986
