### PR TITLE
tighten up regex pattern for timezoneapi

### DIFF
--- a/pkg/detectors/timezoneapi/timezoneapi.go
+++ b/pkg/detectors/timezoneapi/timezoneapi.go
@@ -20,7 +20,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"timezoneapi"}) + `\b([a-zA-Z0-9]{20})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"timezoneapi"}) + `\b([a-zA-Z]{20})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/timezoneapi/timezoneapi.go
+++ b/pkg/detectors/timezoneapi/timezoneapi.go
@@ -54,8 +54,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			res, err := client.Do(req)
 			if err == nil {
+				verifiedBodyResponse, err := common.ResponseContainsSubstring(res.Body, "date")
+				if err != nil {
+					return nil, err
+				}
 				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
+				if res.StatusCode >= 200 && res.StatusCode < 300 && verifiedBodyResponse {
 					s1.Verified = true
 				} else {
 					// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

generated a handful of timezoneapi keys - none include numbers, so removing numerals from the regex pattern. 