### PR TITLE
synchronize print operations to stdout

### DIFF
--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -3,6 +3,7 @@ package output
 import (
 	"encoding/json"
 	"fmt"
+	"sync"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -12,7 +13,7 @@ import (
 )
 
 // JSONPrinter is a printer that prints results in JSON format.
-type JSONPrinter struct{}
+type JSONPrinter struct{ mu sync.Mutex }
 
 func (p *JSONPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) error {
 	v := &struct {
@@ -60,6 +61,9 @@ func (p *JSONPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) 
 	if err != nil {
 		return fmt.Errorf("could not marshal result: %w", err)
 	}
+
+	p.mu.Lock()
 	fmt.Println(string(out))
+	p.mu.Unlock()
 	return nil
 }

--- a/pkg/output/legacy_json.go
+++ b/pkg/output/legacy_json.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync"
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -20,7 +21,7 @@ import (
 )
 
 // LegacyJSONPrinter is a printer that prints results in legacy JSON format for backwards compatibility.
-type LegacyJSONPrinter struct{}
+type LegacyJSONPrinter struct{ mu sync.Mutex }
 
 func (p *LegacyJSONPrinter) Print(ctx context.Context, r *detectors.ResultWithMetadata) error {
 	var repo string
@@ -52,7 +53,10 @@ func (p *LegacyJSONPrinter) Print(ctx context.Context, r *detectors.ResultWithMe
 	if err != nil {
 		return fmt.Errorf("could not marshal result: %w", err)
 	}
+
+	p.mu.Lock()
 	fmt.Println(string(out))
+	p.mu.Unlock()
 	return nil
 }
 

--- a/pkg/output/plain.go
+++ b/pkg/output/plain.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/fatih/color"
 	"golang.org/x/text/cases"
@@ -22,7 +23,7 @@ var (
 )
 
 // PlainPrinter is a printer that prints results in plain text format.
-type PlainPrinter struct{}
+type PlainPrinter struct{ mu sync.Mutex }
 
 func (p *PlainPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) error {
 	out := outputFormat{
@@ -39,6 +40,8 @@ func (p *PlainPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata)
 	}
 
 	printer := greenPrinter
+	p.mu.Lock()
+	defer p.mu.Unlock()
 
 	if out.Verified {
 		yellowPrinter.Print("Found verified result 🐷🔑\n")


### PR DESCRIPTION
### Description:
Ensure print operations to stdout are serialized for all `Printer` implementations. We want to avoid:
![Screenshot 2023-08-02 at 8 11 26 AM](https://github.com/trufflesecurity/trufflehog/assets/21311841/d82ab536-e803-4004-a2ba-614ba2ec73fe)


### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

