### PR TITLE
Expand paypal regex

### DIFF
--- a/pkg/detectors/paypaloauth/paypaloauth.go
+++ b/pkg/detectors/paypaloauth/paypaloauth.go
@@ -22,8 +22,8 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	idPat  = regexp.MustCompile(`\b([A-Za-z0-9_\.]{7}-[A-Za-z0-9_\.]{72})\b`)
-	keyPat = regexp.MustCompile(`\b([A-Za-z0-9_\.]{69}-[A-Za-z0-9_\.]{10})\b`)
+	idPat  = regexp.MustCompile(`\b([A-Za-z0-9_\.]{7}-[A-Za-z0-9_\.]{72}|[A-Za-z0-9_\.]{5}-[A-Za-z0-9_\.]{34})\b`)
+	keyPat = regexp.MustCompile(`\b([A-Za-z0-9_\.\-]{40,80})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/paypaloauth/paypaloauth_test.go
+++ b/pkg/detectors/paypaloauth/paypaloauth_test.go
@@ -52,6 +52,10 @@ func TestPaypalOauth_FromChunk(t *testing.T) {
 					DetectorType: detectorspb.DetectorType_PaypalOauth,
 					Verified:     true,
 				},
+				{
+					DetectorType: detectorspb.DetectorType_PaypalOauth,
+					Verified:     false,
+				},
 			},
 			wantErr: false,
 		},
@@ -64,6 +68,10 @@ func TestPaypalOauth_FromChunk(t *testing.T) {
 				verify: true,
 			},
 			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_PaypalOauth,
+					Verified:     false,
+				},
 				{
 					DetectorType: detectorspb.DetectorType_PaypalOauth,
 					Verified:     false,


### PR DESCRIPTION
Allow regex to match https://www.paypal.com/us/cshelp/article/how-do-i-get-an-access-token-ts2128

```
curl -v​ https://api.sandbox.paypal.com/v1/oauth2/token \
   -H "Accept: application/json" \
   -H "Accept-Language: en_US" \
   -u "EOJ2S-Z60oN_le_KS1d75wsZ6y0SFdVsY9183IvxFyZp:EC1usMEUk8e9ihI7ZdXLF5cz6y0SFdVsY9183IvxFyZp"
   -d "grant_type=client_credentials"
```