### PR TITLE
implement tri-state verification in FTP detector

### DIFF
--- a/pkg/detectors/ftp/ftp.go
+++ b/pkg/detectors/ftp/ftp.go
@@ -104,7 +104,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 func isErrDeterminate(e error) bool {
 	ftpErr := &textproto.Error{}
-	return errors.As(e, &ftpErr)
+	return errors.As(e, &ftpErr) && ftpErr.Code == ftpNotLoggedIn
 }
 
 func verifyFTP(timeout time.Duration, u *url.URL) error {

--- a/pkg/detectors/ftp/ftp.go
+++ b/pkg/detectors/ftp/ftp.go
@@ -15,8 +15,12 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-// https://datatracker.ietf.org/doc/html/rfc959
-const ftpNotLoggedIn = 530
+const (
+	// https://datatracker.ietf.org/doc/html/rfc959
+	ftpNotLoggedIn = 530
+
+	defaultVerificationTimeout = 5 * time.Second
+)
 
 type Scanner struct {
 	// Verification timeout. Defaults to 5 seconds if unset.
@@ -27,8 +31,7 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultVerificationTimeout = 5 * time.Second
-	keyPat                     = regexp.MustCompile(`\bftp://[\S]{3,50}:([\S]{3,50})@[-.%\w\/:]+\b`)
+	keyPat = regexp.MustCompile(`\bftp://[\S]{3,50}:([\S]{3,50})@[-.%\w\/:]+\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/ftp/ftp.go
+++ b/pkg/detectors/ftp/ftp.go
@@ -2,6 +2,8 @@ package ftp
 
 import (
 	"context"
+	"errors"
+	"net/textproto"
 	"net/url"
 	"regexp"
 	"strings"
@@ -12,6 +14,9 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
+
+// https://datatracker.ietf.org/doc/html/rfc959
+const ftpNotLoggedIn = 530
 
 type Scanner struct{}
 
@@ -90,7 +95,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 }
 
 func isErrDeterminate(e error) bool {
-	return true
+	ftpErr := &textproto.Error{}
+	return errors.As(e, &ftpErr)
 }
 
 func verifyFTP(ctx context.Context, u *url.URL) error {

--- a/pkg/detectors/ftp/ftp.go
+++ b/pkg/detectors/ftp/ftp.go
@@ -67,7 +67,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		if verify {
 			verificationErr := verifyFTP(ctx, parsedURL)
 			s.Verified = verificationErr == nil
-			if isErrDeterminate(verificationErr) {
+			if !isErrDeterminate(verificationErr) {
 				s.VerificationError = verificationErr
 			}
 		}

--- a/pkg/detectors/ftp/ftp_test.go
+++ b/pkg/detectors/ftp/ftp_test.go
@@ -48,7 +48,7 @@ func TestFTP_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_FTP,
 					Verified:     true,
-					Redacted:     "ftp://dlpuser:*************************@ftp.dlptest.com",
+					Redacted:     "ftp://dlpuser:********@ftp.dlptest.com",
 				},
 			},
 			wantErr: false,
@@ -66,7 +66,7 @@ func TestFTP_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_FTP,
 					Verified:     false,
-					Redacted:     "ftp://dlpuser:*******@ftp.dlptest.com",
+					Redacted:     "ftp://dlpuser:********@ftp.dlptest.com",
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
This PR implements tri-state verification in the FTP detector. The verification timeout was made injectable to support a new test case.

The dogfood/Github action detection of "new" secrets is just picking up new test cases that use the existing test FTP secrets, which are already cleartext elsewhere in the codebase. (They're publicly available.)