### PR TITLE
Add max-depth support for github scans

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,6 +82,7 @@ var (
 	githubExcludeRepos     = githubScan.Flag("exclude-repos", `Repositories to exclude in an org scan. This can also be a glob pattern. You can repeat this flag. Must use Github repo full name. Example: "trufflesecurity/driftwood", "trufflesecurity/d*"`).Strings()
 	githubScanIncludePaths = githubScan.Flag("include-paths", "Path to file with newline separated regexes for files to include in scan.").Short('i').String()
 	githubScanExcludePaths = githubScan.Flag("exclude-paths", "Path to file with newline separated regexes for files to exclude in scan.").Short('x').String()
+	githubScanMaxDepth     = githubScan.Flag("max-depth", "Maximum depth of commits to scan.").Int()
 
 	gitlabScan = cli.Command("gitlab", "Find credentials in GitLab repositories.")
 	// TODO: Add more GitLab options
@@ -405,6 +406,7 @@ func run(state overseer.State) {
 			Repos:          *githubScanRepos,
 			Orgs:           *githubScanOrgs,
 			Filter:         filter,
+			MaxDepth:       *githubScanMaxDepth,
 		}
 		if err := e.ScanGitHub(ctx, cfg); err != nil {
 			logFatal(err, "Failed to scan Github.")

--- a/pkg/engine/github.go
+++ b/pkg/engine/github.go
@@ -42,6 +42,11 @@ func (e *Engine) ScanGitHub(ctx context.Context, c sources.GithubConfig) error {
 		git.ScanOptionFilter(c.Filter),
 		git.ScanOptionLogOptions(logOptions),
 	}
+
+	if c.MaxDepth != 0 {
+		opts = append(opts, git.ScanOptionMaxDepth(int64(c.MaxDepth)))
+	}
+
 	scanOptions := git.NewScanOptions(opts...)
 
 	handle, err := e.sourceManager.Enroll(ctx, "trufflehog - github", new(github.Source).Type(),

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -172,6 +172,8 @@ type GithubConfig struct {
 	IncludeRepos []string
 	// Filter is the filter to use to scan the source.
 	Filter *common.Filter
+	// MaxDepth is the maximum depth to scan the source.
+	MaxDepth int
 }
 
 // GitlabConfig defines the optional configuration for a gitlab source.


### PR DESCRIPTION
This addresses #989 

### Description:
Add max-depth support for GitHub, reusing the already present git scan options.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

