### PR TITLE
Move commits_scanned to ScanRepo

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -163,7 +163,7 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk) err
 	}
 
 	totalRepos := len(s.conn.Repositories) + len(s.conn.Directories)
-	ctx.Logger().V(1).Info("Git source finished scanning", "repo_count", totalRepos, "commits_scanned", atomic.LoadUint64(&s.git.metrics.commitsScanned))
+	ctx.Logger().V(1).Info("Git source finished scanning", "repo_count", totalRepos)
 	s.SetProgressComplete(
 		totalRepos, totalRepos,
 		fmt.Sprintf("Completed scanning source %s", s.name), "",
@@ -640,7 +640,7 @@ func (s *Git) ScanRepo(ctx context.Context, repo *git.Repository, repoPath strin
 	}
 
 	scanTime := time.Now().Unix() - start
-	ctx.Logger().V(1).Info("scanning git repo complete", "repo", repoUrl, "path", repoPath, "time_seconds", scanTime)
+	ctx.Logger().V(1).Info("scanning git repo complete", "repo", repoUrl, "path", repoPath, "time_seconds", scanTime, "commits_scanned", atomic.LoadUint64(&s.metrics.commitsScanned))
 	return nil
 }
 


### PR DESCRIPTION
Move `commits_scanned` from `Chunks` to `ScanRepo` to show up when the Git source is utilized from another source, such as GitHub.
