### PR TITLE
bug fix - change verification endpoint for opsgenie scanner

### DIFF
--- a/pkg/detectors/opsgenie/opsgenie.go
+++ b/pkg/detectors/opsgenie/opsgenie.go
@@ -52,7 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.opsgenie.com/v2/users", nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.opsgenie.com/v2/alerts", nil)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
### Description:
The current verification endpoint `https://api.opsgenie.com/v2/users` does not work for some Opsgenie keys:
https://community.atlassian.com/t5/Opsgenie-questions/quot-Team-API-Keys-not-authorized-to-perform-this-action-quot/qaq-p/1926094
https://docs.opsgenie.com/docs/api-access-management

The `alert` endpoint seems to work with all types of Opsgenie keys.


