### PR TITLE
Refactor FragmentLineOffset to match multiline secrets

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -599,10 +599,13 @@ func FragmentLineOffset(chunk *sources.Chunk, result *detectors.Result) (int64, 
 	if !found {
 		return 0, false
 	}
-	lineNumber := int64(len(bytes.Split(before, []byte("\n")))) - 1
-	// if the line contains the ignore tag, we should ignore the result
+	lineNumber := int64(bytes.Count(before, []byte("\n")))
+	// If the line contains the ignore tag, we should ignore the result.
 	endLine := bytes.Index(after, []byte("\n"))
-	if endLine != -1 && bytes.Contains(after[:endLine], []byte(ignoreTag)) {
+	if endLine == -1 {
+		endLine = len(after)
+	}
+	if bytes.Contains(after[:endLine], []byte(ignoreTag)) {
 		return lineNumber, true
 	}
 	return lineNumber, false

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -73,6 +73,17 @@ func TestFragmentLineOffset(t *testing.T) {
 			expectedLine: 3,
 			ignore:       true,
 		},
+		{
+			name: "ignore on last line",
+			chunk: &sources.Chunk{
+				Data: []byte("line1\nline2\nline3\nsecret here // trufflehog:ignore"),
+			},
+			result: &detectors.Result{
+				Raw: []byte("secret here"),
+			},
+			expectedLine: 3,
+			ignore:       true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Refactors `FragmentLineOffset` to search for the needle *before* splitting by newlines. This allows matching `Raw` multi-line secrets.

* All tests still pass 
* Added multiline tests with ignore
* Added benchmarks for finding the needle at the start / middle / end of the haystack
  * Before / after runs shown in PR comment

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

