### PR TITLE
Support indeterminate verification in Gitlab detector

### DIFF
--- a/pkg/detectors/gitlab/gitlab.go
+++ b/pkg/detectors/gitlab/gitlab.go
@@ -82,11 +82,15 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					// 200 means good key and has `read_user` scope
 					// 403 means good key but not the right scope
 					// 401 is bad key
-					if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusForbidden {
+					switch res.StatusCode {
+					case http.StatusOK:
 						secret.Verified = true
-					} else if res.StatusCode == http.StatusUnauthorized {
-						// Nothing to do; zero values of Result are the ones we want
-					} else {
+					case http.StatusForbidden:
+						// Good key but not the right scope
+						secret.Verified = true
+					case http.StatusUnauthorized:
+						// Nothing to do; zero values are the ones we want
+					default:
 						secret.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
 					}
 				} else {

--- a/pkg/detectors/gitlab/gitlab.go
+++ b/pkg/detectors/gitlab/gitlab.go
@@ -89,6 +89,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					} else {
 						secret.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
 					}
+				} else {
+					secret.VerificationError = err
 				}
 			}
 		}

--- a/pkg/detectors/gitlab/gitlab.go
+++ b/pkg/detectors/gitlab/gitlab.go
@@ -84,6 +84,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					// 401 is bad key
 					if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusForbidden {
 						secret.Verified = true
+					} else if res.StatusCode == http.StatusUnauthorized {
+						// Nothing to do; zero values of Result are the ones we want
+					} else {
+						secret.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
 					}
 				}
 			}

--- a/pkg/detectors/gitlab/gitlab_test.go
+++ b/pkg/detectors/gitlab/gitlab_test.go
@@ -134,8 +134,7 @@ func TestGitlab_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := Scanner{}
-			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gitlab.FromData() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/detectors/gitlab/gitlab_test.go
+++ b/pkg/detectors/gitlab/gitlab_test.go
@@ -88,7 +88,7 @@ func TestGitlab_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found, would be verified but for timeout",
-			s:    Scanner{},
+			s:    Scanner{client: common.SaneHttpClientTimeOut(1 * time.Microsecond)},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a gitlab super secret %s within", secret)),
@@ -105,7 +105,7 @@ func TestGitlab_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found and valid but unexpected api response",
-			s:    Scanner{},
+			s:    Scanner{client: common.ConstantResponseHttpClient(500, "")},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a gitlab super secret %s within", secret)),

--- a/pkg/detectors/gitlab/gitlab_test.go
+++ b/pkg/detectors/gitlab/gitlab_test.go
@@ -121,6 +121,22 @@ func TestGitlab_FromChunk(t *testing.T) {
 			wantVerificationErr: true,
 		},
 		{
+			name: "found, good key but wrong scope",
+			s:    Scanner{client: common.ConstantResponseHttpClient(403, "")},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a gitlab super secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Gitlab,
+					Verified:     true,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "not found",
 			s:    Scanner{},
 			args: args{

--- a/pkg/detectors/gitlab/gitlab_test.go
+++ b/pkg/detectors/gitlab/gitlab_test.go
@@ -6,10 +6,10 @@ package gitlab
 import (
 	"context"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
-
-	"github.com/kylelemons/godebug/pretty"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -109,9 +109,9 @@ func TestGitlab_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatal("no raw secret present")
 				}
-				got[i].Raw = nil
 			}
-			if diff := pretty.Compare(got, tt.want); diff != "" {
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("Gitlab.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
 		})


### PR DESCRIPTION
This PR adds support for tri-state verification to the Gitlab detector.