### PR TITLE
stop saving Alchemy URL on error

### DIFF
--- a/pkg/detectors/alchemy/alchemy.go
+++ b/pkg/detectors/alchemy/alchemy.go
@@ -65,7 +65,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("request to %v returned unexpected status %d", res.Request.URL, res.StatusCode)
+					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
 				}
 			} else {
 				s1.VerificationError = err


### PR DESCRIPTION
Verification of an Alchemy secret requires putting the candidate secret directly into a URL. This makes the URL potentially sensitive, and if the request fails, we don't want to save it anywhere that might inadvertently get logged elsewhere - like the resulting error message. (Remember that despite verification failing, this error message is only saved if the failure is _indeterminate_, which means that the secret might actually be live.)