### PR TITLE
bump go to 1.21

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -1,4 +1,4 @@
-name: Performance Test 
+name: Performance Test
 
 on: [pull_request]
 
@@ -7,13 +7,13 @@ jobs:
     #   skip if PR is from a fork.
     # TODO: this could probabaly be refactored a bit so that it runs on forks
     if: ${{ ! github.event.pull_request.head.repo.fork }}
-    
+
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
 
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
     - name: Checkout code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Smoke

--- a/.github/workflows/snifftest.yml
+++ b/.github/workflows/snifftest.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.21'
       - uses: actions/checkout@v3
       - name: Run Snifftest
         run: make snifftest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
     - name: Checkout code
       uses: actions/checkout@v3
     - id: 'auth'
@@ -42,7 +42,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
     - name: Checkout code
       uses: actions/checkout@v3
     - id: 'auth'
@@ -63,7 +63,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.20'
+        go-version: '1.21'
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Test


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR updates all the go versions defined in our ci/cd to `v1.21.0` https://tip.golang.org/doc/go1.21

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

