### PR TITLE
Add `since` parameter to be used with timestamps

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,18 +60,19 @@ var (
 	includeDetectors     = cli.Flag("include-detectors", "Comma separated list of detector types to include. Protobuf name or IDs may be used, as well as ranges.").Default("all").String()
 	excludeDetectors     = cli.Flag("exclude-detectors", "Comma separated list of detector types to exclude. Protobuf name or IDs may be used, as well as ranges. IDs defined here take precedence over the include list.").String()
 
-	gitScan             = cli.Command("git", "Find credentials in git repositories.")
-	gitScanURI          = gitScan.Arg("uri", "Git repository URL. https://, file://, or ssh:// schema expected.").Required().String()
-	gitScanIncludePaths = gitScan.Flag("include-paths", "Path to file with newline separated regexes for files to include in scan.").Short('i').String()
-	gitScanExcludePaths = gitScan.Flag("exclude-paths", "Path to file with newline separated regexes for files to exclude in scan.").Short('x').String()
-	gitScanExcludeGlobs = gitScan.Flag("exclude-globs", "Comma separated list of globs to exclude in scan. This option filters at the `git log` level, resulting in faster scans.").String()
-	gitScanSinceCommit  = gitScan.Flag("since-commit", "Commit to start scan from.").String()
-	gitScanBranch       = gitScan.Flag("branch", "Branch to scan.").String()
-	gitScanMaxDepth     = gitScan.Flag("max-depth", "Maximum depth of commits to scan.").Int()
-	gitScanBare         = gitScan.Flag("bare", "Scan bare repository (e.g. useful while using in pre-receive hooks)").Bool()
-	_                   = gitScan.Flag("allow", "No-op flag for backwards compat.").Bool()
-	_                   = gitScan.Flag("entropy", "No-op flag for backwards compat.").Bool()
-	_                   = gitScan.Flag("regex", "No-op flag for backwards compat.").Bool()
+	gitScan              = cli.Command("git", "Find credentials in git repositories.")
+	gitScanURI           = gitScan.Arg("uri", "Git repository URL. https://, file://, or ssh:// schema expected.").Required().String()
+	gitScanIncludePaths  = gitScan.Flag("include-paths", "Path to file with newline separated regexes for files to include in scan.").Short('i').String()
+	gitScanExcludePaths  = gitScan.Flag("exclude-paths", "Path to file with newline separated regexes for files to exclude in scan.").Short('x').String()
+	gitScanExcludeGlobs  = gitScan.Flag("exclude-globs", "Comma separated list of globs to exclude in scan. This option filters at the `git log` level, resulting in faster scans.").String()
+	gitScanSinceCommit   = gitScan.Flag("since-commit", "Commit to start scan from.").String()
+	gitScanSinceDuration = gitScan.Flag("since", "Date or duration to start scan from. Can not be used togehter with `since-commit`.").String()
+	gitScanBranch        = gitScan.Flag("branch", "Branch to scan.").String()
+	gitScanMaxDepth      = gitScan.Flag("max-depth", "Maximum depth of commits to scan.").Int()
+	gitScanBare          = gitScan.Flag("bare", "Scan bare repository (e.g. useful while using in pre-receive hooks)").Bool()
+	_                    = gitScan.Flag("allow", "No-op flag for backwards compat.").Bool()
+	_                    = gitScan.Flag("entropy", "No-op flag for backwards compat.").Bool()
+	_                    = gitScan.Flag("regex", "No-op flag for backwards compat.").Bool()
 
 	githubScan             = cli.Command("github", "Find credentials in GitHub repositories.")
 	githubScanEndpoint     = githubScan.Flag("endpoint", "GitHub endpoint.").Default("https://api.github.com").String()
@@ -225,6 +226,14 @@ func run(state overseer.State) {
 		*concurrency = 1
 	}
 
+	if *gitScanSinceDuration != "" {
+		*concurrency = 1
+	}
+
+	if *gitScanSinceCommit != "" && *gitScanSinceDuration != "" {
+		logFatal(fmt.Errorf("cannot use both --since-commit and --since"), "invalid git scan configuration")
+	}
+	
 	if *profile {
 		go func() {
 			router := http.NewServeMux()
@@ -375,7 +384,7 @@ func run(state overseer.State) {
 		if err != nil {
 			logFatal(err, "could not create filter")
 		}
-		repoPath, remote, err = git.PrepareRepoSinceCommit(ctx, *gitScanURI, *gitScanSinceCommit)
+		repoPath, remote, err = git.PrepareRepoSinceCommit(ctx, *gitScanURI, *gitScanSinceCommit, *gitScanSinceDuration)
 		if err != nil || repoPath == "" {
 			logFatal(err, "error preparing git repo for scanning")
 		}

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -752,8 +752,8 @@ func TryAdditionalBaseRefs(repo *git.Repository, base string) (*plumbing.Hash, e
 }
 
 // PrepareRepoSinceCommit clones a repo starting at the given commitHash and returns the cloned repo path.
-func PrepareRepoSinceCommit(ctx context.Context, uriString, commitHash string) (string, bool, error) {
-	if commitHash == "" {
+func PrepareRepoSinceCommit(ctx context.Context, uriString, commitHash string, since string) (string, bool, error) {
+	if commitHash == "" && since == "" {
 		return PrepareRepo(ctx, uriString)
 	}
 	// TODO: refactor with PrepareRepo to remove duplicated logic
@@ -787,17 +787,21 @@ func PrepareRepoSinceCommit(ctx context.Context, uriString, commitHash string) (
 		client = github.NewClient(tc)
 	}
 
-	commit, _, err := client.Git.GetCommit(context.Background(), owner, repoName, commitHash)
-	if err != nil {
-		return PrepareRepo(ctx, uriString)
-	}
 	var timestamp string
-	{
-		author := commit.GetAuthor()
-		if author == nil {
+	if since == "" {
+		commit, _, err := client.Git.GetCommit(context.Background(), owner, repoName, commitHash)
+		if err != nil {
 			return PrepareRepo(ctx, uriString)
 		}
-		timestamp = author.GetDate().Format(time.RFC3339)
+		{
+			author := commit.GetAuthor()
+			if author == nil {
+				return PrepareRepo(ctx, uriString)
+			}
+			timestamp = author.GetDate().Format(time.RFC3339)
+		}
+	} else {
+		timestamp = since
 	}
 
 	remotePath := uri.String()
@@ -815,6 +819,8 @@ func PrepareRepoSinceCommit(ctx context.Context, uriString, commitHash string) (
 		}
 	default:
 		ctx.Logger().V(1).Info("cloning repo without authentication", "uri", uri)
+		ctx.Logger().V(1).Info("SINCE", "since", timestamp)
+
 		path, _, err = CloneRepoUsingUnauthenticated(ctx, remotePath, "--shallow-since", timestamp)
 		if err != nil {
 			return path, true, fmt.Errorf("failed to clone unauthenticated Git repo (%s): %s", remotePath, err)

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -819,8 +819,6 @@ func PrepareRepoSinceCommit(ctx context.Context, uriString, commitHash string, s
 		}
 	default:
 		ctx.Logger().V(1).Info("cloning repo without authentication", "uri", uri)
-		ctx.Logger().V(1).Info("SINCE", "since", timestamp)
-
 		path, _, err = CloneRepoUsingUnauthenticated(ctx, remotePath, "--shallow-since", timestamp)
 		if err != nil {
 			return path, true, fmt.Errorf("failed to clone unauthenticated Git repo (%s): %s", remotePath, err)


### PR DESCRIPTION
### Description:

Similar to the `since-commit` arg this `since` arg can directly be used with git dates.

e.g. `trufflehog git --since "6 hours" https://github.com/trufflesecurity/trufflehog`

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

