### PR TITLE
Add ScanChunk to allow injecting Chunks into the SourceManager's channel

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -415,6 +415,13 @@ func (e *Engine) ResultsChan() chan detectors.ResultWithMetadata {
 	return e.results
 }
 
+// ScanChunk injects a chunk into the output stream of chunks to be scanned.
+// This method should rarely be used. TODO: Remove when dependencies no longer
+// rely on this functionality.
+func (e *Engine) ScanChunk(chunk *sources.Chunk) {
+	e.sourceManager.ScanChunk(chunk)
+}
+
 // detectableChunk is a decoded chunk that is ready to be scanned by its detector.
 type detectableChunk struct {
 	detector detectors.Detector

--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -191,6 +191,13 @@ func (s *SourceManager) Wait() error {
 	return s.pool.Wait()
 }
 
+// ScanChunk injects a chunk into the output stream of chunks to be scanned.
+// This method should rarely be used. TODO: Remove when dependencies no longer
+// rely on this functionality.
+func (s *SourceManager) ScanChunk(chunk *Chunk) {
+	s.outputChunks <- chunk
+}
+
 // preflightChecks is a helper method to check the Manager or the context isn't
 // done and that the handle is valid.
 func (s *SourceManager) preflightChecks(ctx context.Context, handle handle) error {


### PR DESCRIPTION
With the introduction of the SourceManager, the chunks channel became private and read-only. This provides a method to write chunks into the channel as we transition away from needing to do that.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

