### PR TITLE
[bug] - handle IOOR panic

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -1023,10 +1023,10 @@ func (s *Source) scanComments(ctx context.Context, repoPath string, chunksChan c
 			}
 		}
 	}
-	return s.handleComments(ctx, repoPath, trimmedURL, repoURL, chunksChan)
+	return s.processRepoComments(ctx, repoPath, trimmedURL, repoURL, chunksChan)
 }
 
-func (s *Source) handleComments(ctx context.Context, repoPath string, trimmedURL []string, repoURL *url.URL, chunksChan chan *sources.Chunk) error {
+func (s *Source) processRepoComments(ctx context.Context, repoPath string, trimmedURL []string, repoURL *url.URL, chunksChan chan *sources.Chunk) error {
 	// Normal repository URL (https://github.com/<owner>/<repo>).
 	if len(trimmedURL) < 3 {
 		return fmt.Errorf("url missing owner and/or repo: '%s'", repoURL.String())

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -1064,11 +1064,11 @@ func (s *Source) processRepoComments(ctx context.Context, repoPath string, trimm
 
 	}
 
-	if !s.includePRComments {
-		return nil
+	if s.includePRComments {
+		return s.processPRComments(ctx, repoInfo, chunksChan)
 	}
+	return nil
 
-	return s.processPRComments(ctx, repoInfo, chunksChan)
 }
 
 func (s *Source) processIssueComments(ctx context.Context, info repoInfo, chunksChan chan *sources.Chunk) error {

--- a/pkg/sources/github/github_integration_test.go
+++ b/pkg/sources/github/github_integration_test.go
@@ -81,7 +81,7 @@ func TestSource_Token(t *testing.T) {
 }
 
 func TestSource_ScanComments(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
 	secret, err := common.GetTestSecret(ctx)
@@ -190,7 +190,7 @@ func TestSource_ScanComments(t *testing.T) {
 				return
 			}
 
-			chunksCh := make(chan *sources.Chunk, 5)
+			chunksCh := make(chan *sources.Chunk, 1)
 			go func() {
 				// Close the channel
 				defer close(chunksCh)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
A url sometimes doesn't include an owner or repo. This causes the slice operation to panic. Check the len of the url prior to indexing.

Refactor the comment handling code into its own function.

```
panic: runtime error: index out of range [2] with length 2

goroutine 3105 [running]:
github.com/trufflesecurity/trufflehog/v3/pkg/sources/github.(*Source).scanComments(0xc0017ce4e0, {0x301eb20?, 0xc00300d860}, {0xc004dafd40, 0x3c}, 0x17?)
	github.com/trufflesecurity/trufflehog/v3@v3.52.0/pkg/sources/github/github.go:1028 +0x8b5
github.com/trufflesecurity/trufflehog/v3/pkg/sources/github.(*Source).scan.func1()
	github.com/trufflesecurity/trufflehog/v3@v3.52.0/pkg/sources/github/github.go:725 +0x82b
golang.org/x/sync/errgroup.(*Group).Go.func1()
	golang.org/x/sync@v0.3.0/errgroup/errgroup.go:75 +0x64
created by golang.org/x/sync/errgroup.(*Group).Go
	golang.org/x/sync@v0.3.0/errgroup/errgroup.go:72 +0xa5
```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

