### PR TITLE
[bug] - Only scan gist comments or repo comments

### DIFF
--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -743,3 +743,22 @@ func TestProcessRepoComments(t *testing.T) {
 		})
 	}
 }
+
+func TestGetGistID(t *testing.T) {
+	tests := []struct {
+		trimmedURL []string
+		expected   string
+		err        bool
+	}{
+		{[]string{"https://gist.github.com", "12345"}, "12345", false},
+		{[]string{"https://gist.github.com", "owner", "12345"}, "12345", false},
+		{[]string{"https://gist.github.com"}, "", true},
+		{[]string{"https://gist.github.com", "owner", "12345", "extra"}, "", true},
+	}
+
+	for _, tt := range tests {
+		got, err := extractGistID(tt.trimmedURL)
+		assert.Equal(t, tt.err, err != nil)
+		assert.Equal(t, tt.expected, got)
+	}
+}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We should only scan gist comments or repo comments.
```
{"level":"info-2","ts":"2023-08-18T07:09:55Z","logger":"thog/scanner","msg":"Errors encountered while scanning","pid":"CPTDi","version":"v1.70.18","source_type":"SOURCE_TYPE_GITHUB","source_name":"GitHub_Scheduled_Scan_GTL","job_id":47112,"source_id":212,"error-count":147,"errors":"[error scanning comments in repo https://gist.github.com/19bbb62cea62a831e31b11ca8b6f5d33.git: url missing owner and/or repo: 'https://gist.github.com/19bbb62cea62a831e31b11ca8b6f5d33.git' ... # Repeated for hundreds of gists
```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

