### PR TITLE
Fix reversed ordering of arguments

### DIFF
--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -19,7 +19,7 @@ type handle int64
 
 // SourceInitFunc is a function that takes a source and job ID and returns an
 // initialized Source.
-type SourceInitFunc func(ctx context.Context, sourceID int64, jobID int64) (Source, error)
+type SourceInitFunc func(ctx context.Context, jobID, sourceID int64) (Source, error)
 
 // sourceInfo is an aggregate struct to store source information provided on
 // initialization.
@@ -228,7 +228,7 @@ func (s *SourceManager) run(ctx context.Context, handle handle, jobID int64, rep
 		report.ReportError(Fatal{err})
 		return Fatal{err}
 	}
-	source, err := sourceInfo.initFunc(ctx, int64(handle), jobID)
+	source, err := sourceInfo.initFunc(ctx, jobID, int64(handle))
 	if err != nil {
 		report.ReportError(Fatal{err})
 		return Fatal{err}


### PR DESCRIPTION
The source manager initialization function was defined as `sourceID` followed by `jobID`, while the source initialization function is the reverse. This is confusing and easy to mix up since the parameters are the same type.

This commit adds a test to make sure the source manager initializes in the correct order, but it doesn't prevent the library user to make the same mistake. We may want to consider using different types.
