### PR TITLE
Update S3 test bucket

### DIFF
--- a/pkg/sources/s3/s3_test.go
+++ b/pkg/sources/s3/s3_test.go
@@ -52,7 +52,7 @@ func TestSource_Chunks(t *testing.T) {
 							Secret: s3secret,
 						},
 					},
-					Buckets: []string{"thog-tmp-test"},
+					Buckets: []string{"truffletestbucket-s3-tests"},
 				},
 			},
 			wantErr:       false,


### PR DESCRIPTION
We're switching our S3 source test account over to a different one, which means we have to change the bucket name.