### PR TITLE
Include the job ID in a chunk

### DIFF
--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -6,10 +6,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
-	"golang.org/x/sync/errgroup"
 )
 
 // handle uniquely identifies a Source given to the manager to manage. If the
@@ -256,6 +257,7 @@ func (s *SourceManager) runWithoutUnits(ctx context.Context, handle handle, sour
 		defer wg.Done()
 		for chunk := range ch {
 			report.ReportChunk(nil, chunk)
+			chunk.JobID = source.JobID()
 			s.outputChunks <- chunk
 		}
 	}()

--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -256,8 +256,8 @@ func (s *SourceManager) runWithoutUnits(ctx context.Context, handle handle, sour
 	go func() {
 		defer wg.Done()
 		for chunk := range ch {
-			report.ReportChunk(nil, chunk)
 			chunk.JobID = source.JobID()
+			report.ReportChunk(nil, chunk)
 			s.outputChunks <- chunk
 		}
 	}()

--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -336,6 +336,9 @@ func (s *SourceManager) runWithUnits(ctx context.Context, handle handle, source 
 			defer wg.Done()
 			defer func() { report.EndUnitChunking(unit, time.Now()) }()
 			for chunk := range chunkReporter.chunkCh {
+				if src, ok := source.(Source); ok {
+					chunk.JobID = src.JobID()
+				}
 				s.outputChunks <- chunk
 			}
 		}()

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -17,6 +17,8 @@ type Chunk struct {
 	SourceName string
 	// SourceID is the ID of the source that the Chunk originated from.
 	SourceID int64
+	// JobID is the ID of the job that the Chunk originated from.
+	JobID int64
 	// SourceType is the type of Source that produced the chunk.
 	SourceType sourcespb.SourceType
 	// SourceMetadata holds the context of where the Chunk was found.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Includes the job ID in the chunk struct. This can then be used in the pipeline to lookup jobs as well as potentially terminate jobs that are no longer running.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

