### PR TITLE
Unify S3 client creation logic

### DIFF
--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -104,7 +104,7 @@ func (s *Source) setMaxObjectSize(maxObjectSize int64) {
 	}
 }
 
-func (s *Source) newUnifiedClient(region, roleArn string) (*s3.S3, error) {
+func (s *Source) newClient(region, roleArn string) (*s3.S3, error) {
 	cfg := aws.NewConfig()
 	cfg.CredentialsChainVerboseErrors = aws.Bool(true)
 	cfg.Region = aws.String(region)
@@ -182,7 +182,7 @@ func (s *Source) scanBuckets(ctx context.Context, client *s3.S3, role string, bu
 
 		var regionalClient *s3.S3
 		if region != defaultAWSRegion {
-			regionalClient, err = s.newUnifiedClient(region, role)
+			regionalClient, err = s.newClient(region, role)
 			if err != nil {
 				s.log.Error(err, "could not make regional s3 client")
 				continue
@@ -219,7 +219,7 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk) err
 	}
 
 	for _, role := range roles {
-		client, err := s.newUnifiedClient(defaultAWSRegion, role)
+		client, err := s.newClient(defaultAWSRegion, role)
 		if err != nil {
 			return errors.WrapPrefix(err, "could not create s3 client", 0)
 		}

--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -189,6 +189,7 @@ func (s *Source) scanBuckets(ctx context.Context, client *s3.S3, role string, bu
 			}
 			if err != nil {
 				s.log.Error(err, "could not make regional s3 client")
+				continue
 			}
 		} else {
 			regionalClient = client

--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -182,11 +182,7 @@ func (s *Source) scanBuckets(ctx context.Context, client *s3.S3, role string, bu
 
 		var regionalClient *s3.S3
 		if region != defaultAWSRegion {
-			if role != "" {
-				regionalClient, err = s.newUnifiedClient(region, role)
-			} else {
-				regionalClient, err = s.newUnifiedClient(region, "")
-			}
+			regionalClient, err = s.newUnifiedClient(region, role)
 			if err != nil {
 				s.log.Error(err, "could not make regional s3 client")
 				continue


### PR DESCRIPTION
### Description

This PR unifies some code paths within the S3 source. This is being done to better support a future implementation of S3 source validation; less code that runs means less code to validate. The logical change is to move the handling of "role-less" operation down the call tree, which allows for a single code path for more of the S3 code.

This PR also fixes a bug that would occur in the (rare) case that the source couldn't create a regional S3 client. Before, an error would be logged, but it would be followed by a panic. Now the bucket in question is skipped.