### PR TITLE
Add SourceName to JobProgressRef

### DIFF
--- a/pkg/sources/job_progress.go
+++ b/pkg/sources/job_progress.go
@@ -41,8 +41,9 @@ type JobProgressHook interface {
 
 // JobProgressRef is a wrapper of a JobProgress for read-only access to its state.
 type JobProgressRef struct {
-	SourceID    int64
 	JobID       int64
+	SourceID    int64
+	SourceName  string
 	jobProgress *JobProgress
 }
 
@@ -88,8 +89,9 @@ func (f ChunkError) Unwrap() error { return f.err }
 // JobProgress aggregates information about a run of a Source.
 type JobProgress struct {
 	// Unique identifiers for this job.
-	SourceID int64
-	JobID    int64
+	JobID      int64
+	SourceID   int64
+	SourceName string
 	// Tracks whether the job is finished or not.
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -134,13 +136,14 @@ func WithHooks(hooks ...JobProgressHook) func(*JobProgress) {
 }
 
 // NewJobProgress creates a new job report for the given source and job ID.
-func NewJobProgress(sourceID, jobID int64, opts ...func(*JobProgress)) *JobProgress {
+func NewJobProgress(jobID, sourceID int64, sourceName string, opts ...func(*JobProgress)) *JobProgress {
 	ctx, cancel := context.WithCancel(context.Background())
 	jp := &JobProgress{
-		SourceID: sourceID,
-		JobID:    jobID,
-		ctx:      ctx,
-		cancel:   cancel,
+		JobID:      jobID,
+		SourceID:   sourceID,
+		SourceName: sourceName,
+		ctx:        ctx,
+		cancel:     cancel,
 	}
 	for _, opt := range opts {
 		opt(jp)
@@ -260,6 +263,7 @@ func (jp *JobProgress) Ref() JobProgressRef {
 	return JobProgressRef{
 		SourceID:    jp.SourceID,
 		JobID:       jp.JobID,
+		SourceName:  jp.SourceName,
 		jobProgress: jp,
 	}
 }

--- a/pkg/sources/job_progress_test.go
+++ b/pkg/sources/job_progress_test.go
@@ -36,10 +36,10 @@ func TestJobProgressFatalErrors(t *testing.T) {
 }
 
 func TestJobProgressRef(t *testing.T) {
-	jp := NewJobProgress(123, 456)
+	jp := NewJobProgress(123, 456, "source name")
 	ref := jp.Ref()
-	assert.Equal(t, int64(123), ref.SourceID)
-	assert.Equal(t, int64(456), ref.JobID)
+	assert.Equal(t, int64(123), ref.JobID)
+	assert.Equal(t, int64(456), ref.SourceID)
 
 	// Test Done() blocks until Finish() is called.
 	select {
@@ -61,7 +61,7 @@ func TestJobProgressHook(t *testing.T) {
 	defer ctrl.Finish()
 
 	hook := NewMockJobProgressHook(ctrl)
-	jp := NewJobProgress(123, 456, WithHooks(hook))
+	jp := NewJobProgress(123, 456, "source name", WithHooks(hook))
 
 	// Start(JobProgressRef, time.Time)
 	// End(JobProgressRef, time.Time)

--- a/pkg/sources/source_manager_test.go
+++ b/pkg/sources/source_manager_test.go
@@ -280,7 +280,10 @@ func TestSourceManagerJobAndSourceIDs(t *testing.T) {
 		})
 	assert.NoError(t, err)
 
-	_, _ = mgr.Run(context.Background(), handle)
+	ref, _ := mgr.Run(context.Background(), handle)
 	assert.Equal(t, int64(1337), initializedSourceID)
+	assert.Equal(t, int64(1337), ref.SourceID)
 	assert.Equal(t, int64(9001), initializedJobID)
+	assert.Equal(t, int64(9001), ref.JobID)
+	assert.Equal(t, "dummy", ref.SourceName)
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Add `SourceName` to the `JobProgressRef` which already contains the `JobID` and `SourceID`. The `SourceName` is nice to have for logs and debugging. 

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

