### PR TITLE
[chore] - Prevent nil deref panic

### DIFF
--- a/pkg/output/legacy_json.go
+++ b/pkg/output/legacy_json.go
@@ -133,7 +133,7 @@ func BranchHeads(repo *gogit.Repository) (map[string]*object.Commit, error) {
 		}
 		headCommit, err := repo.CommitObject(*headHash)
 		if err != nil {
-			logger.Error(err, "unable to get commit", "commit", headCommit.String())
+			logger.Error(err, "unable to get commit", "head_hash", headHash.String())
 			return nil
 		}
 		branches[branchName] = headCommit

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -149,14 +149,14 @@ func (s *Source) newFilteredRepoCache(c cache.Cache, include, exclude []string) 
 	for _, ig := range include {
 		g, err := glob.Compile(ig)
 		if err != nil {
-			s.log.V(1).Info("invalid include glob", "glob", g, "err", err)
+			s.log.V(1).Info("invalid include glob", "include_value", ig, "err", err)
 		}
 		includeGlobs = append(includeGlobs, g)
 	}
 	for _, eg := range exclude {
 		g, err := glob.Compile(eg)
 		if err != nil {
-			s.log.V(1).Info("invalid exclude glob", "glob", g, "err", err)
+			s.log.V(1).Info("invalid exclude glob", "exclude_value", eg, "err", err)
 		}
 		excludeGlobs = append(excludeGlobs, g)
 	}

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -150,6 +150,7 @@ func (s *Source) newFilteredRepoCache(c cache.Cache, include, exclude []string) 
 		g, err := glob.Compile(ig)
 		if err != nil {
 			s.log.V(1).Info("invalid include glob", "include_value", ig, "err", err)
+			continue
 		}
 		includeGlobs = append(includeGlobs, g)
 	}
@@ -157,6 +158,7 @@ func (s *Source) newFilteredRepoCache(c cache.Cache, include, exclude []string) 
 		g, err := glob.Compile(eg)
 		if err != nil {
 			s.log.V(1).Info("invalid exclude glob", "exclude_value", eg, "err", err)
+			continue
 		}
 		excludeGlobs = append(excludeGlobs, g)
 	}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
- Don't log `headCommit.Strin()` since `headCommit` will likely be nil if err is not nil.
- Similarly when logging an error for an invalid glob, don't log the glob since it will be nil and continue.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

