### PR TITLE
Optimize read to max

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -192,6 +192,9 @@ func (a *Archive) ReadToMax(ctx context.Context, reader io.Reader) (data []byte,
 
 	var fileContent bytes.Buffer
 	buf := make([]byte, defaultBufferSize)
+	// Using io.CopyBuffer for performance gains. The buffer, buf, is required
+	// for the method but isn't used since *bytes.Buffer implements io.WriterTo
+	// and io.ReaderFrom. Therefore, changing buf's size won't affect performance.
 	_, err = io.CopyBuffer(&fileContent, reader, buf)
 	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -29,6 +29,8 @@ var (
 	maxDepth   = 5
 	maxSize    = 250 * 1024 * 1024 // 20MB
 	maxTimeout = time.Duration(30) * time.Second
+
+	defaultBufferSize = 512
 )
 
 // Ensure the Archive satisfies the interfaces at compile time.
@@ -62,7 +64,7 @@ func SetArchiveMaxTimeout(timeout time.Duration) {
 
 // FromFile extracts the files from an archive.
 func (a *Archive) FromFile(originalCtx context.Context, data io.Reader) chan []byte {
-	archiveChan := make(chan []byte, 512)
+	archiveChan := make(chan []byte, defaultBufferSize)
 	go func() {
 		ctx, cancel := context.WithTimeout(originalCtx, maxTimeout)
 		logger := logContext.AddLogger(ctx).Logger()
@@ -183,29 +185,22 @@ func (a *Archive) ReadToMax(ctx context.Context, reader io.Reader) (data []byte,
 			logger.Error(err, "Panic occurred when reading archive")
 		}
 	}()
-	fileContent := bytes.Buffer{}
-	logger.V(5).Info("Remaining buffer capacity", "bytes", maxSize-a.size)
-	for i := 0; i <= maxSize/512; i++ {
-		if common.IsDone(ctx) {
-			return nil, ctx.Err()
-		}
-		fileChunk := make([]byte, 512)
-		bRead, err := reader.Read(fileChunk)
-		if err != nil && !errors.Is(err, io.EOF) {
-			return []byte{}, err
-		}
-		a.size += bRead
-		if len(fileChunk) > 0 {
-			fileContent.Write(fileChunk[0:bRead])
-		}
-		if bRead < 512 {
-			return fileContent.Bytes(), nil
-		}
-		if a.size >= maxSize && bRead == 512 {
-			logger.V(2).Info("Max archive size reached.")
-			return fileContent.Bytes(), nil
-		}
+
+	if common.IsDone(ctx) {
+		return nil, fmt.Errorf("context is done")
 	}
+
+	var fileContent bytes.Buffer
+	buf := make([]byte, defaultBufferSize)
+	_, err = io.CopyBuffer(&fileContent, reader, buf)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	if fileContent.Len() >= maxSize {
+		logger.V(2).Info("Max archive size reached.")
+		return fileContent.Bytes()[:maxSize], nil
+	}
+
 	return fileContent.Bytes(), nil
 }
 

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -167,6 +167,97 @@ func (a *Archive) extractorHandler(archiveChan chan []byte) func(context.Context
 	}
 }
 
+// limitedBytesReader is a custom reader that wraps another io.Reader
+// and limits the bytes read from it. Unlike io.LimitedReader, it retains
+// the performance optimization benefits of the WriteTo method present
+// in some underlying readers, especially bytes.Reader.
+type limitedBytesReader struct {
+	r    io.Reader // The wrapped reader
+	n    int64     // Maximum bytes allowed to be read
+	read int64     // Bytes read so far
+}
+
+// Read attempts to read up to len(p) bytes into p.
+// It respects the read limit set in the reader and adjusts the
+// bytes read if it would exceed the allowed maximum.
+func (l *limitedBytesReader) Read(p []byte) (n int, err error) {
+	if l.read == l.n { // If we have already read up to the limit
+		return 0, io.EOF
+	}
+
+	remaining := l.n - l.read
+	if remaining <= 0 {
+		return 0, io.EOF
+	}
+
+	if int64(len(p)) > remaining {
+		p = p[:remaining]
+	}
+
+	n, err = l.r.Read(p)
+	l.read += int64(n)
+	return
+}
+
+// WriteTo overrides the standard WriteTo to implement a byte limit while writing.
+// It provides a fast path when the underlying reader is a *bytes.Reader to avoid
+// extra allocations and retain the efficiency benefits of bytes.Reader's WriteTo.
+// For other reader types, it reads from the source and writes to the destination
+// while ensuring that it doesn't exceed the specified byte limit.
+//
+// The main reasons for this override are:
+//  1. Efficiency: By respecting the native WriteTo of a bytes.Reader, we avoid unnecessary
+//     allocations and data copying, making the write process faster.
+//  2. Safety: This method ensures we never write more than the preset byte limit, even if
+//     the underlying reader contains more data.
+func (l *limitedBytesReader) WriteTo(w io.Writer) (n int64, err error) {
+	switch reader := l.r.(type) {
+	case *bytes.Reader:
+		remaining := l.n - l.read
+		if remaining > int64(reader.Len()) {
+			remaining = int64(reader.Len())
+		}
+		data := make([]byte, remaining)
+		_, readErr := reader.ReadAt(data, l.read)
+		if readErr != nil && readErr != io.EOF {
+			return 0, readErr
+		}
+
+		nn, err := w.Write(data)
+		l.read += int64(nn)
+		return int64(nn), err
+	default:
+		const bufSize = 4096
+		buf := make([]byte, bufSize)
+		var totalWritten int64
+
+		for l.read < l.n {
+			remaining := l.n - l.read
+			if int64(bufSize) > remaining {
+				buf = buf[:remaining]
+			}
+
+			read, readErr := l.r.Read(buf)
+			if readErr != nil && readErr != io.EOF {
+				return totalWritten, readErr
+			}
+
+			nn, writeErr := w.Write(buf[:read])
+			totalWritten += int64(nn)
+
+			if writeErr != nil {
+				return totalWritten, writeErr
+			}
+
+			if readErr == io.EOF {
+				break
+			}
+		}
+
+		return totalWritten, nil
+	}
+}
+
 // ReadToMax reads up to the max size.
 func (a *Archive) ReadToMax(ctx context.Context, reader io.Reader) (data []byte, err error) {
 	// Archiver v4 is in alpha and using an experimental version of
@@ -191,9 +282,8 @@ func (a *Archive) ReadToMax(ctx context.Context, reader io.Reader) (data []byte,
 	}
 
 	var fileContent bytes.Buffer
-	// Wrap the reader with io.LimitedReader.
-	// This is to prevent the reader from reading more than maxSize.
-	lr := &io.LimitedReader{R: reader, N: int64(maxSize)}
+	lr := &limitedBytesReader{r: reader, n: int64(maxSize)}
+
 	// Using io.CopyBuffer for performance advantages. Though buf is mandatory
 	// for the method, due to the internal implementation of io.CopyBuffer, when
 	// *bytes.Buffer implements io.WriterTo or io.ReaderFrom, the provided buf

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -192,9 +192,11 @@ func (a *Archive) ReadToMax(ctx context.Context, reader io.Reader) (data []byte,
 
 	var fileContent bytes.Buffer
 	buf := make([]byte, defaultBufferSize)
-	// Using io.CopyBuffer for performance gains. The buffer, buf, is required
-	// for the method but isn't used since *bytes.Buffer implements io.WriterTo
-	// and io.ReaderFrom. Therefore, changing buf's size won't affect performance.
+	// Using io.CopyBuffer for performance advantages. Though buf is mandatory
+	// for the method, due to the internal implementation of io.CopyBuffer, when
+	// *bytes.Buffer implements io.WriterTo or io.ReaderFrom, the provided buf
+	// is simply ignored. Thus, adjusting buf's size won't change the effect
+	// or execution of the operation.
 	_, err = io.CopyBuffer(&fileContent, reader, buf)
 	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -187,17 +187,15 @@ func (a *Archive) ReadToMax(ctx context.Context, reader io.Reader) (data []byte,
 	}()
 
 	if common.IsDone(ctx) {
-		return nil, fmt.Errorf("context is done")
+		return nil, ctx.Err()
 	}
 
 	var fileContent bytes.Buffer
-	buf := make([]byte, defaultBufferSize)
 	// Using io.CopyBuffer for performance advantages. Though buf is mandatory
 	// for the method, due to the internal implementation of io.CopyBuffer, when
 	// *bytes.Buffer implements io.WriterTo or io.ReaderFrom, the provided buf
-	// is simply ignored. Thus, adjusting buf's size won't change the effect
-	// or execution of the operation.
-	_, err = io.CopyBuffer(&fileContent, reader, buf)
+	// is simply ignored. Thus, we can pass nil for the buf parameter.
+	_, err = io.CopyBuffer(&fileContent, reader, nil)
 	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, err
 	}

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -295,7 +295,6 @@ func (a *Archive) ReadToMax(ctx context.Context, reader io.Reader) (data []byte,
 
 	if fileContent.Len() == maxSize {
 		logger.V(2).Info("Max archive size reached.")
-		return fileContent.Bytes()[:maxSize], nil
 	}
 
 	return fileContent.Bytes(), nil

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -192,6 +192,7 @@ func (a *Archive) ReadToMax(ctx context.Context, reader io.Reader) (data []byte,
 
 	var fileContent bytes.Buffer
 	// Wrap the reader with io.LimitedReader.
+	// This is to prevent the reader from reading more than maxSize.
 	lr := &io.LimitedReader{R: reader, N: int64(maxSize)}
 	// Using io.CopyBuffer for performance advantages. Though buf is mandatory
 	// for the method, due to the internal implementation of io.CopyBuffer, when
@@ -202,7 +203,7 @@ func (a *Archive) ReadToMax(ctx context.Context, reader io.Reader) (data []byte,
 		return nil, err
 	}
 
-	if fileContent.Len() >= maxSize {
+	if fileContent.Len() == maxSize {
 		logger.V(2).Info("Max archive size reached.")
 		return fileContent.Bytes()[:maxSize], nil
 	}

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -171,11 +171,11 @@ func BenchmarkReadToMax(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StartTimer()
-		a.ReadToMax(context.Background(), reader)
+		_, _ = a.ReadToMax(context.Background(), reader)
 		b.StopTimer()
 
-		reader.Seek(0, 0) // Reset the reader position.
-		a.size = 0        // Reset archive size.
+		_, _ = reader.Seek(0, 0) // Reset the reader position.
+		a.size = 0               // Reset archive size.
 	}
 }
 

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -150,7 +150,7 @@ func TestReadToMax(t *testing.T) {
 		},
 	}
 
-	a := &Archive{} // Assuming a is the relevant struct for this method.
+	a := &Archive{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -146,7 +146,7 @@ func TestReadToMax(t *testing.T) {
 		{
 			name:     "empty input",
 			input:    []byte(""),
-			expected: []byte(""),
+			expected: nil,
 		},
 	}
 

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net/http"
@@ -124,6 +125,58 @@ func TestHandleFile(t *testing.T) {
 	assert.Equal(t, 0, len(ch))
 	assert.True(t, HandleFile(context.Background(), reader, &sources.Chunk{}, ch))
 	assert.Equal(t, 1, len(ch))
+}
+
+func TestReadToMax(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected []byte
+	}{
+		{
+			name:     "read full content within maxSize",
+			input:    []byte("abcdefg"),
+			expected: []byte("abcdefg"),
+		},
+		{
+			name:     "read content larger than maxSize",
+			input:    make([]byte, maxSize+10), // this creates a byte slice 10 bytes larger than maxSize
+			expected: make([]byte, maxSize),
+		},
+		{
+			name:     "empty input",
+			input:    []byte(""),
+			expected: []byte(""),
+		},
+	}
+
+	a := &Archive{} // Assuming a is the relevant struct for this method.
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := bytes.NewReader(tt.input)
+			output, err := a.ReadToMax(context.Background(), reader)
+			assert.Nil(t, err)
+
+			assert.Equal(t, tt.expected, output)
+		})
+	}
+}
+
+func BenchmarkReadToMax(b *testing.B) {
+	data := bytes.Repeat([]byte("a"), 1024*1000) // 1MB of data.
+	reader := bytes.NewReader(data)
+	a := &Archive{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		b.StartTimer()
+		a.ReadToMax(context.Background(), reader)
+		b.StopTimer()
+
+		reader.Seek(0, 0) // Reset the reader position.
+		a.size = 0        // Reset archive size.
+	}
 }
 
 func TestExtractDebContent(t *testing.T) {

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -146,7 +146,7 @@ func TestReadToMax(t *testing.T) {
 		{
 			name:     "empty input",
 			input:    []byte(""),
-			expected: nil,
+			expected: []byte(""),
 		},
 	}
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Use the std lib's CopyBuffer to speed up the copying process. We lose some granularity with this approach but the performance gains I think are well worth the tradeoff.

![Screenshot 2023-08-29 at 4 42 50 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/31da74ee-0567-46de-8555-25a77bc3647f)





### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

