### PR TITLE
Add the 'Cause' family of functions to the context wrapper library

### DIFF
--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -3,6 +3,7 @@ package context
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -176,4 +177,11 @@ func TestRace(t *testing.T) {
 	go func() { _ = ctx.Err() }()
 	cancel()
 	_ = ctx.Err()
+}
+
+func TestCause(t *testing.T) {
+	ctx, cancel := WithCancelCause(Background())
+	err := fmt.Errorf("oh no")
+	cancel(err)
+	assert.Equal(t, err, Cause(ctx))
 }


### PR DESCRIPTION
### Description:

Go 1.20 introduced `WithCancelCause`, `WithTimeoutCause`, and `WithDeadlineCause` to allow adding a reason to context cancellations. Adding it to our wrapper will allow us to use these features.


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

