### PR TITLE
[chore] - fix sentry detector

### DIFF
--- a/pkg/detectors/sentrytoken/sentrytoken.go
+++ b/pkg/detectors/sentrytoken/sentrytoken.go
@@ -68,10 +68,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			default:
 				s1.VerificationError = verificationErr
 			}
+		}
 
-			if !s1.Verified && detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
-				continue
-			}
+		if !s1.Verified && detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
+			continue
 		}
 		results = append(results, s1)
 	}

--- a/pkg/detectors/sentrytoken/sentrytoken.go
+++ b/pkg/detectors/sentrytoken/sentrytoken.go
@@ -2,7 +2,10 @@ package sentrytoken
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -12,16 +15,22 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{}
+type Scanner struct {
+	client *http.Client
+}
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClient()
+	defaultClient = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"sentry"}) + `\b([a-f0-9]{64})\b`)
+
+	// Errors.
+	errIndeterminate = fmt.Errorf("indeterminate verification state")
+	errUnauthorized  = fmt.Errorf("token unauthorized")
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -47,30 +56,76 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://sentry.io/api/0/projects/", nil)
-			if err != nil {
+			client := s.client
+			if client == nil {
+				client = defaultClient
+			}
+			isVerified, verificationErr := verifyToken(ctx, client, resMatch)
+
+			switch {
+			case errors.Is(verificationErr, errUnauthorized):
+				s1.Verified = false
+			case isVerified:
+				s1.Verified = true
+			default:
+				s1.VerificationError = verificationErr
+			}
+
+			if !s1.Verified && detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
 				continue
 			}
-			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
-			// req.Header.Add("Cookie", "sc=g2ceDPcsBwPLGXugHUv0coGBi09TQYKqmtp0u4JYdIvOTFd28yVvn1yiuXgmJJa8; session=.eJwNyE0OwiAQQGGsPwtP4kqoGQa4gUdgZ2CGiaZJCUqjGxOPbnfve7_h29QpHpVSvbw61To9StvEwzre9TkVbkPcr7jN5dPbNl7X1jUt_a4vLpEHgUycQSgFZ0YBRkGxnthxwIyBAgdngcF4YxBssiMjekGv2245_wHyySMG:1m0J5S:FjpRlBVuFx577UQp6GcSGWTq0uk")
-			res, err := client.Do(req)
-			if err == nil {
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					s1.Verified = true
-				} else {
-					// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
-					if detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
-						continue
-					}
-				}
-			}
 		}
-
 		results = append(results, s1)
 	}
 
 	return results, nil
+}
+
+type Response []Project
+
+type Project struct {
+	Organization Organization `json:"organization"`
+}
+
+type Organization struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func verifyToken(ctx context.Context, client *http.Client, token string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://sentry.io/api/0/projects/", nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, errIndeterminate
+	}
+	defer res.Body.Close()
+
+	var isVerified bool
+	switch res.StatusCode {
+	case http.StatusOK, http.StatusForbidden:
+		isVerified = true
+	case http.StatusUnauthorized:
+		return false, errUnauthorized
+	default:
+		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
+
+	bytes, readErr := io.ReadAll(res.Body)
+	if readErr != nil {
+		return false, readErr
+	}
+
+	var resp Response
+	if err = json.Unmarshal(bytes, &resp); err != nil {
+		return false, err
+	}
+
+	return isVerified, err
 }
 
 func (s Scanner) Type() detectorspb.DetectorType {

--- a/pkg/detectors/sentrytoken/sentrytoken.go
+++ b/pkg/detectors/sentrytoken/sentrytoken.go
@@ -28,9 +28,7 @@ var (
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"sentry"}) + `\b([a-f0-9]{64})\b`)
 
-	// Errors.
-	errIndeterminate = fmt.Errorf("indeterminate verification state")
-	errUnauthorized  = fmt.Errorf("token unauthorized")
+	errUnauthorized = fmt.Errorf("token unauthorized")
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -101,7 +99,7 @@ func verifyToken(ctx context.Context, client *http.Client, token string) (bool, 
 
 	res, err := client.Do(req)
 	if err != nil {
-		return false, errIndeterminate
+		return false, err
 	}
 	defer res.Body.Close()
 

--- a/pkg/detectors/sentrytoken/sentrytoken_test.go
+++ b/pkg/detectors/sentrytoken/sentrytoken_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kylelemons/godebug/pretty"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
@@ -32,11 +34,12 @@ func TestSentryToken_FromChunk(t *testing.T) {
 		verify bool
 	}
 	tests := []struct {
-		name    string
-		s       Scanner
-		args    args
-		want    []detectors.Result
-		wantErr bool
+		name                string
+		s                   Scanner
+		args                args
+		want                []detectors.Result
+		wantErr             bool
+		wantVerificationErr bool
 	}{
 		{
 			name: "found, verified",
@@ -71,6 +74,56 @@ func TestSentryToken_FromChunk(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "found, would be verified but for timeout",
+			s:    Scanner{client: common.SaneHttpClientTimeOut(1 * time.Microsecond)},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a sentry super secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_SentryToken,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+		{
+			name: "found and valid but unexpected api response",
+			s:    Scanner{client: common.ConstantResponseHttpClient(500, "")},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a sentry super secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_SentryToken,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+		{
+			name: "found, good key but wrong scope",
+			s:    Scanner{client: common.ConstantResponseHttpClient(403, respnseBody403)},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a sentry super secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_SentryToken,
+					Verified:     true,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "not found",
 			s:    Scanner{},
 			args: args{
@@ -82,26 +135,45 @@ func TestSentryToken_FromChunk(t *testing.T) {
 			wantErr: false,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := Scanner{}
-			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("SentryToken.FromData() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Gitlab.FromData() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			for i := range got {
 				if len(got[i].Raw) == 0 {
-					t.Fatalf("no raw secret present: \n %+v", got[i])
+					t.Fatal("no raw secret present")
 				}
-				got[i].Raw = nil
+				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
+				}
 			}
-			if diff := pretty.Compare(got, tt.want); diff != "" {
-				t.Errorf("SentryToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
+				t.Errorf("Gitlab.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
 		})
 	}
 }
+
+const respnseBody403 = `
+[
+  {
+    "organization": {
+      "id": "911964",
+      "slug": "wigslap",
+      "status": {
+        "id": "active",
+        "name": "active"
+      },
+      "name": "wigslap"
+    }
+  }
+]
+`
 
 func BenchmarkFromData(benchmark *testing.B) {
 	ctx := context.Background()

--- a/pkg/detectors/sentrytoken/sentrytoken_test.go
+++ b/pkg/detectors/sentrytoken/sentrytoken_test.go
@@ -109,7 +109,7 @@ func TestSentryToken_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found, good key but wrong scope",
-			s:    Scanner{client: common.ConstantResponseHttpClient(403, respnseBody403)},
+			s:    Scanner{client: common.ConstantResponseHttpClient(403, responseBody403)},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a sentry super secret %s within", secret)),
@@ -148,7 +148,7 @@ func TestSentryToken_FromChunk(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
-					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
 			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
@@ -159,7 +159,7 @@ func TestSentryToken_FromChunk(t *testing.T) {
 	}
 }
 
-const respnseBody403 = `
+const responseBody403 = `
 [
   {
     "organization": {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
- The sentry detector returns 200s when you provide a token from an account that no longer exists. Check the response before marking it verified.
- Add tri-state verification

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

