### PR TITLE
Skip detectors for known bad chunks

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -802,6 +802,11 @@ func (e *Engine) scannerWorker(ctx context.Context) {
 			}
 
 			for _, detector := range matchingDetectors {
+				if d, ok := detector.Detector.(detectors.ConditionalDetector); ok && !d.ShouldScanChunk(*chunk) {
+					ctx.Logger().V(4).Info("skipping detector for chunk", "detector", detector.Type().String(), "chunk", chunk)
+					continue
+				}
+
 				decoded.Chunk.Verify = e.shouldVerifyChunk(sourceVerify, detector, e.detectorVerificationOverrides)
 				wgDetect.Add(1)
 				e.detectableChunksChan <- detectableChunk{

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -45,6 +45,42 @@ type Chunk struct {
 	Verify bool
 }
 
+// GitSourceMetadata defines a common struct for Git-based source metadata.
+type GitSourceMetadata struct {
+	Repository string
+	Commit     string
+	File       string
+}
+
+func NewGitSourceMetadata(source sourcespb.SourceType, data *source_metadatapb.MetaData) (*GitSourceMetadata, bool) {
+	if data == nil {
+		return nil, false
+	}
+
+	switch source {
+	case sourcespb.SourceType_SOURCE_TYPE_GIT:
+		md := data.GetGit()
+		return &GitSourceMetadata{md.GetRepository(), md.GetCommit(), md.GetFile()}, true
+	case sourcespb.SourceType_SOURCE_TYPE_AZURE_REPOS:
+		md := data.GetAzureRepos()
+		return &GitSourceMetadata{md.GetRepository(), md.GetCommit(), md.GetFile()}, true
+	case sourcespb.SourceType_SOURCE_TYPE_BITBUCKET:
+		md := data.GetBitbucket()
+		return &GitSourceMetadata{md.GetRepository(), md.GetCommit(), md.GetFile()}, true
+	case sourcespb.SourceType_SOURCE_TYPE_GERRIT:
+		md := data.GetGerrit()
+		return &GitSourceMetadata{md.GetProject(), md.GetCommit(), md.GetFile()}, true
+	case sourcespb.SourceType_SOURCE_TYPE_GITHUB:
+		md := data.GetGithub()
+		return &GitSourceMetadata{md.GetRepository(), md.GetCommit(), md.GetFile()}, true
+	case sourcespb.SourceType_SOURCE_TYPE_GITLAB:
+		md := data.GetGitlab()
+		return &GitSourceMetadata{md.GetRepository(), md.GetCommit(), md.GetFile()}, true
+	default:
+		return nil, false
+	}
+}
+
 // ChunkingTarget specifies criteria for a targeted chunking process.
 // Instead of collecting data indiscriminately, this struct allows the caller
 // to specify particular subsets of data they're interested in. This becomes


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:

This is a POC to fix #1517. Skipping detectors on chunks that are known to be problematic (e.g., #1460) should improve performance by reducing the number of false-positives and extraneous network requests.

Any feedback and suggestions are welcome. (Also, I have yet to test whether this specific code works; emphasis on "concept".)

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

