### PR TITLE
Fix pagerdutyapikey Detector

### DIFF
--- a/pkg/detectors/pagerdutyapikey/pagerdutyapikey.go
+++ b/pkg/detectors/pagerdutyapikey/pagerdutyapikey.go
@@ -21,13 +21,13 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"pagerduty"}) + `\b([a-zA-Z0-9_+-]{20})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"pagerduty", "pd"}) + `\b([a-zA-Z0-9_+-]{20})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"pagerduty"}
+	return []string{"pagerduty", "pd"}
 }
 
 // FromData will find and optionally verify PagerDutyApiKey secrets in a given set of bytes.

--- a/pkg/detectors/pagerdutyapikey/pagerdutyapikey.go
+++ b/pkg/detectors/pagerdutyapikey/pagerdutyapikey.go
@@ -21,7 +21,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"pagerduty"}) + `\b([a-z]{1}\+[a-zA-Z]{9}\-[a-z]{2}\-[a-z0-9]{5})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"pagerduty"}) + `\b([a-zA-Z0-9_+-]{20})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.


### PR DESCRIPTION
### Description:
Resolves #1658 by fixing `pagerdutyapikey` detector

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

