### PR TITLE
Include flag for `--fail-fast`

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -98,7 +98,8 @@ func (t *terminationSignal) signalFinish() {
 
 	if t.exitChan != nil {
 		close(t.exitChan)
-		t.exitChan = nil // Set to nil to prevent double close
+		// Setting exitChan to nil to prevent inadvertent double close in future calls.
+		t.exitChan = nil
 	}
 	t.failFastCondition.Signal() // Signal the condition to unblock Finish.
 }

--- a/pkg/output/github_actions.go
+++ b/pkg/output/github_actions.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"sync"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -14,7 +13,7 @@ import (
 var dedupeCache = make(map[string]struct{})
 
 // GitHubActionsPrinter is a printer that prints results in GitHub Actions format.
-type GitHubActionsPrinter struct{ mu sync.Mutex }
+type GitHubActionsPrinter struct{}
 
 func (p *GitHubActionsPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) error {
 	out := gitHubActionsOutputFormat{
@@ -57,8 +56,6 @@ func (p *GitHubActionsPrinter) Print(_ context.Context, r *detectors.ResultWithM
 	}
 	dedupeCache[key] = struct{}{}
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	message := fmt.Sprintf("Found %s %s result 🐷🔑\n", verifiedStatus, out.DetectorType)
 	if r.Result.DecoderType != detectorspb.DecoderType_PLAIN {
 		message = fmt.Sprintf("Found %s %s result with %s encoding 🐷🔑\n", verifiedStatus, out.DetectorType, out.DecoderType)

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -3,7 +3,6 @@ package output
 import (
 	"encoding/json"
 	"fmt"
-	"sync"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -13,7 +12,7 @@ import (
 )
 
 // JSONPrinter is a printer that prints results in JSON format.
-type JSONPrinter struct{ mu sync.Mutex }
+type JSONPrinter struct{}
 
 func (p *JSONPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) error {
 	v := &struct {
@@ -62,8 +61,6 @@ func (p *JSONPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) 
 		return fmt.Errorf("could not marshal result: %w", err)
 	}
 
-	p.mu.Lock()
 	fmt.Println(string(out))
-	p.mu.Unlock()
 	return nil
 }

--- a/pkg/output/legacy_json.go
+++ b/pkg/output/legacy_json.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"sync"
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -21,7 +20,7 @@ import (
 )
 
 // LegacyJSONPrinter is a printer that prints results in legacy JSON format for backwards compatibility.
-type LegacyJSONPrinter struct{ mu sync.Mutex }
+type LegacyJSONPrinter struct{}
 
 func (p *LegacyJSONPrinter) Print(ctx context.Context, r *detectors.ResultWithMetadata) error {
 	var repo string
@@ -54,9 +53,7 @@ func (p *LegacyJSONPrinter) Print(ctx context.Context, r *detectors.ResultWithMe
 		return fmt.Errorf("could not marshal result: %w", err)
 	}
 
-	p.mu.Lock()
 	fmt.Println(string(out))
-	p.mu.Unlock()
 	return nil
 }
 

--- a/pkg/output/plain.go
+++ b/pkg/output/plain.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/fatih/color"
 	"golang.org/x/text/cases"
@@ -23,7 +22,7 @@ var (
 )
 
 // PlainPrinter is a printer that prints results in plain text format.
-type PlainPrinter struct{ mu sync.Mutex }
+type PlainPrinter struct{}
 
 func (p *PlainPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) error {
 	out := outputFormat{
@@ -40,8 +39,6 @@ func (p *PlainPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata)
 	}
 
 	printer := greenPrinter
-	p.mu.Lock()
-	defer p.mu.Unlock()
 
 	if out.Verified {
 		yellowPrinter.Print("Found verified result 🐷🔑\n")


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
When supplied, the --fail-flag causes the scanner to exit immediately upon discovering a single result. It acknowledges and works in tandem with other flags. So, if paired with --only-verified, the scanner stops at the first verified credential.

Also make notifying thread-safe since we are printing results we don't need multiple notifier workers.

![Screenshot 2023-09-07 at 7 14 50 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/453dc9cf-6eae-489b-9ff2-70769e734652)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

