### PR TITLE
Always attempt to return a git link

### DIFF
--- a/pkg/giturl/giturl.go
+++ b/pkg/giturl/giturl.go
@@ -119,7 +119,18 @@ func GenerateLink(repo, commit, file string, line int64) string {
 	case providerBitbucket:
 		return repo[:len(repo)-4] + "/commits/" + commit
 
+	case providerAzure:
+		baseLink := repo + "/commit/" + commit + "/" + file
+		if line > 0 {
+			baseLink += "?line=" + strconv.FormatInt(line, 10)
+		}
+		return baseLink
+
 	case providerGithub, providerGitlab:
+		// If the provider name isn't one of the cloud defaults, it is probably an on-prem github or gitlab.
+		// So do the same thing.
+		fallthrough
+	default:
 		var baseLink string
 		if file == "" {
 			baseLink = repo[:len(repo)-4] + "/commit/" + commit
@@ -130,15 +141,5 @@ func GenerateLink(repo, commit, file string, line int64) string {
 			}
 		}
 		return baseLink
-
-	case providerAzure:
-		baseLink := repo + "/commit/" + commit + "/" + file
-		if line > 0 {
-			baseLink += "?line=" + strconv.FormatInt(line, 10)
-		}
-		return baseLink
-
-	default:
-		return ""
 	}
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The GenerateLink function used to always attempt to generate a link, but would change how it did it if the provider was bitbucket. Due to a change, it would now only generate a link if the provider was a known cloud provider. However, gitlab and github can frequently be used in a self-hosted manner. The previous change accidentally removed the ability to support links for self-hosted instances.

[Link to previous functionality](https://github.com/trufflesecurity/trufflehog/blob/f2bfcc7ac6d8ca915c18f66b9ab1ccb0adaa9b14/pkg/sources/git/git.go#L697)

This PR returns that original functionality.

**Note** I'm not yet sure why `make test-community` isn't passing. Though it seems unrelated.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

