### PR TITLE
Retry AWS verification 403s

### DIFF
--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -104,8 +104,6 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 		}
 
-		//fmt.Printf("=========== the number of secret matches %d", len(secretMatches))
-
 		for _, secretMatch := range secretMatches {
 			if len(secretMatch) != 2 {
 				continue
@@ -124,7 +122,6 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			results = append(results, s1)
-			//fmt.Printf("%+v\n", results)
 			// If we've found a verified match with this ID, we don't need to look for any more. So move on to the next ID.
 			if s1.Verified {
 				break

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -112,14 +112,15 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			s1 := s.verifyMatch(ctx, resIDMatch, resSecretMatch, true)
 
-			// This function will check false positives for common test words, but also it will make sure the key appears "random" enough to be a real key.
-			if !s1.Verified && detectors.IsKnownFalsePositive(resSecretMatch, detectors.DefaultFalsePositives, true) {
-				continue
-			}
-
-			// If the result is unverified and matches something like a git hash, don't include it in the results.
-			if !s1.Verified && falsePositiveSecretCheck.MatchString(resSecretMatch) {
-				continue
+			if !s1.Verified {
+				// Unverified results that contain common test words are probably not secrets
+				if detectors.IsKnownFalsePositive(resSecretMatch, detectors.DefaultFalsePositives, true) {
+					continue
+				}
+				// Unverified results that look like hashes are probably not secrets
+				if falsePositiveSecretCheck.MatchString(resSecretMatch) {
+					continue
+				}
 			}
 
 			results = append(results, s1)

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -254,12 +254,12 @@ func executeRequest(client *http.Client, req *http.Request, r *detectors.Result,
 				if strings.EqualFold(body.Error.Code, "InvalidClientTokenId") {
 					// determinate failure - nothing to do
 				} else if strings.EqualFold(body.Error.Code, "SignatureDoesNotMatch") && retryOnSignatureMismatch {
-					// Based on experimentation, we've inferred this about the SigV4 process: When you make two
-					// GetCallerIdentity calls within five seconds, if you use the same key ID for both, AWS will expect
-					// you to sign them with the same secret. Within those five seconds, any requests against the
-					// original key ID that are signed with a different secret will be rejected with a signature
-					// mismatch error. However, when this rejection happens, AWS appears to evict whatever it's caching,
-					// so repeating the exact same request will generate the expected result.
+					// From experimentation, we've inferred this about the SigV4 process: When you make two
+					// GetCallerIdentity calls within five seconds that use the same key ID AWS will expect you to sign
+					// them with the same secret. Within those five seconds, any requests against the original key ID
+					// that are signed with a different secret will be rejected with a signature mismatch error.
+					// However, when this rejection happens, AWS appears to evict whatever it's caching, so repeating
+					// the exact same request will generate the expected result.
 					executeRequest(client, req, r, false)
 				} else {
 					r.VerificationError = fmt.Errorf("request to %v returned status %d with an unexpected reason (%s: %s)", res.Request.URL, res.StatusCode, body.Error.Code, body.Error.Message)

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -131,7 +131,7 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	return awsCustomCleanResults(results), nil
 }
 
-func (s scanner) verifyMatch(ctx context.Context, resIDMatch, resSecretMatch string, retryOnSignatureMismatch bool) detectors.Result {
+func (s scanner) verifyMatch(ctx context.Context, resIDMatch, resSecretMatch string, retryOn403 bool) detectors.Result {
 	s1 := detectors.Result{
 		DetectorType: detectorspb.DetectorType_AWS,
 		Raw:          []byte(resIDMatch),
@@ -238,7 +238,7 @@ func (s scanner) verifyMatch(ctx context.Context, resIDMatch, resSecretMatch str
 				//
 				// We are clearly deep in the guts of AWS implementation details here, so this all might change with no
 				// notice. If you're here because something in this detector broke, you have my condolences.
-				if retryOnSignatureMismatch {
+				if retryOn403 {
 					return s.verifyMatch(ctx, resIDMatch, resSecretMatch, false)
 				}
 				var body awsErrorResponseBody

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -220,7 +220,6 @@ func (s scanner) verifyMatch(ctx context.Context, resIDMatch, resSecretMatch str
 			}
 			res.Body.Close()
 		} else {
-
 			if res.StatusCode == 403 {
 				// Experimentation has indicated that if you make two GetCallerIdentity requests within five seconds
 				// that share a key ID but are signed with different secrets the second one will be rejected with a 403

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -230,7 +230,7 @@ func (s scanner) verifyMatch(ctx context.Context, resIDMatch, resSecretMatch str
 			// valid. Since this is exactly our access pattern, we need to work around it.
 			//
 			// Fortunately, experimentation has also revealed a workaround: simply resubmit the second request. The
-			// response to the resubmission will be as expected. But there's a caveat: You can't have closed the body o
+			// response to the resubmission will be as expected. But there's a caveat: You can't have closed the body of
 			// the response to the original second request, or read to its end, or the resubmission will also yield a
 			// SignatureDoesNotMatch. For this reason, we have to re-request all 403s. We can't re-request only
 			// SignatureDoesNotMatch responses, because we can only tell whether a given 403 is a SignatureDoesNotMatch

--- a/pkg/detectors/aws/aws_test.go
+++ b/pkg/detectors/aws/aws_test.go
@@ -42,7 +42,6 @@ func TestAWS_FromChunk(t *testing.T) {
 	tests := []struct {
 		name                  string
 		s                     scanner
-		sleepBefore           time.Duration // One of these tests needs to ensure that AWS's signature cache is empty before running
 		args                  args
 		want                  []detectors.Result
 		wantErr               bool
@@ -250,9 +249,8 @@ func TestAWS_FromChunk(t *testing.T) {
 			wantVerificationError: true,
 		},
 		{
-			name:        "verified secret checked directly after unverified secret with same key id",
-			s:           scanner{},
-			sleepBefore: 6 * time.Second, // AWS's signature cache appears to expire after 5 seconds
+			name: "verified secret checked directly after unverified secret with same key id",
+			s:    scanner{},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("%s\n%s\n%s", inactiveSecret, id, secret)),
@@ -275,7 +273,6 @@ func TestAWS_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			time.Sleep(tt.sleepBefore)
 			s := tt.s
 			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {

--- a/pkg/detectors/aws/aws_test.go
+++ b/pkg/detectors/aws/aws_test.go
@@ -42,6 +42,7 @@ func TestAWS_FromChunk(t *testing.T) {
 	tests := []struct {
 		name                  string
 		s                     scanner
+		sleepBefore           time.Duration // One of these tests needs to ensure that AWS's signature cache is empty before running
 		args                  args
 		want                  []detectors.Result
 		wantErr               bool
@@ -248,9 +249,33 @@ func TestAWS_FromChunk(t *testing.T) {
 			wantErr:               false,
 			wantVerificationError: true,
 		},
+		{
+			name:        "verified secret checked directly after unverified secret with same key id",
+			s:           scanner{},
+			sleepBefore: 6 * time.Second, // AWS's signature cache appears to expire after 5 seconds
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("%s\n%s\n%s", inactiveSecret, id, secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_AWS,
+					Verified:     true,
+					Redacted:     "AKIASP2TPHJSQH3FJRUX",
+					ExtraData: map[string]string{
+						"account": "171436882533",
+						"arn":     "arn:aws:iam::171436882533:user/canarytokens.com@@4dxkh0pdeop3bzu9zx5wob793",
+						"user_id": "AIDASP2TPHJSUFRSTTZX4",
+					},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			time.Sleep(tt.sleepBefore)
 			s := tt.s
 			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {


### PR DESCRIPTION
### Description:
This PR introduces retries on 403s in the AWS detector in attempt to work around erroneous `SignatureDoesNotMatch` errors. As part of the work, the detector has been refactored somewhat, resulting in two minor semantic changes:
* Errors crafting the verification HTTP request no longer result in the candidate secret being discarded.
* The known-words-based false positive check now runs (and potentially discards candidate secrets) even if verification is disabled. This unifies its behavior with the hash-based false positive check.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

