### PR TITLE
Always close AWS response body

### DIFF
--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -208,11 +208,10 @@ func (s scanner) verifyMatch(ctx context.Context, resIDMatch, resSecretMatch str
 
 	res, err := client.Do(req)
 	if err == nil {
-
+		defer res.Body.Close()
 		if res.StatusCode >= 200 && res.StatusCode < 300 {
 			identityInfo := identityRes{}
 			err := json.NewDecoder(res.Body).Decode(&identityInfo)
-			res.Body.Close()
 			if err == nil {
 				extraData := map[string]string{
 					"account": identityInfo.GetCallerIdentityResponse.GetCallerIdentityResult.Account,
@@ -244,7 +243,6 @@ func (s scanner) verifyMatch(ctx context.Context, resIDMatch, resSecretMatch str
 			}
 			var body awsErrorResponseBody
 			err = json.NewDecoder(res.Body).Decode(&body)
-			res.Body.Close()
 			if err == nil {
 				// All instances of the code I've seen in the wild are PascalCased but this check is
 				// case-insensitive out of an abundance of caution


### PR DESCRIPTION
### Description:
This change ensures that the bodies of responses from AWS requests are always closed so that we don't leak anything.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

