### PR TITLE
Implement Gitlab source validation

### DIFF
--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -189,8 +189,6 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 }
 
 func (s *Source) Validate(ctx context.Context) []error {
-	var errs []error
-
 	apiClient, err := s.newClient()
 	if err != nil {
 		return []error{err}
@@ -201,7 +199,12 @@ func (s *Source) Validate(ctx context.Context) []error {
 		return []error{err}
 	}
 
-	return errs
+	_, errs := s.getRepos()
+	if len(errs) > 0 {
+		return errs
+	}
+
+	return []error{}
 }
 
 func (s *Source) newClient() (*gitlab.Client, error) {

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -178,7 +178,7 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 
 func (s *Source) Validate(ctx context.Context) []error {
 	// The client is only used to query Gitlab for a repo list - it's not used to actually clone anything. Thus, we
-	// don't use it if there is a list of explicitly-configured repos. However, constructing it validates that the
+	// don't use it if there is a list of explicitly configured repos. However, constructing it validates that the
 	// configured authentication method is sensible, so we'll do it here.
 	apiClient, err := s.newClient()
 	if err != nil {

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -177,6 +177,9 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 }
 
 func (s *Source) Validate(ctx context.Context) []error {
+	// The client is only used to query Gitlab for a repo list - it's not used to actually clone anything. Thus, we
+	// don't use it if there is a list of explicitly-configured repos. However, constructing it validates that the
+	// configured authentication method is sensible, so we'll do it here.
 	apiClient, err := s.newClient()
 	if err != nil {
 		return []error{err}

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -232,6 +232,11 @@ func (s *Source) Validate(ctx context.Context) []error {
 		}
 	}
 
+	_, err = s.getAllProjects(ctx, apiClient)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
 	return errs
 }
 

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -53,6 +53,7 @@ type Source struct {
 // Ensure the Source satisfies the interfaces at compile time.
 var _ sources.Source = (*Source)(nil)
 var _ sources.SourceUnitUnmarshaller = (*Source)(nil)
+var _ sources.Validator = (*Source)(nil)
 
 // Type returns the type of source.
 // It is used for matching source types in configuration and job input.
@@ -185,6 +186,11 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 	slices.Sort(s.repos)
 
 	return s.scanRepos(ctx, chunksChan)
+}
+
+func (s *Source) Validate(ctx context.Context) []error {
+	//TODO implement me
+	panic("implement me")
 }
 
 func (s *Source) newClient() (*gitlab.Client, error) {

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -206,9 +206,12 @@ func (s *Source) Validate(ctx context.Context) []error {
 				errs = append(errs, err)
 			}
 		}
+
+		if len(s.ignoreRepos) > 0 {
+			errs = append(errs, fmt.Errorf("both repositories and ignore patterns were explicitly configured; ignore patterns will not be used"))
+		}
 	}
 
-	// todo: sort out whether to check ignore globs if repos are explicitly configured
 	if len(errs) > 0 {
 		return errs
 	}

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -196,7 +196,8 @@ func (s *Source) Validate(ctx context.Context) []error {
 
 	_, _, err = apiClient.Users.CurrentUser()
 	if err != nil {
-		return []error{err}
+		msg := fmt.Sprintf("gitlab authentication failed using method %v", s.authMethod)
+		return []error{errors.WrapPrefix(err, msg, 0)}
 	}
 
 	_, errs := s.getRepos()
@@ -207,7 +208,7 @@ func (s *Source) Validate(ctx context.Context) []error {
 	for _, ignore := range s.ignoreRepos {
 		_, err := glob.Compile(ignore)
 		if err != nil {
-			msg := fmt.Sprintf("could not compile ignore repo pattern %q", ignore)
+			msg := fmt.Sprintf("could not compile ignore repo pattern %v", ignore)
 			errs = append(errs, errors.WrapPrefix(err, msg, 0))
 		}
 	}

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -207,7 +207,8 @@ func (s *Source) Validate(ctx context.Context) []error {
 	for _, ignore := range s.ignoreRepos {
 		_, err := glob.Compile(ignore)
 		if err != nil {
-			errs = append(errs, err)
+			msg := fmt.Sprintf("could not compile ignore repo pattern %q", ignore)
+			errs = append(errs, errors.WrapPrefix(err, msg, 0))
 		}
 	}
 

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -212,7 +212,7 @@ func (s *Source) Validate(ctx context.Context) []error {
 		}
 	}
 
-	if len(errs) > 0 {
+	if len(explicitlyConfiguredRepos) > 0 || len(errs) > 0 {
 		return errs
 	}
 

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -189,8 +189,19 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 }
 
 func (s *Source) Validate(ctx context.Context) []error {
-	//TODO implement me
-	panic("implement me")
+	var errs []error
+
+	apiClient, err := s.newClient()
+	if err != nil {
+		return []error{err}
+	}
+
+	_, _, err = apiClient.Users.CurrentUser()
+	if err != nil {
+		return []error{err}
+	}
+
+	return errs
 }
 
 func (s *Source) newClient() (*gitlab.Client, error) {

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -204,7 +204,14 @@ func (s *Source) Validate(ctx context.Context) []error {
 		return errs
 	}
 
-	return []error{}
+	for _, ignore := range s.ignoreRepos {
+		_, err := glob.Compile(ignore)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errs
 }
 
 func (s *Source) newClient() (*gitlab.Client, error) {

--- a/pkg/sources/gitlab/gitlab_test.go
+++ b/pkg/sources/gitlab/gitlab_test.go
@@ -195,10 +195,6 @@ func TestSource_Validate(t *testing.T) {
 		wantErrCount int
 		wantErrs     []string
 	}{
-		//{
-		//	name:         "oauth did not authenticate",
-		//	wantErrCount: 1,
-		//},
 		{
 			name: "basic auth did not authenticate",
 			connection: &sourcespb.GitLab{

--- a/pkg/sources/gitlab/gitlab_test.go
+++ b/pkg/sources/gitlab/gitlab_test.go
@@ -186,8 +186,6 @@ func TestSource_Validate(t *testing.T) {
 		t.Fatal(fmt.Errorf("failed to access secret: %v", err))
 	}
 	token := secret.MustGetField("GITLAB_TOKEN")
-	//basicUser := secret.MustGetField("GITLAB_USER")
-	//basicPass := secret.MustGetField("GITLAB_PASS")
 
 	tests := []struct {
 		name         string

--- a/pkg/sources/gitlab/gitlab_test.go
+++ b/pkg/sources/gitlab/gitlab_test.go
@@ -243,6 +243,22 @@ func TestSource_Validate(t *testing.T) {
 			wantErrCount: 1,
 		},
 		{
+			name: "repositories and ignore globs both configured",
+			connection: &sourcespb.GitLab{
+				Credential: &sourcespb.GitLab_Token{
+					Token: token,
+				},
+				Repositories: []string{
+					"https://gitlab.com/testermctestface/testy", // valid
+				},
+				IgnoreRepos: []string{
+					"tes1188/*-gitlab",
+					"[", // glob doesn't compile, but this won't be checked
+				},
+			},
+			wantErrCount: 1,
+		},
+		{
 			name: "could not compile ignore glob(s)",
 			connection: &sourcespb.GitLab{
 				Credential: &sourcespb.GitLab_Token{

--- a/pkg/sources/gitlab/gitlab_test.go
+++ b/pkg/sources/gitlab/gitlab_test.go
@@ -219,10 +219,6 @@ func TestSource_Validate(t *testing.T) {
 			},
 			wantErrCount: 1,
 		},
-		//{
-		//	name:         "client could not authenticate",
-		//	wantErrCount: 1,
-		//},
 		{
 			name: "bad repo urls",
 			connection: &sourcespb.GitLab{
@@ -254,7 +250,17 @@ func TestSource_Validate(t *testing.T) {
 		//	wantErrCount: 1,
 		//},
 		{
-			name:         "could not compile ignore glob(s)",
+			name: "could not compile ignore glob(s)",
+			connection: &sourcespb.GitLab{
+				Credential: &sourcespb.GitLab_Token{
+					Token: token,
+				},
+				IgnoreRepos: []string{
+					"tes1188/*-gitlab",
+					"[",    // glob doesn't compile
+					"[a-]", // glob doesn't compile
+				},
+			},
 			wantErrCount: 2,
 		},
 	}

--- a/pkg/sources/gitlab/gitlab_test.go
+++ b/pkg/sources/gitlab/gitlab_test.go
@@ -186,6 +186,7 @@ func TestSource_Validate(t *testing.T) {
 		t.Fatal(fmt.Errorf("failed to access secret: %v", err))
 	}
 	token := secret.MustGetField("GITLAB_TOKEN")
+	tokenWrongScope := secret.MustGetField("GITLAB_TOKEN_WRONG_SCOPE")
 
 	tests := []struct {
 		name         string
@@ -232,18 +233,15 @@ func TestSource_Validate(t *testing.T) {
 			},
 			wantErrCount: 6,
 		},
-		//{
-		//	name:         "could not list user projects", // will require scope juggling, maybe not possible
-		//	wantErrCount: 1,
-		//},
-		//{
-		//	name:         "could not list groups", // will require scope juggling, maybe not possible
-		//	wantErrCount: 1,
-		//},
-		//{
-		//	name:         "could not list a group's projects", // will require scope juggling, maybe not possible
-		//	wantErrCount: 1,
-		//},
+		{
+			name: "token does not have permission to list projects",
+			connection: &sourcespb.GitLab{
+				Credential: &sourcespb.GitLab_Token{
+					Token: tokenWrongScope,
+				},
+			},
+			wantErrCount: 1,
+		},
 		{
 			name: "could not compile ignore glob(s)",
 			connection: &sourcespb.GitLab{

--- a/pkg/sources/gitlab/gitlab_test.go
+++ b/pkg/sources/gitlab/gitlab_test.go
@@ -181,35 +181,49 @@ func TestSource_Validate(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	secret, err := common.GetTestSecret(ctx)
+	_, err := common.GetTestSecret(ctx)
 	if err != nil {
 		t.Fatal(fmt.Errorf("failed to access secret: %v", err))
 	}
-	token := secret.MustGetField("GITLAB_TOKEN")
-	basicUser := secret.MustGetField("GITLAB_USER")
-	basicPass := secret.MustGetField("GITLAB_PASS")
+	//token := secret.MustGetField("GITLAB_TOKEN")
+	//basicUser := secret.MustGetField("GITLAB_USER")
+	//basicPass := secret.MustGetField("GITLAB_PASS")
 
 	tests := []struct {
 		name         string
 		connection   *sourcespb.GitLab
 		wantErrCount int
 	}{
+		//{
+		//	name:         "oauth did not authenticate",
+		//	wantErrCount: 1,
+		//},
 		{
-			name:         "failure to create oauth client",
+			name: "basic auth did not authenticate",
+			connection: &sourcespb.GitLab{
+				Repositories: []string{"https://gitlab.com/testermctestface/testy.git"},
+				Credential: &sourcespb.GitLab_BasicAuth{
+					BasicAuth: &credentialspb.BasicAuth{
+						Username: "bad-user",
+						Password: "bad-password",
+					},
+				},
+			},
 			wantErrCount: 1,
 		},
 		{
-			name:         "failure to create basic auth client",
+			name: "token did not authenticate",
+			connection: &sourcespb.GitLab{
+				Credential: &sourcespb.GitLab_Token{
+					Token: "bad-token",
+				},
+			},
 			wantErrCount: 1,
 		},
-		{
-			name:         "failure to create token client",
-			wantErrCount: 1,
-		},
-		{
-			name:         "client could not authenticate",
-			wantErrCount: 1,
-		},
+		//{
+		//	name:         "client could not authenticate",
+		//	wantErrCount: 1,
+		//},
 		{
 			name:         "bad repo urls (bad protocol, could not parse, no path, 2 parts no org, 3 parts no org, no trailing slash",
 			wantErrCount: 6,

--- a/pkg/sources/gitlab/gitlab_test.go
+++ b/pkg/sources/gitlab/gitlab_test.go
@@ -286,6 +286,18 @@ func TestSource_Validate(t *testing.T) {
 			},
 			wantErrCount: 2,
 		},
+		{
+			name: "ignore globs exclude all repos",
+			connection: &sourcespb.GitLab{
+				Credential: &sourcespb.GitLab_Token{
+					Token: token,
+				},
+				IgnoreRepos: []string{
+					"*",
+				},
+			},
+			wantErrCount: 1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sources/gitlab/gitlab_test.go
+++ b/pkg/sources/gitlab/gitlab_test.go
@@ -260,6 +260,20 @@ func TestSource_Validate(t *testing.T) {
 			},
 			wantErrCount: 2,
 		},
+		{
+			name: "repositories do not exist or are not accessible",
+			connection: &sourcespb.GitLab{
+				Credential: &sourcespb.GitLab_Token{
+					Token: token,
+				},
+				Repositories: []string{
+					"https://gitlab.com/testermctestface/testy",
+					"https://gitlab.com/testermctestface/doesn't-exist",
+					"https://gitlab.com/testermctestface/also-doesn't-exist",
+				},
+			},
+			wantErrCount: 2,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/sources/gitlab/gitlab_test.go
+++ b/pkg/sources/gitlab/gitlab_test.go
@@ -193,6 +193,7 @@ func TestSource_Validate(t *testing.T) {
 		name         string
 		connection   *sourcespb.GitLab
 		wantErrCount int
+		wantErrs     []string
 	}{
 		//{
 		//	name:         "oauth did not authenticate",
@@ -228,7 +229,7 @@ func TestSource_Validate(t *testing.T) {
 				Repositories: []string{
 					"https://gitlab.com/testermctestface/testy",  // valid
 					"https://gitlab.com/testermctestface/testy/", // trailing slash
-					"ssh://gitlab.com/testermctestface/testy",    // bad protocol
+					"ssh:git@gitlab.com/testermctestface/testy",  // bad protocol
 					"https://gitlab.com",                         // no path
 					"https://gitlab.com/",                        // no org name
 					"https://gitlab.com//testy",                  // no org name


### PR DESCRIPTION
### Description:
This PR implements validation of Gitlab source configuration.

I was hoping to be able to unify more of the implementation of `Validate` and `Chunks`, but there was more divergence than I expected. Specifically, `Chunks` handles a fair number of Gitlab errors that aren't configuration errors (e.g. "Gitlab returned a repo with an unparseable URL"). Accommodating these in the `Validate` code path felt wrong, and I wasn't able to create a common code path that could accommodate both `Validate` and `Chunks` without looking awful.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

