### PR TITLE
Add a SourceType constant to all source packages

### DIFF
--- a/pkg/engine/circleci.go
+++ b/pkg/engine/circleci.go
@@ -27,7 +27,7 @@ func (e *Engine) ScanCircleCI(ctx context.Context, token string) error {
 	}
 
 	sourceName := "trufflehog - Circle CI"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, new(circleci.Source).Type())
+	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, circleci.SourceType)
 
 	circleSource := &circleci.Source{}
 	if err := circleSource.Init(ctx, "trufflehog - Circle CI", int64(jobID), int64(sourceID), true, &conn, runtime.NumCPU()); err != nil {

--- a/pkg/engine/docker.go
+++ b/pkg/engine/docker.go
@@ -12,7 +12,7 @@ import (
 // ScanDocker scans a given docker connection.
 func (e *Engine) ScanDocker(ctx context.Context, conn *anypb.Any) error {
 	sourceName := "trufflehog - docker"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, new(docker.Source).Type())
+	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, docker.SourceType)
 
 	dockerSource := &docker.Source{}
 	if err := dockerSource.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, conn, runtime.NumCPU()); err != nil {

--- a/pkg/engine/filesystem.go
+++ b/pkg/engine/filesystem.go
@@ -25,7 +25,7 @@ func (e *Engine) ScanFileSystem(ctx context.Context, c sources.FilesystemConfig)
 	}
 
 	sourceName := "trufflehog - filesystem"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, new(filesystem.Source).Type())
+	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, filesystem.SourceType)
 
 	fileSystemSource := &filesystem.Source{}
 	fileSystemSource.WithFilter(c.Filter)

--- a/pkg/engine/gcs.go
+++ b/pkg/engine/gcs.go
@@ -45,7 +45,7 @@ func (e *Engine) ScanGCS(ctx context.Context, c sources.GCSConfig) error {
 	}
 
 	sourceName := "trufflehog - gcs"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, new(gcs.Source).Type())
+	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, gcs.SourceType)
 
 	gcsSource := &gcs.Source{}
 	if err := gcsSource.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, &conn, int(c.Concurrency)); err != nil {

--- a/pkg/engine/git.go
+++ b/pkg/engine/git.go
@@ -52,7 +52,7 @@ func (e *Engine) ScanGit(ctx context.Context, c sources.GitConfig) error {
 	}
 
 	sourceName := "trufflehog - git"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, new(git.Source).Type())
+	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, git.SourceType)
 
 	gitSource := &git.Source{}
 	if err := gitSource.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, &conn, runtime.NumCPU()); err != nil {

--- a/pkg/engine/github.go
+++ b/pkg/engine/github.go
@@ -48,7 +48,7 @@ func (e *Engine) ScanGitHub(ctx context.Context, c sources.GithubConfig) error {
 	scanOptions := git.NewScanOptions(opts...)
 
 	sourceName := "trufflehog - github"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, new(github.Source).Type())
+	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, github.SourceType)
 
 	githubSource := &github.Source{}
 	if err := githubSource.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, &conn, c.Concurrency); err != nil {

--- a/pkg/engine/gitlab.go
+++ b/pkg/engine/gitlab.go
@@ -51,7 +51,7 @@ func (e *Engine) ScanGitLab(ctx context.Context, c sources.GitlabConfig) error {
 	}
 
 	sourceName := "trufflehog - gitlab"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, new(gitlab.Source).Type())
+	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, gitlab.SourceType)
 
 	gitlabSource := &gitlab.Source{}
 	if err := gitlabSource.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, &conn, runtime.NumCPU()); err != nil {

--- a/pkg/engine/s3.go
+++ b/pkg/engine/s3.go
@@ -59,7 +59,7 @@ func (e *Engine) ScanS3(ctx context.Context, c sources.S3Config) error {
 	}
 
 	sourceName := "trufflehog - s3"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, new(s3.Source).Type())
+	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, s3.SourceType)
 
 	s3Source := &s3.Source{}
 	if err := s3Source.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, &conn, runtime.NumCPU()); err != nil {

--- a/pkg/engine/syslog.go
+++ b/pkg/engine/syslog.go
@@ -42,7 +42,7 @@ func (e *Engine) ScanSyslog(ctx context.Context, c sources.SyslogConfig) error {
 	}
 
 	sourceName := "trufflehog - syslog"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, new(syslog.Source).Type())
+	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, syslog.SourceType)
 	syslogSource := &syslog.Source{}
 	if err := syslogSource.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, &conn, c.Concurrency); err != nil {
 		return err

--- a/pkg/sources/circleci/circleci.go
+++ b/pkg/sources/circleci/circleci.go
@@ -19,7 +19,11 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
-const baseURL = "https://circleci.com/api/v1.1/"
+const (
+	SourceType = sourcespb.SourceType_SOURCE_TYPE_CIRCLECI
+
+	baseURL = "https://circleci.com/api/v1.1/"
+)
 
 type Source struct {
 	name     string
@@ -40,7 +44,7 @@ var _ sources.SourceUnitUnmarshaller = (*Source)(nil)
 // Type returns the type of source.
 // It is used for matching source types in configuration and job input.
 func (s *Source) Type() sourcespb.SourceType {
-	return sourcespb.SourceType_SOURCE_TYPE_CIRCLECI
+	return SourceType
 }
 
 func (s *Source) SourceID() int64 {

--- a/pkg/sources/docker/docker.go
+++ b/pkg/sources/docker/docker.go
@@ -24,6 +24,8 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
+const SourceType = sourcespb.SourceType_SOURCE_TYPE_DOCKER
+
 type Source struct {
 	name        string
 	sourceId    int64
@@ -42,7 +44,7 @@ var _ sources.SourceUnitUnmarshaller = (*Source)(nil)
 // Type returns the type of source.
 // It is used for matching source types in configuration and job input.
 func (s *Source) Type() sourcespb.SourceType {
-	return sourcespb.SourceType_SOURCE_TYPE_DOCKER
+	return SourceType
 }
 
 func (s *Source) SourceID() int64 {

--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -22,6 +22,8 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
+const SourceType = sourcespb.SourceType_SOURCE_TYPE_FILESYSTEM
+
 type Source struct {
 	name     string
 	sourceId int64
@@ -43,7 +45,7 @@ var _ sources.SourceUnitChunker = (*Source)(nil)
 // Type returns the type of source.
 // It is used for matching source types in configuration and job input.
 func (s *Source) Type() sourcespb.SourceType {
-	return sourcespb.SourceType_SOURCE_TYPE_FILESYSTEM
+	return SourceType
 }
 
 func (s *Source) SourceID() int64 {

--- a/pkg/sources/gcs/gcs.go
+++ b/pkg/sources/gcs/gcs.go
@@ -28,7 +28,11 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
-const defaultCachePersistIncrement = 2500
+const (
+	SourceType = sourcespb.SourceType_SOURCE_TYPE_GCS
+
+	defaultCachePersistIncrement = 2500
+)
 
 // Ensure the Source satisfies the interfaces at compile time.
 var _ sources.Source = (*Source)(nil)
@@ -37,7 +41,7 @@ var _ sources.SourceUnitUnmarshaller = (*Source)(nil)
 // Type returns the type of source.
 // It is used for matching source types in configuration and job input.
 func (s *Source) Type() sourcespb.SourceType {
-	return sourcespb.SourceType_SOURCE_TYPE_GCS
+	return SourceType
 }
 
 // SourceID number for GCS Source.

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -34,6 +34,8 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
+const SourceType = sourcespb.SourceType_SOURCE_TYPE_GIT
+
 type Source struct {
 	name     string
 	sourceId int64
@@ -84,7 +86,7 @@ var _ sources.SourceUnitUnmarshaller = (*Source)(nil)
 // Type returns the type of source.
 // It is used for matching source types in configuration and job input.
 func (s *Source) Type() sourcespb.SourceType {
-	return sourcespb.SourceType_SOURCE_TYPE_GIT
+	return SourceType
 }
 
 func (s *Source) SourceID() int64 {

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -39,6 +39,8 @@ import (
 )
 
 const (
+	SourceType = sourcespb.SourceType_SOURCE_TYPE_GITHUB
+
 	unauthGithubOrgRateLimt = 30
 	defaultPagination       = 100
 	membersAppPagination    = 500
@@ -104,7 +106,7 @@ var endsWithGithub = regexp.MustCompile(`github\.com/?$`)
 // Type returns the type of source.
 // It is used for matching source types in configuration and job input.
 func (s *Source) Type() sourcespb.SourceType {
-	return sourcespb.SourceType_SOURCE_TYPE_GITHUB
+	return SourceType
 }
 
 func (s *Source) SourceID() int64 {

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -29,6 +29,8 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+const SourceType = sourcespb.SourceType_SOURCE_TYPE_GITLAB
+
 type Source struct {
 	name            string
 	sourceId        int64
@@ -57,7 +59,7 @@ var _ sources.SourceUnitUnmarshaller = (*Source)(nil)
 // Type returns the type of source.
 // It is used for matching source types in configuration and job input.
 func (s *Source) Type() sourcespb.SourceType {
-	return sourcespb.SourceType_SOURCE_TYPE_GITLAB
+	return SourceType
 }
 
 func (s *Source) SourceID() int64 {

--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -31,6 +31,8 @@ import (
 )
 
 const (
+	SourceType = sourcespb.SourceType_SOURCE_TYPE_S3
+
 	defaultAWSRegion     = "us-east-1"
 	defaultMaxObjectSize = 250 * 1024 * 1024 // 250 MiB
 	maxObjectSizeLimit   = 250 * 1024 * 1024 // 250 MiB
@@ -58,7 +60,7 @@ var _ sources.Validator = (*Source)(nil)
 
 // Type returns the type of source
 func (s *Source) Type() sourcespb.SourceType {
-	return sourcespb.SourceType_SOURCE_TYPE_S3
+	return SourceType
 }
 
 func (s *Source) SourceID() int64 {

--- a/pkg/sources/syslog/syslog.go
+++ b/pkg/sources/syslog/syslog.go
@@ -23,7 +23,11 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
-const nilString = ""
+const (
+	SourceType = sourcespb.SourceType_SOURCE_TYPE_SYSLOG
+
+	nilString = ""
+)
 
 type Source struct {
 	name     string
@@ -103,7 +107,7 @@ var _ sources.Source = (*Source)(nil)
 // Type returns the type of source.
 // It is used for matching source types in configuration and job input.
 func (s *Source) Type() sourcespb.SourceType {
-	return sourcespb.SourceType_SOURCE_TYPE_SYSLOG
+	return SourceType
 }
 
 func (s *Source) SourceID() int64 {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Add a SourceType constant to all source packages, so you don't have to create a `Source` object to get it's type.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

