### PR TITLE
fix: add missing error check in archive handler

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -102,6 +102,10 @@ func (a *Archive) openArchive(ctx context.Context, depth int, reader io.Reader, 
 		return a.handleNonArchiveContent(ctx, arReader, archiveChan)
 	}
 
+	if err != nil {
+		return err
+	}
+
 	switch archive := format.(type) {
 	case archiver.Decompressor:
 		info := decompressorInfo{depth: depth, reader: arReader, archiveChan: archiveChan, archiver: archive}

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -236,3 +236,15 @@ func TestExtractRPMContent(t *testing.T) {
 	expectedLength := 1822720
 	assert.Equal(t, expectedLength, len(string(content)))
 }
+
+func TestOpenInvalidArchive(t *testing.T) {
+	reader := strings.NewReader("invalid archive")
+
+	ctx := logContext.AddLogger(context.Background())
+	a := &Archive{}
+
+	archiveChan := make(chan []byte)
+
+	err := a.openArchive(ctx, 0, reader, archiveChan)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Fixes #1769

### Description:

The existing error check `errors.Is(err, archiver.ErrNoMatch) && depth > 0` only conditionally handled a specific error.

Any other error case was not short circuited and ended up causing a nil-pointer dereference further down the method when `format.Name()` was invoked.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

