### PR TITLE
Update Source interface to use SourceID and JobID types

### DIFF
--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -66,7 +66,7 @@ type ResultWithMetadata struct {
 	// SourceMetadata contains source-specific contextual information.
 	SourceMetadata *source_metadatapb.MetaData
 	// SourceID is the ID of the source that the API uses to map secrets to specific sources.
-	SourceID int64
+	SourceID sources.SourceID
 	// SourceType is the type of Source.
 	SourceType sourcespb.SourceType
 	// SourceName is the name of the Source.

--- a/pkg/engine/circleci.go
+++ b/pkg/engine/circleci.go
@@ -30,7 +30,7 @@ func (e *Engine) ScanCircleCI(ctx context.Context, token string) error {
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, circleci.SourceType)
 
 	circleSource := &circleci.Source{}
-	if err := circleSource.Init(ctx, "trufflehog - Circle CI", int64(jobID), int64(sourceID), true, &conn, runtime.NumCPU()); err != nil {
+	if err := circleSource.Init(ctx, "trufflehog - Circle CI", jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return err
 	}
 	_, err = e.sourceManager.Run(ctx, sourceName, circleSource)

--- a/pkg/engine/docker.go
+++ b/pkg/engine/docker.go
@@ -15,7 +15,7 @@ func (e *Engine) ScanDocker(ctx context.Context, conn *anypb.Any) error {
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, docker.SourceType)
 
 	dockerSource := &docker.Source{}
-	if err := dockerSource.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, conn, runtime.NumCPU()); err != nil {
+	if err := dockerSource.Init(ctx, sourceName, jobID, sourceID, true, conn, runtime.NumCPU()); err != nil {
 		return err
 	}
 	_, err := e.sourceManager.Run(ctx, sourceName, dockerSource)

--- a/pkg/engine/filesystem.go
+++ b/pkg/engine/filesystem.go
@@ -29,7 +29,7 @@ func (e *Engine) ScanFileSystem(ctx context.Context, c sources.FilesystemConfig)
 
 	fileSystemSource := &filesystem.Source{}
 	fileSystemSource.WithFilter(c.Filter)
-	if err := fileSystemSource.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, &conn, runtime.NumCPU()); err != nil {
+	if err := fileSystemSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return err
 	}
 	_, err = e.sourceManager.Run(ctx, sourceName, fileSystemSource)

--- a/pkg/engine/gcs.go
+++ b/pkg/engine/gcs.go
@@ -48,7 +48,7 @@ func (e *Engine) ScanGCS(ctx context.Context, c sources.GCSConfig) error {
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, gcs.SourceType)
 
 	gcsSource := &gcs.Source{}
-	if err := gcsSource.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, &conn, int(c.Concurrency)); err != nil {
+	if err := gcsSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, int(c.Concurrency)); err != nil {
 		return err
 	}
 	_, err = e.sourceManager.Run(ctx, sourceName, gcsSource)

--- a/pkg/engine/git.go
+++ b/pkg/engine/git.go
@@ -55,7 +55,7 @@ func (e *Engine) ScanGit(ctx context.Context, c sources.GitConfig) error {
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, git.SourceType)
 
 	gitSource := &git.Source{}
-	if err := gitSource.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, &conn, runtime.NumCPU()); err != nil {
+	if err := gitSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return err
 	}
 	gitSource.WithScanOptions(scanOptions)

--- a/pkg/engine/github.go
+++ b/pkg/engine/github.go
@@ -51,7 +51,7 @@ func (e *Engine) ScanGitHub(ctx context.Context, c sources.GithubConfig) error {
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, github.SourceType)
 
 	githubSource := &github.Source{}
-	if err := githubSource.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, &conn, c.Concurrency); err != nil {
+	if err := githubSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, c.Concurrency); err != nil {
 		return err
 	}
 	githubSource.WithScanOptions(scanOptions)

--- a/pkg/engine/gitlab.go
+++ b/pkg/engine/gitlab.go
@@ -54,7 +54,7 @@ func (e *Engine) ScanGitLab(ctx context.Context, c sources.GitlabConfig) error {
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, gitlab.SourceType)
 
 	gitlabSource := &gitlab.Source{}
-	if err := gitlabSource.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, &conn, runtime.NumCPU()); err != nil {
+	if err := gitlabSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return err
 	}
 	gitlabSource.WithScanOptions(scanOptions)

--- a/pkg/engine/s3.go
+++ b/pkg/engine/s3.go
@@ -62,7 +62,7 @@ func (e *Engine) ScanS3(ctx context.Context, c sources.S3Config) error {
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, s3.SourceType)
 
 	s3Source := &s3.Source{}
-	if err := s3Source.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, &conn, runtime.NumCPU()); err != nil {
+	if err := s3Source.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return err
 	}
 	_, err = e.sourceManager.Run(ctx, sourceName, s3Source)

--- a/pkg/engine/syslog.go
+++ b/pkg/engine/syslog.go
@@ -44,7 +44,7 @@ func (e *Engine) ScanSyslog(ctx context.Context, c sources.SyslogConfig) error {
 	sourceName := "trufflehog - syslog"
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, syslog.SourceType)
 	syslogSource := &syslog.Source{}
-	if err := syslogSource.Init(ctx, sourceName, int64(jobID), int64(sourceID), true, &conn, c.Concurrency); err != nil {
+	if err := syslogSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, c.Concurrency); err != nil {
 		return err
 	}
 	syslogSource.InjectConnection(connection)

--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -10,6 +10,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
 // JSONPrinter is a printer that prints results in JSON format.
@@ -20,7 +21,7 @@ func (p *JSONPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) 
 		// SourceMetadata contains source-specific contextual information.
 		SourceMetadata *source_metadatapb.MetaData
 		// SourceID is the ID of the source that the API uses to map secrets to specific sources.
-		SourceID int64
+		SourceID sources.SourceID
 		// SourceType is the type of Source.
 		SourceType sourcespb.SourceType
 		// SourceName is the name of the Source.

--- a/pkg/sources/circleci/circleci.go
+++ b/pkg/sources/circleci/circleci.go
@@ -28,8 +28,8 @@ const (
 type Source struct {
 	name     string
 	token    string
-	sourceId int64
-	jobId    int64
+	sourceId sources.SourceID
+	jobId    sources.JobID
 	verify   bool
 	jobPool  *errgroup.Group
 	sources.Progress
@@ -47,16 +47,16 @@ func (s *Source) Type() sourcespb.SourceType {
 	return SourceType
 }
 
-func (s *Source) SourceID() int64 {
+func (s *Source) SourceID() sources.SourceID {
 	return s.sourceId
 }
 
-func (s *Source) JobID() int64 {
+func (s *Source) JobID() sources.JobID {
 	return s.jobId
 }
 
 // Init returns an initialized CircleCI source.
-func (s *Source) Init(_ context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(_ context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
 	s.name = name
 	s.sourceId = sourceId
 	s.jobId = jobId

--- a/pkg/sources/docker/docker.go
+++ b/pkg/sources/docker/docker.go
@@ -28,8 +28,8 @@ const SourceType = sourcespb.SourceType_SOURCE_TYPE_DOCKER
 
 type Source struct {
 	name        string
-	sourceId    int64
-	jobId       int64
+	sourceId    sources.SourceID
+	jobId       sources.JobID
 	verify      bool
 	concurrency int
 	conn        sourcespb.Docker
@@ -47,16 +47,16 @@ func (s *Source) Type() sourcespb.SourceType {
 	return SourceType
 }
 
-func (s *Source) SourceID() int64 {
+func (s *Source) SourceID() sources.SourceID {
 	return s.sourceId
 }
 
-func (s *Source) JobID() int64 {
+func (s *Source) JobID() sources.JobID {
 	return s.jobId
 }
 
 // Init initializes the source.
-func (s *Source) Init(_ context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(_ context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
 	s.name = name
 	s.sourceId = sourceId
 	s.jobId = jobId

--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -26,8 +26,8 @@ const SourceType = sourcespb.SourceType_SOURCE_TYPE_FILESYSTEM
 
 type Source struct {
 	name     string
-	sourceId int64
-	jobId    int64
+	sourceId sources.SourceID
+	jobId    sources.JobID
 	verify   bool
 	paths    []string
 	log      logr.Logger
@@ -48,16 +48,16 @@ func (s *Source) Type() sourcespb.SourceType {
 	return SourceType
 }
 
-func (s *Source) SourceID() int64 {
+func (s *Source) SourceID() sources.SourceID {
 	return s.sourceId
 }
 
-func (s *Source) JobID() int64 {
+func (s *Source) JobID() sources.JobID {
 	return s.jobId
 }
 
 // Init returns an initialized Filesystem source.
-func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, _ int) error {
+func (s *Source) Init(aCtx context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, _ int) error {
 	s.log = aCtx.Logger()
 
 	s.name = name

--- a/pkg/sources/gcs/gcs.go
+++ b/pkg/sources/gcs/gcs.go
@@ -45,12 +45,12 @@ func (s *Source) Type() sourcespb.SourceType {
 }
 
 // SourceID number for GCS Source.
-func (s *Source) SourceID() int64 {
+func (s *Source) SourceID() sources.SourceID {
 	return s.sourceId
 }
 
 // JobID number for GCS Source.
-func (s *Source) JobID() int64 {
+func (s *Source) JobID() sources.JobID {
 	return s.jobId
 }
 
@@ -62,8 +62,8 @@ type objectManager interface {
 // Source represents a GCS source.
 type Source struct {
 	name        string
-	jobId       int64
-	sourceId    int64
+	jobId       sources.JobID
+	sourceId    sources.SourceID
 	concurrency int
 	verify      bool
 
@@ -111,7 +111,7 @@ func (c *persistableCache) shouldPersist() (bool, string) {
 }
 
 // Init returns an initialized GCS source.
-func (s *Source) Init(aCtx context.Context, name string, id int64, sourceID int64, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(aCtx context.Context, name string, id sources.JobID, sourceID sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
 	s.log = aCtx.Logger()
 
 	s.name = name

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -38,8 +38,8 @@ const SourceType = sourcespb.SourceType_SOURCE_TYPE_GIT
 
 type Source struct {
 	name     string
-	sourceId int64
-	jobId    int64
+	sourceId sources.SourceID
+	jobId    sources.JobID
 	verify   bool
 	git      *Git
 	sources.Progress
@@ -53,8 +53,8 @@ type Source struct {
 type Git struct {
 	sourceType         sourcespb.SourceType
 	sourceName         string
-	sourceID           int64
-	jobID              int64
+	sourceID           sources.SourceID
+	jobID              sources.JobID
 	sourceMetadataFunc func(file, email, commit, timestamp, repository string, line int64) *source_metadatapb.MetaData
 	verify             bool
 	metrics            metrics
@@ -65,7 +65,7 @@ type metrics struct {
 	commitsScanned uint64
 }
 
-func NewGit(sourceType sourcespb.SourceType, jobID, sourceID int64, sourceName string, verify bool, concurrency int,
+func NewGit(sourceType sourcespb.SourceType, jobID sources.JobID, sourceID sources.SourceID, sourceName string, verify bool, concurrency int,
 	sourceMetadataFunc func(file, email, commit, timestamp, repository string, line int64) *source_metadatapb.MetaData,
 ) *Git {
 	return &Git{
@@ -89,11 +89,11 @@ func (s *Source) Type() sourcespb.SourceType {
 	return SourceType
 }
 
-func (s *Source) SourceID() int64 {
+func (s *Source) SourceID() sources.SourceID {
 	return s.sourceId
 }
 
-func (s *Source) JobID() int64 {
+func (s *Source) JobID() sources.JobID {
 	return s.jobId
 }
 
@@ -111,7 +111,7 @@ func (s *Source) WithPreserveTempDirs(preserve bool) {
 }
 
 // Init returns an initialized GitHub source.
-func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(aCtx context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
 	s.name = name
 	s.sourceId = sourceId
 	s.jobId = jobId

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -53,8 +53,8 @@ type Source struct {
 	githubUser  string
 	githubToken string
 
-	sourceID          int64
-	jobID             int64
+	sourceID          sources.SourceID
+	jobID             sources.JobID
 	verify            bool
 	repos             []string
 	members           []string
@@ -109,11 +109,11 @@ func (s *Source) Type() sourcespb.SourceType {
 	return SourceType
 }
 
-func (s *Source) SourceID() int64 {
+func (s *Source) SourceID() sources.SourceID {
 	return s.sourceID
 }
 
-func (s *Source) JobID() int64 {
+func (s *Source) JobID() sources.JobID {
 	return s.jobID
 }
 
@@ -202,7 +202,7 @@ func (c *filteredRepoCache) includeRepo(s string) bool {
 }
 
 // Init returns an initialized GitHub source.
-func (s *Source) Init(aCtx context.Context, name string, jobID, sourceID int64, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, sourceID sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
 	s.log = aCtx.Logger()
 
 	s.name = name

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -33,8 +33,8 @@ const SourceType = sourcespb.SourceType_SOURCE_TYPE_GITLAB
 
 type Source struct {
 	name            string
-	sourceId        int64
-	jobId           int64
+	sourceId        sources.SourceID
+	jobId           sources.JobID
 	verify          bool
 	authMethod      string
 	user            string
@@ -62,16 +62,16 @@ func (s *Source) Type() sourcespb.SourceType {
 	return SourceType
 }
 
-func (s *Source) SourceID() int64 {
+func (s *Source) SourceID() sources.SourceID {
 	return s.sourceId
 }
 
-func (s *Source) JobID() int64 {
+func (s *Source) JobID() sources.JobID {
 	return s.jobId
 }
 
 // Init returns an initialized Gitlab source.
-func (s *Source) Init(_ context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(_ context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
 	s.name = name
 	s.sourceId = sourceId
 	s.jobId = jobId

--- a/pkg/sources/job_progress.go
+++ b/pkg/sources/job_progress.go
@@ -43,8 +43,8 @@ type JobProgressHook interface {
 // If the job supports it, the reference can also be used to cancel running via
 // CancelRun.
 type JobProgressRef struct {
-	JobID       int64
-	SourceID    int64
+	JobID       JobID
+	SourceID    SourceID
 	SourceName  string
 	jobProgress *JobProgress
 }
@@ -101,8 +101,8 @@ func (f ChunkError) Unwrap() error { return f.err }
 // JobProgress aggregates information about a run of a Source.
 type JobProgress struct {
 	// Unique identifiers for this job.
-	JobID      int64
-	SourceID   int64
+	JobID      JobID
+	SourceID   SourceID
 	SourceName string
 	// Tracks whether the job is finished or not.
 	ctx    context.Context
@@ -155,7 +155,7 @@ func WithCancel(cancel context.CancelCauseFunc) func(*JobProgress) {
 }
 
 // NewJobProgress creates a new job report for the given source and job ID.
-func NewJobProgress(jobID, sourceID int64, sourceName string, opts ...func(*JobProgress)) *JobProgress {
+func NewJobProgress(jobID JobID, sourceID SourceID, sourceName string, opts ...func(*JobProgress)) *JobProgress {
 	ctx, cancel := context.WithCancel(context.Background())
 	jp := &JobProgress{
 		JobID:      jobID,

--- a/pkg/sources/job_progress_test.go
+++ b/pkg/sources/job_progress_test.go
@@ -38,8 +38,8 @@ func TestJobProgressFatalErrors(t *testing.T) {
 func TestJobProgressRef(t *testing.T) {
 	jp := NewJobProgress(123, 456, "source name")
 	ref := jp.Ref()
-	assert.Equal(t, int64(123), ref.JobID)
-	assert.Equal(t, int64(456), ref.SourceID)
+	assert.Equal(t, JobID(123), ref.JobID)
+	assert.Equal(t, SourceID(456), ref.SourceID)
 
 	// Test Done() blocks until Finish() is called.
 	select {

--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -40,8 +40,8 @@ const (
 
 type Source struct {
 	name        string
-	sourceId    int64
-	jobId       int64
+	sourceId    sources.SourceID
+	jobId       sources.JobID
 	verify      bool
 	concurrency int
 	log         logr.Logger
@@ -63,16 +63,16 @@ func (s *Source) Type() sourcespb.SourceType {
 	return SourceType
 }
 
-func (s *Source) SourceID() int64 {
+func (s *Source) SourceID() sources.SourceID {
 	return s.sourceId
 }
 
-func (s *Source) JobID() int64 {
+func (s *Source) JobID() sources.JobID {
 	return s.jobId
 }
 
 // Init returns an initialized AWS source
-func (s *Source) Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(aCtx context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
 	s.log = context.WithValues(aCtx, "source", s.Type(), "name", name).Logger()
 
 	s.name = name

--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -30,11 +30,6 @@ type SourceManager struct {
 	done bool
 }
 
-type (
-	SourceID int64
-	JobID    int64
-)
-
 // apiClient is an interface for optionally communicating with an external API.
 type apiClient interface {
 	// GetIDs informs the API of the source that's about to run and returns

--- a/pkg/sources/source_manager_test.go
+++ b/pkg/sources/source_manager_test.go
@@ -15,15 +15,15 @@ import (
 
 // DummySource implements Source and is used for testing a SourceManager.
 type DummySource struct {
-	sourceID int64
-	jobID    int64
+	sourceID SourceID
+	jobID    JobID
 	chunker
 }
 
 func (d *DummySource) Type() sourcespb.SourceType { return 1337 }
-func (d *DummySource) SourceID() int64            { return d.sourceID }
-func (d *DummySource) JobID() int64               { return d.jobID }
-func (d *DummySource) Init(_ context.Context, _ string, jobID, sourceID int64, _ bool, _ *anypb.Any, _ int) error {
+func (d *DummySource) SourceID() SourceID         { return d.sourceID }
+func (d *DummySource) JobID() JobID               { return d.jobID }
+func (d *DummySource) Init(_ context.Context, _ string, jobID JobID, sourceID SourceID, _ bool, _ *anypb.Any, _ int) error {
 	d.sourceID = sourceID
 	d.jobID = jobID
 	return nil

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -11,14 +11,19 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 )
 
+type (
+	SourceID int64
+	JobID    int64
+)
+
 // Chunk contains data to be decoded and scanned along with context on where it came from.
 type Chunk struct {
 	// SourceName is the name of the Source that produced the chunk.
 	SourceName string
 	// SourceID is the ID of the source that the Chunk originated from.
-	SourceID int64
+	SourceID SourceID
 	// JobID is the ID of the job that the Chunk originated from.
-	JobID int64
+	JobID JobID
 	// SourceType is the type of Source that produced the chunk.
 	SourceType sourcespb.SourceType
 	// SourceMetadata holds the context of where the Chunk was found.
@@ -45,11 +50,11 @@ type Source interface {
 	// Type returns the source type, used for matching against configuration and jobs.
 	Type() sourcespb.SourceType
 	// SourceID returns the initialized source ID used for tracking relationships in the DB.
-	SourceID() int64
+	SourceID() SourceID
 	// JobID returns the initialized job ID used for tracking relationships in the DB.
-	JobID() int64
+	JobID() JobID
 	// Init initializes the source.
-	Init(aCtx context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error
+	Init(aCtx context.Context, name string, jobId JobID, sourceId SourceID, verify bool, connection *anypb.Any, concurrency int) error
 	// Chunks emits data over a channel which is then decoded and scanned for secrets.
 	// By default, data is obtained indiscriminately. However, by providing one or more
 	// ChunkingTarget parameters, the caller can direct the function to retrieve

--- a/pkg/sources/syslog/syslog.go
+++ b/pkg/sources/syslog/syslog.go
@@ -31,8 +31,8 @@ const (
 
 type Source struct {
 	name     string
-	sourceId int64
-	jobId    int64
+	sourceId sources.SourceID
+	jobId    sources.JobID
 	verify   bool
 	syslog   *Syslog
 	sources.Progress
@@ -42,14 +42,14 @@ type Source struct {
 type Syslog struct {
 	sourceType         sourcespb.SourceType
 	sourceName         string
-	sourceID           int64
-	jobID              int64
+	sourceID           sources.SourceID
+	jobID              sources.JobID
 	sourceMetadataFunc func(hostname, appname, procid, timestamp, facility, client string) *source_metadatapb.MetaData
 	verify             bool
 	concurrency        *semaphore.Weighted
 }
 
-func NewSyslog(sourceType sourcespb.SourceType, jobID, sourceID int64, sourceName string, verify bool, concurrency int,
+func NewSyslog(sourceType sourcespb.SourceType, jobID sources.JobID, sourceID sources.SourceID, sourceName string, verify bool, concurrency int,
 	sourceMetadataFunc func(hostname, appname, procid, timestamp, facility, client string) *source_metadatapb.MetaData,
 ) *Syslog {
 	return &Syslog{
@@ -110,11 +110,11 @@ func (s *Source) Type() sourcespb.SourceType {
 	return SourceType
 }
 
-func (s *Source) SourceID() int64 {
+func (s *Source) SourceID() sources.SourceID {
 	return s.sourceId
 }
 
-func (s *Source) JobID() int64 {
+func (s *Source) JobID() sources.JobID {
 	return s.jobId
 }
 
@@ -123,7 +123,7 @@ func (s *Source) InjectConnection(conn *sourcespb.Syslog) {
 }
 
 // Init returns an initialized Syslog source.
-func (s *Source) Init(_ context.Context, name string, jobId, sourceId int64, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(_ context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
 
 	s.name = name
 	s.sourceId = sourceId


### PR DESCRIPTION
### Description:
The previous implementation used int64 for both, which can be mixed up easily. Using distinct types adds a layer of type safety checked by the compiler.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

