### PR TITLE
migrate buildpulse to integration test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,30 @@ jobs:
         service_account: 'github-ci-external@trufflehog-testing.iam.gserviceaccount.com'
     - name: Test
       run: make test-integration
+    - name: Set up gotestsum
+      run: |
+        go install gotest.tools/gotestsum@latest
+        mkdir -p tmp/test-results
+    - name: Test 
+      run: |
+        CGO_ENABLED=1 gotestsum --junitfile tmp/test-results/test.xml --raw-command -- go test -json -tags=sources $(go list ./... | grep -v /vendor/ | grep -v pkg/detectors)
+      if: ${{ success() || failure() }} # always run this step, even if there were previous errors
+    - name: Upload test results to BuildPulse for flaky test detection
+      if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
+      uses: buildpulse/buildpulse-action@main
+      with:
+        account: 79229934
+        repository: 77726177
+        path: |
+          tmp/test-results/*.xml
+        key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
+        secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
+        tags: integration
+    - name: Annotate test results
+      uses: mikepenz/action-junit-report@v3
+      if: success() || failure() # always run even if the previous step fails
+      with:
+        report_paths: 'tmp/test-results/*.xml'
   test-detectors:
     if: ${{ ! github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
@@ -66,27 +90,5 @@ jobs:
         go-version: '1.21'
     - name: Checkout code
       uses: actions/checkout@v3
-    - name: Set up gotestsum
-      run: |
-        go install gotest.tools/gotestsum@latest
-        mkdir -p tmp/test-results
-    - name: Test 
-      run: |
-        CGO_ENABLED=1 gotestsum --junitfile tmp/test-results/test.xml --raw-command -- go test -json -tags=sources $(go list ./... | grep -v /vendor/ | grep -v pkg/detectors | grep -v pkg/sources)
-      if: ${{ success() || failure() }} # always run this step, even if there were previous errors
-    - name: Upload test results to BuildPulse for flaky test detection
-      if: '!cancelled()' # Run this step even when the tests fail. Skip if the workflow is cancelled.
-      uses: buildpulse/buildpulse-action@main
-      with:
-        account: 79229934
-        repository: 77726177
-        path: |
-          tmp/test-results/*.xml
-        key: ${{ secrets.BUILDPULSE_ACCESS_KEY_ID }}
-        secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
-        tags: community
-    - name: Annotate test results
-      uses: mikepenz/action-junit-report@v3
-      if: success() || failure() # always run even if the previous step fails
-      with:
-        report_paths: 'tmp/test-results/*.xml'
+    - name: Test
+      run: make test-community


### PR DESCRIPTION
### Description:
After discussion with @rosecodym on the best source for test data, we decided to move buildpulse to the integration test suite

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

