### PR TITLE
added regex to detect the old format for dockerhub tokens

### DIFF
--- a/pkg/detectors/dockerhub/dockerhub.go
+++ b/pkg/detectors/dockerhub/dockerhub.go
@@ -26,7 +26,7 @@ var (
 	emailPat    = regexp.MustCompile(common.EmailPattern)
 
 	// Can use password or personal access token (PAT) for login, but this scanner will only check for PATs.
-	accessTokenPat = regexp.MustCompile(`\bdckr_pat_([a-zA-Z0-9_-]{27}\b)|\b[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}\b`)
+	accessTokenPat = regexp.MustCompile(`\b(dckr_pat_[a-zA-Z0-9_-]{27}|[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/dockerhub/dockerhub.go
+++ b/pkg/detectors/dockerhub/dockerhub.go
@@ -32,7 +32,7 @@ var (
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"docker"}
+	return []string{"dckr_pat_","docker"}
 }
 
 // FromData will find and optionally verify Dockerhub secrets in a given set of bytes.

--- a/pkg/detectors/dockerhub/dockerhub.go
+++ b/pkg/detectors/dockerhub/dockerhub.go
@@ -22,17 +22,17 @@ var (
 	client = common.SaneHttpClient()
 
 	// Can use email or username for login.
-	usernamePat = regexp.MustCompile(`(?im)(?:user|usr|-u)\S{0,40}?[:=\s]{1,3}[ '"=]?([a-zA-Z0-9]{4,40})\b`)
+	usernamePat = regexp.MustCompile(`(?im)(?:user|usr|-u|id)\S{0,40}?[:=\s]{1,3}[ '"=]?([a-zA-Z0-9]{4,40})\b`)
 	emailPat    = regexp.MustCompile(common.EmailPattern)
 
 	// Can use password or personal access token (PAT) for login, but this scanner will only check for PATs.
-	accessTokenPat = regexp.MustCompile(`\bdckr_pat_([a-zA-Z0-9_-]){27}\b`)
+	accessTokenPat = regexp.MustCompile(`\bdckr_pat_([a-zA-Z0-9_-]{27}\b)|\b[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"dckr_pat_"}
+	return []string{"docker"}
 }
 
 // FromData will find and optionally verify Dockerhub secrets in a given set of bytes.


### PR DESCRIPTION
This PR added to the dockerhub regex detecting the old format of the dockerhub token which is still active. Also added another parameter for username detection "id".

Tested and it works

