### PR TITLE
Ability to update line number in link

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -548,8 +548,9 @@ func (e *Engine) processResult(ctx context.Context, data detectableChunk, res de
 		}
 		fragStart, mdLine, link := FragmentFirstLineAndLink(&copyChunk)
 		ignoreLinePresent = SetResultLineNumber(&copyChunk, &res, fragStart, mdLine)
-		newLink := giturl.UpdateLinkLineNumber(ctx, link, *mdLine)
-		copyChunk.SourceMetadata.GetGithub().Link = newLink
+		if link != "" {
+			copyChunk.SourceMetadata.GetGithub().Link = giturl.UpdateLinkLineNumber(ctx, link, *mdLine)
+		}
 		data.chunk = copyChunk
 	}
 	if ignoreLinePresent {

--- a/pkg/giturl/giturl.go
+++ b/pkg/giturl/giturl.go
@@ -151,7 +151,6 @@ var linePattern = regexp.MustCompile(`L\d+`)
 
 // UpdateLinkLineNumber updates the line number in a repository link.
 // Used post-link generation to refine reported issue locations within large scanned blocks.
-// Also checks for an "ignore tag" on the result line, allowing certain detections to be disregarded.
 func UpdateLinkLineNumber(ctx context.Context, link string, newLine int64) string {
 	parsedURL, err := url.Parse(link)
 	if err != nil {

--- a/pkg/giturl/giturl.go
+++ b/pkg/giturl/giturl.go
@@ -171,6 +171,8 @@ func UpdateLinkLineNumber(ctx context.Context, link string, newLine int64) strin
 		parsedURL.RawQuery = query.Encode()
 
 	case providerGithub, providerGitlab:
+		// If the provider name isn't one of the cloud defaults, it is probably an on-prem github or gitlab.
+		// So do the same thing.
 		fallthrough
 	default:
 		// Assumed format: .../blob/<commit>/file.go#L<number>

--- a/pkg/giturl/giturl_test.go
+++ b/pkg/giturl/giturl_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 
 func Test_NormalizeOrgRepoURL(t *testing.T) {
@@ -183,6 +185,79 @@ func TestGenerateLink(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := GenerateLink(tt.args.repo, tt.args.commit, tt.args.file, tt.args.line); got != tt.want {
 				t.Errorf("generateLink() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateLinkLineNumber(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		link    string
+		newLine int64
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Update github link with line",
+			args: args{
+				link:    "https://github.com/trufflesec-julian/confluence-go-api/blob/047b4a2ba42fc5b6c0bd535c5307434a666db5ec/.gitignore#L4",
+				newLine: int64(10),
+			},
+			want: "https://github.com/trufflesec-julian/confluence-go-api/blob/047b4a2ba42fc5b6c0bd535c5307434a666db5ec/.gitignore#L10",
+		},
+		{
+			name: "Update Azure link with line",
+			args: args{
+				link:    "https://dev.azure.com/org/project/_git/repo/commit/abcdef/main.go?line=20",
+				newLine: int64(40),
+			},
+			want: "https://dev.azure.com/org/project/_git/repo/commit/abcdef/main.go?line=40",
+		},
+		{
+			name: "Add line to github link without line",
+			args: args{
+				link:    "https://github.com/trufflesec-julian/confluence-go-api/blob/047b4a2ba42fc5b6c0bd535c5307434a666db5ec/.gitignore",
+				newLine: int64(7),
+			},
+			want: "https://github.com/trufflesec-julian/confluence-go-api/blob/047b4a2ba42fc5b6c0bd535c5307434a666db5ec/.gitignore#L7",
+		},
+		{
+			name: "Update Unknown provider on-prem instance with line",
+			args: args{
+				link:    "https://onprem.customdomain.com/org/repo/blob/xyz123/main.go#L30",
+				newLine: int64(50),
+			},
+			want: "https://onprem.customdomain.com/org/repo/blob/xyz123/main.go#L50",
+		},
+		{
+			name: "Update Unknown provider on-prem instance without line",
+			args: args{
+				link:    "https://onprem.customdomain.com/org/repo/commit/xyz123",
+				newLine: int64(50),
+			},
+			want: "https://onprem.customdomain.com/org/repo/commit/xyz123#L50",
+		},
+		{
+			name: "Invalid link",
+			args: args{
+				link:    "definitely not a link",
+				newLine: int64(50),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := UpdateLinkLineNumber(context.Background(), tt.args.link, tt.args.newLine)
+			if got != tt.want && !tt.wantErr {
+				t.Errorf("UpdateLinkLineNumber() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/giturl/giturl_test.go
+++ b/pkg/giturl/giturl_test.go
@@ -204,6 +204,14 @@ func TestUpdateLinkLineNumber(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "Update bitbucket, no line number supported",
+			args: args{
+				link:    "https://bitbucket.org/org/repo/blob/xyz123/main.go",
+				newLine: int64(10),
+			},
+			want: "https://bitbucket.org/org/repo/blob/xyz123/main.go",
+		},
+		{
 			name: "Update github link with line",
 			args: args{
 				link:    "https://github.com/trufflesec-julian/confluence-go-api/blob/047b4a2ba42fc5b6c0bd535c5307434a666db5ec/.gitignore#L4",


### PR DESCRIPTION


<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Add functionality to update a source's link in the metadata with the update line number after detection.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

