### PR TITLE
add line to link for azure repos

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -605,7 +605,8 @@ func SupportsLineNumbers(sourceType sourcespb.SourceType) bool {
 		sourcespb.SourceType_SOURCE_TYPE_GERRIT,
 		sourcespb.SourceType_SOURCE_TYPE_GITHUB_UNAUTHENTICATED_ORG,
 		sourcespb.SourceType_SOURCE_TYPE_PUBLIC_GIT,
-		sourcespb.SourceType_SOURCE_TYPE_FILESYSTEM:
+		sourcespb.SourceType_SOURCE_TYPE_FILESYSTEM,
+		sourcespb.SourceType_SOURCE_TYPE_AZURE_REPOS:
 		return true
 	default:
 		return false
@@ -662,6 +663,9 @@ func FragmentFirstLineAndLink(chunk *sources.Chunk) (int64, *int64, string) {
 	case *source_metadatapb.MetaData_Filesystem:
 		fragmentStart = &metadata.Filesystem.Line
 		link = metadata.Filesystem.Link
+	case *source_metadatapb.MetaData_AzureRepos:
+		fragmentStart = &metadata.AzureRepos.Line
+		link = metadata.AzureRepos.Link
 	default:
 		return 0, nil, ""
 	}
@@ -697,6 +701,8 @@ func UpdateLink(ctx context.Context, metadata *source_metadatapb.MetaData, link 
 		meta.Bitbucket.Link = newLink
 	case *source_metadatapb.MetaData_Filesystem:
 		meta.Filesystem.Link = newLink
+	case *source_metadatapb.MetaData_AzureRepos:
+		meta.AzureRepos.Link = newLink
 	default:
 		return fmt.Errorf("unsupported metadata type")
 	}

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -152,21 +152,27 @@ func TestDefaultDecoders(t *testing.T) {
 }
 
 func TestSupportsLineNumbers(t *testing.T) {
-	testCases := []struct {
-		name     string
-		input    sourcespb.SourceType
-		expected bool
+	tests := []struct {
+		name          string
+		sourceType    sourcespb.SourceType
+		expectedValue bool
 	}{
-		{"Git source type", sourcespb.SourceType_SOURCE_TYPE_GIT, true},
-		{"Github source type", sourcespb.SourceType_SOURCE_TYPE_GITHUB, true},
-		{"Gitlab source type", sourcespb.SourceType_SOURCE_TYPE_GITLAB, true},
+		{"Git source", sourcespb.SourceType_SOURCE_TYPE_GIT, true},
+		{"Github source", sourcespb.SourceType_SOURCE_TYPE_GITHUB, true},
+		{"Gitlab source", sourcespb.SourceType_SOURCE_TYPE_GITLAB, true},
+		{"Bitbucket source", sourcespb.SourceType_SOURCE_TYPE_BITBUCKET, true},
+		{"Gerrit source", sourcespb.SourceType_SOURCE_TYPE_GERRIT, true},
+		{"Github unauthenticated org source", sourcespb.SourceType_SOURCE_TYPE_GITHUB_UNAUTHENTICATED_ORG, true},
+		{"Public Git source", sourcespb.SourceType_SOURCE_TYPE_PUBLIC_GIT, true},
+		{"Filesystem source", sourcespb.SourceType_SOURCE_TYPE_FILESYSTEM, true},
+		{"Azure Repos source", sourcespb.SourceType_SOURCE_TYPE_AZURE_REPOS, true},
+		{"Unsupported type", sourcespb.SourceType_SOURCE_TYPE_BUILDKITE, false},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			if result := SupportsLineNumbers(tc.input); result != tc.expected {
-				t.Errorf("Expected %v for input %v, got %v", tc.expected, tc.input, result)
-			}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SupportsLineNumbers(tt.sourceType)
+			assert.Equal(t, tt.expectedValue, result)
 		})
 	}
 }
@@ -244,6 +250,21 @@ func TestFragmentFirstLineAndLink(t *testing.T) {
 			expectedLink: "https://example.github.com",
 		},
 		{
+			name: "Test Azure Repos Metadata",
+			chunk: &sources.Chunk{
+				SourceMetadata: &source_metadatapb.MetaData{
+					Data: &source_metadatapb.MetaData_AzureRepos{
+						AzureRepos: &source_metadatapb.AzureRepos{
+							Line: 5,
+							Link: "https://example.azure.com",
+						},
+					},
+				},
+			},
+			expectedLine: 5,
+			expectedLink: "https://example.azure.com",
+		},
+		{
 			name:         "Unsupported Type",
 			chunk:        &sources.Chunk{},
 			expectedLine: 0,
@@ -318,6 +339,17 @@ func TestSetLink(t *testing.T) {
 			wantLink: "file:///path/to/example#L3",
 		},
 		{
+			name: "Azure Repos link set",
+			input: &source_metadatapb.MetaData{
+				Data: &source_metadatapb.MetaData_AzureRepos{
+					AzureRepos: &source_metadatapb.AzureRepos{},
+				},
+			},
+			link:     "https://dev.azure.com/example",
+			line:     3,
+			wantLink: "https://dev.azure.com/example?line=3",
+		},
+		{
 			name: "Unsupported metadata type",
 			input: &source_metadatapb.MetaData{
 				Data: &source_metadatapb.MetaData_Git{
@@ -359,6 +391,8 @@ func TestSetLink(t *testing.T) {
 				assert.Equal(t, tt.wantLink, data.Bitbucket.Link, "Bitbucket link mismatch")
 			case *source_metadatapb.MetaData_Filesystem:
 				assert.Equal(t, tt.wantLink, data.Filesystem.Link, "Filesystem link mismatch")
+			case *source_metadatapb.MetaData_AzureRepos:
+				assert.Equal(t, tt.wantLink, data.AzureRepos.Link, "Azure Repos link mismatch")
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Azure Repos also supports line numbers. We should update the link's line number.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

