### PR TITLE
Github partial scan

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -1350,15 +1350,15 @@ func (s *Source) scanTarget(ctx context.Context, target sources.ChunkingTarget, 
 		return fmt.Errorf("unable to parse GitHub URL: %w", err)
 	}
 
-	// The owner is the second segment of the path.
-	// Ex: https://github.com/trufflesecurity/.....
+	// The owner is the second segment and the repo is the third segment of the path.
+	// Ex: https://github.com/owner/repo/.....
 	segments := strings.Split(u.Path, "/")
-	if len(segments) <= 1 {
+	if len(segments) < 3 {
 		return fmt.Errorf("invalid GitHub URL")
 	}
 
 	qry := commitQuery{
-		repo:     meta.GetRepository(),
+		repo:     segments[2],
 		owner:    segments[1],
 		sha:      meta.GetCommit(),
 		filename: meta.GetFile(),

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -423,6 +423,7 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, tar
 
 	// If targets are provided, we're only scanning the data in those targets.
 	// Otherwise, we're scanning all data.
+	// This allows us to only scan the commit where a vulnerability was found.
 	if len(targets) > 0 {
 		return s.scanTargets(ctx, targets, chunksChan)
 	}

--- a/pkg/sources/github/github_integration_test.go
+++ b/pkg/sources/github/github_integration_test.go
@@ -862,7 +862,7 @@ func TestSource_Chunks_TargetedScan(t *testing.T) {
 		wantChunks int
 	}{
 		{
-			name: "targeted scan, one file in commit",
+			name: "targeted scan, one file in small commit",
 			init: init{
 				name:       "test source",
 				connection: &sourcespb.GitHub{Credential: &sourcespb.GitHub_Token{Token: githubToken}},
@@ -873,6 +873,24 @@ func TestSource_Chunks_TargetedScan(t *testing.T) {
 							Link:       "https://github.com/trufflesecurity/test_keys/blob/fbc14303ffbf8fb1c2c1914e8dda7d0121633aca/keys#L4",
 							Commit:     "fbc14303ffbf8fb1c2c1914e8dda7d0121633aca",
 							File:       "keys",
+						},
+					},
+				},
+			},
+			wantChunks: 1,
+		},
+		{
+			name: "targeted scan, one file in med commit",
+			init: init{
+				name:       "test source",
+				connection: &sourcespb.GitHub{Credential: &sourcespb.GitHub_Token{Token: githubToken}},
+				queryCriteria: &source_metadatapb.MetaData{
+					Data: &source_metadatapb.MetaData_Github{
+						Github: &source_metadatapb.Github{
+							Repository: "https://github.com/trufflesecurity/trufflehog.git",
+							Link:       "https://github.com/trufflesecurity/trufflehog/blob/33eed42e17fda8b1a66feaeafcd57efccff26c11/pkg/sources/s3/s3_test.go#L78",
+							Commit:     "33eed42e17fda8b1a66feaeafcd57efccff26c11",
+							File:       "pkg/sources/s3/s3_test.go",
 						},
 					},
 				},

--- a/pkg/sources/github/repo.go
+++ b/pkg/sources/github/repo.go
@@ -239,6 +239,41 @@ func (s *Source) processRepos(ctx context.Context, target string, listRepos repo
 	return nil
 }
 
+// commitQuery represents the details required to fetch a commit.
+type commitQuery struct {
+	repo     string
+	owner    string
+	sha      string
+	filename string
+}
+
+// getDiffForFileInCommit retrieves the diff for a specified file in a commit.
+// If the file or its diff is not found, it returns an error.
+func (s *Source) getDiffForFileInCommit(ctx context.Context, query commitQuery) (string, error) {
+	commit, resp, err := s.apiClient.Repositories.GetCommit(ctx, query.owner, query.repo, query.sha, nil)
+	if handled := s.handleRateLimit(err, resp); handled {
+		return "", fmt.Errorf("error fetching commit %s due to rate limit: %w", query.sha, err)
+	}
+	if err != nil {
+		return "", fmt.Errorf("error fetching commit %s: %w", query.sha, err)
+	}
+
+	// Only return the diff if the file is in the commit.
+	for _, file := range commit.Files {
+		if *file.Filename != query.filename {
+			continue
+		}
+
+		if file.Patch == nil {
+			return "", fmt.Errorf("commit %s file %s does not have a diff", query.sha, query.filename)
+		}
+
+		return *file.Patch, nil
+	}
+
+	return "", fmt.Errorf("commit %s does not contain file %s", query.sha, query.filename)
+}
+
 func (s *Source) normalizeRepo(repo string) (string, error) {
 	// If there's a '/', assume it's a URL and try to normalize it.
 	if strings.ContainsRune(repo, '/') {

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -42,7 +42,7 @@ type Chunk struct {
 // without processing the entire dataset.
 type ChunkingTarget struct {
 	// QueryCriteria represents specific parameters or conditions to target the chunking process.
-	QueryCriteria source_metadatapb.MetaData
+	QueryCriteria *source_metadatapb.MetaData
 }
 
 // Source defines the interface required to implement a source chunker.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Include the ability for the Github source to handle partial scans of the source. This allows us to use the metadata for a secret to only scan the chunk the secret was found in. This can be used for efficient revivification of the secret.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

