### PR TITLE
Update protos image to use correct go version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROTOS_IMAGE ?= trufflesecurity/protos:1.18-0
+PROTOS_IMAGE ?= trufflesecurity/protos:1.21-0
 
 .PHONY: check
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ protos-windows:
 
 release-protos-image:
 	docker buildx build --push --platform=linux/amd64,linux/arm64 \
-	-t trufflesecurity/protos:1.18-0 -f hack/Dockerfile.protos .
+	-t trufflesecurity/protos:1.21-0 -f hack/Dockerfile.protos .
 
 snifftest:
 	./hack/snifftest/snifftest.sh

--- a/hack/Dockerfile.protos
+++ b/hack/Dockerfile.protos
@@ -1,6 +1,6 @@
 # trufflesecurity/protos:1.18-0
 
-FROM golang:1.21-buster
+FROM golang:1.21-bullseye
 
 ARG TARGETARCH
 ARG TARGETOS

--- a/hack/Dockerfile.protos
+++ b/hack/Dockerfile.protos
@@ -1,6 +1,6 @@
 # trufflesecurity/protos:1.18-0
 
-FROM golang:1.18-buster
+FROM golang:1.21-buster
 
 ARG TARGETARCH
 ARG TARGETOS


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Update the protos docker image to use the correct go version (1.21)

### Checklist:
* [X] Tests passing (`make test-community`)?
* [X] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

