### PR TITLE
Use S3 credentials waterfall

### DIFF
--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -130,20 +130,21 @@ func (s *Source) newClient(region, roleArn string) (*s3.S3, error) {
 	cfg.CredentialsChainVerboseErrors = aws.Bool(true)
 	cfg.Region = aws.String(region)
 
-	if roleArn == "" {
-		switch cred := s.conn.GetCredential().(type) {
-		case *sourcespb.S3_SessionToken:
-			cfg.Credentials = credentials.NewStaticCredentials(cred.SessionToken.Key, cred.SessionToken.Secret, cred.SessionToken.SessionToken)
-		case *sourcespb.S3_AccessKey:
-			cfg.Credentials = credentials.NewStaticCredentials(cred.AccessKey.Key, cred.AccessKey.Secret, "")
-		case *sourcespb.S3_Unauthenticated:
-			cfg.Credentials = credentials.AnonymousCredentials
-		case *sourcespb.S3_CloudEnvironment:
-			// Nothing needs to be done!
-		default:
-			return nil, errors.Errorf("invalid configuration given for %s source", s.name)
-		}
-	} else {
+	//if roleArn == "" {
+	switch cred := s.conn.GetCredential().(type) {
+	case *sourcespb.S3_SessionToken:
+		cfg.Credentials = credentials.NewStaticCredentials(cred.SessionToken.Key, cred.SessionToken.Secret, cred.SessionToken.SessionToken)
+	case *sourcespb.S3_AccessKey:
+		cfg.Credentials = credentials.NewStaticCredentials(cred.AccessKey.Key, cred.AccessKey.Secret, "")
+	case *sourcespb.S3_Unauthenticated:
+		cfg.Credentials = credentials.AnonymousCredentials
+	case *sourcespb.S3_CloudEnvironment:
+		// Nothing needs to be done!
+		//default:
+		//	return nil, errors.Errorf("invalid configuration given for %s source", s.name)
+	}
+	//} else {
+	if roleArn != "" {
 		sess, err := session.NewSession(cfg)
 		if err != nil {
 			return nil, err

--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -130,7 +130,6 @@ func (s *Source) newClient(region, roleArn string) (*s3.S3, error) {
 	cfg.CredentialsChainVerboseErrors = aws.Bool(true)
 	cfg.Region = aws.String(region)
 
-	//if roleArn == "" {
 	switch cred := s.conn.GetCredential().(type) {
 	case *sourcespb.S3_SessionToken:
 		cfg.Credentials = credentials.NewStaticCredentials(cred.SessionToken.Key, cred.SessionToken.Secret, cred.SessionToken.SessionToken)
@@ -138,12 +137,11 @@ func (s *Source) newClient(region, roleArn string) (*s3.S3, error) {
 		cfg.Credentials = credentials.NewStaticCredentials(cred.AccessKey.Key, cred.AccessKey.Secret, "")
 	case *sourcespb.S3_Unauthenticated:
 		cfg.Credentials = credentials.AnonymousCredentials
-	case *sourcespb.S3_CloudEnvironment:
-		// Nothing needs to be done!
-		//default:
-		//	return nil, errors.Errorf("invalid configuration given for %s source", s.name)
+	default:
+		// In all other cases, the AWS SDK will follow its normal waterfall logic to pick up credentials (i.e. they can
+		// come from the environment or the credentials file or whatever else AWS gets up to).
 	}
-	//} else {
+
 	if roleArn != "" {
 		sess, err := session.NewSession(cfg)
 		if err != nil {

--- a/pkg/sources/s3/s3_integration_test.go
+++ b/pkg/sources/s3/s3_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/credentialspb"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"

--- a/pkg/sources/s3/s3_integration_test.go
+++ b/pkg/sources/s3/s3_integration_test.go
@@ -181,8 +181,8 @@ func runTestCase(t *testing.T, tt validationTestCase, s3key, s3secret string, cr
 		name += " [creds in config]"
 	} else {
 		setupCreds = func(t *testing.T, _ *sourcespb.S3) {
-			t.Setenv("AWS_ACCESS_KEY_ID", s3key)
-			t.Setenv("AWS_SECRET_ACCESS_KEY", s3secret)
+			//t.Setenv("AWS_ACCESS_KEY_ID", s3key)
+			//t.Setenv("AWS_SECRET_ACCESS_KEY", s3secret)
 		}
 		name += " [creds in env]"
 	}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR updates the S3 source to use explicitly configured credentials if they're available and follow the normal AWS credentials waterfall if they're not. This is irrespective of whether role assumption is configured. This changes the previous behavior, which was to use waterfall credentials **only** if role assumption was configured and explicitly configured credentials **only** when it was not.

### Checklist:
* [x] Tests passing (`make test-community`)?
  * There's failing archive extraction test that seems completely unrelated. I'm chasing that independently.
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

