### PR TITLE
update braintreepayments detector to tri-state verification

### DIFF
--- a/pkg/detectors/braintreepayments/braintreepayments.go
+++ b/pkg/detectors/braintreepayments/braintreepayments.go
@@ -65,7 +65,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if verify {
 				client := s.getClient()
 				url := s.getBraintreeURL()
-				fmt.Println(url)
 				isVerified, verificationErr := verifyBraintree(ctx, client, url, resIdMatch, resMatch)
 				s1.Verified = isVerified
 				s1.VerificationError = verificationErr

--- a/pkg/detectors/braintreepayments/braintreepayments.go
+++ b/pkg/detectors/braintreepayments/braintreepayments.go
@@ -21,11 +21,13 @@ type Scanner struct {
 // Ensure the Scanner satisfies the interface at compile time
 var _ detectors.Detector = (*Scanner)(nil)
 
-var (
-	defaultClient = common.SaneHttpClient()
+const (
 	verifyURL     = "https://payments.braintree-api.com/graphql"
 	verifyTestURL = "https://payments.sandbox.braintree-api.com/graphql"
+)
 
+var (
+	defaultClient = common.SaneHttpClient()
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"braintree"}) + `\b([0-9a-f]{32})\b`)
 	idPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"braintree"}) + `\b([0-9a-z]{16})\b`)
@@ -54,7 +56,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if len(idMatch) != 2 {
 				continue
 			}
-
 			resIdMatch := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/braintreepayments/braintreepayments.go
+++ b/pkg/detectors/braintreepayments/braintreepayments.go
@@ -2,6 +2,7 @@ package braintreepayments
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"regexp"
@@ -12,13 +13,18 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{}
+type Scanner struct {
+	client     *http.Client
+	useTestURL bool
+}
 
 // Ensure the Scanner satisfies the interface at compile time
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClient()
+	defaultClient = common.SaneHttpClient()
+	verifyURL     = "https://payments.braintree-api.com/graphql"
+	verifyTestURL = "https://payments.sandbox.braintree-api.com/graphql"
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"braintree"}) + `\b([0-9a-f]{32})\b`)
@@ -57,34 +63,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				payload := strings.NewReader(`{"query": "query { ping }"}`)
-				req, err := http.NewRequestWithContext(ctx, "POST", "https://payments.braintree-api.com/graphql", payload)
-				if err != nil {
-					continue
-				}
-				req.Header.Add("Content-Type", "application/json")
-				req.Header.Add("Braintree-Version", "2019-01-01")
-				req.SetBasicAuth(resIdMatch, resMatch)
-				res, err := client.Do(req)
-				if err == nil {
-					bodyBytes, err := io.ReadAll(res.Body)
-					if err != nil {
-						continue
-					}
+				client := s.getClient()
+				url := s.getBraintreeURL()
+				fmt.Println(url)
+				isVerified, verificationErr := verifyBraintree(ctx, client, url, resIdMatch, resMatch)
+				s1.Verified = isVerified
+				s1.VerificationError = verificationErr
+			}
 
-					bodyString := string(bodyBytes)
-					validResponse := strings.Contains(bodyString, `"data":{`)
-
-					defer res.Body.Close()
-					if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
-						s1.Verified = true
-					} else {
-						// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key
-						if detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
-							continue
-						}
-					}
-				}
+			// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key
+			if !s1.Verified && detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
+				continue
 			}
 
 			results = append(results, s1)
@@ -92,6 +81,53 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	return results, nil
+}
+
+func (s Scanner) getBraintreeURL() string {
+	if s.useTestURL {
+		return verifyTestURL
+	}
+	return verifyURL
+}
+
+func (s Scanner) getClient() *http.Client {
+	if s.client != nil {
+		return s.client
+	}
+	return defaultClient
+}
+
+func verifyBraintree(ctx context.Context, client *http.Client, url, pubKey, privKey string) (bool, error) {
+	payload := strings.NewReader(`{"query": "query { ping }"}`)
+	req, err := http.NewRequestWithContext(ctx, "POST", url, payload)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Braintree-Version", "2019-01-01")
+	req.SetBasicAuth(pubKey, privKey)
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+
+	bodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return false, err
+	}
+	defer res.Body.Close()
+
+	bodyString := string(bodyBytes)
+	if !(res.StatusCode == http.StatusOK) {
+		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
+
+	validResponse := `"data":{`
+	if strings.Contains(bodyString, validResponse) {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func (s Scanner) Type() detectorspb.DetectorType {

--- a/pkg/detectors/braintreepayments/braintreepayments.go
+++ b/pkg/detectors/braintreepayments/braintreepayments.go
@@ -99,7 +99,7 @@ func (s Scanner) getClient() *http.Client {
 
 func verifyBraintree(ctx context.Context, client *http.Client, url, pubKey, privKey string) (bool, error) {
 	payload := strings.NewReader(`{"query": "query { ping }"}`)
-	req, err := http.NewRequestWithContext(ctx, "POST", url, payload)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, payload)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/detectors/braintreepayments/braintreepayments_test.go
+++ b/pkg/detectors/braintreepayments/braintreepayments_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kylelemons/godebug/pretty"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
@@ -30,15 +31,16 @@ func TestBraintreePayments_FromChunk(t *testing.T) {
 		verify bool
 	}
 	tests := []struct {
-		name    string
-		s       Scanner
-		args    args
-		want    []detectors.Result
-		wantErr bool
+		name                string
+		s                   Scanner
+		args                args
+		want                []detectors.Result
+		wantErr             bool
+		wantVerificationErr bool
 	}{
 		{
 			name: "found, verified",
-			s:    Scanner{},
+			s:    Scanner{useTestURL: true},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a braintree secret %s within braintree %s", secret, id)),
@@ -53,8 +55,46 @@ func TestBraintreePayments_FromChunk(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "found, verified but unexpected api surface",
+			s: Scanner{
+				client: common.ConstantResponseHttpClient(404, ""),
+			},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a braintree secret %s within braintree %s", secret, id)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_BraintreePayments,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+		{
+			name: "found, would be verified if not for timeout",
+			s: Scanner{
+				client: common.SaneHttpClientTimeOut(1 * time.Microsecond),
+			},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a braintree secret %s within braintree %s", secret, id)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_BraintreePayments,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+		{
 			name: "found, unverified",
-			s:    Scanner{},
+			s:    Scanner{useTestURL: true},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a braintree secret %s within braintree %s but not valid", inactiveSecret, id)), // the secret would satisfy the regex but not pass validation
@@ -82,8 +122,7 @@ func TestBraintreePayments_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := Scanner{}
-			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("BraintreePayments.FromData() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -92,9 +131,13 @@ func TestBraintreePayments_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				got[i].Raw = nil
+				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+				}
 			}
-			if diff := pretty.Compare(got, tt.want); diff != "" {
+
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("BraintreePayments.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
 		})


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
update braintreepayments detector to tri-state verification.
also adding sandbox url, otherwise our tests will fail (bc they use sandbox secrets).


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

