### PR TITLE
Fix bug in chunker that surfaces with a flaky passed in io.Reader

### DIFF
--- a/pkg/sources/chunker.go
+++ b/pkg/sources/chunker.go
@@ -34,7 +34,7 @@ func Chunker(originalChunk *Chunk) chan *Chunk {
 			chunkBytes := make([]byte, TotalChunkSize)
 			chunk := *originalChunk
 			chunkBytes = chunkBytes[:ChunkSize]
-			n, err := reader.Read(chunkBytes)
+			n, err := io.ReadFull(reader, chunkBytes)
 			if n > 0 {
 				peekData, _ := reader.Peek(TotalChunkSize - n)
 				chunkBytes = append(chunkBytes[:n], peekData...)

--- a/pkg/sources/chunker.go
+++ b/pkg/sources/chunker.go
@@ -135,7 +135,7 @@ func readInChunks(ctx context.Context, reader io.Reader, config *chunkReaderConf
 			chunkRes := ChunkResult{}
 			chunkBytes := make([]byte, config.totalSize)
 			chunkBytes = chunkBytes[:config.chunkSize]
-			n, err := chunkReader.Read(chunkBytes)
+			n, err := io.ReadFull(chunkReader, chunkBytes)
 			if n > 0 {
 				peekData, _ := chunkReader.Peek(config.totalSize - n)
 				chunkBytes = append(chunkBytes[:n], peekData...)
@@ -143,8 +143,8 @@ func readInChunks(ctx context.Context, reader io.Reader, config *chunkReaderConf
 			}
 
 			// If there is an error other than EOF, or if we have read some bytes, send the chunk.
-			if err != nil && !errors.Is(err, io.EOF) || n > 0 {
-				if err != nil && !errors.Is(err, io.EOF) {
+			if (err != nil && !errors.Is(err, io.ErrUnexpectedEOF)) || n > 0 {
+				if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) {
 					ctx.Logger().Error(err, "error reading chunk")
 					chunkRes.err = err
 				}

--- a/pkg/sources/chunker_test.go
+++ b/pkg/sources/chunker_test.go
@@ -198,7 +198,7 @@ func BenchmarkChunkReader(b *testing.B) {
 	}
 }
 
-func TestFlakyReader(t *testing.T) {
+func TestFlakyChunkReader(t *testing.T) {
 	a := "aaaa"
 	b := "bbbb"
 

--- a/pkg/sources/chunker_test.go
+++ b/pkg/sources/chunker_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"testing/iotest"
 
 	diskbufferreader "github.com/bill-rich/disk-buffer-reader"
 	"github.com/stretchr/testify/assert"
@@ -195,4 +196,24 @@ func BenchmarkChunkReader(b *testing.B) {
 		_, err := reader.Seek(0, 0)
 		assert.Nil(b, err)
 	}
+}
+
+func TestFlakyReader(t *testing.T) {
+	a := "aaaa"
+	b := "bbbb"
+
+	reader := iotest.OneByteReader(strings.NewReader(a + b))
+
+	chunkReader := NewChunkReader()
+	chunkResChan := chunkReader(context.TODO(), reader)
+
+	var chunks []ChunkResult
+	for chunk := range chunkResChan {
+		chunks = append(chunks, chunk)
+	}
+
+	assert.Equal(t, 1, len(chunks))
+	chunk := chunks[0]
+	assert.NoError(t, chunk.Error())
+	assert.Equal(t, a+b, string(chunk.Bytes()))
 }


### PR DESCRIPTION
### Description:

The chunker was previously expecting the passed in io.Reader to always successfully read a full buffer of data, however it's valid for a Reader to return less data than requested. When this happens, the chunker would peek the same data that it then reads in the next iteration of the loop, causing the same data to be scanned twice.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

