### PR TITLE
Add generic glob filter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,6 +81,7 @@ require (
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/h2non/gock.v1 v1.1.2
+	pgregory.net/rapid v1.1.0
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1010,6 +1010,8 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+pgregory.net/rapid v1.1.0 h1:CMa0sjHSru3puNx+J0MIAuiiEV4N0qj8/cMWGBBCsjw=
+pgregory.net/rapid v1.1.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/common/glob/glob.go
+++ b/pkg/common/glob/glob.go
@@ -12,9 +12,6 @@ import (
 type Filter struct {
 	exclude []glob.Glob
 	include []glob.Glob
-	// If an object is not found in either of the filters, return this
-	// value in ShouldInclude.
-	notFoundShouldIncludeBehavior bool
 }
 
 type globFilterOpt func(*Filter) error
@@ -43,26 +40,6 @@ func WithIncludeGlobs(includes ...string) globFilterOpt {
 			}
 			f.include = append(f.include, g)
 		}
-		return nil
-	}
-}
-
-// WithDefaultDeny configures the filter to deny objects that are not found
-// in either exclude or include filter (in the ambiguous case where both are
-// configured).
-func WithDefaultDeny() globFilterOpt {
-	return func(f *Filter) error {
-		f.notFoundShouldIncludeBehavior = false
-		return nil
-	}
-}
-
-// WithDefaultAllow configures the filter to allow objects that are not found
-// in either exclude or include filter (in the ambiguous case where both are
-// configured).
-func WithDefaultAllow() globFilterOpt {
-	return func(f *Filter) error {
-		f.notFoundShouldIncludeBehavior = true
 		return nil
 	}
 }
@@ -96,7 +73,7 @@ func (f *Filter) ShouldInclude(object string) bool {
 			return ok
 		}
 		// Ambiguous case.
-		return f.notFoundShouldIncludeBehavior
+		return false
 	}
 }
 

--- a/pkg/common/glob/glob.go
+++ b/pkg/common/glob/glob.go
@@ -22,7 +22,7 @@ func WithExcludeGlobs(excludes ...string) globFilterOpt {
 		for _, exclude := range excludes {
 			g, err := glob.Compile(exclude)
 			if err != nil {
-				return err
+				return fmt.Errorf("invalid exclude glob %q: %w", exclude, err)
 			}
 			f.exclude = append(f.exclude, g)
 		}
@@ -36,7 +36,7 @@ func WithIncludeGlobs(includes ...string) globFilterOpt {
 		for _, include := range includes {
 			g, err := glob.Compile(include)
 			if err != nil {
-				return err
+				return fmt.Errorf("invalid include glob %q: %w", include, err)
 			}
 			f.include = append(f.include, g)
 		}

--- a/pkg/common/glob/glob.go
+++ b/pkg/common/glob/glob.go
@@ -58,6 +58,9 @@ func NewGlobFilter(opts ...globFilterOpt) (*Filter, error) {
 // Pass returns whether the object is not in the include list or in the exclude
 // list.
 func (f *Filter) Pass(object string) bool {
+	if f == nil {
+		return false
+	}
 	exclude, include := len(f.exclude), len(f.include)
 	if exclude == 0 && include == 0 {
 		return false

--- a/pkg/common/glob/glob.go
+++ b/pkg/common/glob/glob.go
@@ -1,0 +1,120 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/gobwas/glob"
+)
+
+// Filter is a generic filter for excluding and including globs (limited
+// regular expressions). Exclusion takes precedence if both include and exclude
+// lists are provided.
+type Filter struct {
+	exclude []glob.Glob
+	include []glob.Glob
+}
+
+type globFilterOpt func(*Filter) error
+
+// WithExcludeGlobs adds exclude globs to the filter.
+func WithExcludeGlobs(excludes ...string) globFilterOpt {
+	return func(f *Filter) error {
+		for _, exclude := range excludes {
+			g, err := glob.Compile(exclude)
+			if err != nil {
+				return err
+			}
+			f.exclude = append(f.exclude, g)
+		}
+		return nil
+	}
+}
+
+// WithIncludeGlobs adds include globs to the filter.
+func WithIncludeGlobs(includes ...string) globFilterOpt {
+	return func(f *Filter) error {
+		for _, include := range includes {
+			g, err := glob.Compile(include)
+			if err != nil {
+				return err
+			}
+			f.include = append(f.include, g)
+		}
+		return nil
+	}
+}
+
+// NewGlobFilter creates a new Filter with the provided options.
+func NewGlobFilter(opts ...globFilterOpt) (*Filter, error) {
+	filter := &Filter{}
+	for _, opt := range opts {
+		if err := opt(filter); err != nil {
+			return nil, err
+		}
+	}
+	return filter, nil
+}
+
+// Pass returns whether the object is not in the include list or in the exclude
+// list.
+func (f *Filter) Pass(object string) bool {
+	exclude, include := len(f.exclude), len(f.include)
+	if exclude == 0 && include == 0 {
+		return false
+	} else if exclude > 0 && include == 0 {
+		return f.passExclude(object)
+	} else if exclude == 0 && include > 0 {
+		return f.passInclude(object)
+	} else {
+		if pass, err := f.passExcludeInclude(object); err == nil {
+			return pass
+		}
+		// Ambiguous case. Should we skip? Should we not skip?
+		// Let's skip since the user indicated they want *some* form of
+		// filtering.
+		// TODO: Maybe this could be configurable.
+		return true
+	}
+}
+
+// passExclude checks for explicitly excluded paths. This should only be called
+// when the include list is empty.
+func (f *Filter) passExclude(object string) bool {
+	for _, glob := range f.exclude {
+		if glob.Match(object) {
+			return true
+		}
+	}
+	return false
+}
+
+// passInclude checks for explicitly included paths. This should only be called
+// when the exclude list is empty.
+func (f *Filter) passInclude(object string) bool {
+	for _, glob := range f.include {
+		if glob.Match(object) {
+			return false
+		}
+	}
+	return true
+}
+
+// passExcludeInclude checks for either excluded or included paths. Exclusion
+// takes precedence. If neither list contains the object, true is returned.
+func (f *Filter) passExcludeInclude(object string) (bool, error) {
+	// Exclude takes precedence. If we find the object in the exclude list,
+	// we should pass.
+	for _, glob := range f.exclude {
+		if glob.Match(object) {
+			return true, nil
+		}
+	}
+	// If we find the object in the include list, we should not pass.
+	for _, glob := range f.include {
+		if glob.Match(object) {
+			return false, nil
+		}
+	}
+	// If we find it in neither, return an error to let the caller decide.
+	return false, fmt.Errorf("ambiguous match")
+}

--- a/pkg/common/glob/glob_test.go
+++ b/pkg/common/glob/glob_test.go
@@ -108,3 +108,10 @@ func TestGlobNil(t *testing.T) {
 		globTest{"anything else", true},
 	)
 }
+
+func TestGlobErrorContainsGlob(t *testing.T) {
+	invalidGlob := "[this is invalid because it doesn't close the capture group"
+	_, err := NewGlobFilter(WithExcludeGlobs(invalidGlob))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), invalidGlob)
+}

--- a/pkg/common/glob/glob_test.go
+++ b/pkg/common/glob/glob_test.go
@@ -94,17 +94,20 @@ func TestGlobFilterExcludePrecedence(t *testing.T) {
 	)
 }
 
-func TestGlobNil(t *testing.T) {
-	testGlobs(t, nil,
-		globTest{"foo", true},
-		globTest{"bar", true},
-		globTest{"bara", true},
-		globTest{"barb", true},
-		globTest{"barbosa", true},
-		globTest{"foobar", true},
-		globTest{"food", true},
-		globTest{"anything else", true},
-	)
+func TestGlobDefault(t *testing.T) {
+	// Test default *Filter and Filter have the same behavior.
+	for _, filter := range []*Filter{nil, {}} {
+		testGlobs(t, filter,
+			globTest{"foo", true},
+			globTest{"bar", true},
+			globTest{"bara", true},
+			globTest{"barb", true},
+			globTest{"barbosa", true},
+			globTest{"foobar", true},
+			globTest{"food", true},
+			globTest{"anything else", true},
+		)
+	}
 }
 
 func TestGlobErrorContainsGlob(t *testing.T) {

--- a/pkg/common/glob/glob_test.go
+++ b/pkg/common/glob/glob_test.go
@@ -95,3 +95,16 @@ func TestGlobFilterExcludePrecdence(t *testing.T) {
 		globTest{"foobar", true},
 	)
 }
+
+func TestGlobNil(t *testing.T) {
+	testGlobs(t, nil,
+		globTest{"foo", true},
+		globTest{"bar", true},
+		globTest{"bara", true},
+		globTest{"barb", true},
+		globTest{"barbosa", true},
+		globTest{"foobar", true},
+		globTest{"food", true},
+		globTest{"anything else", true},
+	)
+}

--- a/pkg/common/glob/glob_test.go
+++ b/pkg/common/glob/glob_test.go
@@ -16,7 +16,7 @@ func testGlobs(t *testing.T, filter *Filter, tests ...globTest) {
 		t.Run(tt.input, func(t *testing.T) {
 			// Invert because mentally it's easier to say whether an
 			// input should be included.
-			assert.Equal(t, !tt.shouldInclude, filter.Pass(tt.input))
+			assert.Equal(t, tt.shouldInclude, filter.ShouldInclude(tt.input))
 		})
 	}
 }

--- a/pkg/common/glob/glob_test.go
+++ b/pkg/common/glob/glob_test.go
@@ -113,3 +113,33 @@ func TestGlobErrorContainsGlob(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), invalidGlob)
 }
+
+func TestGlobDefaultDeny(t *testing.T) {
+	filter, err := NewGlobFilter(
+		WithExcludeGlobs("/foo/bar/**"),
+		WithIncludeGlobs("/foo/**"),
+		WithDefaultDeny(),
+	)
+	assert.NoError(t, err)
+
+	testGlobs(t, filter,
+		globTest{"/foo/a", true},
+		globTest{"/foo/bar/a", false},
+		globTest{"/any/other/path", false},
+	)
+}
+
+func TestGlobDefaultAllow(t *testing.T) {
+	filter, err := NewGlobFilter(
+		WithExcludeGlobs("/foo/bar/**"),
+		WithIncludeGlobs("/foo/**"),
+		WithDefaultAllow(),
+	)
+	assert.NoError(t, err)
+
+	testGlobs(t, filter,
+		globTest{"/foo/a", true},
+		globTest{"/foo/bar/a", false},
+		globTest{"/any/other/path", true},
+	)
+}

--- a/pkg/common/glob/glob_test.go
+++ b/pkg/common/glob/glob_test.go
@@ -70,23 +70,21 @@ func TestGlobFilterEmpty(t *testing.T) {
 }
 
 func TestGlobFilterExcludeInclude(t *testing.T) {
-	// This is effectively the same as only an include filter.
-	filter, err := NewGlobFilter(WithExcludeGlobs("foo*"), WithIncludeGlobs("bar*"))
+	filter, err := NewGlobFilter(WithExcludeGlobs("/foo/bar/**"), WithIncludeGlobs("/foo/**"))
 	assert.NoError(t, err)
 
 	testGlobs(t, filter,
-		globTest{"foo", false},
-		globTest{"bar", true},
-		globTest{"bara", true},
-		globTest{"barb", true},
-		globTest{"barbosa", true},
-		globTest{"foobar", false},
-		globTest{"food", false},
-		globTest{"ambiguous anything else", false},
+		globTest{"/foo/a", true},
+		globTest{"/foo/b", true},
+		globTest{"/foo/c/d/e", true},
+		globTest{"/foo/bar/a", false},
+		globTest{"/foo/bar/b", false},
+		globTest{"/foo/bar/c/d/e", false},
+		globTest{"/any/other/path", false},
 	)
 }
 
-func TestGlobFilterExcludePrecdence(t *testing.T) {
+func TestGlobFilterExcludePrecedence(t *testing.T) {
 	filter, err := NewGlobFilter(WithExcludeGlobs("foo"), WithIncludeGlobs("foo*"))
 	assert.NoError(t, err)
 

--- a/pkg/common/glob/glob_test.go
+++ b/pkg/common/glob/glob_test.go
@@ -1,0 +1,97 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type globTest struct {
+	input         string
+	shouldInclude bool
+}
+
+func testGlobs(t *testing.T, filter *Filter, tests ...globTest) {
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			// Invert because mentally it's easier to say whether an
+			// input should be included.
+			assert.Equal(t, !tt.shouldInclude, filter.Pass(tt.input))
+		})
+	}
+}
+
+func TestGlobFilterExclude(t *testing.T) {
+	filter, err := NewGlobFilter(WithExcludeGlobs("foo", "bar*"))
+	assert.NoError(t, err)
+
+	testGlobs(t, filter,
+		globTest{"foo", false},
+		globTest{"bar", false},
+		globTest{"bara", false},
+		globTest{"barb", false},
+		globTest{"barbosa", false},
+		globTest{"foobar", true},
+		globTest{"food", true},
+		globTest{"anything else", true},
+	)
+}
+
+func TestGlobFilterInclude(t *testing.T) {
+	filter, err := NewGlobFilter(WithIncludeGlobs("foo", "bar*"))
+	assert.NoError(t, err)
+
+	testGlobs(t, filter,
+		globTest{"foo", true},
+		globTest{"bar", true},
+		globTest{"bara", true},
+		globTest{"barb", true},
+		globTest{"barbosa", true},
+		globTest{"foobar", false},
+		globTest{"food", false},
+		globTest{"anything else", false},
+	)
+}
+
+func TestGlobFilterEmpty(t *testing.T) {
+	filter, err := NewGlobFilter()
+	assert.NoError(t, err)
+
+	testGlobs(t, filter,
+		globTest{"foo", true},
+		globTest{"bar", true},
+		globTest{"bara", true},
+		globTest{"barb", true},
+		globTest{"barbosa", true},
+		globTest{"foobar", true},
+		globTest{"food", true},
+		globTest{"anything else", true},
+	)
+}
+
+func TestGlobFilterExcludeInclude(t *testing.T) {
+	// This is effectively the same as only an include filter.
+	filter, err := NewGlobFilter(WithExcludeGlobs("foo*"), WithIncludeGlobs("bar*"))
+	assert.NoError(t, err)
+
+	testGlobs(t, filter,
+		globTest{"foo", false},
+		globTest{"bar", true},
+		globTest{"bara", true},
+		globTest{"barb", true},
+		globTest{"barbosa", true},
+		globTest{"foobar", false},
+		globTest{"food", false},
+		globTest{"ambiguous anything else", false},
+	)
+}
+
+func TestGlobFilterExcludePrecdence(t *testing.T) {
+	filter, err := NewGlobFilter(WithExcludeGlobs("foo"), WithIncludeGlobs("foo*"))
+	assert.NoError(t, err)
+
+	testGlobs(t, filter,
+		globTest{"foo", false},
+		globTest{"foobar", true},
+	)
+}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Adds a generic glob filter for arbitrary include and ignore lists.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

