### PR TITLE
[bug] - use Repositories field from conn

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -222,7 +222,7 @@ func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, so
 	}
 	s.conn = &conn
 
-	s.filteredRepoCache = s.newFilteredRepoCache(memory.New(), s.conn.IncludeRepos, s.conn.IgnoreRepos)
+	s.filteredRepoCache = s.newFilteredRepoCache(memory.New(), s.conn.GetRepositories(), s.conn.GetIgnoreRepos())
 	s.memberCache = make(map[string]struct{})
 
 	s.repoSizes = newRepoSize()

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -78,7 +78,7 @@ func TestAddReposByOrg(t *testing.T) {
 		Credential: &sourcespb.GitHub_Token{
 			Token: "super secret token",
 		},
-		IncludeRepos: nil,
+		Repositories: nil,
 		IgnoreRepos:  []string{"secret/super-*-repo2"},
 	})
 	// gock works here because github.NewClient is using the default HTTP Transport
@@ -106,7 +106,7 @@ func TestAddReposByOrg_IncludeRepos(t *testing.T) {
 		Credential: &sourcespb.GitHub_Token{
 			Token: "super secret token",
 		},
-		IncludeRepos:  []string{"secret/super*"},
+		Repositories:  []string{"secret/super*"},
 		Organizations: []string{"super-secret-org"},
 	})
 	// gock works here because github.NewClient is using the default HTTP Transport


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We should be using the `Repositories` field from the Github source proto for the include portion of the include/ignore filtering.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

