### PR TITLE
Detector-Competition-Fix: fix foursquare client id & secret formatting

### DIFF
--- a/pkg/detectors/foursquare/foursquare.go
+++ b/pkg/detectors/foursquare/foursquare.go
@@ -51,7 +51,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_FourSquare,
 				Raw:          []byte(resMatch),
-				RawV2:        []byte(resMatch + resSecret),
+				RawV2:        []byte(resMatch + ":" + resSecret),
 			}
 
 			if verify {


### PR DESCRIPTION
### Description:
This fixes the client id & secret formatting for the FourSquare detector.

`client_id:client_secret` is easier to read compared to `client_idclient_secret`

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

