### PR TITLE
[chore] Fix flaky TestJobProgressElapsedTime

### DIFF
--- a/pkg/sources/job_progress_test.go
+++ b/pkg/sources/job_progress_test.go
@@ -120,7 +120,7 @@ func TestJobProgressElapsedTime(t *testing.T) {
 	metrics := JobProgressMetrics{}
 	assert.Equal(t, time.Duration(0), metrics.ElapsedTime())
 
-	metrics.StartTime = time.Now()
+	metrics.StartTime = time.Date(2022, time.March, 30, 0, 0, 0, 0, time.UTC)
 	assert.Greater(t, metrics.ElapsedTime(), time.Duration(0))
 
 	metrics.EndTime = metrics.StartTime.Add(1 * time.Hour)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Fixes a flaky `JobProgress` test that measures the elapsed time. It previously used `time.Now()` and if it executed fast enough, the elapsed time would be `0`. This sets the start date to a fixed time, so as long as time flows forward, elapsed time should always be greater than `0`.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

