### PR TITLE
Add an option to filter unverified results using shannon entropy

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ var (
 	noVerification      = cli.Flag("no-verification", "Don't verify the results.").Bool()
 	onlyVerified        = cli.Flag("only-verified", "Only output verified results.").Bool()
 	filterUnverified    = cli.Flag("filter-unverified", "Only output first unverified result per chunk per detector if there are more than one results.").Bool()
+	filterEntropy       = cli.Flag("filter-entropy", "Filter unverified results with Shannon entropy. Start with 3.0.").Float64()
 	configFilename      = cli.Flag("config", "Path to configuration file.").ExistingFile()
 	// rules = cli.Flag("rules", "Path to file with custom rules.").String()
 	printAvgDetectorTime = cli.Flag("print-avg-detector-time", "Print the average time spent on each detector.").Bool()
@@ -370,6 +371,7 @@ func run(state overseer.State) {
 		engine.WithOnlyVerified(*onlyVerified),
 		engine.WithPrintAvgDetectorTime(*printAvgDetectorTime),
 		engine.WithPrinter(printer),
+		engine.WithFilterEntropy(*filterEntropy),
 	)
 	if err != nil {
 		logFatal(err, "error initializing engine")

--- a/pkg/detectors/detectors_test.go
+++ b/pkg/detectors/detectors_test.go
@@ -12,15 +12,15 @@ func TestPrefixRegex(t *testing.T) {
 	}{
 		{
 			keywords: []string{"securitytrails"},
-			expected: `(?i)(?:securitytrails).|(?:[\n\r]){0,40}`,
+			expected: `(?i)(?:securitytrails)(?:.|[\n\r]){0,40}`,
 		},
 		{
 			keywords: []string{"zipbooks"},
-			expected: `(?i)(?:zipbooks).|(?:[\n\r]){0,40}`,
+			expected: `(?i)(?:zipbooks)(?:.|[\n\r]){0,40}`,
 		},
 		{
 			keywords: []string{"wrike"},
-			expected: `(?i)(?:wrike).|(?:[\n\r]){0,40}`,
+			expected: `(?i)(?:wrike)(?:.|[\n\r]){0,40}`,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/detectors/falsepositives.go
+++ b/pkg/detectors/falsepositives.go
@@ -92,20 +92,18 @@ func bytesToCleanWordList(data []byte) []string {
 	return words
 }
 
-// DefaultMinEntropy setting inspired by the original TruffleHog's default value for strings
-const DefaultMinEntropy = 3.0
-
 func StringShannonEntropy(input string) float64 {
 	chars := make(map[rune]float64)
+	inverseTotal := 1 / float64(len(input)) // precompute the inverse
 
 	for _, char := range input {
 		chars[char]++
 	}
 
 	entropy := 0.0
-	for _, value := range chars {
-		value /= float64(len(input))
-		entropy += value * math.Log2(value)
+	for _, count := range chars {
+		probability := count * inverseTotal
+		entropy += probability * math.Log2(probability)
 	}
 
 	return -entropy

--- a/pkg/detectors/falsepositives.go
+++ b/pkg/detectors/falsepositives.go
@@ -115,7 +115,7 @@ func StringShannonEntropy(input string) float64 {
 func FilterResultsWithEntropy(results []Result, entropy float64) []Result {
 	filteredResults := []Result{}
 	for _, result := range results {
-		if result.Verified == false && result.VerificationError == nil {
+		if !result.Verified && result.VerificationError == nil {
 			if result.RawV2 != nil {
 				if StringShannonEntropy(string(result.RawV2)) >= entropy {
 					filteredResults = append(filteredResults, result)

--- a/pkg/detectors/falsepositives.go
+++ b/pkg/detectors/falsepositives.go
@@ -2,6 +2,7 @@ package detectors
 
 import (
 	_ "embed"
+	"math"
 	"strings"
 	"unicode"
 )
@@ -89,4 +90,42 @@ func bytesToCleanWordList(data []byte) []string {
 		}
 	}
 	return words
+}
+
+// DefaultMinEntropy setting inspired by the original TruffleHog's default value for strings
+const DefaultMinEntropy = 3.0
+
+func StringShannonEntropy(input string) float64 {
+	chars := make(map[rune]float64)
+
+	for _, char := range input {
+		chars[char]++
+	}
+
+	entropy := 0.0
+	for _, value := range chars {
+		value /= float64(len(input))
+		entropy += value * math.Log2(value)
+	}
+
+	return -entropy
+}
+
+// FilterResultsWithEntropy filters out determinately unverified results that have a shannon entropy below the given value.
+func FilterResultsWithEntropy(results []Result, entropy float64) []Result {
+	filteredResults := []Result{}
+	for _, result := range results {
+		if result.Verified == false && result.VerificationError == nil {
+			if result.RawV2 != nil {
+				if StringShannonEntropy(string(result.RawV2)) >= entropy {
+					filteredResults = append(filteredResults, result)
+				}
+			} else {
+				if StringShannonEntropy(string(result.Raw)) >= entropy {
+					filteredResults = append(filteredResults, result)
+				}
+			}
+		}
+	}
+	return filteredResults
 }

--- a/pkg/detectors/falsepositives_test.go
+++ b/pkg/detectors/falsepositives_test.go
@@ -3,7 +3,10 @@
 
 package detectors
 
-import "testing"
+import (
+	_ "embed"
+	"testing"
+)
 
 func TestIsFalsePositive(t *testing.T) {
 	type args struct {
@@ -36,6 +39,46 @@ func TestIsFalsePositive(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsKnownFalsePositive(tt.args.match, tt.args.falsePositives, false); got != tt.want {
 				t.Errorf("IsKnownFalsePositive() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStringShannonEntropy(t *testing.T) {
+	type args struct {
+		input string
+	}
+	tests := []struct {
+		name string
+		args args
+		want float64
+	}{
+		{
+			name: "entropy 1",
+			args: args{
+				input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			},
+			want: 0,
+		},
+		{
+			name: "entropy 2",
+			args: args{
+				input: "aaaaaaaaaaaaaaaaaaaaaaaaaaab",
+			},
+			want: 0.22228483068568816,
+		},
+		{
+			name: "entropy 3",
+			args: args{
+				input: "aaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaab",
+			},
+			want: 0.22228483068568816,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StringShannonEntropy(tt.args.input); got != tt.want {
+				t.Errorf("StringShannonEntropy() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Adds an option to filter out unverified results using shannon entropy.

### Checklist:
* [X] Tests passing (`make test-community`)?
* [X] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

