### PR TITLE
[bug] - Don't modify global client var

### DIFF
--- a/pkg/detectors/twilio/twilio.go
+++ b/pkg/detectors/twilio/twilio.go
@@ -23,7 +23,6 @@ var (
 	identifierPat = regexp.MustCompile(`(?i)sid.{0,20}AC[0-9a-f]{32}`) // Should we have this? Seems restrictive.
 	sidPat        = regexp.MustCompile(`\bAC[0-9a-f]{32}\b`)
 	keyPat        = regexp.MustCompile(`\b[0-9a-f]{32}\b`)
-	client        = common.SaneHttpClient()
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/twilio/twilio.go
+++ b/pkg/detectors/twilio/twilio.go
@@ -59,7 +59,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				client = s.client
+				client := s.client
 				if client == nil {
 					client = defaultClient
 				}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Modifying the global client var has side-effects which we should avoid. We should set the client locally within the verify block.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

