### PR TITLE
Add ShannonEntropy test for an empty string

### DIFF
--- a/pkg/detectors/falsepositives_test.go
+++ b/pkg/detectors/falsepositives_test.go
@@ -74,6 +74,13 @@ func TestStringShannonEntropy(t *testing.T) {
 			},
 			want: 0.22228483068568816,
 		},
+		{
+			name: "empty",
+			args: args{
+				input: "",
+			},
+			want: 0.0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Description:
I thought I noticed a divide by 0 error in `ShannonEntropy`, so I added a test for it and it passed! I forgot `1 / 0.0` is `+inf` in floating point instead of an error. Adding the test in case the implementation ever changes.


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

