### PR TITLE
Fix GitHub `--repo` cache behaviour

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -233,7 +233,7 @@ func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, so
 			aCtx.Logger().Error(err, "invalid repository", "repo", repo)
 			continue
 		}
-		s.filteredRepoCache.Set(r, r)
+		s.filteredRepoCache.Set(repo, r)
 	}
 
 	s.includeIssueComments = s.conn.IncludeIssueComments


### PR DESCRIPTION
### Description:

This fixes #1896.

```sh
$ go build && ./trufflehog github --repo https://github.com/trufflesecurity/trufflehog
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

2023-10-17T17:37:30-04:00       info-0  trufflehog      Completed enumeration   {"num_repos": 1, "num_orgs": 0, "num_members": 0}
...
```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

