### PR TITLE
Scan GitHub issue & pr titles

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -1356,7 +1356,7 @@ func (s *Source) chunkIssues(ctx context.Context, repoInfo repoInfo, issues []*g
 					},
 				},
 			},
-			Data:   []byte(sanitizer.UTF8(issue.GetBody())),
+			Data:   []byte(sanitizer.UTF8(issue.GetTitle() + issue.GetBody())),
 			Verify: s.verify,
 		}
 
@@ -1455,7 +1455,7 @@ func (s *Source) chunkPullRequests(ctx context.Context, repoInfo repoInfo, prs [
 					},
 				},
 			},
-			Data:   []byte(sanitizer.UTF8(pr.GetBody())),
+			Data:   []byte(sanitizer.UTF8(pr.GetTitle() + pr.GetBody())),
 			Verify: s.verify,
 		}
 


### PR DESCRIPTION
### Description:

This change appends issue and pr titles to the scan data for `--issue-comments` and `--pr-comments` respectively. People apparently share secrets in titles, for instance: https://github.com/coinbase/waas-client-library-go /issues/52 (intentional space to avoid linking).

It would be ideal to write test cases for this, however, off the top of my head I'm not sure the best way to test `chunkIssues` and `chunkPullRequests`. Unit tests would seemingly require either mocking `s.visibilityOf()` or rewriting the code.

https://github.com/trufflesecurity/trufflehog/blob/6ea3a7da4a868b9e1375f038a65da0e8d1112a9f/pkg/sources/github/github.go#L1313-L1335


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

