### PR TITLE
Added Support for '-h' Option for Help Documentation

### DIFF
--- a/main.go
+++ b/main.go
@@ -152,6 +152,9 @@ func init() {
 
 	cli.Version("trufflehog " + version.BuildVersion)
 
+	//Support -h for help
+	cli.HelpFlag.Short('h')
+
 	if len(os.Args) <= 1 && isatty.IsTerminal(os.Stdout.Fd()) {
 		args := tui.Run()
 		if len(args) == 0 {


### PR DESCRIPTION
Fixes: #1855 

### Description:
Adds support for `-h` Option for Help Documentation

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

