### PR TITLE
Dockerfiles - Alpine Linux 3.15 EoL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN  --mount=type=cache,target=/go/pkg/mod \
      --mount=type=cache,target=/root/.cache/go-build \
      GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o trufflehog .
 
-FROM alpine:3.15
+FROM alpine:3.16
 RUN apk add --no-cache bash git openssh-client ca-certificates \
-    && update-ca-certificates
+    && rm -rf /var/cache/apk/* && update-ca-certificates
 COPY --from=builder /build/trufflehog /usr/bin/trufflehog
 COPY entrypoint.sh /etc/entrypoint.sh
 RUN chmod +x /etc/entrypoint.sh

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,8 +1,7 @@
-FROM alpine:3.15
+FROM alpine:3.16
 
 RUN apk add --no-cache bash git openssh-client ca-certificates \
-    && rm -rf /var/cache/apk/* && \
-    update-ca-certificates
+    && rm -rf /var/cache/apk/* && update-ca-certificates
 WORKDIR /usr/bin/
 COPY trufflehog .
 COPY entrypoint.sh /etc/entrypoint.sh


### PR DESCRIPTION
### Description:
Alpine Linux 3.15 support ends in 2 weeks (01 Nov 2023).

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

