### PR TITLE
[chore] Fix glob package name

### DIFF
--- a/pkg/common/glob/glob.go
+++ b/pkg/common/glob/glob.go
@@ -1,4 +1,4 @@
-package common
+package glob
 
 import (
 	"fmt"

--- a/pkg/common/glob/glob_test.go
+++ b/pkg/common/glob/glob_test.go
@@ -1,4 +1,4 @@
-package common
+package glob
 
 import (
 	"testing"


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
I accidentally used `package common` in the files instead of `package glob`.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

