### PR TITLE
Detector-Competition-fix: NewRelic Detector -fallback to EU Api for verification

### DIFF
--- a/pkg/detectors/newrelicpersonalapikey/newrelicpersonalapikey.go
+++ b/pkg/detectors/newrelicpersonalapikey/newrelicpersonalapikey.go
@@ -48,14 +48,29 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 		if verify {
 			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.newrelic.com/v2/users.json", nil)
-			if err != nil {
+			reqEU, errEU := http.NewRequestWithContext(ctx, "GET", "https://api.eu.newrelic.com/v2/users.json", nil)
+			if err != nil || errEU != nil {
 				continue
 			}
 			req.Header.Add("X-Api-Key", resMatch)
+			reqEU.Header.Add("X-Api-Key", resMatch)
+			
 			res, err := client.Do(req)
+			resEU, errEU := client.Do(reqEU)
+
 			if err == nil {
 				defer res.Body.Close()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
+					s1.Verified = true
+				} else {
+					// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
+					if detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, false) {
+						continue
+					}
+				}
+			} else if errEU == nil {
+				defer resEU.Body.Close()
+				if resEU.StatusCode >= 200 && resEU.StatusCode < 300 {
 					s1.Verified = true
 				} else {
 					// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.


### PR DESCRIPTION
### Description:
Fallback to EU API endpoint for New Relic Detector if US API returns 401 status code.

### Docs:
Link: https://docs.newrelic.com/docs/apis/rest-api-v2/get-started/introduction-new-relic-rest-api-v2/#appid

### Checklist:
* [] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

### Tests Image

<img width="925" alt="Screenshot 2023-10-21 at 5 58 41 PM" src="https://github.com/trufflesecurity/trufflehog/assets/8335453/a7323bdb-e5da-4799-87ab-b5827ab2b2a6">

I