### PR TITLE
Detector-Competition-Fix : fixed monday.com regex

### DIFF
--- a/pkg/detectors/monday/monday.go
+++ b/pkg/detectors/monday/monday.go
@@ -20,7 +20,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"monday"}) + `\b(ey[a-zA-Z0-9_.]{210,225})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"monday"}) + `\b(eyJ[A-Za-z0-9-_]{15,100}\.eyJ[A-Za-z0-9-_]{100,300}\.[A-Za-z0-9-_]{25,100})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/monday/monday_test.go
+++ b/pkg/detectors/monday/monday_test.go
@@ -19,7 +19,7 @@ import (
 func TestMonday_FromChunk(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors3")
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors5")
 	if err != nil {
 		t.Fatalf("could not get test secrets from GCP: %s", err)
 	}


### PR DESCRIPTION
The regex of monday.com was not detecting the monday.com token. The bounded range was wrong. I refined the regex and made it more specific and accurate.

![monday](https://github.com/trufflesecurity/trufflehog/assets/10580970/89acd80b-801f-43eb-bbc6-a08d1871516f)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

