### PR TITLE
Revert "Fix wrong line number"

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -623,7 +623,7 @@ func FragmentLineOffset(chunk *sources.Chunk, result *detectors.Result) (int64, 
 	if !found {
 		return 0, false
 	}
-	lineNumber := int64(bytes.Count(before, []byte("\n")) + 1)
+	lineNumber := int64(bytes.Count(before, []byte("\n")))
 	// If the line contains the ignore tag, we should ignore the result.
 	endLine := bytes.Index(after, []byte("\n"))
 	if endLine == -1 {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -32,7 +32,7 @@ func TestFragmentLineOffset(t *testing.T) {
 			result: &detectors.Result{
 				Raw: []byte("secret here"),
 			},
-			expectedLine: 3,
+			expectedLine: 2,
 			ignore:       true,
 		},
 		{
@@ -43,7 +43,7 @@ func TestFragmentLineOffset(t *testing.T) {
 			result: &detectors.Result{
 				Raw: []byte("secret here"),
 			},
-			expectedLine: 3,
+			expectedLine: 2,
 			ignore:       false,
 		},
 		{
@@ -54,7 +54,7 @@ func TestFragmentLineOffset(t *testing.T) {
 			result: &detectors.Result{
 				Raw: []byte("secret here"),
 			},
-			expectedLine: 5,
+			expectedLine: 4,
 			ignore:       false,
 		},
 		{
@@ -65,7 +65,7 @@ func TestFragmentLineOffset(t *testing.T) {
 			result: &detectors.Result{
 				Raw: []byte("secret\nhere"),
 			},
-			expectedLine: 5,
+			expectedLine: 4,
 			ignore:       false,
 		},
 		{
@@ -76,7 +76,7 @@ func TestFragmentLineOffset(t *testing.T) {
 			result: &detectors.Result{
 				Raw: []byte("secret\nhere"),
 			},
-			expectedLine: 4,
+			expectedLine: 3,
 			ignore:       true,
 		},
 		{
@@ -87,7 +87,7 @@ func TestFragmentLineOffset(t *testing.T) {
 			result: &detectors.Result{
 				Raw: []byte("secret here"),
 			},
-			expectedLine: 4,
+			expectedLine: 3,
 			ignore:       true,
 		},
 	}


### PR DESCRIPTION
Reverts trufflesecurity/trufflehog#1891

The off-by-one error that the original PR fixed is actually present at the source level, not the engine level. Fixing it at the engine level inadvertently introduced an opposite off-by-one error in other sources.