### PR TITLE
Remove docker container after make protos finishes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,10 @@ run-debug:
 	CGO_ENABLED=0 go run . git file://. --json --debug
 
 protos:
-	docker run -u "$(shell id -u)" -v "$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))":/pwd "${PROTOS_IMAGE}" bash -c "cd /pwd; /pwd/scripts/gen_proto.sh"
+	docker run --rm -u "$(shell id -u)" -v "$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))":/pwd "${PROTOS_IMAGE}" bash -c "cd /pwd; /pwd/scripts/gen_proto.sh"
 
 protos-windows:
-	docker run -v "$(shell cygpath -w $(shell pwd))":/pwd "${PROTOS_IMAGE}" bash -c "cd /pwd; ./scripts/gen_proto.sh"
+	docker run --rm -v "$(shell cygpath -w $(shell pwd))":/pwd "${PROTOS_IMAGE}" bash -c "cd /pwd; ./scripts/gen_proto.sh"
 
 release-protos-image:
 	docker buildx build --push --platform=linux/amd64,linux/arm64 \


### PR DESCRIPTION
### Description:
Running `make protos` makes proto files using docker container but the container is not removed.
This PR adds the `--rm` flag to make sure user won't get a bunch of stopped containers hogging up space

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

