### PR TITLE
Update databricks pat domain regex

### DIFF
--- a/pkg/detectors/databrickstoken/databrickstoken.go
+++ b/pkg/detectors/databrickstoken/databrickstoken.go
@@ -57,7 +57,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				req, err := http.NewRequestWithContext(ctx, "GET", resDomainMatch + "/api/2.0/clusters/list", nil)
+				url := fmt.Sprintf("https://%s/api/2.0/token/list", domain)
+				req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+				
 				if err != nil {
 					continue
 				}

--- a/pkg/detectors/databrickstoken/databrickstoken.go
+++ b/pkg/detectors/databrickstoken/databrickstoken.go
@@ -21,7 +21,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	domain = regexp.MustCompile(`\b(https:\/\/[a-z0-9-]+\.cloud\.databricks\.com)\b`)
+	domain = regexp.MustCompile(`\b([\w-\.]+\.(cloud\.databricks\.com|gcp\.databricks\.com|azuredatabricks\.net))\b`)
 	keyPat = regexp.MustCompile(`\b(dapi[a-z0-9]{32})\b`)
 )
 


### PR DESCRIPTION
### Description:
The existing regex doesn’t cover instances hosted on azure and GCP
the prefix can also be a number or a name and can contain one or two dots.
this change makes it cover all the known cases
 
I also fixed the url that lacked the scheme and change it to point to the token API which make more sense here since we are trying to validate tokens.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

