### PR TITLE
add rpm2cpio as dependency to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN  --mount=type=cache,target=/go/pkg/mod \
      GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o trufflehog .
 
 FROM alpine:3.18
-RUN apk add --no-cache bash git openssh-client ca-certificates \
+RUN apk add --no-cache bash git openssh-client ca-certificates rpm2cpio \
     && rm -rf /var/cache/apk/* && update-ca-certificates
 COPY --from=builder /build/trufflehog /usr/bin/trufflehog
 COPY entrypoint.sh /etc/entrypoint.sh

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,6 +1,6 @@
 FROM alpine:3.18
 
-RUN apk add --no-cache bash git openssh-client ca-certificates \
+RUN apk add --no-cache bash git openssh-client ca-certificates rpm2cpio \
     && rm -rf /var/cache/apk/* && update-ca-certificates
 WORKDIR /usr/bin/
 COPY trufflehog .


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Add rpm2cpio dependency to our Dockerfile as it's needed to extract .rpm archives.
### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

