### PR TITLE
fixing Databricks detector

### DIFF
--- a/pkg/detectors/databrickstoken/databrickstoken.go
+++ b/pkg/detectors/databrickstoken/databrickstoken.go
@@ -21,52 +21,54 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	domain = regexp.MustCompile(`\b(https:\/\/[a-z0-9-]+\.cloud\.databricks\.com)\b`)
-	keyPat = regexp.MustCompile(`\b(dapi[a-z0-9]{32})\b`)
+	keyPat    = regexp.MustCompile(`\b(dapi[0-9Aa-f]{32})\b`)
+	domainPat = regexp.MustCompile(`\b([\w-\.]+\.(cloud\.databricks\.com|gcp\.databricks\.com|azuredatabricks\.net))\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"databricks", "dapi"}
+	return []string{"dapi"}
 }
 
-// FromData will find and optionally verify Databrickstoken secrets in a given set of bytes.
+// FromData will find and optionally verify DatabricksToken secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
-	dataStr := string(data)
 
-	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
-	domainMatches := domain.FindAllStringSubmatch(dataStr, -1)
+	matches := keyPat.FindAll(data, -1)
+	domainMatches := domainPat.FindAll(data, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
-		resMatch := strings.TrimSpace(match[1])
 
-		for _, domainmatch := range domainMatches {
-			if len(domainmatch) != 2 {
-				continue
-			}
-			resDomainMatch := strings.TrimSpace(domainmatch[1])
+		resMatch := strings.TrimSpace(string(match))
+
+		for _, domainMatch := range domainMatches {
+
+			domain := strings.TrimSpace(string(domainMatch))
 
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_DatabricksToken,
 				Raw:          []byte(resMatch),
-				RawV2:        []byte(resMatch + resDomainMatch),
+				Verified:     false,
 			}
 
 			if verify {
-				req, err := http.NewRequestWithContext(ctx, "GET", resDomainMatch + "/api/2.0/clusters/list", nil)
+
+				verifyUrl := fmt.Sprintf("https://%s/api/2.0/token/list", domain)
+
+				req, err := http.NewRequestWithContext(ctx, "GET", verifyUrl, nil)
 				if err != nil {
 					continue
 				}
+
 				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
+
 				res, err := client.Do(req)
 				if err == nil {
 					defer res.Body.Close()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
+
+					if res.StatusCode == 200 {
 						s1.Verified = true
+						s1.ExtraData = map[string]string{"url": domain} // store the domain with the result
 					} else {
 						// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
 						if detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
@@ -77,8 +79,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			results = append(results, s1)
+
 		}
 	}
+
 	return results, nil
 }
 


### PR DESCRIPTION
I'm just sending our internal developed detector

### Description:
we used this detector at Databricks for couple of months, 
and I noticed that the current detector is broken in many ways , so I just copy/pasted a working code.

![image](https://github.com/trufflesecurity/trufflehog/assets/63428291/5df4e04c-cc1d-4b3e-ae72-ea16246a6632)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

