### PR TITLE
Competition-Detector-Fix: fixed zendesk token regex

### DIFF
--- a/pkg/detectors/zendeskapi/zendeskapi.go
+++ b/pkg/detectors/zendeskapi/zendeskapi.go
@@ -21,8 +21,8 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	client = common.SaneHttpClient()
 
-	token  = regexp.MustCompile(detectors.PrefixRegex([]string{"zendesk"}) + `([A-Za-z0-9_-]{40})`)
-	email  = regexp.MustCompile(`\b([a-zA-Z-0-9-]{5,16}\@[a-zA-Z-0-9]{4,16}\.[a-zA-Z-0-9]{3,6})\b`)
+	token  = regexp.MustCompile(`([A-Za-z0-9_-]{40})`)
+	email  = regexp.MustCompile(`\b(\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,7}\b)\b`)
 	domain = regexp.MustCompile(`\b([a-zA-Z-0-9]{3,16}\.zendesk\.com)\b`)
 )
 


### PR DESCRIPTION

### Description:
Removed the prefix regex "zendesk" from the token regex as it was hindering with detection. Sometimes, the zendesk keyword will not be in the 40 char range. Either way, it shouldn't matter removing it because there are 3 regexes in place for this to work so no chance for false positives. Also the domain part contains the word "zendesk".

I have seen in the wild where this detector didn't work but valid credentials were present. 
![zendesk](https://github.com/trufflesecurity/trufflehog/assets/10580970/93f0fcbb-8e64-4595-a7c8-8e4738e5e3eb)

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

