### PR TITLE
adding 'token' keyword to regex for github_old

### DIFF
--- a/pkg/detectors/github_old/github_old.go
+++ b/pkg/detectors/github_old/github_old.go
@@ -43,7 +43,7 @@ type userRes struct {
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"github", "gh", "pat"}
+	return []string{"github", "gh", "pat", "token"}
 }
 
 // FromData will find and optionally verify GitHub secrets in a given set of bytes.

--- a/pkg/detectors/github_old/github_old.go
+++ b/pkg/detectors/github_old/github_old.go
@@ -25,7 +25,7 @@ func (Scanner) DefaultEndpoint() string { return "https://api.github.com" }
 var (
 	// Oauth token
 	// https://developer.github.com/v3/#oauth2-token-sent-in-a-header
-	keyPat = regexp.MustCompile(`(?i)(?:github|gh|pat)[^\.].{0,40}[ =:'"]+([a-f0-9]{40})\b`)
+	keyPat = regexp.MustCompile(`(?i)(?:github|gh|pat|token)[^\.].{0,40}[ =:'"]+([a-f0-9]{40})\b`)
 
 	// TODO: Oauth2 client_id and client_secret
 	// https://developer.github.com/v3/#oauth2-keysecret


### PR DESCRIPTION

### Description:
Seen the keyword token in the wild for the old format of GitHub token so adding that to the regex.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

