### PR TITLE
Competition-detector-fix: fixed helpscout detector regex and verifier

### DIFF
--- a/pkg/detectors/helpscout/helpscout.go
+++ b/pkg/detectors/helpscout/helpscout.go
@@ -2,7 +2,6 @@ package helpscout
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
@@ -21,7 +20,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"helpscout"}) + `\b([A-Za-z0-9]{56})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"helpscout"}) + `\b([a-z0-9]{40})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -52,7 +51,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err != nil {
 				continue
 			}
-			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", resMatch))
+			req.SetBasicAuth(resMatch, "X")
 			res, err := client.Do(req)
 			if err == nil {
 				defer res.Body.Close()


### PR DESCRIPTION

### Description:
I created a helpscout account and regenerated token many times and it always gave a [a-z0-9]{40} char long token and not the [A-Za-z0-9]{56} one so i replaced the regex. Maybe that was old format and not valid anymore. i have no way to check if the old format style tokens are supported or not. if they are, we can have a OR style regex match or i can close this PR and create a V2 style detector for the helpscout.

Verifier:
https://developer.helpscout.com/docs-api/

It suggests a basic auth-style API call so added that logic as well
![helpscout](https://github.com/trufflesecurity/trufflehog/assets/10580970/aa6ab8a5-e5ec-4368-b0dc-20a80ec187ca)


### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

