### PR TITLE
use rawv2 for pubnubpublish

### DIFF
--- a/pkg/detectors/pubnubpublishkey/pubnubpublishkey.go
+++ b/pkg/detectors/pubnubpublishkey/pubnubpublishkey.go
@@ -55,6 +55,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_PubNubPublishKey,
 				Raw:          []byte(resMatch),
+				RawV2:        []byte(resMatch + "/" + ressubMatch),
 			}
 
 			if verify {

--- a/pkg/detectors/pubnubpublishkey/pubnubpublishkey_test.go
+++ b/pkg/detectors/pubnubpublishkey/pubnubpublishkey_test.go
@@ -6,10 +6,11 @@ package pubnubpublishkey
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -134,7 +135,7 @@ func TestPubNubPublishKey_FromChunk(t *testing.T) {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "VerificationError")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("PubNubPublishKey.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We're seeing secrets of this type flap between verified and unverified, which is expected behavior for multipart secrets without `RawV2` defined. This PR adds `RawV2` for secrets of this type.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

