### PR TITLE
Centralize logic for checking archive extraction tools

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -268,7 +268,7 @@ func ensureToolsForMimeType(mimeType mimeType) error {
 	}
 
 	for _, tool := range tools {
-		if installed, ok := extractToolCache[tool]; !ok || !installed {
+		if installed := extractToolCache[tool]; !installed {
 			return fmt.Errorf("required tool %s is not installed", tool)
 		}
 	}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Only check for archive extraction tools once during init. Reuse the cache during scans to prevent unnecessary filesystem lookups.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

