### PR TITLE
[chore] - correctly handle input shorter than 512 bytes

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -418,7 +418,7 @@ func determineMimeType(reader io.Reader) (mimeType, io.Reader, error) {
 	// If fewer bytes are read, MIME type detection may still succeed.
 	buffer := make([]byte, 512)
 	n, err := reader.Read(buffer)
-	if err != nil && err != io.EOF {
+	if err != nil && !errors.Is(err, io.EOF) {
 		return "", nil, fmt.Errorf("unable to read file for MIME type detection: %w", err)
 	}
 

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -414,9 +414,11 @@ func (a *Archive) handleNestedFileMIME(ctx logContext.Context, tempEnv tempEnv, 
 // determineMimeType reads from the provided reader to detect the MIME type.
 // It returns the detected MIME type and a new reader that includes the read portion.
 func determineMimeType(reader io.Reader) (mimeType, io.Reader, error) {
+	// A buffer of 512 bytes is used since many file formats store their magic numbers within the first 512 bytes.
+	// If fewer bytes are read, MIME type detection may still succeed.
 	buffer := make([]byte, 512)
 	n, err := reader.Read(buffer)
-	if err != nil {
+	if err != nil && err != io.EOF {
 		return "", nil, fmt.Errorf("unable to read file for MIME type detection: %w", err)
 	}
 

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -308,16 +308,16 @@ func TestDetermineMimeType(t *testing.T) {
 			shouldFail: false,
 		},
 		{
-			name:       "Truncated JPEG file",
-			input:      io.LimitReader(bytes.NewReader(jpegBytes), 2),
-			expected:   mimeType("unknown"),
-			shouldFail: true, // Explicit failure expectation
-		},
-		{
 			name:       "RPM file",
 			input:      bytes.NewReader(rpmBytes),
 			expected:   mimeType("application/x-rpm"),
 			shouldFail: false,
+		},
+		{
+			name:       "Truncated JPEG file",
+			input:      io.LimitReader(bytes.NewReader(jpegBytes), 2),
+			expected:   mimeType("unknown"),
+			shouldFail: true, // Explicit failure expectation
 		},
 	}
 

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -11,8 +11,9 @@ import (
 	"testing"
 	"time"
 
-	diskbufferreader "github.com/trufflesecurity/disk-buffer-reader"
+	"github.com/h2non/filetype"
 	"github.com/stretchr/testify/assert"
+	diskbufferreader "github.com/trufflesecurity/disk-buffer-reader"
 
 	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
@@ -270,4 +271,73 @@ func TestNestedDirArchive(t *testing.T) {
 		count++
 	}
 	assert.Equal(t, want, count)
+}
+
+func TestDetermineMimeType(t *testing.T) {
+	filetype.AddMatcher(filetype.NewType("txt", "text/plain"), func(buf []byte) bool {
+		return strings.HasPrefix(string(buf), "text:")
+	})
+
+	pngBytes := []byte("\x89PNG\r\n\x1a\n")
+	jpegBytes := []byte{0xFF, 0xD8, 0xFF}
+	textBytes := []byte("text: This is a plain text")
+	rpmBytes := []byte("\xed\xab\xee\xdb")
+
+	tests := []struct {
+		name       string
+		input      io.Reader
+		expected   mimeType
+		shouldFail bool
+	}{
+		{
+			name:       "PNG file",
+			input:      bytes.NewReader(pngBytes),
+			expected:   mimeType("image/png"),
+			shouldFail: false,
+		},
+		{
+			name:       "JPEG file",
+			input:      bytes.NewReader(jpegBytes),
+			expected:   mimeType("image/jpeg"),
+			shouldFail: false,
+		},
+		{
+			name:       "Text file",
+			input:      bytes.NewReader(textBytes),
+			expected:   mimeType("text/plain"),
+			shouldFail: false,
+		},
+		{
+			name:       "Truncated JPEG file",
+			input:      io.LimitReader(bytes.NewReader(jpegBytes), 2),
+			expected:   mimeType("unknown"),
+			shouldFail: true, // Explicit failure expectation
+		},
+		{
+			name:       "RPM file",
+			input:      bytes.NewReader(rpmBytes),
+			expected:   mimeType("application/x-rpm"),
+			shouldFail: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalData, _ := io.ReadAll(io.TeeReader(tt.input, &bytes.Buffer{}))
+			tt.input = bytes.NewReader(originalData) // Reset the reader
+
+			mime, reader, err := determineMimeType(tt.input)
+			if err != nil && !tt.shouldFail {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !tt.shouldFail {
+				assert.Equal(t, tt.expected, mime)
+			}
+
+			// Ensure the reader still contains all the original data.
+			data, _ := io.ReadAll(reader)
+			assert.Equal(t, originalData, data)
+		})
+	}
 }

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -317,7 +317,12 @@ func TestDetermineMimeType(t *testing.T) {
 			name:       "Truncated JPEG file",
 			input:      io.LimitReader(bytes.NewReader(jpegBytes), 2),
 			expected:   mimeType("unknown"),
-			shouldFail: true, // Explicit failure expectation
+			shouldFail: true,
+		},
+		{
+			name:       "Empty reader",
+			input:      bytes.NewReader([]byte{}),
+			shouldFail: true,
 		},
 	}
 

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -310,7 +310,7 @@ func TestDetermineMimeType(t *testing.T) {
 		{
 			name:       "RPM file",
 			input:      bytes.NewReader(rpmBytes),
-			expected:   mimeType("application/x-rpm"),
+			expected:   rpmMimeType,
 			shouldFail: false,
 		},
 		{

--- a/pkg/sources/chunker_test.go
+++ b/pkg/sources/chunker_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"testing/iotest"
 
-	diskbufferreader "github.com/trufflesecurity/disk-buffer-reader"
 	"github.com/stretchr/testify/assert"
+	diskbufferreader "github.com/trufflesecurity/disk-buffer-reader"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Check for EOF error as well as err != nil so that input shorter than 512 bytes is also correctly processed.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

