### PR TITLE
Drain response body before closing

### DIFF
--- a/pkg/detectors/abbysale/abbysale.go
+++ b/pkg/detectors/abbysale/abbysale.go
@@ -2,6 +2,7 @@ package abbysale
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("x-api-key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/abstract/abstract.go
+++ b/pkg/detectors/abstract/abstract.go
@@ -3,6 +3,7 @@ package abstract
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				// Ensure we drain the response body so this connection can be reused.
+				_, _ = io.Copy(io.Discard, res.Body)
+				_ = res.Body.Close()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/abuseipdb/abuseipdb.go
+++ b/pkg/detectors/abuseipdb/abuseipdb.go
@@ -56,13 +56,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
+				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err == nil {
 					bodyString := string(bodyBytes)
 					validResponse := strings.Contains(bodyString, `ipAddress`)
 					// errCode := strings.Contains(bodyString, `AbuseIPDB APIv2 Server.`)
 
-					defer res.Body.Close()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						if validResponse {
 							s1.Verified = true

--- a/pkg/detectors/accuweather/accuweather.go
+++ b/pkg/detectors/accuweather/accuweather.go
@@ -2,6 +2,7 @@ package accuweather
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				// Ensure we drain the response body so this connection can be reused.
+				_, _ = io.Copy(io.Discard, res.Body)
+				_ = res.Body.Close()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/adafruitio/adafruitio.go
+++ b/pkg/detectors/adafruitio/adafruitio.go
@@ -2,6 +2,7 @@ package adafruitio
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				// Ensure we drain the response body so this connection can be reused.
+				_, _ = io.Copy(io.Discard, res.Body)
+				_ = res.Body.Close()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/adobeio/adobeio.go
+++ b/pkg/detectors/adobeio/adobeio.go
@@ -2,6 +2,7 @@ package adobeio
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("x-product", resIdMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/adzuna/adzuna.go
+++ b/pkg/detectors/adzuna/adzuna.go
@@ -3,6 +3,7 @@ package adzuna
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -62,7 +63,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/agora/agora.go
+++ b/pkg/detectors/agora/agora.go
@@ -2,6 +2,7 @@ package agora
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -65,7 +66,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				res, err := client.Do(req)
 
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/aha/aha.go
+++ b/pkg/detectors/aha/aha.go
@@ -3,6 +3,7 @@ package aha
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/airship/airship.go
+++ b/pkg/detectors/airship/airship.go
@@ -3,6 +3,7 @@ package airship
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/aiven/aiven.go
+++ b/pkg/detectors/aiven/aiven.go
@@ -3,6 +3,7 @@ package aiven
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("aivenv1 %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/alchemy/alchemy.go
+++ b/pkg/detectors/alchemy/alchemy.go
@@ -3,6 +3,7 @@ package alchemy
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -59,7 +60,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else if res.StatusCode == 401 {

--- a/pkg/detectors/alconost/alconost.go
+++ b/pkg/detectors/alconost/alconost.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -59,7 +60,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", sEnc))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/alegra/alegra.go
+++ b/pkg/detectors/alegra/alegra.go
@@ -2,6 +2,7 @@ package alegra
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -64,7 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.SetBasicAuth(userPatMatch, tokenPatMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/amadeus/amadeus.go
+++ b/pkg/detectors/amadeus/amadeus.go
@@ -65,7 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					bodyBytes, err := io.ReadAll(res.Body)
 					if err != nil {
 						continue

--- a/pkg/detectors/ambee/ambee.go
+++ b/pkg/detectors/ambee/ambee.go
@@ -2,6 +2,7 @@ package ambee
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("x-api-key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/anypoint/anypoint.go
+++ b/pkg/detectors/anypoint/anypoint.go
@@ -3,6 +3,7 @@ package anypoint
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -64,7 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/apacta/apacta.go
+++ b/pkg/detectors/apacta/apacta.go
@@ -3,6 +3,7 @@ package apacta
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/api2cart/api2cart.go
+++ b/pkg/detectors/api2cart/api2cart.go
@@ -56,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Accept", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				body, errBody := io.ReadAll(res.Body)
 
 				var result Response

--- a/pkg/detectors/apideck/apideck.go
+++ b/pkg/detectors/apideck/apideck.go
@@ -3,6 +3,7 @@ package apideck
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -65,7 +66,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/apiflash/apiflash.go
+++ b/pkg/detectors/apiflash/apiflash.go
@@ -3,6 +3,7 @@ package apiflash
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -62,7 +63,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/apify/apify.go
+++ b/pkg/detectors/apify/apify.go
@@ -2,6 +2,7 @@ package apify
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/apilayer/apilayer.go
+++ b/pkg/detectors/apilayer/apilayer.go
@@ -2,6 +2,7 @@ package apilayer
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("apikey", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/apimatic/apimatic.go
+++ b/pkg/detectors/apimatic/apimatic.go
@@ -2,6 +2,7 @@ package apimatic
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -67,7 +68,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				res, err := client.Do(req)
 
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/apollo/apollo.go
+++ b/pkg/detectors/apollo/apollo.go
@@ -3,6 +3,7 @@ package apollo
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/appcues/appcues.go
+++ b/pkg/detectors/appcues/appcues.go
@@ -3,6 +3,7 @@ package appcues
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -73,7 +74,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					req.SetBasicAuth(resUserMatch, resMatch)
 					res, err := client.Do(req)
 					if err == nil {
-						defer res.Body.Close()
+						defer func() {
+							// Ensure we drain the response body so this connection can be reused.
+							_, _ = io.Copy(io.Discard, res.Body)
+							_ = res.Body.Close()
+						}()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
 						} else {

--- a/pkg/detectors/appoptics/appoptics_test.go
+++ b/pkg/detectors/appoptics/appoptics_test.go
@@ -86,7 +86,7 @@ func TestAppoptics_FromChunk(t *testing.T) {
 			want:                nil,
 			wantErr:             false,
 			wantVerificationErr: false,
-		},		
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/detectors/apptivo/apptivo.go
+++ b/pkg/detectors/apptivo/apptivo.go
@@ -69,7 +69,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					}
 					bodyString := string(bodyBytes)
 					validResponse := strings.Contains(bodyString, `displayName`)
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						if validResponse {
 							s1.Verified = true

--- a/pkg/detectors/artsy/artsy.go
+++ b/pkg/detectors/artsy/artsy.go
@@ -2,6 +2,7 @@ package artsy
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/atera/atera.go
+++ b/pkg/detectors/atera/atera.go
@@ -2,6 +2,7 @@ package atera
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-API-KEY", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/audd/audd.go
+++ b/pkg/detectors/audd/audd.go
@@ -59,7 +59,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err == nil {
 					bodyString := string(bodyBytes)
 					validResponse := strings.Contains(bodyString, `"status":"success"`)
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						if validResponse {
 							s1.Verified = true

--- a/pkg/detectors/autodesk/autodesk.go
+++ b/pkg/detectors/autodesk/autodesk.go
@@ -3,6 +3,7 @@ package autodesk
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -64,7 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -247,7 +248,11 @@ func (s scanner) verifyMatch(ctx context.Context, resIDMatch, resSecretMatch str
 
 	res, err := client.Do(req)
 	if err == nil {
-		defer res.Body.Close()
+		defer func() {
+			// Ensure we drain the response body so this connection can be reused.
+			_, _ = io.Copy(io.Discard, res.Body)
+			_ = res.Body.Close()
+		}()
 		if res.StatusCode >= 200 && res.StatusCode < 300 {
 			identityInfo := identityRes{}
 			err := json.NewDecoder(res.Body).Decode(&identityInfo)

--- a/pkg/detectors/axonaut/axonaut.go
+++ b/pkg/detectors/axonaut/axonaut.go
@@ -2,6 +2,7 @@ package axonaut
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("userApiKey", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/aylien/aylien.go
+++ b/pkg/detectors/aylien/aylien.go
@@ -2,6 +2,7 @@ package aylien
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("X-AYLIEN-NewsAPI-Application-Key", resMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/ayrshare/ayrshare.go
+++ b/pkg/detectors/ayrshare/ayrshare.go
@@ -3,6 +3,7 @@ package ayrshare
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/azurecontainerregistry/azurecontainerregistry_test.go
+++ b/pkg/detectors/azurecontainerregistry/azurecontainerregistry_test.go
@@ -28,7 +28,6 @@ func TestAzureContainerRegistry_FromChunk(t *testing.T) {
 	password := testSecrets.MustGetField("AZURE_CR_PASSWORD")
 	passwordInactive := testSecrets.MustGetField("AZURE_CR_PASSWORD_INACTIVE")
 
-
 	type args struct {
 		ctx    context.Context
 		data   []byte
@@ -104,7 +103,7 @@ func TestAzureContainerRegistry_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw","Redacted", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw", "Redacted", "VerificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("AzureContainerRegistry.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/beamer/beamer.go
+++ b/pkg/detectors/beamer/beamer.go
@@ -2,6 +2,7 @@ package beamer
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Beamer-Api-Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/beebole/beebole.go
+++ b/pkg/detectors/beebole/beebole.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -60,7 +61,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", sEnc))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/besnappy/besnappy.go
+++ b/pkg/detectors/besnappy/besnappy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -57,7 +58,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", sEnc))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/besttime/besttime.go
+++ b/pkg/detectors/besttime/besttime.go
@@ -54,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue

--- a/pkg/detectors/billomat/billomat.go
+++ b/pkg/detectors/billomat/billomat.go
@@ -3,6 +3,7 @@ package billomat
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -64,7 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("X-BillomatApiKey", resMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/bitbar/bitbar.go
+++ b/pkg/detectors/bitbar/bitbar.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -59,7 +60,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", baseToken))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/bitmex/bitmex.go
+++ b/pkg/detectors/bitmex/bitmex.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -79,7 +80,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("api-signature", signature)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/blitapp/blitapp.go
+++ b/pkg/detectors/blitapp/blitapp.go
@@ -2,6 +2,7 @@ package blitapp
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("API-Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/blogger/blogger.go
+++ b/pkg/detectors/blogger/blogger.go
@@ -2,6 +2,7 @@ package blogger
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -52,7 +53,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/bombbomb/bombbomb.go
+++ b/pkg/detectors/bombbomb/bombbomb.go
@@ -2,6 +2,7 @@ package bombbomb
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/borgbase/borgbase.go
+++ b/pkg/detectors/borgbase/borgbase.go
@@ -65,7 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err == nil {
 					bodyString := string(bodyBytes)
 					validResponse := strings.Contains(bodyString, `"sshList":[]`)
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						if validResponse {
 							s1.Verified = true

--- a/pkg/detectors/browshot/browshot.go
+++ b/pkg/detectors/browshot/browshot.go
@@ -2,6 +2,7 @@ package browshot
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/buddyns/buddyns.go
+++ b/pkg/detectors/buddyns/buddyns.go
@@ -3,6 +3,7 @@ package buddyns
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Token %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/budibase/budibase_test.go
+++ b/pkg/detectors/budibase/budibase_test.go
@@ -68,8 +68,8 @@ func TestBudibase_FromChunk(t *testing.T) {
 			},
 			want: []detectors.Result{
 				{
-					DetectorType: detectorspb.DetectorType_Budibase,
-					Verified:     false,
+					DetectorType:      detectorspb.DetectorType_Budibase,
+					Verified:          false,
 					VerificationError: fmt.Errorf("unexpected HTTP response status 403"),
 				},
 			},
@@ -88,7 +88,6 @@ func TestBudibase_FromChunk(t *testing.T) {
 			wantErr:             false,
 			wantVerificationErr: false,
 		},
-		
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/detectors/bugherd/bugherd.go
+++ b/pkg/detectors/bugherd/bugherd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -59,7 +60,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", sEnc))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/bugsnag/bugsnag.go
+++ b/pkg/detectors/bugsnag/bugsnag.go
@@ -3,6 +3,7 @@ package bugsnag
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("token %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/bulbul/bulbul.go
+++ b/pkg/detectors/bulbul/bulbul.go
@@ -64,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				bodyString := string(bodyBytes)
 				validResponse := strings.Contains(bodyString, `"message":"Successful",`)
 
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					if validResponse {
 						s1.Verified = true

--- a/pkg/detectors/bulksms/bulksms.go
+++ b/pkg/detectors/bulksms/bulksms.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -66,7 +67,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Basic %s", sEnc))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/caflou/caflou.go
+++ b/pkg/detectors/caflou/caflou.go
@@ -3,6 +3,7 @@ package caflou
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -58,7 +59,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/campayn/campayn.go
+++ b/pkg/detectors/campayn/campayn.go
@@ -2,6 +2,7 @@ package campayn
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", "TRUEREST apikey="+resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/cannyio/cannyio.go
+++ b/pkg/detectors/cannyio/cannyio.go
@@ -2,6 +2,7 @@ package cannyio
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/caspio/caspio.go
+++ b/pkg/detectors/caspio/caspio.go
@@ -3,6 +3,7 @@ package caspio
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -75,7 +76,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					req.Header.Add("Content-Type", "text/plain")
 					res, err := client.Do(req)
 					if err == nil {
-						defer res.Body.Close()
+						defer func() {
+							// Ensure we drain the response body so this connection can be reused.
+							_, _ = io.Copy(io.Discard, res.Body)
+							_ = res.Body.Close()
+						}()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
 						} else {

--- a/pkg/detectors/censys/censys.go
+++ b/pkg/detectors/censys/censys.go
@@ -2,6 +2,7 @@ package censys
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -62,7 +63,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.SetBasicAuth(userPatMatch, tokenPatMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/cexio/cexio.go
+++ b/pkg/detectors/cexio/cexio.go
@@ -89,7 +89,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 					res, err := client.Do(req)
 					if err == nil {
-						defer res.Body.Close()
+						defer func() {
+							// Ensure we drain the response body so this connection can be reused.
+							_, _ = io.Copy(io.Discard, res.Body)
+							_ = res.Body.Close()
+						}()
 
 						body, err := io.ReadAll(res.Body)
 						if err != nil {

--- a/pkg/detectors/chatbot/chatbot.go
+++ b/pkg/detectors/chatbot/chatbot.go
@@ -3,6 +3,7 @@ package chatbot
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/chatfule/chatfule.go
+++ b/pkg/detectors/chatfule/chatfule.go
@@ -3,6 +3,7 @@ package chatfule
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/checio/checio.go
+++ b/pkg/detectors/checio/checio.go
@@ -2,6 +2,8 @@ package checio
 
 import (
 	"context"
+	"io"
+
 	// "log"
 	"net/http"
 	"regexp"
@@ -55,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-Authorization", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/checkout/checkout.go
+++ b/pkg/detectors/checkout/checkout.go
@@ -2,6 +2,7 @@ package checkout
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -65,7 +66,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", resMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/cicero/cicero.go
+++ b/pkg/detectors/cicero/cicero.go
@@ -3,6 +3,7 @@ package cicero
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/circleci/circleci.go
+++ b/pkg/detectors/circleci/circleci.go
@@ -2,6 +2,7 @@ package circleci
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 
@@ -52,7 +53,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Circle-Token", token)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 			}
 			if res != nil && res.StatusCode >= 200 && res.StatusCode < 300 {
 				s.Verified = true

--- a/pkg/detectors/clarifai/clarifai.go
+++ b/pkg/detectors/clarifai/clarifai.go
@@ -3,6 +3,7 @@ package clarifai
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Key %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				}
@@ -70,7 +75,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Key %s", resMatch))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/clearbit/clearbit.go
+++ b/pkg/detectors/clearbit/clearbit.go
@@ -3,6 +3,7 @@ package clearbit
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/cliengo/cliengo.go
+++ b/pkg/detectors/cliengo/cliengo.go
@@ -2,6 +2,7 @@ package cliengo
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/clockify/clockify.go
+++ b/pkg/detectors/clockify/clockify.go
@@ -2,6 +2,7 @@ package clockify
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-Api-Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/closecrm/close.go
+++ b/pkg/detectors/closecrm/close.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -59,7 +60,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/cloverly/cloverly.go
+++ b/pkg/detectors/cloverly/cloverly.go
@@ -3,6 +3,7 @@ package cloverly
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/cloze/cloze.go
+++ b/pkg/detectors/cloze/cloze.go
@@ -2,6 +2,7 @@ package cloze
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -67,7 +68,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/clustdoc/clustdoc.go
+++ b/pkg/detectors/clustdoc/clustdoc.go
@@ -3,6 +3,7 @@ package clustdoc
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/codacy/codacy.go
+++ b/pkg/detectors/codacy/codacy.go
@@ -2,6 +2,7 @@ package codacy
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("api-token", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/coinapi/coinapi.go
+++ b/pkg/detectors/coinapi/coinapi.go
@@ -2,6 +2,7 @@ package coinapi
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-CoinAPI-Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/coinbase/coinbase.go
+++ b/pkg/detectors/coinbase/coinbase.go
@@ -3,6 +3,7 @@ package coinbase
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/coinlib/coinlib.go
+++ b/pkg/detectors/coinlib/coinlib.go
@@ -3,6 +3,7 @@ package coinlib
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/collect2/collect2.go
+++ b/pkg/detectors/collect2/collect2.go
@@ -3,6 +3,7 @@ package collect2
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/column/column.go
+++ b/pkg/detectors/column/column.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"regexp"
@@ -59,7 +60,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(resMatch))))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/convier/convier.go
+++ b/pkg/detectors/convier/convier.go
@@ -65,7 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				bodyString := string(bodyBytes)
 				validResponse := strings.Contains(bodyString, `"error":false`)
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					if validResponse {
 						s1.Verified = true

--- a/pkg/detectors/copper/copper.go
+++ b/pkg/detectors/copper/copper.go
@@ -2,6 +2,7 @@ package copper
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -70,7 +71,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Content-Type", "application/json")
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/courier/courier.go
+++ b/pkg/detectors/courier/courier.go
@@ -3,6 +3,7 @@ package courier
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				}

--- a/pkg/detectors/crowdin/crowdin.go
+++ b/pkg/detectors/crowdin/crowdin.go
@@ -3,6 +3,7 @@ package crowdin
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/dailyco/dailyco.go
+++ b/pkg/detectors/dailyco/dailyco.go
@@ -3,6 +3,7 @@ package dailyco
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/databox/databox.go
+++ b/pkg/detectors/databox/databox.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -68,7 +69,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", sEnc))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/datagov/datagov.go
+++ b/pkg/detectors/datagov/datagov.go
@@ -3,6 +3,7 @@ package datagov
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/debounce/debounce.go
+++ b/pkg/detectors/debounce/debounce.go
@@ -2,6 +2,7 @@ package debounce
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/deepai/deepai.go
+++ b/pkg/detectors/deepai/deepai.go
@@ -69,7 +69,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("api-key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/deepgram/deepgram.go
+++ b/pkg/detectors/deepgram/deepgram.go
@@ -3,6 +3,7 @@ package deepgram
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Token %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/demio/demio.go
+++ b/pkg/detectors/demio/demio.go
@@ -3,6 +3,7 @@ package demio
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -61,7 +62,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/deputy/deputy.go
+++ b/pkg/detectors/deputy/deputy.go
@@ -3,6 +3,7 @@ package deputy
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -64,7 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("OAuth %s", resMatch))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/dfuse/dfuse.go
+++ b/pkg/detectors/dfuse/dfuse.go
@@ -2,6 +2,7 @@ package dfuse
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/diffbot/diffbot.go
+++ b/pkg/detectors/diffbot/diffbot.go
@@ -62,7 +62,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err == nil {
 					bodyString := string(bodyBytes)
 					validResponse := strings.Contains(bodyString, `"token":`) && strings.Contains(bodyString, `"planCredits":`)
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						if validResponse {
 							s1.Verified = true

--- a/pkg/detectors/disqus/disqus.go
+++ b/pkg/detectors/disqus/disqus.go
@@ -2,6 +2,7 @@ package disqus
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/ditto/ditto.go
+++ b/pkg/detectors/ditto/ditto.go
@@ -3,6 +3,7 @@ package ditto
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("token %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/dnscheck/dnscheck.go
+++ b/pkg/detectors/dnscheck/dnscheck.go
@@ -2,6 +2,7 @@ package dnscheck
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -62,7 +63,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/documo/documo.go
+++ b/pkg/detectors/documo/documo.go
@@ -3,6 +3,7 @@ package documo
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/doppler/doppler.go
+++ b/pkg/detectors/doppler/doppler.go
@@ -2,6 +2,7 @@ package doppler
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.SetBasicAuth(resMatch, "")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/dovico/dovico.go
+++ b/pkg/detectors/dovico/dovico.go
@@ -3,6 +3,7 @@ package dovico
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf(`WRAP access_token="client=%s&user_token=%s"`, resMatch, resUser))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/dronahq/dronahq.go
+++ b/pkg/detectors/dronahq/dronahq.go
@@ -3,6 +3,7 @@ package dronahq
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/droneci/droneci.go
+++ b/pkg/detectors/droneci/droneci.go
@@ -3,6 +3,7 @@ package droneci
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/duply/duply.go
+++ b/pkg/detectors/duply/duply.go
@@ -2,6 +2,7 @@ package duply
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -67,7 +68,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/dwolla/dwolla.go
+++ b/pkg/detectors/dwolla/dwolla.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -73,7 +74,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/dynalist/dynalist.go
+++ b/pkg/detectors/dynalist/dynalist.go
@@ -61,7 +61,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err == nil {
 					bodyString := string(bodyBytes)
 					validResponse := strings.Contains(bodyString, `"_code":"Ok"`)
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						if validResponse {
 							s1.Verified = true

--- a/pkg/detectors/dyspatch/dyspatch.go
+++ b/pkg/detectors/dyspatch/dyspatch.go
@@ -57,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue

--- a/pkg/detectors/edamam/edamam.go
+++ b/pkg/detectors/edamam/edamam.go
@@ -3,6 +3,7 @@ package edamam
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -62,7 +63,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Content-Type", "application/json")
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/edenai/edenai.go
+++ b/pkg/detectors/edenai/edenai.go
@@ -3,6 +3,7 @@ package edenai
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/enablex/enablex.go
+++ b/pkg/detectors/enablex/enablex.go
@@ -2,6 +2,7 @@ package enablex
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.SetBasicAuth(userPatMatch, tokenPatMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/enigma/enigma.go
+++ b/pkg/detectors/enigma/enigma.go
@@ -2,6 +2,7 @@ package enigma
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("x-api-key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/everhour/everhour.go
+++ b/pkg/detectors/everhour/everhour.go
@@ -2,6 +2,7 @@ package everhour
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-Api-Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/feedier/feedier.go
+++ b/pkg/detectors/feedier/feedier.go
@@ -3,6 +3,7 @@ package feedier
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/fetchrss/fetchrss.go
+++ b/pkg/detectors/fetchrss/fetchrss.go
@@ -54,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue

--- a/pkg/detectors/fibery/fibery.go
+++ b/pkg/detectors/fibery/fibery.go
@@ -3,6 +3,7 @@ package fibery
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -68,7 +69,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Token %s", resMatch))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/fileio/fileio.go
+++ b/pkg/detectors/fileio/fileio.go
@@ -60,7 +60,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err == nil {
 					isJson := json.Valid(bodyBytes)
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						if isJson {
 							s1.Verified = true

--- a/pkg/detectors/findl/findl.go
+++ b/pkg/detectors/findl/findl.go
@@ -2,6 +2,7 @@ package findl
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -57,7 +58,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-API-Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/finnhub/finnhub.go
+++ b/pkg/detectors/finnhub/finnhub.go
@@ -3,6 +3,7 @@ package finnhub
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/fixerio/fixerio.go
+++ b/pkg/detectors/fixerio/fixerio.go
@@ -55,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue
@@ -67,7 +71,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				// ingenious!
 
 				validResponse := strings.Contains(body, `"success": true`) || strings.Contains(body, `"info":"Access Restricted - Your current Subscription Plan does not support HTTPS Encryption."`)
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 
 				if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
 					s1.Verified = true

--- a/pkg/detectors/flatio/flatio.go
+++ b/pkg/detectors/flatio/flatio.go
@@ -3,6 +3,7 @@ package flatio
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/flickr/flickr.go
+++ b/pkg/detectors/flickr/flickr.go
@@ -56,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue

--- a/pkg/detectors/float/float.go
+++ b/pkg/detectors/float/float.go
@@ -3,6 +3,7 @@ package float
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("User-Agent", "TruffleHog3 (example@example.com)")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/flowdash/flowdash.go
+++ b/pkg/detectors/flowdash/flowdash.go
@@ -3,6 +3,7 @@ package flowdash
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/flowflu/flowflu.go
+++ b/pkg/detectors/flowflu/flowflu.go
@@ -72,7 +72,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					bodyString := string(bodyBytes)
 					validResponse := strings.Contains(bodyString, `total_result`)
 
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						if validResponse {
 							s1.Verified = true

--- a/pkg/detectors/fmfw/fmfw.go
+++ b/pkg/detectors/fmfw/fmfw.go
@@ -2,6 +2,7 @@ package fmfw
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -66,7 +67,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.SetBasicAuth(userPatMatch, tokenPatMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/formio/formio.go
+++ b/pkg/detectors/formio/formio.go
@@ -2,6 +2,7 @@ package formio
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("x-jwt-token", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/formsite/formsite.go
+++ b/pkg/detectors/formsite/formsite.go
@@ -3,6 +3,7 @@ package formsite
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -68,7 +69,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 					res, err := client.Do(req)
 					if err == nil {
-						defer res.Body.Close()
+						defer func() {
+							// Ensure we drain the response body so this connection can be reused.
+							_, _ = io.Copy(io.Discard, res.Body)
+							_ = res.Body.Close()
+						}()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
 						} else {

--- a/pkg/detectors/frameio/frameio.go
+++ b/pkg/detectors/frameio/frameio.go
@@ -3,6 +3,7 @@ package frameio
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/front/front.go
+++ b/pkg/detectors/front/front.go
@@ -3,6 +3,7 @@ package front
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/fulcrum/fulcrum.go
+++ b/pkg/detectors/fulcrum/fulcrum.go
@@ -2,6 +2,7 @@ package fulcrum
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-ApiToken", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/fullstory_v2/fullstory_v2.go
+++ b/pkg/detectors/fullstory_v2/fullstory_v2.go
@@ -3,6 +3,7 @@ package fullstory_v2
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -58,7 +59,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/fusebill/fusebill.go
+++ b/pkg/detectors/fusebill/fusebill.go
@@ -3,6 +3,7 @@ package fusebill
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/fxmarket/fxmarket.go
+++ b/pkg/detectors/fxmarket/fxmarket.go
@@ -3,6 +3,7 @@ package fxmarket
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/gengo/gengo.go
+++ b/pkg/detectors/gengo/gengo.go
@@ -76,7 +76,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Accept", "application/json")
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					body, errBody := io.ReadAll(res.Body)
 
 					if errBody == nil {

--- a/pkg/detectors/geoapify/geoapify.go
+++ b/pkg/detectors/geoapify/geoapify.go
@@ -3,6 +3,7 @@ package geoapify
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/geocode/geocode.go
+++ b/pkg/detectors/geocode/geocode.go
@@ -59,7 +59,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err == nil {
 					bodyString := string(bodyBytes)
 					validResponse := strings.Contains(bodyString, `"remaining_credits" :`)
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						if validResponse {
 							s1.Verified = true

--- a/pkg/detectors/geocodio/geocodio.go
+++ b/pkg/detectors/geocodio/geocodio.go
@@ -3,6 +3,7 @@ package geocodio
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -62,7 +63,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
+
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/geoipifi/geoipifi.go
+++ b/pkg/detectors/geoipifi/geoipifi.go
@@ -2,6 +2,7 @@ package geoipifi
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/getemail/getemail.go
+++ b/pkg/detectors/getemail/getemail.go
@@ -62,7 +62,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				bodyString := string(bodyBytes)
 				errCode := strings.Contains(bodyString, `"code":"USER_NOT_EXIST"`)
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					if errCode {
 						s1.Verified = false

--- a/pkg/detectors/getgist/getgist.go
+++ b/pkg/detectors/getgist/getgist.go
@@ -3,6 +3,7 @@ package getgist
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/gitlabv2/gitlab_v2.go
+++ b/pkg/detectors/gitlabv2/gitlab_v2.go
@@ -3,6 +3,7 @@ package gitlabv2
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -92,7 +93,9 @@ func (s Scanner) verifyGitlab(ctx context.Context, resMatch string) (bool, error
 		if err != nil {
 			return false, err
 		}
-		defer res.Body.Close() // The request body is unused.
+		// Ensure we drain the response body so this connection can be reused.
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
 
 		// 200 means good key and has `read_user` scope
 		// 403 means good key but not the right scope

--- a/pkg/detectors/gitter/gitter.go
+++ b/pkg/detectors/gitter/gitter.go
@@ -3,6 +3,7 @@ package gitter
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/gocanvas/gocanvas.go
+++ b/pkg/detectors/gocanvas/gocanvas.go
@@ -71,7 +71,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					body, errBody := io.ReadAll(res.Body)
 
 					if errBody == nil {

--- a/pkg/detectors/goodday/goodday.go
+++ b/pkg/detectors/goodday/goodday.go
@@ -2,6 +2,7 @@ package goodday
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("gd-api-token", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/graphcms/graphcms.go
+++ b/pkg/detectors/graphcms/graphcms.go
@@ -3,6 +3,7 @@ package graphcms
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -67,7 +68,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
+
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					}

--- a/pkg/detectors/groovehq/groovehq.go
+++ b/pkg/detectors/groovehq/groovehq.go
@@ -3,6 +3,7 @@ package groovehq
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/gtmetrix/gtmetrix.go
+++ b/pkg/detectors/gtmetrix/gtmetrix.go
@@ -2,6 +2,7 @@ package gtmetrix
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.SetBasicAuth(resMatch, "")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/gumroad/gumroad.go
+++ b/pkg/detectors/gumroad/gumroad.go
@@ -2,6 +2,7 @@ package gumroad
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/guru/guru.go
+++ b/pkg/detectors/guru/guru.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -69,7 +70,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encoded))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/gyazo/gyazo.go
+++ b/pkg/detectors/gyazo/gyazo.go
@@ -2,6 +2,7 @@ package gyazo
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/harvest/harvest.go
+++ b/pkg/detectors/harvest/harvest.go
@@ -2,6 +2,7 @@ package harvest
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -60,7 +61,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
+
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/hereapi/hereapi.go
+++ b/pkg/detectors/hereapi/hereapi.go
@@ -3,6 +3,7 @@ package hereapi
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -52,7 +53,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/heroku/heroku.go
+++ b/pkg/detectors/heroku/heroku.go
@@ -3,6 +3,7 @@ package heroku
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/hive/hive.go
+++ b/pkg/detectors/hive/hive.go
@@ -2,6 +2,7 @@ package hive
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -62,7 +63,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
+
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/hiveage/hiveage.go
+++ b/pkg/detectors/hiveage/hiveage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -59,7 +60,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", encoded))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/holistic/holistic.go
+++ b/pkg/detectors/holistic/holistic.go
@@ -63,7 +63,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				bodyString := string(bodyBytes)
 				errorResponse := strings.Contains(bodyString, `"data":[]`)
 
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 && !errorResponse {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/host/host.go
+++ b/pkg/detectors/host/host.go
@@ -3,6 +3,7 @@ package host
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/html2pdf/html2pdf.go
+++ b/pkg/detectors/html2pdf/html2pdf.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -60,7 +61,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			res, err := http.Post("https://api.html2pdf.app/v1/generate", "application/json", reqBuf)
 
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/humanity/humanity.go
+++ b/pkg/detectors/humanity/humanity.go
@@ -54,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue

--- a/pkg/detectors/hunter/hunter.go
+++ b/pkg/detectors/hunter/hunter.go
@@ -2,6 +2,8 @@ package hunter
 
 import (
 	"context"
+	"io"
+
 	// "fmt"
 	// "log"
 	"net/http"
@@ -54,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/hybiscus/hybiscus.go
+++ b/pkg/detectors/hybiscus/hybiscus.go
@@ -2,6 +2,7 @@ package hybiscus
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-API-KEY", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/iexapis/iexapis.go
+++ b/pkg/detectors/iexapis/iexapis.go
@@ -2,6 +2,7 @@ package iexapis
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/iexcloud/iexcloud.go
+++ b/pkg/detectors/iexcloud/iexcloud.go
@@ -3,6 +3,7 @@ package iexcloud
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/imagekit/imagekit.go
+++ b/pkg/detectors/imagekit/imagekit.go
@@ -2,6 +2,7 @@ package imagekit
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			res, err := client.Do(req)
 
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/imagga/imagga.go
+++ b/pkg/detectors/imagga/imagga.go
@@ -3,6 +3,7 @@ package imagga
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/impala/impala.go
+++ b/pkg/detectors/impala/impala.go
@@ -2,6 +2,7 @@ package impala
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("x-api-key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/infura/infura.go
+++ b/pkg/detectors/infura/infura.go
@@ -56,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue

--- a/pkg/detectors/instabot/instabot.go
+++ b/pkg/detectors/instabot/instabot.go
@@ -2,6 +2,7 @@ package instabot
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-Instabot-Api-Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/instamojo/instamojo.go
+++ b/pkg/detectors/instamojo/instamojo.go
@@ -24,7 +24,7 @@ var (
 	defaultClient = common.SaneHttpClient()
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	//KeyPat is client_id
-	keyPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"instamojo"}) + `\b([0-9a-zA-Z]{40})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"instamojo"}) + `\b([0-9a-zA-Z]{40})\b`)
 	//Secretpat is Client_secret
 	secretPat = regexp.MustCompile(detectors.PrefixRegex([]string{"instamojo"}) + `\b([0-9a-zA-Z]{128})\b`)
 )

--- a/pkg/detectors/instamojo/instamojo_test.go
+++ b/pkg/detectors/instamojo/instamojo_test.go
@@ -67,7 +67,7 @@ func TestInstamojo_FromChunk(t *testing.T) {
 			},
 			want: []detectors.Result{
 				{
-					DetectorType: detectorspb.DetectorType_Instamojo,
+					DetectorType:      detectorspb.DetectorType_Instamojo,
 					VerificationError: fmt.Errorf("unexpected HTTP response status 401"),
 				},
 			},
@@ -82,7 +82,7 @@ func TestInstamojo_FromChunk(t *testing.T) {
 				data:   []byte("You cannot find the secret within"),
 				verify: true,
 			},
-			want: nil,
+			want:                nil,
 			wantErr:             false,
 			wantVerificationErr: true,
 		},

--- a/pkg/detectors/intercom/intercom.go
+++ b/pkg/detectors/intercom/intercom.go
@@ -3,6 +3,7 @@ package intercom
 import (
 	"context"
 	"encoding/base64"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -65,7 +66,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/intrinio/intrinio.go
+++ b/pkg/detectors/intrinio/intrinio.go
@@ -3,6 +3,7 @@ package intrinio
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/ip2location/ip2location.go
+++ b/pkg/detectors/ip2location/ip2location.go
@@ -12,7 +12,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct {}
+type Scanner struct{}
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
@@ -47,8 +47,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.ip2location.io/?key=" + resMatch, nil)
-			
+			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.ip2location.io/?key="+resMatch, nil)
+
 			if err != nil {
 				continue
 			}
@@ -79,6 +79,3 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func (s Scanner) Type() detectorspb.DetectorType {
 	return detectorspb.DetectorType_Ip2location
 }
-
-
-

--- a/pkg/detectors/ipapi/ipapi.go
+++ b/pkg/detectors/ipapi/ipapi.go
@@ -61,7 +61,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					bodyString := string(bodyBytes)
 					valid := strings.Contains(bodyString, "continent_code") || strings.Contains(bodyString, `"info":"Access Restricted - Your current Subscription Plan does not support HTTPS Encryption."`)
 
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						if valid {
 							s1.Verified = true

--- a/pkg/detectors/ipify/ipify.go
+++ b/pkg/detectors/ipify/ipify.go
@@ -3,6 +3,7 @@ package ipify
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -57,7 +58,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/ipinfo/ipinfo.go
+++ b/pkg/detectors/ipinfo/ipinfo.go
@@ -3,6 +3,7 @@ package ipinfo
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -60,7 +61,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			res, err := client.Do(req)
 			if err == nil {
 				fmt.Println(res.Status, resMatch)
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else if res.StatusCode == 403 {

--- a/pkg/detectors/ipinfodb/ipinfodb.go
+++ b/pkg/detectors/ipinfodb/ipinfodb.go
@@ -59,7 +59,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err == nil {
 					bodyString := string(bodyBytes)
 					validResponse := strings.Contains(bodyString, `"statusCode": "OK"`)
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						if validResponse {
 							s1.Verified = true

--- a/pkg/detectors/ipstack/ipstack.go
+++ b/pkg/detectors/ipstack/ipstack.go
@@ -53,7 +53,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue

--- a/pkg/detectors/jdbc/sqlite.go
+++ b/pkg/detectors/jdbc/sqlite.go
@@ -14,7 +14,7 @@ type sqliteJDBC struct {
 	testing  bool
 }
 
-var cannotVerifySqliteError error = errors.New("sqlite credentials cannot be verified")
+var cannotVerifySqliteError = errors.New("sqlite credentials cannot be verified")
 
 func (s *sqliteJDBC) ping(ctx context.Context) pingResult {
 	if !s.testing {

--- a/pkg/detectors/jotform/jotform.go
+++ b/pkg/detectors/jotform/jotform.go
@@ -2,6 +2,7 @@ package jotform
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/juro/juro.go
+++ b/pkg/detectors/juro/juro.go
@@ -2,6 +2,7 @@ package juro
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("x-api-key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/kanban/kanban.go
+++ b/pkg/detectors/kanban/kanban.go
@@ -3,6 +3,7 @@ package kanban
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/karmacrm/karmacrm.go
+++ b/pkg/detectors/karmacrm/karmacrm.go
@@ -3,6 +3,7 @@ package karmacrm
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/keenio/keenio.go
+++ b/pkg/detectors/keenio/keenio.go
@@ -2,6 +2,7 @@ package keenio
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", resMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/kickbox/kickbox.go
+++ b/pkg/detectors/kickbox/kickbox.go
@@ -2,6 +2,7 @@ package kickbox
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				}

--- a/pkg/detectors/klaviyo/klaviyo.go
+++ b/pkg/detectors/klaviyo/klaviyo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -75,7 +76,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Set("Authorization", "Klaviyo-API-Key "+resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else if res.StatusCode == 403 {

--- a/pkg/detectors/kontent/kontent.go
+++ b/pkg/detectors/kontent/kontent.go
@@ -3,6 +3,7 @@ package kontent
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/kraken/kraken.go
+++ b/pkg/detectors/kraken/kraken.go
@@ -85,7 +85,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					out, _ := io.ReadAll(res.Body)
 					if !strings.Contains(string(out), "Invalid key") {
 						s1.Verified = true

--- a/pkg/detectors/kucoin/kucoin.go
+++ b/pkg/detectors/kucoin/kucoin.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"io"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -91,7 +92,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 					res, err := client.Do(req)
 					if err == nil {
-						defer res.Body.Close()
+						defer func() {
+							// Ensure we drain the response body so this connection can be reused.
+							_, _ = io.Copy(io.Discard, res.Body)
+							_ = res.Body.Close()
+						}()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
 						} else {

--- a/pkg/detectors/kylas/kylas.go
+++ b/pkg/detectors/kylas/kylas.go
@@ -2,6 +2,7 @@ package kylas
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("api-key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/lastfm/lastfm.go
+++ b/pkg/detectors/lastfm/lastfm.go
@@ -2,6 +2,7 @@ package lastfm
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/lemlist/lemlist.go
+++ b/pkg/detectors/lemlist/lemlist.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -58,7 +59,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", sEnc))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/lendflow/lendflow.go
+++ b/pkg/detectors/lendflow/lendflow.go
@@ -3,6 +3,7 @@ package lendflow
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -60,7 +61,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Accept", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				}

--- a/pkg/detectors/lexigram/lexigram.go
+++ b/pkg/detectors/lexigram/lexigram.go
@@ -3,6 +3,7 @@ package lexigram
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/loadmill/loadmill.go
+++ b/pkg/detectors/loadmill/loadmill.go
@@ -3,6 +3,7 @@ package loadmill
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/lob/lob.go
+++ b/pkg/detectors/lob/lob.go
@@ -2,6 +2,7 @@ package lob
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.SetBasicAuth(resMatch, "")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/loggly/loggly.go
+++ b/pkg/detectors/loggly/loggly.go
@@ -1,15 +1,16 @@
 package loggly
 
 import (
-        "context"
-        "fmt"
-        "net/http"
-        "regexp"
-        "strings"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
 
-        "github.com/trufflesecurity/trufflehog/v3/pkg/common"
-        "github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
-        "github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
 type Scanner struct {
@@ -20,82 +21,85 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-        defaultClient = common.SaneHttpClient()
-        // Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-        domainPat = regexp.MustCompile(`\b([a-zA-Z0-9-]+\.loggly\.com)\b`)
-        keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"loggly"}) + `\b([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\b`)
+	defaultClient = common.SaneHttpClient()
+	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
+	domainPat = regexp.MustCompile(`\b([a-zA-Z0-9-]+\.loggly\.com)\b`)
+	keyPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"loggly"}) + `\b([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-        return []string{"loggly"}
+	return []string{"loggly"}
 }
 
 // FromData will find and optionally verify Loggly secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
-        dataStr := string(data)
+	dataStr := string(data)
 
-        keyMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
-        domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
+	keyMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
+	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 
-        for _, match := range keyMatches {
-                if len(match) != 2 {
-                        continue
-                }
-                key := strings.TrimSpace(match[1])
+	for _, match := range keyMatches {
+		if len(match) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(match[1])
 
-                for _, domainMatch := range domainMatches {
-                        if len(domainMatch) != 2 {
-                                continue
-                        }
+		for _, domainMatch := range domainMatches {
+			if len(domainMatch) != 2 {
+				continue
+			}
 
-                        domainRes := strings.TrimSpace(domainMatch[1])
+			domainRes := strings.TrimSpace(domainMatch[1])
 
-                        s1 := detectors.Result{
-                                DetectorType: detectorspb.DetectorType_Loggly,
-                                Raw:          []byte(key),
-                                RawV2:        []byte(fmt.Sprintf("%s:%s", domainRes, key)),
+			s1 := detectors.Result{
+				DetectorType: detectorspb.DetectorType_Loggly,
+				Raw:          []byte(key),
+				RawV2:        []byte(fmt.Sprintf("%s:%s", domainRes, key)),
+			}
 
-                        }
+			if verify {
+				client := s.client
+				if client == nil {
+					client = defaultClient
+				}
+				req, err := http.NewRequestWithContext(ctx, "GET", "https://"+domainRes+"/apiv2/customer", nil)
+				if err != nil {
+					continue
+				}
+				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", key))
+				res, err := client.Do(req)
+				if err == nil {
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
+					if res.StatusCode >= 200 && res.StatusCode < 300 {
+						s1.Verified = true
+					} else if res.StatusCode == 401 {
+						// The secret is determinately not verified (nothing to do)
+					} else {
+						s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					}
+				} else {
+					s1.VerificationError = err
+				}
+			}
 
-                        if verify {
-				 client := s.client
-                        	if client == nil {
-                                client = defaultClient
-                        	}
-                                req, err := http.NewRequestWithContext(ctx, "GET", "https://"+domainRes+"/apiv2/customer", nil)
-                                if err != nil {
-                                        continue
-                                }
-                                req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", key))
-                                res, err := client.Do(req)
-                                if err == nil {
-                                        defer res.Body.Close()
-                                        if res.StatusCode >= 200 && res.StatusCode < 300 {
-                                                s1.Verified = true
-                                        } else if res.StatusCode == 401 {
-                                                // The secret is determinately not verified (nothing to do)
-                                        } else {
-                                                s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
-                                        }
-                                } else {
-                                        s1.VerificationError = err
-                                }
-                        }
+			// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
+			if !s1.Verified && detectors.IsKnownFalsePositive(key, detectors.DefaultFalsePositives, true) {
+				continue
+			}
 
-                        // This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
-                        if !s1.Verified && detectors.IsKnownFalsePositive(key, detectors.DefaultFalsePositives, true) {
-                                continue
-                        }
+			results = append(results, s1)
+		}
+	}
 
-                        results = append(results, s1)
-                }
-        }
-
-        return results, nil
+	return results, nil
 }
 
 func (s Scanner) Type() detectorspb.DetectorType {
-        return detectorspb.DetectorType_Loggly
+	return detectorspb.DetectorType_Loggly
 }

--- a/pkg/detectors/loyverse/loyverse.go
+++ b/pkg/detectors/loyverse/loyverse.go
@@ -3,6 +3,7 @@ package loyverse
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/luno/luno.go
+++ b/pkg/detectors/luno/luno.go
@@ -2,6 +2,7 @@ package luno
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.SetBasicAuth(userPatMatch, tokenPatMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/m3o/m3o.go
+++ b/pkg/detectors/m3o/m3o.go
@@ -3,6 +3,7 @@ package m3o
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -60,7 +61,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/madkudu/madkudu.go
+++ b/pkg/detectors/madkudu/madkudu.go
@@ -2,6 +2,7 @@ package madkudu
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.SetBasicAuth(resMatch, "")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/magnetic/magnetic.go
+++ b/pkg/detectors/magnetic/magnetic.go
@@ -2,6 +2,7 @@ package magnetic
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/mailgun/mailgun.go
+++ b/pkg/detectors/mailgun/mailgun.go
@@ -3,6 +3,7 @@ package mailgun
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err != nil {
 					continue
 				}
-				
+
 				// If resMatch has "key" prefix, use it as the username for basic auth.
 				if strings.HasPrefix(resMatch, "key-") {
 					req.SetBasicAuth("api", resMatch)
@@ -65,7 +66,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/mailmodo/mailmodo.go
+++ b/pkg/detectors/mailmodo/mailmodo.go
@@ -2,6 +2,7 @@ package mailmodo
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("mmApiKey", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/mailsac/mailsac.go
+++ b/pkg/detectors/mailsac/mailsac.go
@@ -2,6 +2,7 @@ package mailsac
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Mailsac-Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/mandrill/mandrill.go
+++ b/pkg/detectors/mandrill/mandrill.go
@@ -3,6 +3,7 @@ package mandrill
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/manifest/manifest.go
+++ b/pkg/detectors/manifest/manifest.go
@@ -2,6 +2,7 @@ package manifest
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/mapbox/mapbox.go
+++ b/pkg/detectors/mapbox/mapbox.go
@@ -2,6 +2,8 @@ package mapbox
 
 import (
 	"context"
+	"io"
+
 	// "log"
 	"net/http"
 	"regexp"
@@ -57,7 +59,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					}
 					res, err := client.Do(req)
 					if err == nil {
-						defer res.Body.Close()
+						defer func() {
+							// Ensure we drain the response body so this connection can be reused.
+							_, _ = io.Copy(io.Discard, res.Body)
+							_ = res.Body.Close()
+						}()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
 						} else {

--- a/pkg/detectors/mapquest/mapquest.go
+++ b/pkg/detectors/mapquest/mapquest.go
@@ -2,6 +2,7 @@ package mapquest
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/mesibo/mesibo.go
+++ b/pkg/detectors/mesibo/mesibo.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Scanner struct{}
+
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue

--- a/pkg/detectors/metaapi/metaapi.go
+++ b/pkg/detectors/metaapi/metaapi.go
@@ -65,7 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("apikey", resMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					body, errBody := io.ReadAll(res.Body)
 
 					if errBody == nil {

--- a/pkg/detectors/metabase/metabase.go
+++ b/pkg/detectors/metabase/metabase.go
@@ -2,6 +2,7 @@ package metabase
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -64,7 +65,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("X-Metabase-Session", resMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
+
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/metrilo/metrilo.go
+++ b/pkg/detectors/metrilo/metrilo.go
@@ -2,6 +2,7 @@ package metrilo
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Length", `0`)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/miro/miro.go
+++ b/pkg/detectors/miro/miro.go
@@ -3,6 +3,7 @@ package miro
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/mite/mite.go
+++ b/pkg/detectors/mite/mite.go
@@ -3,6 +3,7 @@ package mite
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("X-MiteApiKey", resMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/mixmax/mixmax.go
+++ b/pkg/detectors/mixmax/mixmax.go
@@ -2,6 +2,7 @@ package mixmax
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-API-Token", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/mixpanel/mixpanel.go
+++ b/pkg/detectors/mixpanel/mixpanel.go
@@ -2,6 +2,7 @@ package mixpanel
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.SetBasicAuth(userPatMatch, tokenPatMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
+
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/mockaroo/mockaroo.go
+++ b/pkg/detectors/mockaroo/mockaroo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					var t typeRes
 					err = json.NewDecoder(res.Body).Decode(&t)

--- a/pkg/detectors/monday/monday.go
+++ b/pkg/detectors/monday/monday.go
@@ -2,6 +2,7 @@ package monday
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/moosend/moosend.go
+++ b/pkg/detectors/moosend/moosend.go
@@ -54,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue

--- a/pkg/detectors/moralis/moralis.go
+++ b/pkg/detectors/moralis/moralis.go
@@ -2,6 +2,7 @@ package moralis
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-API-Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/mux/mux.go
+++ b/pkg/detectors/mux/mux.go
@@ -2,6 +2,7 @@ package mux
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -64,7 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.SetBasicAuth(resMatch, resSecretMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/nethunt/nethunt.go
+++ b/pkg/detectors/nethunt/nethunt.go
@@ -2,6 +2,7 @@ package nethunt
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.SetBasicAuth(userPatMatch, tokenPatMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/netlify/netlify.go
+++ b/pkg/detectors/netlify/netlify.go
@@ -3,6 +3,7 @@ package netlify
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -57,7 +58,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/newrelicpersonalapikey/newrelicpersonalapikey.go
+++ b/pkg/detectors/newrelicpersonalapikey/newrelicpersonalapikey.go
@@ -54,7 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			req.Header.Add("X-Api-Key", resMatch)
 			reqEU.Header.Add("X-Api-Key", resMatch)
-			
+
 			res, err := client.Do(req)
 			resEU, errEU := client.Do(reqEU)
 

--- a/pkg/detectors/newsapi/newsapi.go
+++ b/pkg/detectors/newsapi/newsapi.go
@@ -2,6 +2,7 @@ package newsapi
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/nftport/nftport.go
+++ b/pkg/detectors/nftport/nftport.go
@@ -2,6 +2,7 @@ package nftport
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/ngc/ngc.go
+++ b/pkg/detectors/ngc/ngc.go
@@ -3,6 +3,7 @@ package ngc
 import (
 	"context"
 	"encoding/base64"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/nimble/nimble.go
+++ b/pkg/detectors/nimble/nimble.go
@@ -3,6 +3,7 @@ package nimble
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/nitro/nitro.go
+++ b/pkg/detectors/nitro/nitro.go
@@ -2,6 +2,7 @@ package nitro
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.SetBasicAuth(resMatch, "")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/notion/notion.go
+++ b/pkg/detectors/notion/notion.go
@@ -3,6 +3,7 @@ package notion
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 || res.StatusCode == 403 {
 					// if >= 200 and < 300, the secret is valid and has privileges for the /v1/users endpoint
 					// If 403, the secret is valid, but does not have privileges for the /v1/users endpoint,

--- a/pkg/detectors/npmtoken/npmtoken.go
+++ b/pkg/detectors/npmtoken/npmtoken.go
@@ -3,6 +3,7 @@ package npmtoken
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -59,7 +60,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/nugetapikey/nugetapikey.go
+++ b/pkg/detectors/nugetapikey/nugetapikey.go
@@ -56,7 +56,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			res, err := client.Do(req)
 			if err == nil {
 				defer res.Body.Close()
-					// we can either match on response code "400" or "Bad Request" response
+				// we can either match on response code "400" or "Bad Request" response
 				if res.StatusCode == 400 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/nylas/nylas.go
+++ b/pkg/detectors/nylas/nylas.go
@@ -3,6 +3,7 @@ package nylas
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/nytimes/nytimes.go
+++ b/pkg/detectors/nytimes/nytimes.go
@@ -2,6 +2,7 @@ package nytimes
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/oanda/oanda.go
+++ b/pkg/detectors/oanda/oanda.go
@@ -3,6 +3,7 @@ package oanda
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/okta/okta.go
+++ b/pkg/detectors/okta/okta.go
@@ -65,7 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err != nil {
 					continue
 				}
-				defer resp.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, resp.Body)
+					_ = resp.Body.Close()
+				}()
 				if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 					body, _ := io.ReadAll(resp.Body)
 					if strings.Contains(string(body), "activated") {

--- a/pkg/detectors/omnisend/omnisend.go
+++ b/pkg/detectors/omnisend/omnisend.go
@@ -2,6 +2,7 @@ package omnisend
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-API-KEY", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/onedesk/onedesk.go
+++ b/pkg/detectors/onedesk/onedesk.go
@@ -64,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Content-Type", "application/json")
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					bodyBytes, err := io.ReadAll(res.Body)
 					if err != nil {
 						continue

--- a/pkg/detectors/oopspam/oopspam.go
+++ b/pkg/detectors/oopspam/oopspam.go
@@ -2,6 +2,7 @@ package oopspam
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-Api-Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/openuv/openuv.go
+++ b/pkg/detectors/openuv/openuv.go
@@ -2,6 +2,7 @@ package openuv
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("x-access-token", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/opsgenie/opsgenie.go
+++ b/pkg/detectors/opsgenie/opsgenie.go
@@ -3,6 +3,7 @@ package opsgenie
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -59,7 +60,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("GenieKey %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/owlbot/owlbot.go
+++ b/pkg/detectors/owlbot/owlbot.go
@@ -3,6 +3,7 @@ package owlbot
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Token %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/pandadoc/pandadoc.go
+++ b/pkg/detectors/pandadoc/pandadoc.go
@@ -3,6 +3,7 @@ package pandadoc
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("API-Key %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/parsehub/parsehub.go
+++ b/pkg/detectors/parsehub/parsehub.go
@@ -3,6 +3,7 @@ package parsehub
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/parsers/parsers.go
+++ b/pkg/detectors/parsers/parsers.go
@@ -2,6 +2,7 @@ package parsers
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("x-api-key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/parseur/parseur.go
+++ b/pkg/detectors/parseur/parseur.go
@@ -3,6 +3,7 @@ package parseur
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Token %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/pastebin/pastebin.go
+++ b/pkg/detectors/pastebin/pastebin.go
@@ -84,7 +84,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", writer.FormDataContentType())
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/paymoapp/paymoapp.go
+++ b/pkg/detectors/paymoapp/paymoapp.go
@@ -3,6 +3,7 @@ package paymoapp
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/paymongo/paymongo.go
+++ b/pkg/detectors/paymongo/paymongo.go
@@ -2,6 +2,7 @@ package paymongo
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.SetBasicAuth(resMatch, "")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/paystack/paystack.go
+++ b/pkg/detectors/paystack/paystack.go
@@ -3,6 +3,7 @@ package paystack
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/pdflayer/pdflayer.go
+++ b/pkg/detectors/pdflayer/pdflayer.go
@@ -59,7 +59,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err == nil {
 					bodyString := string(bodyBytes)
 					validResponse := strings.Contains(bodyString, `Contents`)
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						if validResponse {
 							s1.Verified = true

--- a/pkg/detectors/pdfshift/pdfshift.go
+++ b/pkg/detectors/pdfshift/pdfshift.go
@@ -2,6 +2,7 @@ package pdfshift
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.SetBasicAuth("api", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/pepipost/pepipost.go
+++ b/pkg/detectors/pepipost/pepipost.go
@@ -2,6 +2,7 @@ package pepipost
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("api_key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/percy/percy.go
+++ b/pkg/detectors/percy/percy.go
@@ -3,6 +3,7 @@ package percy
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Token %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/pinata/pinata.go
+++ b/pkg/detectors/pinata/pinata.go
@@ -2,6 +2,7 @@ package pinata
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -68,7 +69,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("pinata_secret_api_key", resMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/pixabay/pixabay.go
+++ b/pkg/detectors/pixabay/pixabay.go
@@ -3,6 +3,7 @@ package pixabay
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/plaidkey/plaidkey.go
+++ b/pkg/detectors/plaidkey/plaidkey.go
@@ -3,6 +3,7 @@ package plaidkey
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -65,7 +66,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					req.Header.Add("Content-Type", "application/json")
 					res, err := client.Do(req)
 					if err == nil {
-						defer res.Body.Close()
+						defer func() {
+							// Ensure we drain the response body so this connection can be reused.
+							_, _ = io.Copy(io.Discard, res.Body)
+							_ = res.Body.Close()
+						}()
+
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
 							s1.ExtraData = map[string]string{"environment": fmt.Sprintf("https://%s.plaid.com", env)}

--- a/pkg/detectors/planyo/planyo.go
+++ b/pkg/detectors/planyo/planyo.go
@@ -56,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Accept", "application/vnd.planyo+json; version=3")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue

--- a/pkg/detectors/plivo/plivo.go
+++ b/pkg/detectors/plivo/plivo.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -65,7 +66,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Basic %s", decodeSecret))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/podio/podio.go
+++ b/pkg/detectors/podio/podio.go
@@ -3,6 +3,7 @@ package podio
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/pollsapi/pollsapi.go
+++ b/pkg/detectors/pollsapi/pollsapi.go
@@ -2,6 +2,7 @@ package pollsapi
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("api-key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/polygon/polygon.go
+++ b/pkg/detectors/polygon/polygon.go
@@ -2,6 +2,7 @@ package polygon
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/portainer/portainer.go
+++ b/pkg/detectors/portainer/portainer.go
@@ -23,7 +23,7 @@ var (
 	defaultClient = common.SaneHttpClient()
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	endpointPat = regexp.MustCompile(detectors.PrefixRegex([]string{"portainer"}) + `\b(https?:\/\/\S+(:[0-9]{4,5})?)\b`)
-	tokenPat = regexp.MustCompile(detectors.PrefixRegex([]string{"portainer"}) + `\b(eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[0-9A-Za-z]{50,310}\.[0-9A-Z-a-z\-_]{43})\b`)
+	tokenPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"portainer"}) + `\b(eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[0-9A-Za-z]{50,310}\.[0-9A-Z-a-z\-_]{43})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -59,7 +59,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if client == nil {
 					client = defaultClient
 				}
-				req, err := http.NewRequestWithContext(ctx, "GET",  resEndpointMatch + "/api/endpoints", nil)
+				req, err := http.NewRequestWithContext(ctx, "GET", resEndpointMatch+"/api/endpoints", nil)
 				if err != nil {
 					continue
 				}
@@ -86,7 +86,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if len(endpointMatches) > 0 {
 				results = append(results, s1)
 			}
-			
+
 		}
 	}
 

--- a/pkg/detectors/portainertoken/portainertoken.go
+++ b/pkg/detectors/portainertoken/portainertoken.go
@@ -22,7 +22,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	defaultClient = common.SaneHttpClient()
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"portainertoken"}) + `\b(ptr_[A-Za-z0-9\/_\-+=]{20,60})`)
+	keyPat      = regexp.MustCompile(detectors.PrefixRegex([]string{"portainertoken"}) + `\b(ptr_[A-Za-z0-9\/_\-+=]{20,60})`)
 	endpointPat = regexp.MustCompile(detectors.PrefixRegex([]string{"portainer"}) + `\b(https?:\/\/\S+(:[0-9]{4,5})?)\b`)
 )
 
@@ -59,7 +59,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if client == nil {
 					client = defaultClient
 				}
-				req, err := http.NewRequestWithContext(ctx, "GET", resEndpointMatch + "/api/stacks", nil)
+				req, err := http.NewRequestWithContext(ctx, "GET", resEndpointMatch+"/api/stacks", nil)
 				if err != nil {
 					continue
 				}
@@ -67,7 +67,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("X-API-Key", resMatch)
 
 				res, err := client.Do(req)
-				
+
 				if err == nil {
 					defer res.Body.Close()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {

--- a/pkg/detectors/postman/postman.go
+++ b/pkg/detectors/postman/postman.go
@@ -3,6 +3,7 @@ package postman
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -84,7 +85,11 @@ func verifyPostman(ctx context.Context, client *http.Client, token string) (bool
 	if err != nil {
 		return false, err
 	}
-	defer res.Body.Close()
+	defer func() {
+		// Ensure we drain the response body so this connection can be reused.
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
 
 	switch res.StatusCode {
 	case http.StatusOK:

--- a/pkg/detectors/postmark/postmark.go
+++ b/pkg/detectors/postmark/postmark.go
@@ -2,6 +2,7 @@ package postmark
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-Postmark-Server-Token", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/powrbot/powrbot.go
+++ b/pkg/detectors/powrbot/powrbot.go
@@ -3,6 +3,7 @@ package powrbot
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("secret-key %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/prefect/prefect.go
+++ b/pkg/detectors/prefect/prefect.go
@@ -3,6 +3,7 @@ package prefect
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/privacy/privacy.go
+++ b/pkg/detectors/privacy/privacy.go
@@ -3,6 +3,7 @@ package privacy
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -60,7 +61,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Set("Authorization", "api-key "+resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else if res.StatusCode == 401 {

--- a/pkg/detectors/prodpad/prodpad.go
+++ b/pkg/detectors/prodpad/prodpad.go
@@ -3,6 +3,7 @@ package prodpad
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/pulumi/pulumi.go
+++ b/pkg/detectors/pulumi/pulumi.go
@@ -3,6 +3,7 @@ package pulumi
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -57,7 +58,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("token %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/qase/qase.go
+++ b/pkg/detectors/qase/qase.go
@@ -2,6 +2,7 @@ package qase
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Token", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/qualaroo/qualaroo.go
+++ b/pkg/detectors/qualaroo/qualaroo.go
@@ -3,6 +3,7 @@ package qualaroo
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/qubole/qubole.go
+++ b/pkg/detectors/qubole/qubole.go
@@ -2,6 +2,7 @@ package qubole
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-AUTH-TOKEN", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/ramp/ramp.go
+++ b/pkg/detectors/ramp/ramp.go
@@ -6,6 +6,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -78,7 +79,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else if res.StatusCode == 401 {

--- a/pkg/detectors/raven/raven.go
+++ b/pkg/detectors/raven/raven.go
@@ -60,7 +60,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err != nil {
 					continue
 				}
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					if json.Valid(bodyBytes) {
 						s1.Verified = true

--- a/pkg/detectors/rawg/rawg.go
+++ b/pkg/detectors/rawg/rawg.go
@@ -2,6 +2,7 @@ package rawg
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/readme/readme.go
+++ b/pkg/detectors/readme/readme.go
@@ -2,6 +2,7 @@ package readme
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("accept", "application/json")
 			res, err := http.DefaultClient.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/refiner/refiner.go
+++ b/pkg/detectors/refiner/refiner.go
@@ -3,6 +3,7 @@ package refiner
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -57,7 +58,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/rentman/rentman.go
+++ b/pkg/detectors/rentman/rentman.go
@@ -3,6 +3,7 @@ package rentman
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/replyio/replyio.go
+++ b/pkg/detectors/replyio/replyio.go
@@ -3,6 +3,7 @@ package replyio
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -57,7 +58,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-Api-Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else if res.StatusCode == 401 {

--- a/pkg/detectors/rev/rev.go
+++ b/pkg/detectors/rev/rev.go
@@ -3,6 +3,7 @@ package rev
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Rev %s:%s", resClientMatch, resUserMatch))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
+
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/ritekit/ritekit.go
+++ b/pkg/detectors/ritekit/ritekit.go
@@ -3,6 +3,7 @@ package ritekit
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/roaring/roaring.go
+++ b/pkg/detectors/roaring/roaring.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -68,7 +69,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Basic %s", sEnc))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
+
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/rockset/rockset.go
+++ b/pkg/detectors/rockset/rockset.go
@@ -3,6 +3,7 @@ package rockset
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("ApiKey %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/rownd/rownd.go
+++ b/pkg/detectors/rownd/rownd.go
@@ -2,6 +2,7 @@ package rownd
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -74,7 +75,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					req.Header.Add("x-rownd-app-secret", secretMatch)
 					res, err := client.Do(req)
 					if err == nil {
-						defer res.Body.Close()
+						defer func() {
+							// Ensure we drain the response body so this connection can be reused.
+							_, _ = io.Copy(io.Discard, res.Body)
+							_ = res.Body.Close()
+						}()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
 						} else {

--- a/pkg/detectors/scalr/scalr.go
+++ b/pkg/detectors/scalr/scalr.go
@@ -3,6 +3,7 @@ package scalr
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -64,7 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Prefer", "profile=preview")
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/scrapingbee/scrapingbee.go
+++ b/pkg/detectors/scrapingbee/scrapingbee.go
@@ -2,6 +2,7 @@ package scrapingbee
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/sheety/sheety.go
+++ b/pkg/detectors/sheety/sheety.go
@@ -3,6 +3,7 @@ package sheety
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -62,7 +63,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/shipday/shipday.go
+++ b/pkg/detectors/shipday/shipday.go
@@ -3,6 +3,7 @@ package shipday
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/sigopt/sigopt.go
+++ b/pkg/detectors/sigopt/sigopt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -59,7 +60,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", sEnc))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/simfin/simfin.go
+++ b/pkg/detectors/simfin/simfin.go
@@ -62,7 +62,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				bodyString := string(bodyBytes)
 				validResponse := !strings.Contains(bodyString, `"error"`)
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/simvoly/simvoly.go
+++ b/pkg/detectors/simvoly/simvoly.go
@@ -3,6 +3,7 @@ package simvoly
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/sirv/sirv.go
+++ b/pkg/detectors/sirv/sirv.go
@@ -3,6 +3,7 @@ package sirv
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -67,7 +68,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Content-Type", "application/json")
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/smooch/smooch.go
+++ b/pkg/detectors/smooch/smooch.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -68,7 +69,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Basic %s", sEnc))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/snykkey/snykkey.go
+++ b/pkg/detectors/snykkey/snykkey.go
@@ -3,6 +3,7 @@ package snykkey
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("token %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/sslmate/sslmate.go
+++ b/pkg/detectors/sslmate/sslmate.go
@@ -3,6 +3,7 @@ package sslmate
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/strava/strava.go
+++ b/pkg/detectors/strava/strava.go
@@ -2,6 +2,7 @@ package strava
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -73,7 +74,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 					res, err := client.Do(req)
 					if err == nil {
-						defer res.Body.Close()
+						defer func() {
+							// Ensure we drain the response body so this connection can be reused.
+							_, _ = io.Copy(io.Discard, res.Body)
+							_ = res.Body.Close()
+						}()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
 						} else {

--- a/pkg/detectors/streak/streak.go
+++ b/pkg/detectors/streak/streak.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -58,7 +59,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Basic %s", sEnc))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/stripo/stripo.go
+++ b/pkg/detectors/stripo/stripo.go
@@ -3,6 +3,7 @@ package stripo
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -59,7 +60,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Stripo-Api-Auth", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else if res.StatusCode == 401 {

--- a/pkg/detectors/stytch/stytch.go
+++ b/pkg/detectors/stytch/stytch.go
@@ -2,6 +2,7 @@ package stytch
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -61,7 +62,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.SetBasicAuth(userPatMatch, tokenPatMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/swell/swell.go
+++ b/pkg/detectors/swell/swell.go
@@ -2,6 +2,7 @@ package swell
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -62,7 +63,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.SetBasicAuth(userPatMatch, tokenPatMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/tallyfy/tallyfy.go
+++ b/pkg/detectors/tallyfy/tallyfy.go
@@ -3,6 +3,7 @@ package tallyfy
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/tatumio/tatumio.go
+++ b/pkg/detectors/tatumio/tatumio.go
@@ -2,6 +2,7 @@ package tatumio
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("x-api-key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/taxjar/taxjar.go
+++ b/pkg/detectors/taxjar/taxjar.go
@@ -3,6 +3,7 @@ package taxjar
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/tefter/tefter.go
+++ b/pkg/detectors/tefter/tefter.go
@@ -64,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				bodyString := string(bodyBytes)
 				validResponse := json.Valid([]byte(bodyString))
 
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/telnyx/telnyx.go
+++ b/pkg/detectors/telnyx/telnyx.go
@@ -3,6 +3,7 @@ package telnyx
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/tiingo/tiingo.go
+++ b/pkg/detectors/tiingo/tiingo.go
@@ -3,6 +3,7 @@ package tiingo
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Token %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/tly/tly.go
+++ b/pkg/detectors/tly/tly.go
@@ -2,6 +2,7 @@ package tly
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/tmetric/tmetric.go
+++ b/pkg/detectors/tmetric/tmetric.go
@@ -3,6 +3,7 @@ package tmetric
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/todoist/todoist.go
+++ b/pkg/detectors/todoist/todoist.go
@@ -3,6 +3,7 @@ package todoist
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/tokeet/tokeet.go
+++ b/pkg/detectors/tokeet/tokeet.go
@@ -3,6 +3,7 @@ package tokeet
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -63,7 +64,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", resMatch)
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/tomtom/tomtom.go
+++ b/pkg/detectors/tomtom/tomtom.go
@@ -2,6 +2,7 @@ package tomtom
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/tradier/tradier.go
+++ b/pkg/detectors/tradier/tradier.go
@@ -3,6 +3,7 @@ package tradier
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/tru/tru.go
+++ b/pkg/detectors/tru/tru.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -68,7 +69,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Authorization", fmt.Sprintf("Basic %s", baseToken))
 				res, err := client.Do(req)
 				if err == nil {
-					defer res.Body.Close()
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
 					} else {

--- a/pkg/detectors/twist/twist.go
+++ b/pkg/detectors/twist/twist.go
@@ -3,6 +3,7 @@ package twist
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -60,7 +61,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", setAuth))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/twitch/twitch.go
+++ b/pkg/detectors/twitch/twitch.go
@@ -3,6 +3,7 @@ package twitch
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -103,7 +104,11 @@ func verifyTwitch(ctx context.Context, client *http.Client, resMatch string, res
 	if err != nil {
 		return false, err
 	}
-	defer res.Body.Close()
+	defer func() {
+		// Ensure we drain the response body so this connection can be reused.
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
 
 	switch res.StatusCode {
 	case http.StatusOK:

--- a/pkg/detectors/twitter/twitter.go
+++ b/pkg/detectors/twitter/twitter.go
@@ -3,6 +3,7 @@ package twitter
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				}

--- a/pkg/detectors/tyntec/tyntec.go
+++ b/pkg/detectors/tyntec/tyntec.go
@@ -2,6 +2,7 @@ package tyntec
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("apiKey", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/ubidots/ubidots.go
+++ b/pkg/detectors/ubidots/ubidots.go
@@ -2,6 +2,7 @@ package ubidots
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-Auth-Token", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/unifyid/unifyid.go
+++ b/pkg/detectors/unifyid/unifyid.go
@@ -57,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("X-API-Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue

--- a/pkg/detectors/unplugg/unplugg.go
+++ b/pkg/detectors/unplugg/unplugg.go
@@ -2,6 +2,7 @@ package unplugg
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("x-access-token", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/uplead/uplead.go
+++ b/pkg/detectors/uplead/uplead.go
@@ -2,6 +2,7 @@ package uplead
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/upwave/upwave.go
+++ b/pkg/detectors/upwave/upwave.go
@@ -3,6 +3,7 @@ package upwave
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Token %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/urlscan/urlscan.go
+++ b/pkg/detectors/urlscan/urlscan.go
@@ -2,6 +2,7 @@ package urlscan
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("API-Key", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/user/user.go
+++ b/pkg/detectors/user/user.go
@@ -3,6 +3,7 @@ package user
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Token %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/vagrantcloudpersonaltoken/vagrantcloudpersonaltoken.go
+++ b/pkg/detectors/vagrantcloudpersonaltoken/vagrantcloudpersonaltoken.go
@@ -44,7 +44,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{
-			DetectorType: detectorspb.DetectorType_VagrantCloudPersonalToken, 
+			DetectorType: detectorspb.DetectorType_VagrantCloudPersonalToken,
 			Raw:          []byte(resMatch),
 		}
 
@@ -53,7 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if client == nil {
 				client = defaultClient
 			}
-			
+
 			req, err := http.NewRequestWithContext(ctx, "GET", "https://app.vagrantup.com/api/v2/authenticate", nil)
 			if err != nil {
 				continue

--- a/pkg/detectors/vbout/vbout.go
+++ b/pkg/detectors/vbout/vbout.go
@@ -3,6 +3,7 @@ package vbout
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/vercel/vercel.go
+++ b/pkg/detectors/vercel/vercel.go
@@ -3,6 +3,7 @@ package vercel
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/viewneo/viewneo.go
+++ b/pkg/detectors/viewneo/viewneo.go
@@ -3,6 +3,7 @@ package viewneo
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/vpnapi/vpnapi.go
+++ b/pkg/detectors/vpnapi/vpnapi.go
@@ -2,6 +2,7 @@ package vpnapi
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/vyte/vyte.go
+++ b/pkg/detectors/vyte/vyte.go
@@ -2,6 +2,7 @@ package vyte
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", resMatch)
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/webex/webex.go
+++ b/pkg/detectors/webex/webex.go
@@ -63,8 +63,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				client := common.SaneHttpClient()
 				res, err := client.Do(req)
 				if err == nil {
+					defer func() {
+						// Ensure we drain the response body so this connection can be reused.
+						_, _ = io.Copy(io.Discard, res.Body)
+						_ = res.Body.Close()
+					}()
 					body, err := io.ReadAll(res.Body)
-					res.Body.Close()
 					if err == nil {
 						var message struct {
 							Message string `json:"message"`

--- a/pkg/detectors/webflow/webflow.go
+++ b/pkg/detectors/webflow/webflow.go
@@ -3,6 +3,7 @@ package webflow
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/wepay/wepay.go
+++ b/pkg/detectors/wepay/wepay.go
@@ -2,6 +2,7 @@ package wepay
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -70,7 +71,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+				
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/whoxy/whoxy.go
+++ b/pkg/detectors/whoxy/whoxy.go
@@ -56,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue

--- a/pkg/detectors/wistia/wistia.go
+++ b/pkg/detectors/wistia/wistia.go
@@ -2,6 +2,7 @@ package wistia
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/wit/wit.go
+++ b/pkg/detectors/wit/wit.go
@@ -3,6 +3,7 @@ package wit
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/wrike/wrike.go
+++ b/pkg/detectors/wrike/wrike.go
@@ -3,6 +3,7 @@ package wrike
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/yandex/yandex.go
+++ b/pkg/detectors/yandex/yandex.go
@@ -2,6 +2,7 @@ package yandex
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -53,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/yelp/yelp.go
+++ b/pkg/detectors/yelp/yelp.go
@@ -3,6 +3,7 @@ package yelp
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/yousign/yousign.go
+++ b/pkg/detectors/yousign/yousign.go
@@ -3,6 +3,7 @@ package yousign
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -56,7 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/zenrows/zenrows.go
+++ b/pkg/detectors/zenrows/zenrows.go
@@ -3,6 +3,7 @@ package zenrows
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -54,7 +55,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
+
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/zenserp/zenserp.go
+++ b/pkg/detectors/zenserp/zenserp.go
@@ -54,7 +54,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
 					continue

--- a/pkg/detectors/zeplin/zeplin.go
+++ b/pkg/detectors/zeplin/zeplin.go
@@ -3,6 +3,7 @@ package zeplin
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -55,7 +56,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			res, err := client.Do(req)
 			if err == nil {
-				defer res.Body.Close()
+				defer func() {
+					// Ensure we drain the response body so this connection can be reused.
+					_, _ = io.Copy(io.Discard, res.Body)
+					_ = res.Body.Close()
+				}()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else {

--- a/pkg/detectors/zipapi/zipapi.go
+++ b/pkg/detectors/zipapi/zipapi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -73,7 +74,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					req.Header.Add("Authorization", fmt.Sprintf("Basic %s", sEnc))
 					res, err := client.Do(req)
 					if err == nil {
-						defer res.Body.Close()
+						defer func() {
+							// Ensure we drain the response body so this connection can be reused.
+							_, _ = io.Copy(io.Discard, res.Body)
+							_ = res.Body.Close()
+						}()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
 						} else {

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -77,7 +77,11 @@ func TestArchiveHandler(t *testing.T) {
 		if err != nil || resp.StatusCode != http.StatusOK {
 			t.Error(err)
 		}
-		defer resp.Body.Close()
+		defer func() {
+			// Ensure we drain the response body so this connection can be reused.
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}()
 
 		archive := Archive{}
 		archive.New()
@@ -118,7 +122,11 @@ func TestHandleFile(t *testing.T) {
 	// TODO: Embed a zip without making an HTTP request.
 	resp, err := http.Get("https://raw.githubusercontent.com/bill-rich/bad-secrets/master/aws-canary-creds.zip")
 	assert.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() {
+		// Ensure we drain the response body so this connection can be reused.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
 	archive := Archive{}
 	archive.New()
 	reader, err := diskbufferreader.New(resp.Body)

--- a/pkg/sources/github/repo.go
+++ b/pkg/sources/github/repo.go
@@ -203,21 +203,18 @@ func (s *Source) processRepos(ctx context.Context, target string, listRepos repo
 	uniqueOrgs := map[string]struct{}{}
 
 	for {
-		someRepos, res, err := listRepos(ctx, target, listOpts)
-		if err == nil {
-			res.Body.Close()
-		}
-		if handled := s.handleRateLimit(err, res); handled {
+		someRepos, resp, err := listRepos(ctx, target, listOpts)
+		if handled := s.handleRateLimit(err, resp); handled {
 			continue
 		}
 		if err != nil {
 			return err
 		}
-		if res == nil {
+		if resp == nil {
 			break
 		}
 
-		s.log.V(2).Info("Listed repos", "page", opts.Page, "last_page", res.LastPage)
+		s.log.V(2).Info("Listed repos", "page", opts.Page, "last_page", resp.LastPage)
 		for _, r := range someRepos {
 			if r.GetFork() && !s.conn.IncludeForks {
 				continue
@@ -240,10 +237,10 @@ func (s *Source) processRepos(ctx context.Context, target string, listRepos repo
 			logger.V(3).Info("repo attributes", "name", repoName, "kb_size", r.GetSize(), "repo_url", repoURL)
 		}
 
-		if res.NextPage == 0 {
+		if resp.NextPage == 0 {
 			break
 		}
-		opts.Page = res.NextPage
+		opts.Page = resp.NextPage
 	}
 
 	logger.V(2).Info("found repos", "total", numRepos, "num_forks", numForks, "num_orgs", len(uniqueOrgs))

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -72,8 +72,11 @@ func (g *OSS) Fetch() (io.Reader, error) {
 	if err != nil || resp == nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
-
+	defer func() {
+		// Ensure we drain the response body so this connection can be reused.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
 	if resp.StatusCode == http.StatusNoContent {
 		return nil, errors.New("already up to date")
 	}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:

This adds calls to `io.Copy(io.Discard, res.Body)` prior to closing response bodies, as that is apparently beneficial:
```
# https://pkg.go.dev/net/http#Response
// The default HTTP client's Transport may not
// reuse HTTP/1.x "keep-alive" TCP connections if the Body is
// not read to completion and closed.
```

It would be interesting to benchmark/profile this and see whether it has an impact. It might also be beneficial to have verification logic in separate functions, per [1923#discussion_r1376535636](https://github.com/trufflesecurity/trufflehog/pull/1923#discussion_r1376535636).

https://old.reddit.com/r/golang/comments/13fphyz/til_go_response_body_must_be_closed_even_if_you/jjynmj7/
https://andrii-kushch.medium.com/is-it-necessary-to-close-the-body-in-the-http-response-object-in-golang-171c44c9394d

Edit: apparently find+replace missed quite a few instances. I'll fix that later, if this seems worthwhile.
```sh
$ rg "defer \w+\.Body\.Close\(\)" --no-line-number --no-filename | grep . | wc -l
577
```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

