### PR TITLE
Add support for user:pass@host to postgres JDBC detector

### DIFF
--- a/pkg/detectors/jdbc/postgres.go
+++ b/pkg/detectors/jdbc/postgres.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/lib/pq"
 	"strings"
+
+	"github.com/lib/pq"
 )
 
 type postgresJDBC struct {
@@ -57,17 +58,34 @@ func joinKeyValues(m map[string]string, sep string) string {
 }
 
 func parsePostgres(subname string) (jdbc, error) {
-	// expected form: //HOST/DB?key=value&key=value
+	// expected form: [subprotocol:]//[user:password@]HOST[/DB][?key=val[&key=val]]
 	hostAndDB, paramString, _ := strings.Cut(subname, "?")
 	if !strings.HasPrefix(hostAndDB, "//") {
 		return nil, errors.New("expected host to start with //")
 	}
-	hostAndDB = strings.TrimPrefix(hostAndDB, "//")
-	host, database, _ := strings.Cut(hostAndDB, "/")
+	userPassAndHostAndDB := strings.TrimPrefix(hostAndDB, "//")
+	userPass, hostAndDB, found := strings.Cut(userPassAndHostAndDB, "@")
+	var user, pass string
+	if found {
+		user, pass, _ = strings.Cut(userPass, ":")
+	} else {
+		hostAndDB = userPass
+		userPass = ""
+	}
+	host, database, found := strings.Cut(hostAndDB, "/")
+	if !found {
+		return nil, errors.New("expected host and database to be separated by /")
+	}
 
 	params := map[string]string{
 		"host":   host,
 		"dbname": database,
+	}
+	if len(user) > 0 {
+		params["user"] = user
+	}
+	if len(pass) > 0 {
+		params["password"] = pass
 	}
 	for _, param := range strings.Split(paramString, "&") {
 		key, val, _ := strings.Cut(param, "=")

--- a/pkg/detectors/jdbc/postgres.go
+++ b/pkg/detectors/jdbc/postgres.go
@@ -70,7 +70,6 @@ func parsePostgres(subname string) (jdbc, error) {
 		user, pass, _ = strings.Cut(userPass, ":")
 	} else {
 		hostAndDB = userPass
-		userPass = ""
 	}
 	host, database, found := strings.Cut(hostAndDB, "/")
 	if !found {

--- a/pkg/detectors/jdbc/postgres_integration_test.go
+++ b/pkg/detectors/jdbc/postgres_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os/exec"
 	"testing"
 	"time"
@@ -34,7 +35,15 @@ func TestPostgres(t *testing.T) {
 			want:  result{pingOk: true, pingDeterminate: true},
 		},
 		{
+			input: fmt.Sprintf("//postgres:%s@localhost:5432/foo?sslmode=disable", postgresPass),
+			want:  result{pingOk: true, pingDeterminate: true},
+		},
+		{
 			input: "//localhost:5432/foo?sslmode=disable&user=" + postgresUser + "&password=" + postgresPass,
+			want:  result{pingOk: true, pingDeterminate: true},
+		},
+		{
+			input: fmt.Sprintf("//%s:%s@localhost:5432/foo?sslmode=disable", postgresUser, postgresPass),
 			want:  result{pingOk: true, pingDeterminate: true},
 		},
 		{


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Add support for `user:pass@host` to postgres JDBC detector.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

