### PR TITLE
[chore] Speedup IsKnownFalsePositive using sets

### DIFF
--- a/pkg/detectors/falsepositives_test.go
+++ b/pkg/detectors/falsepositives_test.go
@@ -90,3 +90,10 @@ func TestStringShannonEntropy(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkDefaultIsKnownFalsePositive(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		// Use a string that won't be found in any dictionary for the worst case check.
+		IsKnownFalsePositive("aoeuaoeuaoeuaoeuaoeuaoeu", DefaultFalsePositives, true)
+	}
+}


### PR DESCRIPTION

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Update our false positive checks to use a set instead of iterating over a slice each time.
Also adds a check that the match is a valid UTF-8 string.

Benchmark before (worst case where `IsKnownFalsePositive` returns false):

```
» go test -tags=detectors -bench FalsePositive ./pkg/detectors
goos: darwin
goarch: arm64
pkg: github.com/trufflesecurity/trufflehog/v3/pkg/detectors
BenchmarkDefaultIsKnownFalsePositive-8             24123             49376 ns/op
PASS
ok      github.com/trufflesecurity/trufflehog/v3/pkg/detectors  1.922s
```

Benchmark after:

```
» go test -tags=detectors -bench FalsePositive ./pkg/detectors
goos: darwin
goarch: arm64
pkg: github.com/trufflesecurity/trufflehog/v3/pkg/detectors
BenchmarkDefaultIsKnownFalsePositive-8           5667696               201.6 ns/op
PASS
ok      github.com/trufflesecurity/trufflehog/v3/pkg/detectors  1.537s
```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

