### PR TITLE
Add Telegram bot username to extradata

### DIFF
--- a/pkg/detectors/telegrambottoken/telegrambottoken.go
+++ b/pkg/detectors/telegrambottoken/telegrambottoken.go
@@ -2,6 +2,8 @@ package telegrambottoken
 
 import (
 	"context"
+	"encoding/json"
+
 	//	"fmt"
 	"net/http"
 	"regexp"
@@ -22,13 +24,15 @@ var (
 
 	// https://core.telegram.org/bots#6-botfather
 	// thanks https://stackoverflow.com/questions/61868770/tegram-bot-api-token-format
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"telegram"}) + `\b([0-9]{8,10}:[a-zA-Z0-9_-]{35})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"telegram", "tgram://"}) + `\b([0-9]{8,10}:[a-zA-Z0-9_-]{35})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"telegram"}
+	// Apprise uses the `tgram://` url scheme.
+	// https://github.com/caronc/apprise/wiki/Notify_telegram
+	return []string{"telegram", "tgram"}
 }
 
 // FromData will find and optionally verify TelegramBotToken secrets in a given set of bytes.
@@ -54,11 +58,20 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err != nil {
 				continue
 			}
+
 			res, err := client.Do(req)
 			if err == nil {
 				defer res.Body.Close()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
+
+					apiRes := apiResponse{}
+					err := json.NewDecoder(res.Body).Decode(&apiRes)
+					if err == nil && apiRes.Ok {
+						s1.ExtraData = map[string]string{
+							"username": apiRes.Result.Username,
+						}
+					}
 				} else {
 					if detectors.IsKnownFalsePositive(key, detectors.DefaultFalsePositives, true) {
 						continue
@@ -71,6 +84,18 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	return results, nil
+}
+
+// https://core.telegram.org/bots/api#making-requests
+type apiResponse struct {
+	Ok     bool          `json:"ok"`
+	Result *userResponse `json:"result"`
+}
+
+// https://core.telegram.org/bots/api#user
+type userResponse struct {
+	IsBot    bool   `json:"is_bot"`
+	Username string `json:"username"`
 }
 
 func (s Scanner) Type() detectorspb.DetectorType {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This adds the bot's username to the result. This change was admittedly made haphazardly, so there's the chance I've made a mistake.

```sh
$ curl -i "https://api.telegram.org/bot123:abcdefg/getMe"
HTTP/2 200
...

{"ok":true,"result":{"id":1234,"is_bot":true,"first_name":"Sample","username":"samplebot","can_join_groups":true,"can_read_all_group_messages":true,"supports_inline_queries":false}}
```

It also adds another keyword/prefix that bot tokens are likely to be near. https://github.com/caronc/apprise/wiki/Notify_telegram

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

