### PR TITLE
Detector-Fix: Reintroduce Cloudflareglobalapikey

### DIFF
--- a/pkg/detectors/cloudflareglobalapikey/cloudflareglobalapikey.go
+++ b/pkg/detectors/cloudflareglobalapikey/cloudflareglobalapikey.go
@@ -19,12 +19,13 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	client = common.SaneHttpClient()
 
-	apiKeyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"cloudflare"}) + `([A-Za-z0-9_-]{37})`)
+	apiKeyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"cloudflare"}) + `\b([A-Za-z0-9_-]{37})\b`)
 
 	// email pattern thanks https://golangcode.com/validate-an-email-address/
 	// emailPat = regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+	// the emailPat regex will also match emails ending in .co.uk and .engineering
 
-	emailPat = regexp.MustCompile(`\b([a-zA-Z0-9+._-]+@[a-zA-Z0-9._-]+\.[a-zA-Z0-9_-]+)\b`)
+	emailPat = regexp.MustCompile(`\b([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(\.[A-Za-z]{2})?)\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -47,9 +48,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		apiKeyRes := strings.TrimSpace(apiKeyMatch[1])
 
 		for _, emailMatch := range emailMatches {
-			if len(emailMatch) != 2 {
-				continue
-			}
 			emailRes := strings.TrimSpace(emailMatch[1])
 
 			if detectors.IsKnownFalsePositive(apiKeyRes, detectors.DefaultFalsePositives, true) { // wait- (apiKeyRes, email) might be false positive does not mean (apiKeyRes, another_email) is ?

--- a/pkg/detectors/cloudflareglobalapikey/cloudflareglobalapikey.go
+++ b/pkg/detectors/cloudflareglobalapikey/cloudflareglobalapikey.go
@@ -48,6 +48,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		apiKeyRes := strings.TrimSpace(apiKeyMatch[1])
 
 		for _, emailMatch := range emailMatches {
+			if len(emailMatch) != 2 {
+				continue
+			}
 			emailRes := strings.TrimSpace(emailMatch[1])
 
 			if detectors.IsKnownFalsePositive(apiKeyRes, detectors.DefaultFalsePositives, true) { // wait- (apiKeyRes, email) might be false positive does not mean (apiKeyRes, another_email) is ?

--- a/pkg/engine/defaults.go
+++ b/pkg/engine/defaults.go
@@ -136,6 +136,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/cloudelements"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/cloudflareapitoken"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/cloudflarecakey"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/cloudflareglobalapikey"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/cloudimage"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/cloudmersive"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/cloudplan"
@@ -819,7 +820,7 @@ func DefaultDetectors() []detectors.Detector {
 		&clarifai.Scanner{},
 		&cloudflareapitoken.Scanner{},
 		&cloudflarecakey.Scanner{},
-		// &cloudflareglobalapikey.Scanner{},
+		&cloudflareglobalapikey.Scanner{},
 		&terraformcloudpersonaltoken.Scanner{},
 		&asanapersonalaccesstoken.Scanner{},
 		&trelloapikey.Scanner{},


### PR DESCRIPTION
### Description:
Seen live cloudflareglobalapi credentials in the wild. Fixed the code to reintroduce the detector back. Also tightened up the regex's for better matching.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

![cloudflare](https://github.com/trufflesecurity/trufflehog/assets/10580970/4ae79310-3dc0-4df3-ad41-99947a171f3e)
