### PR TITLE
[thog-1548] add auto redaction for verification errors

### DIFF
--- a/pkg/detectors/airtableapikey/airtableapikey_test.go
+++ b/pkg/detectors/airtableapikey/airtableapikey_test.go
@@ -100,7 +100,7 @@ func TestAirtableApiKey_FromChunk(t *testing.T) {
 				}
 				got[i].Raw = nil
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Airtable.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/airtableapikey/airtableapikey_test.go
+++ b/pkg/detectors/airtableapikey/airtableapikey_test.go
@@ -100,7 +100,7 @@ func TestAirtableApiKey_FromChunk(t *testing.T) {
 				}
 				got[i].Raw = nil
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Airtable.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/alchemy/alchemy.go
+++ b/pkg/detectors/alchemy/alchemy.go
@@ -65,10 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -6,10 +6,11 @@ package alchemy
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -132,11 +133,11 @@ func TestAlchemy_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Alchemy.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -137,7 +137,7 @@ func TestAlchemy_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Alchemy.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/anthropic/anthropic.go
+++ b/pkg/detectors/anthropic/anthropic.go
@@ -82,7 +82,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if res.StatusCode == http.StatusBadRequest {
 					var resp response
 					if err = json.NewDecoder(res.Body).Decode(&resp); err != nil {
-						s1.VerificationError = fmt.Errorf("unexpected HTTP response body: %w", err)
+						err = fmt.Errorf("unexpected HTTP response body: %w", err)
+						s1.SetVerificationError(err, resMatch)
 						continue
 					}
 					if resp.Error.Message == "max_tokens_to_sample: field required" {
@@ -95,10 +96,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					// The secret is determinately not verified (nothing to do)
 					// Anthropic returns 401 on all requests not containing a valid x-api-key header
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/anthropic/anthropic_test.go
+++ b/pkg/detectors/anthropic/anthropic_test.go
@@ -137,7 +137,7 @@ func TestAnthropic_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Anthropic.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/anthropic/anthropic_test.go
+++ b/pkg/detectors/anthropic/anthropic_test.go
@@ -6,10 +6,11 @@ package anthropic
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -132,11 +133,11 @@ func TestAnthropic_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Anthropic.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/appoptics/appoptics.go
+++ b/pkg/detectors/appoptics/appoptics.go
@@ -73,10 +73,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/appoptics/appoptics_test.go
+++ b/pkg/detectors/appoptics/appoptics_test.go
@@ -86,7 +86,7 @@ func TestAppoptics_FromChunk(t *testing.T) {
 			want:                nil,
 			wantErr:             false,
 			wantVerificationErr: false,
-		},		
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -99,11 +99,11 @@ func TestAppoptics_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Appoptics.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/appoptics/appoptics_test.go
+++ b/pkg/detectors/appoptics/appoptics_test.go
@@ -100,10 +100,10 @@ func TestAppoptics_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Appoptics.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -137,8 +137,8 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				verified, extraData, verificationErr := s.verifyMatch(ctx, resIDMatch, resSecretMatch, true)
-				s1.Verified = verified
+				isVerified, extraData, verificationErr := s.verifyMatch(ctx, resIDMatch, resSecretMatch, true)
+				s1.Verified = isVerified
 				// It'd be good to log when calculated account value does not match
 				// the account value from verification. Should only be edge cases at most.
 				// if extraData["account"] != s1.ExtraData["account"] && extraData["account"] != "" {//log here}
@@ -148,7 +148,10 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				for k, v := range extraData {
 					s1.ExtraData[k] = v
 				}
-				s1.VerificationError = verificationErr
+				// s1.VerificationError()=
+				if verificationErr != nil {
+					s1.SetVerificationError(verificationErr, resSecretMatch)
+				}
 			}
 
 			if !s1.Verified {
@@ -286,7 +289,7 @@ func (s scanner) verifyMatch(ctx context.Context, resIDMatch, resSecretMatch str
 				if strings.EqualFold(body.Error.Code, "InvalidClientTokenId") {
 					return false, nil, nil
 				} else {
-					return false, nil, fmt.Errorf("request to %v returned status %d with an unexpected reason (%s: %s)", res.Request.URL, res.StatusCode, body.Error.Code, body.Error.Message)
+					return false, nil, fmt.Errorf("request returned status %d with an unexpected reason (%s: %s)", res.StatusCode, body.Error.Code, body.Error.Message)
 				}
 			} else {
 				return false, nil, fmt.Errorf("couldn't parse the sts response body (%v)", err)

--- a/pkg/detectors/aws/aws.go
+++ b/pkg/detectors/aws/aws.go
@@ -148,7 +148,6 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				for k, v := range extraData {
 					s1.ExtraData[k] = v
 				}
-				// s1.VerificationError()=
 				if verificationErr != nil {
 					s1.SetVerificationError(verificationErr, resSecretMatch)
 				}

--- a/pkg/detectors/aws/aws_test.go
+++ b/pkg/detectors/aws/aws_test.go
@@ -314,11 +314,11 @@ func TestAWS_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationError {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationError {
 					t.Fatalf("wantVerificationError %v, verification error = %v", tt.wantVerificationError, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("AWS.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/aws/aws_test.go
+++ b/pkg/detectors/aws/aws_test.go
@@ -315,10 +315,10 @@ func TestAWS_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationError {
-					t.Fatalf("wantVerificationError %v, verification error = %v", tt.wantVerificationError, got[i].VerificationError)
+					t.Fatalf("wantVerificationError %v, verification error = %v", tt.wantVerificationError, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("AWS.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/awssessionkeys/awssessionkey.go
+++ b/pkg/detectors/awssessionkeys/awssessionkey.go
@@ -139,7 +139,7 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					if extraData != nil {
 						s1.ExtraData = extraData
 					}
-					s1.SetVerificationError(verificationErr, resIDMatch, resSecretMatch, resSessionMatch)
+					s1.SetVerificationError(verificationErr, resSecretMatch)
 				}
 
 				if !s1.Verified {

--- a/pkg/detectors/awssessionkeys/awssessionkey.go
+++ b/pkg/detectors/awssessionkeys/awssessionkey.go
@@ -134,12 +134,12 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 
 				if verify {
-					verified, extraData, verificationErr := s.verifyMatch(ctx, resIDMatch, resSecretMatch, resSessionMatch, true)
-					s1.Verified = verified
+					isVerified, extraData, verificationErr := s.verifyMatch(ctx, resIDMatch, resSecretMatch, resSessionMatch, true)
+					s1.Verified = isVerified
 					if extraData != nil {
 						s1.ExtraData = extraData
 					}
-					s1.VerificationError = verificationErr
+					s1.SetVerificationError(verificationErr, resIDMatch, resSecretMatch, resSessionMatch)
 				}
 
 				if !s1.Verified {

--- a/pkg/detectors/azurebatch/azurebatch_test.go
+++ b/pkg/detectors/azurebatch/azurebatch_test.go
@@ -100,11 +100,11 @@ func TestAzurebatch_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw", "Redacted", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw", "Redacted", *_test.go)
 
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("AzureBatch.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/azurebatch/azurebatch_test.go
+++ b/pkg/detectors/azurebatch/azurebatch_test.go
@@ -101,10 +101,10 @@ func TestAzurebatch_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw", "Redacted", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw", "Redacted", "verificationError")
 
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("AzureBatch.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/azurecontainerregistry/azurecontainerregistry.go
+++ b/pkg/detectors/azurecontainerregistry/azurecontainerregistry.go
@@ -75,10 +75,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					} else if res.StatusCode == 401 {
 						// The secret is determinately not verified (nothing to do)
 					} else {
-						s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						s1.SetVerificationError(err, username, password)
 					}
 				} else {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, username, password)
 				}
 			}
 

--- a/pkg/detectors/azurecontainerregistry/azurecontainerregistry.go
+++ b/pkg/detectors/azurecontainerregistry/azurecontainerregistry.go
@@ -76,7 +76,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						// The secret is determinately not verified (nothing to do)
 					} else {
 						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
-						s1.SetVerificationError(err, username, password)
+						s1.SetVerificationError(err, password)
 					}
 				} else {
 					s1.SetVerificationError(err, username, password)

--- a/pkg/detectors/azurecontainerregistry/azurecontainerregistry_test.go
+++ b/pkg/detectors/azurecontainerregistry/azurecontainerregistry_test.go
@@ -6,10 +6,11 @@ package azurecontainerregistry
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -27,7 +28,6 @@ func TestAzureContainerRegistry_FromChunk(t *testing.T) {
 	azureHost := testSecrets.MustGetField("AZURE_CR_HOST")
 	password := testSecrets.MustGetField("AZURE_CR_PASSWORD")
 	passwordInactive := testSecrets.MustGetField("AZURE_CR_PASSWORD_INACTIVE")
-
 
 	type args struct {
 		ctx    context.Context
@@ -100,11 +100,11 @@ func TestAzureContainerRegistry_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw","Redacted", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw", "Redacted", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("AzureContainerRegistry.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/azurecontainerregistry/azurecontainerregistry_test.go
+++ b/pkg/detectors/azurecontainerregistry/azurecontainerregistry_test.go
@@ -101,10 +101,10 @@ func TestAzureContainerRegistry_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw", "Redacted", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "Raw", "Redacted", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("AzureContainerRegistry.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/azurestorage/azurestorage.go
+++ b/pkg/detectors/azurestorage/azurestorage.go
@@ -79,10 +79,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					s1.Verified = true
 				} else if res.StatusCode == 403 {
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, accountKey)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, accountKey)
 			}
 		}
 

--- a/pkg/detectors/azurestorage/azurestorage_test.go
+++ b/pkg/detectors/azurestorage/azurestorage_test.go
@@ -134,10 +134,10 @@ func TestAzurestorage_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Azurestorage.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/azurestorage/azurestorage_test.go
+++ b/pkg/detectors/azurestorage/azurestorage_test.go
@@ -133,11 +133,11 @@ func TestAzurestorage_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Azurestorage.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/betterstack/betterstack.go
+++ b/pkg/detectors/betterstack/betterstack.go
@@ -66,10 +66,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/betterstack/betterstack_test.go
+++ b/pkg/detectors/betterstack/betterstack_test.go
@@ -99,11 +99,11 @@ func TestBetterstack_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Betterstack.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/betterstack/betterstack_test.go
+++ b/pkg/detectors/betterstack/betterstack_test.go
@@ -100,10 +100,10 @@ func TestBetterstack_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Betterstack.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/bitcoinaverage/bitcoinaverage.go
+++ b/pkg/detectors/bitcoinaverage/bitcoinaverage.go
@@ -63,7 +63,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					resp := &response{}
 					if err = json.NewDecoder(res.Body).Decode(resp); err != nil {
-						s1.VerificationError = err
+						s1.SetVerificationError(err, resMatch)
 						continue
 					}
 					if resp.Success {

--- a/pkg/detectors/braintreepayments/braintreepayments.go
+++ b/pkg/detectors/braintreepayments/braintreepayments.go
@@ -68,7 +68,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				url := s.getBraintreeURL()
 				isVerified, verificationErr := verifyBraintree(ctx, client, url, resIdMatch, resMatch)
 				s1.Verified = isVerified
-				s1.VerificationError = verificationErr
+				s1.SetVerificationError(verificationErr, resMatch, resIdMatch)
 			}
 
 			// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key

--- a/pkg/detectors/braintreepayments/braintreepayments.go
+++ b/pkg/detectors/braintreepayments/braintreepayments.go
@@ -68,7 +68,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				url := s.getBraintreeURL()
 				isVerified, verificationErr := verifyBraintree(ctx, client, url, resIdMatch, resMatch)
 				s1.Verified = isVerified
-				s1.SetVerificationError(verificationErr, resMatch, resIdMatch)
+				s1.SetVerificationError(verificationErr, resMatch)
 			}
 
 			// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key

--- a/pkg/detectors/braintreepayments/braintreepayments_test.go
+++ b/pkg/detectors/braintreepayments/braintreepayments_test.go
@@ -131,12 +131,12 @@ func TestBraintreePayments_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
 
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("BraintreePayments.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/braintreepayments/braintreepayments_test.go
+++ b/pkg/detectors/braintreepayments/braintreepayments_test.go
@@ -132,11 +132,11 @@ func TestBraintreePayments_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
 
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("BraintreePayments.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/browserstack/browserstack.go
+++ b/pkg/detectors/browserstack/browserstack.go
@@ -68,7 +68,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				isVerified, verificationErr := verifyBrowserStackCredentials(ctx, client, resUserMatch, resMatch)
 				s1.Verified = isVerified
-				s1.VerificationError = verificationErr
+				s1.SetVerificationError(verificationErr, resMatch, resUserMatch)
 			}
 
 			// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.

--- a/pkg/detectors/browserstack/browserstack.go
+++ b/pkg/detectors/browserstack/browserstack.go
@@ -68,7 +68,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				isVerified, verificationErr := verifyBrowserStackCredentials(ctx, client, resUserMatch, resMatch)
 				s1.Verified = isVerified
-				s1.SetVerificationError(verificationErr, resMatch, resUserMatch)
+				s1.SetVerificationError(verificationErr, resMatch)
 			}
 
 			// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.

--- a/pkg/detectors/browserstack/browserstack_test.go
+++ b/pkg/detectors/browserstack/browserstack_test.go
@@ -134,11 +134,11 @@ func TestBrowserStack_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("BrowserStack.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/browserstack/browserstack_test.go
+++ b/pkg/detectors/browserstack/browserstack_test.go
@@ -135,10 +135,10 @@ func TestBrowserStack_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("BrowserStack.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/budibase/budibase.go
+++ b/pkg/detectors/budibase/budibase.go
@@ -21,7 +21,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 
 var (
 	defaultClient = common.SaneHttpClient()
-	
+
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"budibase"}) + `\b([a-f0-9]{32}-[a-f0-9]{78,80})\b`)
 )
 
@@ -54,7 +54,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				client = defaultClient
 			}
 
-			
 			// URL: https://docs.budibase.com/reference/appsearch
 			// API searches for the app with given name, since we only need to check api key, sending any appname will work.
 			payload := strings.NewReader(`{"name":"qwerty"}`)
@@ -74,10 +73,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/budibase/budibase_test.go
+++ b/pkg/detectors/budibase/budibase_test.go
@@ -66,13 +66,14 @@ func TestBudibase_FromChunk(t *testing.T) {
 				data:   []byte(fmt.Sprintf("You can find a budibase secret %s within but not valid", inactiveSecret)), // the secret would satisfy the regex but not pass validation
 				verify: true,
 			},
-			want: []detectors.Result{
-				{
-					DetectorType:      detectorspb.DetectorType_Budibase,
-					Verified:          false,
-					VerificationError: fmt.Errorf("unexpected HTTP response status 403"),
-				},
-			},
+			want: func() []detectors.Result {
+				r := detectors.Result{
+					DetectorType: detectorspb.DetectorType_Budibase,
+					Verified:     true,
+				}
+				r.SetVerificationError(fmt.Errorf("unexpected HTTP response status 403"))
+				return []detectors.Result{r}
+			}(),
 			wantErr:             false,
 			wantVerificationErr: true,
 		},
@@ -101,7 +102,7 @@ func TestBudibase_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.want[i].VerificationError(), got[i].VerificationError())
 				}
 			}
 			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")

--- a/pkg/detectors/budibase/budibase_test.go
+++ b/pkg/detectors/budibase/budibase_test.go
@@ -68,8 +68,8 @@ func TestBudibase_FromChunk(t *testing.T) {
 			},
 			want: []detectors.Result{
 				{
-					DetectorType: detectorspb.DetectorType_Budibase,
-					Verified:     false,
+					DetectorType:      detectorspb.DetectorType_Budibase,
+					Verified:          false,
 					VerificationError: fmt.Errorf("unexpected HTTP response status 403"),
 				},
 			},
@@ -88,7 +88,6 @@ func TestBudibase_FromChunk(t *testing.T) {
 			wantErr:             false,
 			wantVerificationErr: false,
 		},
-		
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -101,11 +100,11 @@ func TestBudibase_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Budibase.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/budibase/budibase_test.go
+++ b/pkg/detectors/budibase/budibase_test.go
@@ -101,10 +101,10 @@ func TestBudibase_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Budibase.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/cloudsmith/cloudsmith.go
+++ b/pkg/detectors/cloudsmith/cloudsmith.go
@@ -64,7 +64,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					var r response
 					if err := json.NewDecoder(res.Body).Decode(&r); err != nil {
-						s1.VerificationError = err
+						s1.SetVerificationError(err, resMatch)
 						continue
 					}
 					if r.Authenticated {

--- a/pkg/detectors/coda/coda.go
+++ b/pkg/detectors/coda/coda.go
@@ -66,10 +66,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/coda/coda_test.go
+++ b/pkg/detectors/coda/coda_test.go
@@ -6,10 +6,11 @@ package coda
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -132,11 +133,11 @@ func TestCoda_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Coda.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/coda/coda_test.go
+++ b/pkg/detectors/coda/coda_test.go
@@ -134,10 +134,10 @@ func TestCoda_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Coda.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/codeclimate/codeclimate.go
+++ b/pkg/detectors/codeclimate/codeclimate.go
@@ -67,7 +67,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					var r response
 					if err := json.NewDecoder(res.Body).Decode(&r); err != nil {
-						s1.VerificationError = err
+						s1.SetVerificationError(err, resMatch)
 						continue
 					}
 					if r.Data.Id != "" {

--- a/pkg/detectors/coinbase_waas/coinbase_waas.go
+++ b/pkg/detectors/coinbase_waas/coinbase_waas.go
@@ -6,15 +6,16 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"net/http"
+	"regexp"
+	"strings"
+
 	"github.com/coinbase/waas-client-library-go/auth"
 	"github.com/coinbase/waas-client-library-go/clients"
 	v1clients "github.com/coinbase/waas-client-library-go/clients/v1"
 	v1 "github.com/coinbase/waas-client-library-go/gen/go/coinbase/cloud/pools/v1"
 	"github.com/google/uuid"
 	"google.golang.org/api/googleapi"
-	"net/http"
-	"regexp"
-	"strings"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
@@ -73,7 +74,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if verify {
 				isVerified, verificationErr := s.verifyMatch(ctx, resKeyNameMatch, resPrivKeyMatch)
 				s1.Verified = isVerified
-				s1.VerificationError = verificationErr
+				s1.SetVerificationError(verificationErr, resKeyNameMatch, resPrivKeyMatch)
 			}
 			results = append(results, s1)
 

--- a/pkg/detectors/coinbase_waas/coinbase_waas.go
+++ b/pkg/detectors/coinbase_waas/coinbase_waas.go
@@ -74,7 +74,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if verify {
 				isVerified, verificationErr := s.verifyMatch(ctx, resKeyNameMatch, resPrivKeyMatch)
 				s1.Verified = isVerified
-				s1.SetVerificationError(verificationErr, resKeyNameMatch, resPrivKeyMatch)
+				s1.SetVerificationError(verificationErr, resPrivKeyMatch)
 			}
 			results = append(results, s1)
 

--- a/pkg/detectors/coinbase_waas/coinbase_waas_test.go
+++ b/pkg/detectors/coinbase_waas/coinbase_waas_test.go
@@ -276,10 +276,10 @@ func TestCoinbaseWaaS_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Coinbasewaas.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/coinbase_waas/coinbase_waas_test.go
+++ b/pkg/detectors/coinbase_waas/coinbase_waas_test.go
@@ -275,11 +275,11 @@ func TestCoinbaseWaaS_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Coinbasewaas.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/databrickstoken/databrickstoken.go
+++ b/pkg/detectors/databrickstoken/databrickstoken.go
@@ -71,6 +71,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						// nothing to do here
 					} else {
 						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						s1.SetVerificationError(err, resMatch)
 					}
 				} else {
 					s1.SetVerificationError(err, resMatch)

--- a/pkg/detectors/databrickstoken/databrickstoken.go
+++ b/pkg/detectors/databrickstoken/databrickstoken.go
@@ -12,7 +12,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{
+type Scanner struct {
 	client *http.Client
 }
 
@@ -24,7 +24,7 @@ var (
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	domain = regexp.MustCompile(`\b([a-z0-9-]+(?:\.[a-z0-9-]+)*\.(cloud\.databricks\.com|gcp\.databricks\.com|azurewebsites\.net))\b`)
-	keyPat    = regexp.MustCompile(`\b(dapi[0-9a-f]{32})(-\d)?\b`)
+	keyPat = regexp.MustCompile(`\b(dapi[0-9a-f]{32})(-\d)?\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -54,10 +54,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			if verify {
 				client := s.client
-                        	if client == nil {
-                                	client = defaultClient
-                        	}
-				req, err := http.NewRequestWithContext(ctx, "GET", "https://" + resDomainMatch + "/api/2.0/clusters/list", nil)
+				if client == nil {
+					client = defaultClient
+				}
+				req, err := http.NewRequestWithContext(ctx, "GET", "https://"+resDomainMatch+"/api/2.0/clusters/list", nil)
 				if err != nil {
 					continue
 				}
@@ -70,10 +70,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					} else if res.StatusCode == 403 {
 						// nothing to do here
 					} else {
-						s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
 					}
 				} else {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, resMatch)
 				}
 			}
 			if !s1.Verified && detectors.IsKnownFalsePositive(string(s1.Raw), detectors.DefaultFalsePositives, true) {

--- a/pkg/detectors/databrickstoken/databrickstoken_test.go
+++ b/pkg/detectors/databrickstoken/databrickstoken_test.go
@@ -6,10 +6,11 @@ package databrickstoken
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -133,11 +134,11 @@ func TestDatabricksToken_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("DatabricksToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/databrickstoken/databrickstoken_test.go
+++ b/pkg/detectors/databrickstoken/databrickstoken_test.go
@@ -135,10 +135,10 @@ func TestDatabricksToken_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("DatabricksToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/deno/denodeploy_test.go
+++ b/pkg/detectors/deno/denodeploy_test.go
@@ -227,10 +227,10 @@ func TestDenoDeploy_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go, "ExtraData")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "ExtraData")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Denodeploy.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/deno/denodeploy_test.go
+++ b/pkg/detectors/deno/denodeploy_test.go
@@ -226,11 +226,11 @@ func TestDenoDeploy_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError", "ExtraData")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go, "ExtraData")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Denodeploy.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -3,12 +3,12 @@ package detectors
 import (
 	"context"
 	"crypto/rand"
-	"errors"
-	"fmt"
 	"math/big"
 	"net/url"
 	"strings"
 	"unicode"
+
+	"errors"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
@@ -83,11 +83,12 @@ func redactSecrets(err error, secrets ...string) error {
 	for _, secret := range secrets {
 		errStr = strings.Replace(errStr, secret, "[REDACTED]", -1)
 	}
-	// return redactedError{err, errStr}
-	return fmt.Errorf("%s", errStr)
+	return errors.New(errStr)
 }
 
 // unwrapToLast returns the last error in the chain of errors.
+// This is added to exclude non-essential details (like URLs) for brevity and security.
+// Also helps us optimize performance in redaction and enhance log clarity.
 func unwrapToLast(err error) error {
 	for {
 		unwrapped := errors.Unwrap(err)

--- a/pkg/detectors/eventbrite/eventbrite.go
+++ b/pkg/detectors/eventbrite/eventbrite.go
@@ -65,10 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/eventbrite/eventbrite_test.go
+++ b/pkg/detectors/eventbrite/eventbrite_test.go
@@ -132,7 +132,7 @@ func TestEventbrite_FromChunk(t *testing.T) {
 			for i := range got {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
-				}.VerificationError()
+				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}

--- a/pkg/detectors/eventbrite/eventbrite_test.go
+++ b/pkg/detectors/eventbrite/eventbrite_test.go
@@ -6,10 +6,11 @@ package eventbrite
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -131,12 +132,12 @@ func TestEventbrite_FromChunk(t *testing.T) {
 			for i := range got {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
-				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				}.VerificationError()
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Eventbrite.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/eventbrite/eventbrite_test.go
+++ b/pkg/detectors/eventbrite/eventbrite_test.go
@@ -134,10 +134,10 @@ func TestEventbrite_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}.VerificationError()
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Eventbrite.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/falsepositives.go
+++ b/pkg/detectors/falsepositives.go
@@ -107,7 +107,7 @@ func StringShannonEntropy(input string) float64 {
 func FilterResultsWithEntropy(results []Result, entropy float64) []Result {
 	var filteredResults []Result
 	for _, result := range results {
-		if !result.Verified && result.VerificationError == nil {
+		if !result.Verified && result.VerificationError() == nil {
 			if result.RawV2 != nil {
 				if StringShannonEntropy(string(result.RawV2)) >= entropy {
 					filteredResults = append(filteredResults, result)

--- a/pkg/detectors/figmapersonalaccesstoken/v1/figmapersonalaccesstoken.go
+++ b/pkg/detectors/figmapersonalaccesstoken/v1/figmapersonalaccesstoken.go
@@ -68,10 +68,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else if res.StatusCode != 403 {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/figmapersonalaccesstoken/v1/figmapersonalaccesstoken_test.go
+++ b/pkg/detectors/figmapersonalaccesstoken/v1/figmapersonalaccesstoken_test.go
@@ -129,10 +129,10 @@ func TestFigmaPersonalAccessToken_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("FigmaPersonalAccessToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/figmapersonalaccesstoken/v1/figmapersonalaccesstoken_test.go
+++ b/pkg/detectors/figmapersonalaccesstoken/v1/figmapersonalaccesstoken_test.go
@@ -128,11 +128,11 @@ func TestFigmaPersonalAccessToken_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("FigmaPersonalAccessToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/figmapersonalaccesstoken/v2/figmapersonalaccesstoken_v2.go
+++ b/pkg/detectors/figmapersonalaccesstoken/v2/figmapersonalaccesstoken_v2.go
@@ -67,10 +67,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else if res.StatusCode != 403 {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/figmapersonalaccesstoken/v2/figmapersonalaccesstoken_v2_test.go
+++ b/pkg/detectors/figmapersonalaccesstoken/v2/figmapersonalaccesstoken_v2_test.go
@@ -129,10 +129,10 @@ func TestFigmaPersonalAccessToken_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("FigmaPersonalAccessToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/figmapersonalaccesstoken/v2/figmapersonalaccesstoken_v2_test.go
+++ b/pkg/detectors/figmapersonalaccesstoken/v2/figmapersonalaccesstoken_v2_test.go
@@ -128,11 +128,11 @@ func TestFigmaPersonalAccessToken_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("FigmaPersonalAccessToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/formsite/formsite_test.go
+++ b/pkg/detectors/formsite/formsite_test.go
@@ -50,6 +50,10 @@ func TestFormsite_FromChunk(t *testing.T) {
 					DetectorType: detectorspb.DetectorType_Formsite,
 					Verified:     true,
 				},
+				{
+					DetectorType: detectorspb.DetectorType_Formsite,
+					Verified:     false,
+				},
 			},
 			wantErr: false,
 		},
@@ -62,6 +66,10 @@ func TestFormsite_FromChunk(t *testing.T) {
 				verify: true,
 			},
 			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Formsite,
+					Verified:     false,
+				},
 				{
 					DetectorType: detectorspb.DetectorType_Formsite,
 					Verified:     false,

--- a/pkg/detectors/ftp/ftp_test.go
+++ b/pkg/detectors/ftp/ftp_test.go
@@ -138,10 +138,10 @@ func TestFTP_FromChunk(t *testing.T) {
 				got[i].Raw = nil
 
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, *_test.go)
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "verificationError")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("FTP.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/ftp/ftp_test.go
+++ b/pkg/detectors/ftp/ftp_test.go
@@ -5,10 +5,11 @@ package ftp
 
 import (
 	"context"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
@@ -136,11 +137,11 @@ func TestFTP_FromChunk(t *testing.T) {
 			for i := range got {
 				got[i].Raw = nil
 
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "VerificationError")
+			opts := cmpopts.IgnoreFields(detectors.Result{}, *_test.go)
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("FTP.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/github/github.go
+++ b/pkg/detectors/github/github.go
@@ -101,7 +101,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						}
 					}
 				} else {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, token)
 				}
 			}
 		}

--- a/pkg/detectors/gitlab/gitlab.go
+++ b/pkg/detectors/gitlab/gitlab.go
@@ -62,7 +62,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		if verify {
 			isVerified, verificationErr := s.verifyGitlab(ctx, resMatch)
 			s1.Verified = isVerified
-			s1.VerificationError = verificationErr
+			s1.SetVerificationError(verificationErr, resMatch)
 		}
 
 		if !s1.Verified && detectors.IsKnownFalsePositive(string(s1.Raw), detectors.DefaultFalsePositives, true) {

--- a/pkg/detectors/gitlab/gitlab_v1_test.go
+++ b/pkg/detectors/gitlab/gitlab_v1_test.go
@@ -161,10 +161,10 @@ func TestGitlab_FromChunk(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("Gitlab.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/gitlab/gitlab_v1_test.go
+++ b/pkg/detectors/gitlab/gitlab_v1_test.go
@@ -160,11 +160,11 @@ func TestGitlab_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatal("no raw secret present")
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("Gitlab.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/gitlab/gitlab_v2_test.go
+++ b/pkg/detectors/gitlab/gitlab_v2_test.go
@@ -85,10 +85,10 @@ func TestGitlab_FromChunk_WithV2Secrets(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("Gitlab.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/gitlab/gitlab_v2_test.go
+++ b/pkg/detectors/gitlab/gitlab_v2_test.go
@@ -84,11 +84,11 @@ func TestGitlab_FromChunk_WithV2Secrets(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatal("no raw secret present")
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("Gitlab.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/gitlabv2/gitlab_v1_test.go
+++ b/pkg/detectors/gitlabv2/gitlab_v1_test.go
@@ -95,11 +95,11 @@ func TestGitlabV2_FromChunk_WithV1Secrets(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatal("no raw secret present")
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("Gitlab.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/gitlabv2/gitlab_v1_test.go
+++ b/pkg/detectors/gitlabv2/gitlab_v1_test.go
@@ -96,10 +96,10 @@ func TestGitlabV2_FromChunk_WithV1Secrets(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("Gitlab.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/gitlabv2/gitlab_v2.go
+++ b/pkg/detectors/gitlabv2/gitlab_v2.go
@@ -58,7 +58,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		if verify {
 			isVerified, verificationErr := s.verifyGitlab(ctx, resMatch)
 			s1.Verified = isVerified
-			s1.VerificationError = verificationErr
+			s1.SetVerificationError(verificationErr, resMatch)
 		}
 
 		if !s1.Verified && detectors.IsKnownFalsePositive(string(s1.Raw), detectors.DefaultFalsePositives, true) {

--- a/pkg/detectors/gitlabv2/gitlab_v2_test.go
+++ b/pkg/detectors/gitlabv2/gitlab_v2_test.go
@@ -144,11 +144,11 @@ func TestGitlabV2_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatal("no raw secret present")
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("Gitlab.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/gitlabv2/gitlab_v2_test.go
+++ b/pkg/detectors/gitlabv2/gitlab_v2_test.go
@@ -145,10 +145,10 @@ func TestGitlabV2_FromChunk(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("Gitlab.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/grafana/grafana.go
+++ b/pkg/detectors/grafana/grafana.go
@@ -66,10 +66,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/grafana/grafana_test.go
+++ b/pkg/detectors/grafana/grafana_test.go
@@ -134,10 +134,10 @@ func TestGrafana_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Grafana.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/grafana/grafana_test.go
+++ b/pkg/detectors/grafana/grafana_test.go
@@ -6,10 +6,11 @@ package grafana
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -132,11 +133,11 @@ func TestGrafana_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Grafana.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/grafanaserviceaccount/grafanaserviceaccount.go
+++ b/pkg/detectors/grafanaserviceaccount/grafanaserviceaccount.go
@@ -22,7 +22,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	defaultClient = common.SaneHttpClient()
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(`\b(glsa_[0-9a-zA-Z_]{41})\b`)
+	keyPat    = regexp.MustCompile(`\b(glsa_[0-9a-zA-Z_]{41})\b`)
 	domainPat = regexp.MustCompile(`\b([a-zA-Z0-9-]+\.grafana\.net)\b`)
 )
 
@@ -45,16 +45,16 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 		key := strings.TrimSpace(match[1])
 
-                for _, domainMatch := range domainMatches {
-                        if len(domainMatch) != 2 {
-                                continue
-                        }
+		for _, domainMatch := range domainMatches {
+			if len(domainMatch) != 2 {
+				continue
+			}
 			domainRes := strings.TrimSpace(domainMatch[1])
 
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_GrafanaServiceAccount,
 				Raw:          []byte(key),
-				RawV2: []byte(fmt.Sprintf("%s:%s", domainRes, key)),
+				RawV2:        []byte(fmt.Sprintf("%s:%s", domainRes, key)),
 			}
 
 			if verify {
@@ -75,10 +75,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					} else if res.StatusCode == 401 {
 						// The secret is determinately not verified (nothing to do)
 					} else {
-						s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						s1.SetVerificationError(err, key)
 					}
 				} else {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, key)
 				}
 			}
 

--- a/pkg/detectors/grafanaserviceaccount/grafanaserviceaccount_test.go
+++ b/pkg/detectors/grafanaserviceaccount/grafanaserviceaccount_test.go
@@ -6,10 +6,11 @@ package grafanaserviceaccount
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -133,11 +134,11 @@ func TestGrafanaServiceAccount_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("GrafanaServiceAccount.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/grafanaserviceaccount/grafanaserviceaccount_test.go
+++ b/pkg/detectors/grafanaserviceaccount/grafanaserviceaccount_test.go
@@ -135,10 +135,10 @@ func TestGrafanaServiceAccount_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("GrafanaServiceAccount.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/huggingface/huggingface.go
+++ b/pkg/detectors/huggingface/huggingface.go
@@ -68,10 +68,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/huggingface/huggingface_test.go
+++ b/pkg/detectors/huggingface/huggingface_test.go
@@ -134,10 +134,10 @@ func TestHuggingface_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf(" wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf(" wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Huggingface.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/huggingface/huggingface_test.go
+++ b/pkg/detectors/huggingface/huggingface_test.go
@@ -6,10 +6,11 @@ package huggingface
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -132,11 +133,11 @@ func TestHuggingface_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Huggingface.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/instamojo/instamojo.go
+++ b/pkg/detectors/instamojo/instamojo.go
@@ -83,10 +83,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						s1.Verified = true
 					} else {
 						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
-						s1.SetVerificationError(err, resClientId, resSecret)
+						s1.SetVerificationError(err, resSecret)
 					}
 				} else {
-					s1.SetVerificationError(err, resClientId, resSecret)
+					s1.SetVerificationError(err, resSecret)
 				}
 			}
 

--- a/pkg/detectors/instamojo/instamojo.go
+++ b/pkg/detectors/instamojo/instamojo.go
@@ -24,7 +24,7 @@ var (
 	defaultClient = common.SaneHttpClient()
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	//KeyPat is client_id
-	keyPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"instamojo"}) + `\b([0-9a-zA-Z]{40})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"instamojo"}) + `\b([0-9a-zA-Z]{40})\b`)
 	//Secretpat is Client_secret
 	secretPat = regexp.MustCompile(detectors.PrefixRegex([]string{"instamojo"}) + `\b([0-9a-zA-Z]{128})\b`)
 )
@@ -82,10 +82,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					if (res.StatusCode >= 200 && res.StatusCode < 300) && strings.Contains(body, "access_token") {
 						s1.Verified = true
 					} else {
-						s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						s1.SetVerificationError(err, resClientId, resSecret)
 					}
 				} else {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, resClientId, resSecret)
 				}
 			}
 

--- a/pkg/detectors/instamojo/instamojo_test.go
+++ b/pkg/detectors/instamojo/instamojo_test.go
@@ -68,7 +68,6 @@ func TestInstamojo_FromChunk(t *testing.T) {
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_Instamojo,
-					VerificationError: fmt.Errorf("unexpected HTTP response status 401"),
 				},
 			},
 			wantErr:             false,
@@ -82,7 +81,7 @@ func TestInstamojo_FromChunk(t *testing.T) {
 				data:   []byte("You cannot find the secret within"),
 				verify: true,
 			},
-			want: nil,
+			want:                nil,
 			wantErr:             false,
 			wantVerificationErr: true,
 		},

--- a/pkg/detectors/ip2location/ip2location.go
+++ b/pkg/detectors/ip2location/ip2location.go
@@ -12,7 +12,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct {}
+type Scanner struct{}
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
@@ -47,8 +47,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.ip2location.io/?key=" + resMatch, nil)
-			
+			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.ip2location.io/?key="+resMatch, nil)
+
 			if err != nil {
 				continue
 			}
@@ -60,10 +60,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 		if !s1.Verified && detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
@@ -79,6 +80,3 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func (s Scanner) Type() detectorspb.DetectorType {
 	return detectorspb.DetectorType_Ip2location
 }
-
-
-

--- a/pkg/detectors/ip2location/ip2location_test.go
+++ b/pkg/detectors/ip2location/ip2location_test.go
@@ -99,8 +99,8 @@ func TestIp2location_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError()) != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.want[i].VerificationError(), got[i].VerificationError())
 				}
 			}
 			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")

--- a/pkg/detectors/ip2location/ip2location_test.go
+++ b/pkg/detectors/ip2location/ip2location_test.go
@@ -99,11 +99,11 @@ func TestIp2location_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError()) != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Ip2location.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/ip2location/ip2location_test.go
+++ b/pkg/detectors/ip2location/ip2location_test.go
@@ -100,10 +100,10 @@ func TestIp2location_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError()) != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Ip2location.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/ipinfo/ipinfo.go
+++ b/pkg/detectors/ipinfo/ipinfo.go
@@ -66,10 +66,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 403 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/ipinfo/ipinfo_test.go
+++ b/pkg/detectors/ipinfo/ipinfo_test.go
@@ -6,10 +6,11 @@ package ipinfo
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -132,11 +133,11 @@ func TestIpinfo_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Ipinfo.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/ipinfo/ipinfo_test.go
+++ b/pkg/detectors/ipinfo/ipinfo_test.go
@@ -134,10 +134,10 @@ func TestIpinfo_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Ipinfo.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/jdbc/jdbc.go
+++ b/pkg/detectors/jdbc/jdbc.go
@@ -92,7 +92,8 @@ matchLoop:
 			// behavior before tri-state verification was introduced and preserving it allows us to gradually migrate
 			// detectors to use tri-state verification.
 			if pingRes.err != nil && !pingRes.determinate {
-				s.VerificationError = pingRes.err
+				err = pingRes.err
+				s.SetVerificationError(err, jdbcConn)
 			}
 			// TODO: specialized redaction
 		}

--- a/pkg/detectors/jiratoken/jiratoken.go
+++ b/pkg/detectors/jiratoken/jiratoken.go
@@ -81,7 +81,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					client := s.getClient()
 					isVerified, verificationErr := verifyJiratoken(ctx, client, resEmail, resDomain, resToken)
 					s1.Verified = isVerified
-					s1.VerificationError = verificationErr
+					s1.SetVerificationError(verificationErr, resToken, resEmail)
 				}
 
 				if !s1.Verified && detectors.IsKnownFalsePositive(string(s1.Raw), detectors.DefaultFalsePositives, true) {

--- a/pkg/detectors/jiratoken/jiratoken.go
+++ b/pkg/detectors/jiratoken/jiratoken.go
@@ -81,7 +81,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					client := s.getClient()
 					isVerified, verificationErr := verifyJiratoken(ctx, client, resEmail, resDomain, resToken)
 					s1.Verified = isVerified
-					s1.SetVerificationError(verificationErr, resToken, resEmail)
+					s1.SetVerificationError(verificationErr, resToken)
 				}
 
 				if !s1.Verified && detectors.IsKnownFalsePositive(string(s1.Raw), detectors.DefaultFalsePositives, true) {

--- a/pkg/detectors/jiratoken/jiratoken_test.go
+++ b/pkg/detectors/jiratoken/jiratoken_test.go
@@ -134,11 +134,11 @@ func TestJiraToken_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("JiraToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/jiratoken/jiratoken_test.go
+++ b/pkg/detectors/jiratoken/jiratoken_test.go
@@ -135,10 +135,10 @@ func TestJiraToken_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("JiraToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/jiratoken_v2/jiratoken_v2.go
+++ b/pkg/detectors/jiratoken_v2/jiratoken_v2.go
@@ -79,7 +79,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					client := s.getClient()
 					isVerified, verificationErr := verifyJiratoken(ctx, client, resEmail, resDomain, resToken)
 					s1.Verified = isVerified
-					s1.SetVerificationError(verificationErr, resToken, resEmail)
+					s1.SetVerificationError(verificationErr, resToken)
 				}
 
 				if !s1.Verified && detectors.IsKnownFalsePositive(string(s1.Raw), detectors.DefaultFalsePositives, true) {

--- a/pkg/detectors/jiratoken_v2/jiratoken_v2.go
+++ b/pkg/detectors/jiratoken_v2/jiratoken_v2.go
@@ -79,7 +79,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					client := s.getClient()
 					isVerified, verificationErr := verifyJiratoken(ctx, client, resEmail, resDomain, resToken)
 					s1.Verified = isVerified
-					s1.VerificationError = verificationErr
+					s1.SetVerificationError(verificationErr, resToken, resEmail)
 				}
 
 				if !s1.Verified && detectors.IsKnownFalsePositive(string(s1.Raw), detectors.DefaultFalsePositives, true) {

--- a/pkg/detectors/jiratoken_v2/jiratoken_v2_test.go
+++ b/pkg/detectors/jiratoken_v2/jiratoken_v2_test.go
@@ -134,11 +134,11 @@ func TestJiraToken_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("JiraToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/jiratoken_v2/jiratoken_v2_test.go
+++ b/pkg/detectors/jiratoken_v2/jiratoken_v2_test.go
@@ -135,10 +135,10 @@ func TestJiraToken_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("JiraToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/klaviyo/klaviyo.go
+++ b/pkg/detectors/klaviyo/klaviyo.go
@@ -88,18 +88,19 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 							// Thus, the key is verified, but it is up to the user to determine what scopes the key has.
 							s1.Verified = true
 						} else {
-							s1.VerificationError = fmt.Errorf("errors expected")
+							s1.SetVerificationError(fmt.Errorf("errors expected"), resMatch)
 						}
 					} else {
-						s1.VerificationError = fmt.Errorf("unexpected API JSON response")
+						s1.SetVerificationError(fmt.Errorf("unexpected API JSON response"), resMatch)
 					}
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/klaviyo/klaviyo_test.go
+++ b/pkg/detectors/klaviyo/klaviyo_test.go
@@ -134,10 +134,10 @@ func TestKlaviyo_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Klaviyo.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/klaviyo/klaviyo_test.go
+++ b/pkg/detectors/klaviyo/klaviyo_test.go
@@ -6,10 +6,11 @@ package klaviyo
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -132,11 +133,11 @@ func TestKlaviyo_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Klaviyo.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/launchdarkly/launchdarkly.go
+++ b/pkg/detectors/launchdarkly/launchdarkly.go
@@ -79,10 +79,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					} else if res.StatusCode == 401 {
 						// 401 is expected for an invalid token, so there is nothing to do here.
 					} else {
-						s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						s1.SetVerificationError(err, resMatch)
 					}
 				} else {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
 				// This is a server SDK key. Try to initialize using the SDK.
@@ -94,7 +95,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else {
 					// If the error isn't nil or known, then this is likely a timeout error: ldclient.ErrInitializationTimeout
 					// But any other error here means we don't know if this key is valid.
-					s1.VerificationError = err
+					s1.SetVerificationError(err, resMatch)
 				}
 			}
 		}

--- a/pkg/detectors/ldap/ldap.go
+++ b/pkg/detectors/ldap/ldap.go
@@ -68,7 +68,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					verificationErr := verifyLDAP(username[1], password[1], ldapURL)
 					s1.Verified = verificationErr == nil
 					if !isErrDeterminate(verificationErr) {
-						s1.VerificationError = verificationErr
+						s1.SetVerificationError(verificationErr, username[1], password[1])
 					}
 				}
 
@@ -99,7 +99,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			s1.Verified = verificationError == nil
 			if !isErrDeterminate(verificationError) {
-				s1.VerificationError = verificationError
+				s1.SetVerificationError(verificationError, username, password)
 			}
 		}
 

--- a/pkg/detectors/ldap/ldap.go
+++ b/pkg/detectors/ldap/ldap.go
@@ -68,7 +68,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					verificationErr := verifyLDAP(username[1], password[1], ldapURL)
 					s1.Verified = verificationErr == nil
 					if !isErrDeterminate(verificationErr) {
-						s1.SetVerificationError(verificationErr, username[1], password[1])
+						s1.SetVerificationError(verificationErr, password[1])
 					}
 				}
 
@@ -99,7 +99,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			s1.Verified = verificationError == nil
 			if !isErrDeterminate(verificationError) {
-				s1.SetVerificationError(verificationError, username, password)
+				s1.SetVerificationError(verificationError, password)
 			}
 		}
 

--- a/pkg/detectors/ldap/ldap_integration_test.go
+++ b/pkg/detectors/ldap/ldap_integration_test.go
@@ -198,7 +198,7 @@ func TestLdap_Integration_FromChunk(t *testing.T) {
 			for i := range got {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
-				}.VerificationError()
+				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}

--- a/pkg/detectors/ldap/ldap_integration_test.go
+++ b/pkg/detectors/ldap/ldap_integration_test.go
@@ -7,13 +7,14 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"os"
 	"os/exec"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -197,12 +198,12 @@ func TestLdap_Integration_FromChunk(t *testing.T) {
 			for i := range got {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
-				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				}.VerificationError()
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Ldap.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/ldap/ldap_integration_test.go
+++ b/pkg/detectors/ldap/ldap_integration_test.go
@@ -200,10 +200,10 @@ func TestLdap_Integration_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}.VerificationError()
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Ldap.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/lemonsqueezy/lemonsqueezy.go
+++ b/pkg/detectors/lemonsqueezy/lemonsqueezy.go
@@ -66,10 +66,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/lemonsqueezy/lemonsqueezy_test.go
+++ b/pkg/detectors/lemonsqueezy/lemonsqueezy_test.go
@@ -99,11 +99,11 @@ func TestLemonsqueezy_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Lemonsqueezy.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/lemonsqueezy/lemonsqueezy_test.go
+++ b/pkg/detectors/lemonsqueezy/lemonsqueezy_test.go
@@ -100,10 +100,10 @@ func TestLemonsqueezy_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Lemonsqueezy.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/liveagent/liveagent.go
+++ b/pkg/detectors/liveagent/liveagent.go
@@ -76,7 +76,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					} else if res.StatusCode == 403 {
 						var r response
 						if err := json.NewDecoder(res.Body).Decode(&r); err != nil {
-							s1.VerificationError = err
+							s1.SetVerificationError(err, resMatch)
 							continue
 						}
 

--- a/pkg/detectors/loggly/loggly.go
+++ b/pkg/detectors/loggly/loggly.go
@@ -1,15 +1,15 @@
 package loggly
 
 import (
-        "context"
-        "fmt"
-        "net/http"
-        "regexp"
-        "strings"
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
 
-        "github.com/trufflesecurity/trufflehog/v3/pkg/common"
-        "github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
-        "github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
 type Scanner struct {
@@ -20,82 +20,82 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-        defaultClient = common.SaneHttpClient()
-        // Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-        domainPat = regexp.MustCompile(`\b([a-zA-Z0-9-]+\.loggly\.com)\b`)
-        keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"loggly"}) + `\b([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\b`)
+	defaultClient = common.SaneHttpClient()
+	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
+	domainPat = regexp.MustCompile(`\b([a-zA-Z0-9-]+\.loggly\.com)\b`)
+	keyPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"loggly"}) + `\b([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-        return []string{"loggly"}
+	return []string{"loggly"}
 }
 
 // FromData will find and optionally verify Loggly secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
-        dataStr := string(data)
+	dataStr := string(data)
 
-        keyMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
-        domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
+	keyMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
+	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 
-        for _, match := range keyMatches {
-                if len(match) != 2 {
-                        continue
-                }
-                key := strings.TrimSpace(match[1])
+	for _, match := range keyMatches {
+		if len(match) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(match[1])
 
-                for _, domainMatch := range domainMatches {
-                        if len(domainMatch) != 2 {
-                                continue
-                        }
+		for _, domainMatch := range domainMatches {
+			if len(domainMatch) != 2 {
+				continue
+			}
 
-                        domainRes := strings.TrimSpace(domainMatch[1])
+			domainRes := strings.TrimSpace(domainMatch[1])
 
-                        s1 := detectors.Result{
-                                DetectorType: detectorspb.DetectorType_Loggly,
-                                Raw:          []byte(key),
-                                RawV2:        []byte(fmt.Sprintf("%s:%s", domainRes, key)),
+			s1 := detectors.Result{
+				DetectorType: detectorspb.DetectorType_Loggly,
+				Raw:          []byte(key),
+				RawV2:        []byte(fmt.Sprintf("%s:%s", domainRes, key)),
+			}
 
-                        }
+			if verify {
+				client := s.client
+				if client == nil {
+					client = defaultClient
+				}
+				req, err := http.NewRequestWithContext(ctx, "GET", "https://"+domainRes+"/apiv2/customer", nil)
+				if err != nil {
+					continue
+				}
+				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", key))
+				res, err := client.Do(req)
+				if err == nil {
+					defer res.Body.Close()
+					if res.StatusCode >= 200 && res.StatusCode < 300 {
+						s1.Verified = true
+					} else if res.StatusCode == 401 {
+						// The secret is determinately not verified (nothing to do)
+					} else {
+						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						s1.SetVerificationError(err, key)
+					}
+				} else {
+					s1.SetVerificationError(err, key)
+				}
+			}
 
-                        if verify {
-				 client := s.client
-                        	if client == nil {
-                                client = defaultClient
-                        	}
-                                req, err := http.NewRequestWithContext(ctx, "GET", "https://"+domainRes+"/apiv2/customer", nil)
-                                if err != nil {
-                                        continue
-                                }
-                                req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", key))
-                                res, err := client.Do(req)
-                                if err == nil {
-                                        defer res.Body.Close()
-                                        if res.StatusCode >= 200 && res.StatusCode < 300 {
-                                                s1.Verified = true
-                                        } else if res.StatusCode == 401 {
-                                                // The secret is determinately not verified (nothing to do)
-                                        } else {
-                                                s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
-                                        }
-                                } else {
-                                        s1.VerificationError = err
-                                }
-                        }
+			// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
+			if !s1.Verified && detectors.IsKnownFalsePositive(key, detectors.DefaultFalsePositives, true) {
+				continue
+			}
 
-                        // This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
-                        if !s1.Verified && detectors.IsKnownFalsePositive(key, detectors.DefaultFalsePositives, true) {
-                                continue
-                        }
+			results = append(results, s1)
+		}
+	}
 
-                        results = append(results, s1)
-                }
-        }
-
-        return results, nil
+	return results, nil
 }
 
 func (s Scanner) Type() detectorspb.DetectorType {
-        return detectorspb.DetectorType_Loggly
+	return detectorspb.DetectorType_Loggly
 }

--- a/pkg/detectors/loggly/loggly_test.go
+++ b/pkg/detectors/loggly/loggly_test.go
@@ -135,10 +135,10 @@ func TestLoggly_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Loggly.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/loggly/loggly_test.go
+++ b/pkg/detectors/loggly/loggly_test.go
@@ -6,10 +6,11 @@ package loggly
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -133,11 +134,11 @@ func TestLoggly_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Loggly.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/logzio/logzio.go
+++ b/pkg/detectors/logzio/logzio.go
@@ -67,10 +67,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/logzio/logzio_test.go
+++ b/pkg/detectors/logzio/logzio_test.go
@@ -6,10 +6,11 @@ package logzio
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -132,11 +133,11 @@ func TestLogzIO_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("LogzIO.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/logzio/logzio_test.go
+++ b/pkg/detectors/logzio/logzio_test.go
@@ -134,10 +134,10 @@ func TestLogzIO_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("LogzIO.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/meaningcloud/meaningcloud.go
+++ b/pkg/detectors/meaningcloud/meaningcloud.go
@@ -85,7 +85,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					var r response
 					if err := json.NewDecoder(res.Body).Decode(&r); err != nil {
-						s1.VerificationError = err
+						s1.SetVerificationError(err, resMatch)
 						continue
 					}
 					if r.DeepTime > 0 {

--- a/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
+++ b/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
@@ -62,7 +62,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			isVerified, verificationErr := verifyWebhook(ctx, client, resMatch)
 			s1.Verified = isVerified
-			s1.VerificationError = verificationErr
+			s1.SetVerificationError(verificationErr, resMatch)
 		}
 
 		if !s1.Verified && detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, false) {

--- a/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook_test.go
+++ b/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook_test.go
@@ -151,7 +151,7 @@ func TestMicrosoftTeamsWebhook_FromChunk(t *testing.T) {
 					return
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("MicrosoftTeamsWebhook.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook_test.go
+++ b/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook_test.go
@@ -146,12 +146,12 @@ func TestMicrosoftTeamsWebhook_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
-					t.Errorf("MicrosoftTeamsWebhook.FromData() verificationError = %v, wantVerificationErr %v", got[i].VerificationError, tt.wantVerificationErr)
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Errorf("MicrosoftTeamsWebhook.FromData() verificationError = %v, wantVerificationErr %v", got[i].VerificationError(), tt.wantVerificationErr)
 					return
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("MicrosoftTeamsWebhook.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/mongodb/mongodb.go
+++ b/pkg/detectors/mongodb/mongodb.go
@@ -61,7 +61,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			err := verifyUri(resMatch, timeout)
 			s1.Verified = err == nil
 			if !isErrDeterminate(err) {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 		results = append(results, s1)

--- a/pkg/detectors/mongodb/mongodb_test.go
+++ b/pkg/detectors/mongodb/mongodb_test.go
@@ -132,7 +132,7 @@ func TestMongoDB_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
-				if (got[i].VerificationError()) != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationErr = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}

--- a/pkg/detectors/mongodb/mongodb_test.go
+++ b/pkg/detectors/mongodb/mongodb_test.go
@@ -132,11 +132,11 @@ func TestMongoDB_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError()) != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationErr = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", *_test.go)
 			if diff := cmp.Diff(tt.want, got, ignoreOpts); diff != "" {
 				t.Errorf("MongoDB.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/mongodb/mongodb_test.go
+++ b/pkg/detectors/mongodb/mongodb_test.go
@@ -133,10 +133,10 @@ func TestMongoDB_FromChunk(t *testing.T) {
 				}
 				got[i].Raw = nil
 				if (got[i].VerificationError()) != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationErr = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationErr = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "RawV2", "verificationError")
 			if diff := cmp.Diff(tt.want, got, ignoreOpts); diff != "" {
 				t.Errorf("MongoDB.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/myfreshworks/myfreshworks.go
+++ b/pkg/detectors/myfreshworks/myfreshworks.go
@@ -59,7 +59,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				client := s.getClient()
 				isVerified, verificationErr := verifyMyfreshworks(ctx, client, resMatch, resIdMatch)
 				s1.Verified = isVerified
-				s1.VerificationError = verificationErr
+				s1.SetVerificationError(verificationErr, resMatch, resIdMatch)
 			}
 
 			// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.

--- a/pkg/detectors/myfreshworks/myfreshworks.go
+++ b/pkg/detectors/myfreshworks/myfreshworks.go
@@ -59,7 +59,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				client := s.getClient()
 				isVerified, verificationErr := verifyMyfreshworks(ctx, client, resMatch, resIdMatch)
 				s1.Verified = isVerified
-				s1.SetVerificationError(verificationErr, resMatch, resIdMatch)
+				s1.SetVerificationError(verificationErr, resMatch)
 			}
 
 			// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.

--- a/pkg/detectors/myfreshworks/myfreshworks_test.go
+++ b/pkg/detectors/myfreshworks/myfreshworks_test.go
@@ -131,7 +131,7 @@ func TestMyfreshworks_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Myfreshworks.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/myfreshworks/myfreshworks_test.go
+++ b/pkg/detectors/myfreshworks/myfreshworks_test.go
@@ -131,7 +131,7 @@ func TestMyfreshworks_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Myfreshworks.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/ngrok/ngrok.go
+++ b/pkg/detectors/ngrok/ngrok.go
@@ -16,12 +16,11 @@ type Scanner struct {
 	client *http.Client
 }
 
-
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
 	defaultClient = common.SaneHttpClient()
-	
+
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"ngrok"}) + `\b2[a-zA-Z0-9]{26}_\d[a-zA-Z0-9]{20}\b`)
 )
 
@@ -64,10 +63,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/ngrok/ngrok_test.go
+++ b/pkg/detectors/ngrok/ngrok_test.go
@@ -99,11 +99,11 @@ func TestNgrok_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Ngrok.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/ngrok/ngrok_test.go
+++ b/pkg/detectors/ngrok/ngrok_test.go
@@ -100,10 +100,10 @@ func TestNgrok_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Ngrok.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/notion/notion.go
+++ b/pkg/detectors/notion/notion.go
@@ -73,7 +73,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					}
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/openvpn/openvpn.go
+++ b/pkg/detectors/openvpn/openvpn.go
@@ -25,8 +25,7 @@ var (
 
 	clientIDPat     = regexp.MustCompile(detectors.PrefixRegex([]string{"openvpn"}) + `\b([A-Za-z0-9-]{3,40}\.[A-Za-z0-9-]{3,40})\b`)
 	clientSecretPat = regexp.MustCompile(`\b([a-zA-Z0-9_-]{64,})\b`)
-	domainPat = regexp.MustCompile(`\b(https?://[A-Za-z0-9-]+\.api\.openvpn\.com)\b`) 
-				
+	domainPat       = regexp.MustCompile(`\b(https?://[A-Za-z0-9-]+\.api\.openvpn\.com)\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -42,7 +41,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 	clientIdMatches := clientIDPat.FindAllStringSubmatch(dataStr, -1)
 	clientSecretMatches := clientSecretPat.FindAllStringSubmatch(dataStr, -1)
-	
+
 	for _, clientIdMatch := range clientIdMatches {
 		clientIDRes := strings.TrimSpace(clientIdMatch[1])
 		for _, clientSecretMatch := range clientSecretMatches {
@@ -65,7 +64,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					payload := strings.NewReader("grant_type=client_credentials")
 					// OpenVPN API is in beta, We'll have to update the API endpoint once
 					// Docs: https://openvpn.net/cloud-docs/developer/creating-api-credentials.html
-					req, err := http.NewRequestWithContext(ctx, "POST", domainRes + "/api/beta/oauth/token", payload)
+					req, err := http.NewRequestWithContext(ctx, "POST", domainRes+"/api/beta/oauth/token", payload)
 					if err != nil {
 						continue
 					}
@@ -83,10 +82,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						} else if res.StatusCode == 401 {
 							// The secret is determinately not verified (nothing to do)
 						} else {
-							s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+							err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+							s1.SetVerificationError(err, clientIDRes, clientSecretRes)
 						}
 					} else {
-						s1.VerificationError = err
+						s1.SetVerificationError(err, clientIDRes, clientSecretRes)
 					}
 				}
 				// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
@@ -97,8 +97,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 		}
 
-
-		
 	}
 
 	return results, nil

--- a/pkg/detectors/openvpn/openvpn.go
+++ b/pkg/detectors/openvpn/openvpn.go
@@ -83,10 +83,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 							// The secret is determinately not verified (nothing to do)
 						} else {
 							err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
-							s1.SetVerificationError(err, clientIDRes, clientSecretRes)
+							s1.SetVerificationError(err, clientSecretRes)
 						}
 					} else {
-						s1.SetVerificationError(err, clientIDRes, clientSecretRes)
+						s1.SetVerificationError(err, clientSecretRes)
 					}
 				}
 				// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.

--- a/pkg/detectors/openvpn/openvpn_test.go
+++ b/pkg/detectors/openvpn/openvpn_test.go
@@ -105,10 +105,10 @@ func TestOpenvpn_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Openvpn.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/openvpn/openvpn_test.go
+++ b/pkg/detectors/openvpn/openvpn_test.go
@@ -104,11 +104,11 @@ func TestOpenvpn_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Openvpn.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/overloop/overloop.go
+++ b/pkg/detectors/overloop/overloop.go
@@ -66,10 +66,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/overloop/overloop_test.go
+++ b/pkg/detectors/overloop/overloop_test.go
@@ -132,7 +132,7 @@ func TestOverloop_FromChunk(t *testing.T) {
 			for i := range got {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
-				}.VerificationError()
+				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}

--- a/pkg/detectors/overloop/overloop_test.go
+++ b/pkg/detectors/overloop/overloop_test.go
@@ -134,10 +134,10 @@ func TestOverloop_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}.VerificationError()
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Overloop.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/overloop/overloop_test.go
+++ b/pkg/detectors/overloop/overloop_test.go
@@ -6,10 +6,11 @@ package overloop
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -131,12 +132,12 @@ func TestOverloop_FromChunk(t *testing.T) {
 			for i := range got {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
-				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				}.VerificationError()
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Overloop.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/pagerdutyapikey/pagerdutyapikey.go
+++ b/pkg/detectors/pagerdutyapikey/pagerdutyapikey.go
@@ -53,7 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			client := s.getClient()
 			isVerified, verificationErr := verifyPagerdutyapikey(ctx, client, resMatch)
 			s1.Verified = isVerified
-			s1.VerificationError = verificationErr
+			s1.SetVerificationError(verificationErr, resMatch)
 		}
 
 		if !s1.Verified && detectors.IsKnownFalsePositive(string(s1.Raw), detectors.DefaultFalsePositives, true) {

--- a/pkg/detectors/pagerdutyapikey/pagerdutyapikey_test.go
+++ b/pkg/detectors/pagerdutyapikey/pagerdutyapikey_test.go
@@ -128,11 +128,11 @@ func TestPagerDutyApiKey_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
-					t.Errorf("PagerDutyApiKey.FromData() verificationError = %v, wantVerificationErr %v", got[i].VerificationError, tt.wantVerificationErr)
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Errorf("PagerDutyApiKey.FromData() verificationError = %v, wantVerificationErr %v", got[i].VerificationError(), tt.wantVerificationErr)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("PagerDutyApiKey.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/pagerdutyapikey/pagerdutyapikey_test.go
+++ b/pkg/detectors/pagerdutyapikey/pagerdutyapikey_test.go
@@ -132,7 +132,7 @@ func TestPagerDutyApiKey_FromChunk(t *testing.T) {
 					t.Errorf("PagerDutyApiKey.FromData() verificationError = %v, wantVerificationErr %v", got[i].VerificationError(), tt.wantVerificationErr)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("PagerDutyApiKey.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/planetscale/planetscale.go
+++ b/pkg/detectors/planetscale/planetscale.go
@@ -69,10 +69,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						// The secret is determinately not verified
 						s1.Verified = false
 					} else {
-						s1.VerificationError = fmt.Errorf("unexpected status code %d", res.StatusCode)
+						err = fmt.Errorf("unexpected status code %d", res.StatusCode)
+						s1.SetVerificationError(err, username, password)
 					}
 				} else {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, username, password)
 				}
 			}
 

--- a/pkg/detectors/planetscale/planetscale.go
+++ b/pkg/detectors/planetscale/planetscale.go
@@ -70,10 +70,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						s1.Verified = false
 					} else {
 						err = fmt.Errorf("unexpected status code %d", res.StatusCode)
-						s1.SetVerificationError(err, username, password)
+						s1.SetVerificationError(err, password)
 					}
 				} else {
-					s1.SetVerificationError(err, username, password)
+					s1.SetVerificationError(err, password)
 				}
 			}
 

--- a/pkg/detectors/planetscale/planetscale_test.go
+++ b/pkg/detectors/planetscale/planetscale_test.go
@@ -135,11 +135,11 @@ func TestPlanetscale_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Planetscale.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/planetscale/planetscale_test.go
+++ b/pkg/detectors/planetscale/planetscale_test.go
@@ -136,10 +136,10 @@ func TestPlanetscale_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Planetscale.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/planetscaledb/planetscaledb.go
+++ b/pkg/detectors/planetscaledb/planetscaledb.go
@@ -55,13 +55,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					}
 					db, err := sql.Open("mysql", cfg.FormatDSN())
 					if err != nil {
-						s1.SetVerificationError(err, username[0], password[0])
+						s1.SetVerificationError(err, password[0])
 					} else {
 						err = db.PingContext(ctx)
 						if err == nil {
 							s1.Verified = true
 						} else {
-							s1.SetVerificationError(err, username[0], password[0])
+							s1.SetVerificationError(err, password[0])
 						}
 						db.Close()
 					}

--- a/pkg/detectors/planetscaledb/planetscaledb.go
+++ b/pkg/detectors/planetscaledb/planetscaledb.go
@@ -55,13 +55,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					}
 					db, err := sql.Open("mysql", cfg.FormatDSN())
 					if err != nil {
-						s1.VerificationError = err
+						s1.SetVerificationError(err, username[0], password[0])
 					} else {
 						err = db.PingContext(ctx)
 						if err == nil {
 							s1.Verified = true
 						} else {
-							s1.VerificationError = err
+							s1.SetVerificationError(err, username[0], password[0])
 						}
 						db.Close()
 					}

--- a/pkg/detectors/planetscaledb/planetscaledb_test.go
+++ b/pkg/detectors/planetscaledb/planetscaledb_test.go
@@ -101,10 +101,10 @@ func TestPlanetscaledb_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Planetscaledb.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/planetscaledb/planetscaledb_test.go
+++ b/pkg/detectors/planetscaledb/planetscaledb_test.go
@@ -100,11 +100,11 @@ func TestPlanetscaledb_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Planetscaledb.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/portainer/portainer.go
+++ b/pkg/detectors/portainer/portainer.go
@@ -23,7 +23,7 @@ var (
 	defaultClient = common.SaneHttpClient()
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	endpointPat = regexp.MustCompile(detectors.PrefixRegex([]string{"portainer"}) + `\b(https?:\/\/\S+(:[0-9]{4,5})?)\b`)
-	tokenPat = regexp.MustCompile(detectors.PrefixRegex([]string{"portainer"}) + `\b(eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[0-9A-Za-z]{50,310}\.[0-9A-Z-a-z\-_]{43})\b`)
+	tokenPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"portainer"}) + `\b(eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[0-9A-Za-z]{50,310}\.[0-9A-Z-a-z\-_]{43})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -59,7 +59,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if client == nil {
 					client = defaultClient
 				}
-				req, err := http.NewRequestWithContext(ctx, "GET",  resEndpointMatch + "/api/endpoints", nil)
+				req, err := http.NewRequestWithContext(ctx, "GET", resEndpointMatch+"/api/endpoints", nil)
 				if err != nil {
 					continue
 				}
@@ -72,10 +72,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					} else if res.StatusCode == 401 || res.StatusCode == 403 {
 						// The secret is determinately not verified (nothing to do)
 					} else {
-						s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						s1.SetVerificationError(err, resMatch)
 					}
 				} else {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, resMatch)
 				}
 			}
 
@@ -86,7 +87,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if len(endpointMatches) > 0 {
 				results = append(results, s1)
 			}
-			
+
 		}
 	}
 

--- a/pkg/detectors/portainer/portainer_test.go
+++ b/pkg/detectors/portainer/portainer_test.go
@@ -102,7 +102,7 @@ func TestPortainer_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError()) != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}

--- a/pkg/detectors/portainer/portainer_test.go
+++ b/pkg/detectors/portainer/portainer_test.go
@@ -102,11 +102,11 @@ func TestPortainer_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError()) != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Portainer.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/portainer/portainer_test.go
+++ b/pkg/detectors/portainer/portainer_test.go
@@ -103,10 +103,10 @@ func TestPortainer_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError()) != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Portainer.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/portainertoken/portainertoken.go
+++ b/pkg/detectors/portainertoken/portainertoken.go
@@ -22,7 +22,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	defaultClient = common.SaneHttpClient()
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"portainertoken"}) + `\b(ptr_[A-Za-z0-9\/_\-+=]{20,60})`)
+	keyPat      = regexp.MustCompile(detectors.PrefixRegex([]string{"portainertoken"}) + `\b(ptr_[A-Za-z0-9\/_\-+=]{20,60})`)
 	endpointPat = regexp.MustCompile(detectors.PrefixRegex([]string{"portainer"}) + `\b(https?:\/\/\S+(:[0-9]{4,5})?)\b`)
 )
 
@@ -59,7 +59,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if client == nil {
 					client = defaultClient
 				}
-				req, err := http.NewRequestWithContext(ctx, "GET", resEndpointMatch + "/api/stacks", nil)
+				req, err := http.NewRequestWithContext(ctx, "GET", resEndpointMatch+"/api/stacks", nil)
 				if err != nil {
 					continue
 				}
@@ -67,7 +67,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("X-API-Key", resMatch)
 
 				res, err := client.Do(req)
-				
+
 				if err == nil {
 					defer res.Body.Close()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
@@ -75,10 +75,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					} else if res.StatusCode == 401 {
 						// The secret is determinately not verified (nothing to do)
 					} else {
-						s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						s1.SetVerificationError(err, resMatch)
 					}
 				} else {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, resMatch)
 				}
 			}
 

--- a/pkg/detectors/portainertoken/portainertoken_test.go
+++ b/pkg/detectors/portainertoken/portainertoken_test.go
@@ -103,10 +103,10 @@ func TestPortainertoken_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Portainertoken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/portainertoken/portainertoken_test.go
+++ b/pkg/detectors/portainertoken/portainertoken_test.go
@@ -102,11 +102,11 @@ func TestPortainertoken_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Portainertoken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/postman/postman.go
+++ b/pkg/detectors/postman/postman.go
@@ -55,7 +55,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			client := s.getClient()
 			isVerified, verificationErr := verifyPostman(ctx, client, resMatch)
 			s1.Verified = isVerified
-			s1.VerificationError = verificationErr
+			s1.SetVerificationError(verificationErr, resMatch)
 		}
 
 		if !s1.Verified && detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {

--- a/pkg/detectors/postman/postman_test.go
+++ b/pkg/detectors/postman/postman_test.go
@@ -133,7 +133,7 @@ func TestPostman_FromChunk(t *testing.T) {
 					t.Errorf("Postman.FromData() error = %v, wantErr %v", got[i].VerificationError(), tt.wantVerificationErr)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Postman.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/postman/postman_test.go
+++ b/pkg/detectors/postman/postman_test.go
@@ -129,11 +129,11 @@ func TestPostman_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
-					t.Errorf("Postman.FromData() error = %v, wantErr %v", got[i].VerificationError, tt.wantVerificationErr)
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Errorf("Postman.FromData() error = %v, wantErr %v", got[i].VerificationError(), tt.wantVerificationErr)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Postman.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/privacy/privacy.go
+++ b/pkg/detectors/privacy/privacy.go
@@ -66,10 +66,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/privacy/privacy_test.go
+++ b/pkg/detectors/privacy/privacy_test.go
@@ -132,7 +132,7 @@ func TestPrivacy_FromChunk(t *testing.T) {
 			for i := range got {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
-				}.VerificationError()
+				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}

--- a/pkg/detectors/privacy/privacy_test.go
+++ b/pkg/detectors/privacy/privacy_test.go
@@ -6,10 +6,11 @@ package privacy
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -131,12 +132,12 @@ func TestPrivacy_FromChunk(t *testing.T) {
 			for i := range got {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
-				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				}.VerificationError()
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Privacy.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/privacy/privacy_test.go
+++ b/pkg/detectors/privacy/privacy_test.go
@@ -134,10 +134,10 @@ func TestPrivacy_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}.VerificationError()
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Privacy.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/privatekey/privatekey.go
+++ b/pkg/detectors/privatekey/privatekey.go
@@ -51,25 +51,25 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 			continue
 		}
 
-		secret := detectors.Result{
+		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_PrivateKey,
 			Raw:          []byte(token),
 			Redacted:     token[0:64],
 		}
 
-		secret.ExtraData = make(map[string]string)
+		s1.ExtraData = make(map[string]string)
 
 		var passphrase string
 		parsedKey, err := ssh.ParseRawPrivateKey([]byte(token))
 		if err != nil && strings.Contains(err.Error(), "private key is passphrase protected") {
-			secret.ExtraData["encrypted"] = "true"
+			s1.ExtraData["encrypted"] = "true"
 			parsedKey, passphrase, err = crack([]byte(token))
 			if err != nil {
-				secret.VerificationError = err
+				s1.SetVerificationError(err, token)
 				continue
 			}
 			if passphrase != "" {
-				secret.ExtraData["cracked_encryption_passphrase"] = "true"
+				s1.ExtraData["cracked_encryption_passphrase"] = "true"
 			}
 		} else if err != nil {
 			// couldn't parse key, probably invalid
@@ -86,8 +86,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 			data, err := lookupFingerprint(fingerprint, s.IncludeExpired)
 			if err == nil {
 				if data != nil {
-					secret.Verified = true
-					secret.ExtraData["certificate_urls"] = strings.Join(data.CertificateURLs, ", ")
+					s1.Verified = true
+					s1.ExtraData["certificate_urls"] = strings.Join(data.CertificateURLs, ", ")
 				}
 			} else {
 				verificationErrors = append(verificationErrors, err.Error())
@@ -98,8 +98,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 				verificationErrors = append(verificationErrors, err.Error())
 			}
 			if user != nil {
-				secret.Verified = true
-				secret.ExtraData["github_user"] = *user
+				s1.Verified = true
+				s1.ExtraData["github_user"] = *user
 			}
 
 			user, err = verifyGitLabUser(parsedKey)
@@ -107,20 +107,21 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 				verificationErrors = append(verificationErrors, err.Error())
 			}
 			if user != nil {
-				secret.Verified = true
-				secret.ExtraData["gitlab_user"] = *user
+				s1.Verified = true
+				s1.ExtraData["gitlab_user"] = *user
 			}
 
-			if !secret.Verified && len(verificationErrors) > 0 {
-				secret.VerificationError = fmt.Errorf("verification failures: %s", strings.Join(verificationErrors, ", "))
+			if !s1.Verified && len(verificationErrors) > 0 {
+				err = fmt.Errorf("verification failures: %s", strings.Join(verificationErrors, ", "))
+				s1.SetVerificationError(err, token)
 			}
 		}
 
-		if len(secret.ExtraData) == 0 {
-			secret.ExtraData = nil
+		if len(s1.ExtraData) == 0 {
+			s1.ExtraData = nil
 		}
 
-		results = append(results, secret)
+		results = append(results, s1)
 	}
 
 	return results, nil

--- a/pkg/detectors/pubnubpublishkey/pubnubpublishkey.go
+++ b/pkg/detectors/pubnubpublishkey/pubnubpublishkey.go
@@ -63,7 +63,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				isVerified, verificationErr := verifyPubNub(ctx, client, resMatch, ressubMatch)
 				s1.Verified = isVerified
-				s1.VerificationError = verificationErr
+				s1.SetVerificationError(verificationErr, resMatch)
 			}
 
 			// This function will check false positives for common test words, but also it will make sure the key

--- a/pkg/detectors/pubnubpublishkey/pubnubpublishkey_test.go
+++ b/pkg/detectors/pubnubpublishkey/pubnubpublishkey_test.go
@@ -132,10 +132,10 @@ func TestPubNubPublishKey_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf(" wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf(" wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("PubNubPublishKey.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/pubnubpublishkey/pubnubpublishkey_test.go
+++ b/pkg/detectors/pubnubpublishkey/pubnubpublishkey_test.go
@@ -131,11 +131,11 @@ func TestPubNubPublishKey_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "VerificationError")
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("PubNubPublishKey.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/ramp/ramp.go
+++ b/pkg/detectors/ramp/ramp.go
@@ -3,13 +3,14 @@ package ramp
 import (
 	"context"
 	"fmt"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
 type Scanner struct {
@@ -84,10 +85,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					} else if res.StatusCode == 401 {
 						// The secret is determinately not verified (nothing to do)
 					} else {
-						s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						s1.SetVerificationError(err, resMatch)
 					}
 				} else {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, resMatch)
 				}
 			}
 

--- a/pkg/detectors/ramp/ramp_test.go
+++ b/pkg/detectors/ramp/ramp_test.go
@@ -6,10 +6,11 @@ package ramp
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -134,11 +135,11 @@ func TestRamp_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Ramp.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/ramp/ramp_test.go
+++ b/pkg/detectors/ramp/ramp_test.go
@@ -136,10 +136,10 @@ func TestRamp_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Ramp.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/replicate/replicate.go
+++ b/pkg/detectors/replicate/replicate.go
@@ -21,7 +21,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 
 var (
 	defaultClient = common.SaneHttpClient()
-	keyPat = regexp.MustCompile(`\b(r8_[0-9A-Za-z-_]{37})\b`)
+	keyPat        = regexp.MustCompile(`\b(r8_[0-9A-Za-z-_]{37})\b`)
 )
 
 func (s Scanner) Keywords() []string {
@@ -62,10 +62,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/replicate/replicate_test.go
+++ b/pkg/detectors/replicate/replicate_test.go
@@ -100,10 +100,10 @@ func TestReplicate_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Replicate.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/replicate/replicate_test.go
+++ b/pkg/detectors/replicate/replicate_test.go
@@ -99,11 +99,11 @@ func TestReplicate_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Replicate.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/replyio/replyio.go
+++ b/pkg/detectors/replyio/replyio.go
@@ -63,10 +63,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/replyio/replyio_test.go
+++ b/pkg/detectors/replyio/replyio_test.go
@@ -100,10 +100,10 @@ func TestReplyio_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Replyio.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/replyio/replyio_test.go
+++ b/pkg/detectors/replyio/replyio_test.go
@@ -99,11 +99,11 @@ func TestReplyio_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Replyio.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/requestfinance/requestfinance.go
+++ b/pkg/detectors/requestfinance/requestfinance.go
@@ -21,7 +21,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 
 var (
 	defaultClient = common.SaneHttpClient()
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"requestfinance"}) + `\b([0-9A-Z]{7}-[0-9A-Z]{7}-[0-9A-Z]{7}-[0-9A-Z]{7})\b`)
+	keyPat        = regexp.MustCompile(detectors.PrefixRegex([]string{"requestfinance"}) + `\b([0-9A-Z]{7}-[0-9A-Z]{7}-[0-9A-Z]{7}-[0-9A-Z]{7})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -65,10 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/requestfinance/requestfinance_test.go
+++ b/pkg/detectors/requestfinance/requestfinance_test.go
@@ -100,10 +100,10 @@ func TestRequestfinance_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Requestfinance.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/requestfinance/requestfinance_test.go
+++ b/pkg/detectors/requestfinance/requestfinance_test.go
@@ -99,11 +99,11 @@ func TestRequestfinance_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Requestfinance.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/salesforce/salesforce.go
+++ b/pkg/detectors/salesforce/salesforce.go
@@ -78,7 +78,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				if err != nil {
 					// End execution, append Detector Result if request fails to prevent panic on response body checks
-					s1.VerificationError = err
+					s1.SetVerificationError(err, tokenMatch)
 					results = append(results, s1)
 					continue
 				}
@@ -93,7 +93,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					s1.Verified = false
 				} else {
-					s1.VerificationError = fmt.Errorf("request to %v returned status %d with error %+v", res.Request.URL, res.StatusCode, err)
+					err = fmt.Errorf("request to %v returned status %d with error %+v", res.Request.URL, res.StatusCode, err)
+					s1.SetVerificationError(err, tokenMatch)
 				}
 
 			}

--- a/pkg/detectors/salesforce/salesforce_test.go
+++ b/pkg/detectors/salesforce/salesforce_test.go
@@ -6,10 +6,11 @@ package salesforce
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -139,11 +140,11 @@ func TestSalesforce_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Salesforce.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/salesforce/salesforce_test.go
+++ b/pkg/detectors/salesforce/salesforce_test.go
@@ -141,10 +141,10 @@ func TestSalesforce_FromChunk(t *testing.T) {
 				}
 
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Salesforce.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/screenshotapi/screenshotapi.go
+++ b/pkg/detectors/screenshotapi/screenshotapi.go
@@ -64,7 +64,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				var r response
 				if err := json.NewDecoder(res.Body).Decode(&r); err != nil {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, resMatch)
 					continue
 				}
 				if res.StatusCode >= 200 && res.StatusCode < 300 && r.Screenshot != "" {

--- a/pkg/detectors/sendbird/sendbird.go
+++ b/pkg/detectors/sendbird/sendbird.go
@@ -86,18 +86,21 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						var userResp userResp
 						err := json.NewDecoder(res.Body).Decode(&userResp)
 						if err != nil {
-							s1.VerificationError = fmt.Errorf("error decoding json response body: %w", err)
+							err = fmt.Errorf("error decoding json response body: %w", err)
+							s1.SetVerificationError(err, resMatch)
 						} else if userResp.Code != 400401 {
 							// https://sendbird.com/docs/chat/platform-api/v3/error-codes
 							// Sendbird always includes its own error codes with 400 responses
 							// 400401 (InvalidApiToken) is the only one that indicates a bad token
-							s1.VerificationError = fmt.Errorf("unexpected response code: %d", userResp.Code)
+							err = fmt.Errorf("unexpected response code: %d", userResp.Code)
+							s1.SetVerificationError(err, resMatch)
 						}
 					} else {
-						s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						s1.SetVerificationError(err, resMatch)
 					}
 				} else {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, resMatch)
 				}
 			}
 

--- a/pkg/detectors/sendbird/sendbird_test.go
+++ b/pkg/detectors/sendbird/sendbird_test.go
@@ -167,10 +167,10 @@ func TestSendbird_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Sendbird.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/sendbird/sendbird_test.go
+++ b/pkg/detectors/sendbird/sendbird_test.go
@@ -166,11 +166,11 @@ func TestSendbird_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Sendbird.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/sendbirdorganizationapi/sendbirdorganizationapi.go
+++ b/pkg/detectors/sendbirdorganizationapi/sendbirdorganizationapi.go
@@ -57,18 +57,19 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			req, err := http.NewRequestWithContext(ctx, "GET", "https://gate.sendbird.com/api/v2/applications", nil)
 			if err != nil {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 			req.Header.Add("SENDBIRDORGANIZATIONAPITOKEN", resMatch)
 			res, err := client.Do(req)
 			if err != nil {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			} else {
 				defer res.Body.Close()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
 				} else if res.StatusCode != http.StatusForbidden {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			}
 		}

--- a/pkg/detectors/sendbirdorganizationapi/sendbirdorganizationapi_test.go
+++ b/pkg/detectors/sendbirdorganizationapi/sendbirdorganizationapi_test.go
@@ -133,10 +133,10 @@ func TestSendbirdOrganizationAPI_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Sendbird.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/sendbirdorganizationapi/sendbirdorganizationapi_test.go
+++ b/pkg/detectors/sendbirdorganizationapi/sendbirdorganizationapi_test.go
@@ -132,11 +132,11 @@ func TestSendbirdOrganizationAPI_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Sendbird.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/sendgrid/sendgrid.go
+++ b/pkg/detectors/sendgrid/sendgrid.go
@@ -42,11 +42,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		if len(match) != 2 {
 			continue
 		}
-		res := strings.TrimSpace(match[1])
+		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_SendGrid,
-			Raw:          []byte(res),
+			Raw:          []byte(resMatch),
 		}
 		s1.ExtraData = map[string]string{
 			"rotation_guide": "https://howtorotate.com/docs/tutorials/sendgrid/",
@@ -67,7 +67,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err != nil {
 				continue
 			}
-			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", res))
+			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 			req.Header.Add("Content-Type", "application/json")
 			res, err := client.Do(req)
 			if err == nil {
@@ -79,7 +79,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if res.StatusCode == http.StatusOK || res.StatusCode == http.StatusForbidden {
 					s1.Verified = true
 				} else if res.StatusCode != http.StatusUnauthorized {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			}
 		}

--- a/pkg/detectors/sendgrid/sendgrid_test.go
+++ b/pkg/detectors/sendgrid/sendgrid_test.go
@@ -126,7 +126,7 @@ func TestSendgrid_FromChunk(t *testing.T) {
 				t.Errorf("Sendgrid.FromData() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Sendgrid.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/sendgrid/sendgrid_test.go
+++ b/pkg/detectors/sendgrid/sendgrid_test.go
@@ -126,7 +126,7 @@ func TestSendgrid_FromChunk(t *testing.T) {
 				t.Errorf("Sendgrid.FromData() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Sendgrid.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/sentrytoken/sentrytoken.go
+++ b/pkg/detectors/sentrytoken/sentrytoken.go
@@ -66,7 +66,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			case isVerified:
 				s1.Verified = true
 			default:
-				s1.VerificationError = verificationErr
+				s1.SetVerificationError(verificationErr, resMatch)
 			}
 		}
 

--- a/pkg/detectors/sentrytoken/sentrytoken_test.go
+++ b/pkg/detectors/sentrytoken/sentrytoken_test.go
@@ -182,10 +182,10 @@ func TestSentryToken_FromChunk(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("Gitlab.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/sentrytoken/sentrytoken_test.go
+++ b/pkg/detectors/sentrytoken/sentrytoken_test.go
@@ -181,11 +181,11 @@ func TestSentryToken_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatal("no raw secret present")
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
 				t.Errorf("Gitlab.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/slack/slack.go
+++ b/pkg/detectors/slack/slack.go
@@ -82,7 +82,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					defer res.Body.Close()
 					var authResponse authRes
 					if err := json.NewDecoder(res.Body).Decode(&authResponse); err != nil {
-						s1.VerificationError = fmt.Errorf("failed to decode auth response: %w", err)
+						err = fmt.Errorf("failed to decode auth response: %w", err)
+						s1.SetVerificationError(err, token)
 					}
 
 					if authResponse.Ok {
@@ -91,10 +92,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					} else if authResponse.Error == "invalid_auth" {
 						// The secret is determinately not verified (nothing to do)
 					} else {
-						s1.VerificationError = fmt.Errorf("unexpected error auth response %+v", authResponse.Error)
+						err = fmt.Errorf("unexpected error auth response %+v", authResponse.Error)
+						s1.SetVerificationError(err, token)
 					}
 				} else {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, token)
 				}
 			}
 

--- a/pkg/detectors/slack/slack_test.go
+++ b/pkg/detectors/slack/slack_test.go
@@ -121,10 +121,10 @@ func TestSlack_FromChunk(t *testing.T) {
 				got[i].Raw = nil
 
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.wantResults, ignoreOpts); diff != "" {
 				t.Errorf("Slack.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/slack/slack_test.go
+++ b/pkg/detectors/slack/slack_test.go
@@ -120,11 +120,11 @@ func TestSlack_FromChunk(t *testing.T) {
 				}
 				got[i].Raw = nil
 
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.wantResults, ignoreOpts); diff != "" {
 				t.Errorf("Slack.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/slackwebhook/slackwebhook.go
+++ b/pkg/detectors/slackwebhook/slackwebhook.go
@@ -81,10 +81,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 || res.StatusCode == 403 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/slackwebhook/slackwebhook_test.go
+++ b/pkg/detectors/slackwebhook/slackwebhook_test.go
@@ -183,11 +183,11 @@ func TestSlackWebhook_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("SlackWebhook.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/slackwebhook/slackwebhook_test.go
+++ b/pkg/detectors/slackwebhook/slackwebhook_test.go
@@ -184,10 +184,10 @@ func TestSlackWebhook_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("SlackWebhook.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/snowflake/snowflake.go
+++ b/pkg/detectors/snowflake/snowflake.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"regexp"
+	"strings"
+	"unicode"
+
 	_ "github.com/snowflakedb/gosnowflake"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
-	"regexp"
-	"strings"
-	"unicode"
 )
 
 type Scanner struct {
@@ -120,7 +121,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						if strings.Contains(err.Error(), "Incorrect username or password was specified") {
 							s1.Verified = false
 						} else {
-							s1.VerificationError = err
+							s1.SetVerificationError(err, resAccountMatch, resUsernameMatch, resPasswordMatch)
 						}
 					} else {
 						rows, err := db.Query(retrieveAllDatabasesQuery)
@@ -141,7 +142,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						}
 						s1.ExtraData["databases"] = strings.Join(databases, ", ")
 
-						if s1.VerificationError == nil {
+						if s1.VerificationError() == nil {
 							s1.Verified = true
 						}
 					}

--- a/pkg/detectors/snowflake/snowflake.go
+++ b/pkg/detectors/snowflake/snowflake.go
@@ -121,7 +121,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						if strings.Contains(err.Error(), "Incorrect username or password was specified") {
 							s1.Verified = false
 						} else {
-							s1.SetVerificationError(err, resAccountMatch, resUsernameMatch, resPasswordMatch)
+							s1.SetVerificationError(err, resPasswordMatch)
 						}
 					} else {
 						rows, err := db.Query(retrieveAllDatabasesQuery)

--- a/pkg/detectors/snowflake/snowflake_test.go
+++ b/pkg/detectors/snowflake/snowflake_test.go
@@ -6,10 +6,11 @@ package snowflake
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -133,11 +134,11 @@ func TestSnowflake_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Snowflake.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/snowflake/snowflake_test.go
+++ b/pkg/detectors/snowflake/snowflake_test.go
@@ -135,10 +135,10 @@ func TestSnowflake_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Snowflake.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/sourcegraph/sourcegraph.go
+++ b/pkg/detectors/sourcegraph/sourcegraph.go
@@ -71,10 +71,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/sourcegraph/sourcegraph_test.go
+++ b/pkg/detectors/sourcegraph/sourcegraph_test.go
@@ -6,10 +6,11 @@ package sourcegraph
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -132,11 +133,11 @@ func TestSourcegraph_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Sourcegraph.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/sourcegraph/sourcegraph_test.go
+++ b/pkg/detectors/sourcegraph/sourcegraph_test.go
@@ -134,10 +134,10 @@ func TestSourcegraph_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Sourcegraph.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/sourcegraphcody/sourcegraphcody.go
+++ b/pkg/detectors/sourcegraphcody/sourcegraphcody.go
@@ -68,10 +68,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					// 401 when the token is invalid.
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/sourcegraphcody/sourcegraphcody_test.go
+++ b/pkg/detectors/sourcegraphcody/sourcegraphcody_test.go
@@ -133,11 +133,11 @@ func TestSourcegraphcody_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Sourcegraphcody.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/sourcegraphcody/sourcegraphcody_test.go
+++ b/pkg/detectors/sourcegraphcody/sourcegraphcody_test.go
@@ -134,10 +134,10 @@ func TestSourcegraphcody_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Sourcegraphcody.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/sqlserver/sqlserver.go
+++ b/pkg/detectors/sqlserver/sqlserver.go
@@ -41,7 +41,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			continue
 		}
 
-		detected := detectors.Result{
+		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_SQLServer,
 			Raw:          []byte(paramsUnsafe.Password),
 			RawV2:        []byte(paramsUnsafe.URL().String()),
@@ -49,20 +49,20 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			verified, err := ping(paramsUnsafe)
+			isVerified, err := ping(paramsUnsafe)
 
-			detected.Verified = verified
+			s1.Verified = isVerified
 
 			if mssqlErr, isMssqlErr := err.(mssql.Error); isMssqlErr && mssqlErr.Number == 18456 {
 				// Login failed
 				// Number taken from https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/database-engine-events-and-errors?view=sql-server-ver16
 				// Nothing to do; determinate failure to verify
 			} else {
-				detected.VerificationError = err
+				s1.SetVerificationError(err, paramsUnsafe.Password)
 			}
 		}
 
-		results = append(results, detected)
+		results = append(results, s1)
 	}
 
 	return results, nil

--- a/pkg/detectors/sqlserver/sqlserver_integration_test.go
+++ b/pkg/detectors/sqlserver/sqlserver_integration_test.go
@@ -151,11 +151,11 @@ func TestSQLServerIntegration_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("SQLServer.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/sqlserver/sqlserver_integration_test.go
+++ b/pkg/detectors/sqlserver/sqlserver_integration_test.go
@@ -152,10 +152,10 @@ func TestSQLServerIntegration_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("SQLServer.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/stripo/stripo.go
+++ b/pkg/detectors/stripo/stripo.go
@@ -65,10 +65,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/stripo/stripo_test.go
+++ b/pkg/detectors/stripo/stripo_test.go
@@ -99,11 +99,11 @@ func TestStripo_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Stripo.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/stripo/stripo_test.go
+++ b/pkg/detectors/stripo/stripo_test.go
@@ -100,10 +100,10 @@ func TestStripo_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Stripo.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/surveybot/surveybot.go
+++ b/pkg/detectors/surveybot/surveybot.go
@@ -64,7 +64,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					var r response
 					if err := json.NewDecoder(res.Body).Decode(&r); err != nil {
-						s1.VerificationError = err
+						s1.SetVerificationError(err, resMatch)
 						continue
 					}
 					if len(r.Surveys) > 0 {

--- a/pkg/detectors/tailscale/tailscale.go
+++ b/pkg/detectors/tailscale/tailscale.go
@@ -62,10 +62,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				case http.StatusUnauthorized:
 					// The secret is determinately not verified (nothing to do)
 				default:
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/twilio/twilio.go
+++ b/pkg/detectors/twilio/twilio.go
@@ -80,10 +80,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					} else if res.StatusCode == 401 || res.StatusCode == 403 {
 						// The secret is determinately not verified (nothing to do)
 					} else {
-						s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+						s1.SetVerificationError(err, sid, key)
 					}
 				} else {
-					s1.VerificationError = err
+					s1.SetVerificationError(err, sid, key)
 				}
 			}
 

--- a/pkg/detectors/twilio/twilio.go
+++ b/pkg/detectors/twilio/twilio.go
@@ -81,10 +81,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						// The secret is determinately not verified (nothing to do)
 					} else {
 						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
-						s1.SetVerificationError(err, sid, key)
+						s1.SetVerificationError(err, key)
 					}
 				} else {
-					s1.SetVerificationError(err, sid, key)
+					s1.SetVerificationError(err, key)
 				}
 			}
 

--- a/pkg/detectors/twilio/twilio_test.go
+++ b/pkg/detectors/twilio/twilio_test.go
@@ -6,10 +6,11 @@ package twilio
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -137,11 +138,11 @@ func TestTwilio_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Twilio.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/twilio/twilio_test.go
+++ b/pkg/detectors/twilio/twilio_test.go
@@ -139,10 +139,10 @@ func TestTwilio_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Twilio.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/twitch/twitch.go
+++ b/pkg/detectors/twitch/twitch.go
@@ -65,7 +65,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				client := s.getClient()
 				isVerified, verificationErr := verifyTwitch(ctx, client, resMatch, resIdMatch)
 				s1.Verified = isVerified
-				s1.VerificationError = verificationErr
+				s1.SetVerificationError(verificationErr, resMatch)
 			}
 
 			// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key

--- a/pkg/detectors/twitch/twitch_test.go
+++ b/pkg/detectors/twitch/twitch_test.go
@@ -181,11 +181,11 @@ func TestTwitch_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
-					t.Errorf("Twitch.FromData() verificationError = %v, wantVerificationErr %v", got[i].VerificationError, tt.wantVerificationErr)
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Errorf("Twitch.FromData() verificationError = %v, wantVerificationErr %v", got[i].VerificationError(), tt.wantVerificationErr)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Twitch.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/twitch/twitch_test.go
+++ b/pkg/detectors/twitch/twitch_test.go
@@ -185,7 +185,7 @@ func TestTwitch_FromChunk(t *testing.T) {
 					t.Errorf("Twitch.FromData() verificationError = %v, wantVerificationErr %v", got[i].VerificationError(), tt.wantVerificationErr)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Twitch.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/uri/uri.go
+++ b/pkg/detectors/uri/uri.go
@@ -83,7 +83,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if s.client == nil {
 				s.client = defaultClient
 			}
-			s1.Verified, s1.VerificationError = verifyURL(ctx, s.client, parsedURL)
+			isVerified, verificationError := verifyURL(ctx, s.client, parsedURL)
+			s1.Verified = isVerified
+			s1.SetVerificationError(verificationError, password)
 		}
 
 		if !s1.Verified {

--- a/pkg/detectors/uri/uri_test.go
+++ b/pkg/detectors/uri/uri_test.go
@@ -133,7 +133,7 @@ func TestURI_FromChunk(t *testing.T) {
 			// }
 			for i := range got {
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Errorf("URI.FromData() error = %v, wantVerificationErr %v", got[i].VerificationError, tt.wantErr)
+					t.Errorf("URI.FromData() error = %v, wantVerificationErr %v", got[i].VerificationError(), tt.wantErr)
 					return
 				}
 				got[i].Raw = nil

--- a/pkg/detectors/uri/uri_test.go
+++ b/pkg/detectors/uri/uri_test.go
@@ -132,13 +132,13 @@ func TestURI_FromChunk(t *testing.T) {
 			// 	return
 			// }
 			for i := range got {
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Errorf("URI.FromData() error = %v, wantVerificationErr %v", got[i].VerificationError, tt.wantErr)
 					return
 				}
 				got[i].Raw = nil
 				got[i].RawV2 = nil
-				got[i].VerificationError = nil
+				got[i].SetVerificationError(nil)
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("URI.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/vagrantcloudpersonaltoken/vagrantcloudpersonaltoken.go
+++ b/pkg/detectors/vagrantcloudpersonaltoken/vagrantcloudpersonaltoken.go
@@ -44,7 +44,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{
-			DetectorType: detectorspb.DetectorType_VagrantCloudPersonalToken, 
+			DetectorType: detectorspb.DetectorType_VagrantCloudPersonalToken,
 			Raw:          []byte(resMatch),
 		}
 
@@ -53,7 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if client == nil {
 				client = defaultClient
 			}
-			
+
 			req, err := http.NewRequestWithContext(ctx, "GET", "https://app.vagrantup.com/api/v2/authenticate", nil)
 			if err != nil {
 				continue
@@ -67,10 +67,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/vagrantcloudpersonaltoken/vagrantcloudpersonaltoken_test.go
+++ b/pkg/detectors/vagrantcloudpersonaltoken/vagrantcloudpersonaltoken_test.go
@@ -100,10 +100,10 @@ func TestVagrantcloudpersonaltoken_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Vagrantcloudpersonaltoken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/vagrantcloudpersonaltoken/vagrantcloudpersonaltoken_test.go
+++ b/pkg/detectors/vagrantcloudpersonaltoken/vagrantcloudpersonaltoken_test.go
@@ -99,11 +99,11 @@ func TestVagrantcloudpersonaltoken_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Vagrantcloudpersonaltoken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/voiceflow/voiceflow.go
+++ b/pkg/detectors/voiceflow/voiceflow.go
@@ -80,11 +80,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					if err == nil {
 						bodyString = buf.String()
 					}
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response [status=%d, body=%s]", res.StatusCode, bodyString)
+					verificationErr := fmt.Errorf("unexpected HTTP response [status=%d, body=%s]", res.StatusCode, bodyString)
+					s1.SetVerificationError(verificationErr, resMatch)
 				}
 				_ = res.Body.Close()
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/voiceflow/voiceflow_test.go
+++ b/pkg/detectors/voiceflow/voiceflow_test.go
@@ -6,10 +6,11 @@ package voiceflow
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -270,11 +271,11 @@ func TestVoiceflow_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Voiceflow.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/voiceflow/voiceflow_test.go
+++ b/pkg/detectors/voiceflow/voiceflow_test.go
@@ -272,10 +272,10 @@ func TestVoiceflow_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Voiceflow.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/web3storage/web3storage.go
+++ b/pkg/detectors/web3storage/web3storage.go
@@ -66,10 +66,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(fmt.Errorf("unexpected HTTP response status %d", res.StatusCode))
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/web3storage/web3storage.go
+++ b/pkg/detectors/web3storage/web3storage.go
@@ -66,7 +66,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.SetVerificationError(fmt.Errorf("unexpected HTTP response status %d", res.StatusCode))
+					err := fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
 				s1.SetVerificationError(err, resMatch)

--- a/pkg/detectors/web3storage/web3storage_test.go
+++ b/pkg/detectors/web3storage/web3storage_test.go
@@ -134,10 +134,10 @@ func TestWeb3Storage_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Web3Storage.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/web3storage/web3storage_test.go
+++ b/pkg/detectors/web3storage/web3storage_test.go
@@ -6,10 +6,11 @@ package web3storage
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -132,11 +133,11 @@ func TestWeb3Storage_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Web3Storage.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/zerotier/zerotier.go
+++ b/pkg/detectors/zerotier/zerotier.go
@@ -67,10 +67,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else if res.StatusCode == 401 {
 					// The secret is determinately not verified (nothing to do)
 				} else {
-					s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
 			} else {
-				s1.VerificationError = err
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 

--- a/pkg/detectors/zerotier/zerotier_test.go
+++ b/pkg/detectors/zerotier/zerotier_test.go
@@ -100,10 +100,10 @@ func TestZerotier_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Zerotier.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/zerotier/zerotier_test.go
+++ b/pkg/detectors/zerotier/zerotier_test.go
@@ -99,11 +99,11 @@ func TestZerotier_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Zerotier.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/zulipchat/zulipchat.go
+++ b/pkg/detectors/zulipchat/zulipchat.go
@@ -12,7 +12,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{
+type Scanner struct {
 	client *http.Client
 }
 
@@ -62,14 +62,14 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1 := detectors.Result{
 					DetectorType: detectorspb.DetectorType_ZulipChat,
 					Raw:          []byte(resMatch),
-					RawV2:        []byte(fmt.Sprintf("%s:%s:%s",resMatch, resIdMatch, resDomainMatch)),
+					RawV2:        []byte(fmt.Sprintf("%s:%s:%s", resMatch, resIdMatch, resDomainMatch)),
 				}
 
 				if verify {
 					client := s.client
-                        		if client == nil {
-                                		client = defaultClient
-                        		}
+					if client == nil {
+						client = defaultClient
+					}
 					req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://%s/api/v1/users", resDomainMatch), nil)
 					if err != nil {
 						continue
@@ -85,15 +85,15 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						} else if res.StatusCode == 401 {
 							// This secret is determinately not verified, nothing to do here
 						} else {
-							s1.VerificationError = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+							s1.SetVerificationError(fmt.Errorf("unexpected HTTP response status %d", res.StatusCode), resMatch)
 						}
 					} else {
-						s1.VerificationError = err
+						s1.SetVerificationError(err, resMatch)
 					}
 				}
-                       		if !s1.Verified && detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
-                                	continue
-                        	}
+				if !s1.Verified && detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
+					continue
+				}
 
 				results = append(results, s1)
 			}

--- a/pkg/detectors/zulipchat/zulipchat_test.go
+++ b/pkg/detectors/zulipchat/zulipchat_test.go
@@ -6,10 +6,11 @@ package zulipchat
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"testing"
 	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
@@ -134,11 +135,11 @@ func TestZulipChat_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError)
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "VerificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Zulipchat.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/zulipchat/zulipchat_test.go
+++ b/pkg/detectors/zulipchat/zulipchat_test.go
@@ -139,7 +139,7 @@ func TestZulipChat_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", *_test.go)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Zulipchat.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
VerificationError has been updated to a private variable.
SetVerificationError is now the recommended way to set verification errors, and any sensitive values should be passed-in to be automatically redacted.
All detectors and tests previously using VerificationError has also been updated to use the new logic.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

