### PR TITLE
fixed gist direct link generation

### DIFF
--- a/pkg/giturl/giturl.go
+++ b/pkg/giturl/giturl.go
@@ -135,7 +135,25 @@ func GenerateLink(repo, commit, file string, line int64) string {
 		fallthrough
 	default:
 		var baseLink string
-		if file == "" {
+
+		//Gist links are formatted differently
+		if strings.HasPrefix(repo, "https://gist.github.com") {
+			baseLink = repo[:len(repo)-4] + "/"
+			if commit != "" {
+				baseLink += commit + "/"
+			}
+			if file != "" {
+				cleanedFileName := strings.ReplaceAll(file, ".", "-")
+				baseLink += "#file-" + cleanedFileName
+			}
+			if line > 0 {
+				if strings.Contains(baseLink, "#") {
+					baseLink += "-L" + strconv.FormatInt(line, 10)
+				} else {
+					baseLink += "#L" + strconv.FormatInt(line, 10)
+				}
+			}
+		} else if file == "" {
 			baseLink = repo[:len(repo)-4] + "/commit/" + commit
 		} else {
 			baseLink = repo[:len(repo)-4] + "/blob/" + commit + "/" + file

--- a/pkg/giturl/giturl_test.go
+++ b/pkg/giturl/giturl_test.go
@@ -180,6 +180,26 @@ func TestGenerateLink(t *testing.T) {
 			},
 			want: "https://onprem.customdomain.com/org/repo/commit/xyz123",
 		},
+		{
+			name: "gist link gen",
+			args: args{
+				repo:   "https://gist.github.com/joeleonjr/be68e34b002e236160dbb394bbda86fb.git",
+				commit: "e94c5a1d5607e68f1cae4962bc4dce5de522371b",
+				file:   "test",
+				line:   int64(4),
+			},
+			want: "https://gist.github.com/joeleonjr/be68e34b002e236160dbb394bbda86fb/e94c5a1d5607e68f1cae4962bc4dce5de522371b/#file-test-L4",
+		},
+		{
+			name: "gist link gen - file with multiple extensions",
+			args: args{
+				repo:   "https://gist.github.com/joeleonjr/be68e34b002e236160dbb394bbda86fb.git",
+				commit: "c64bf2345256cca7d2621f9cb78401e8860f82c8",
+				file:   "test.txt.ps1",
+				line:   int64(4),
+			},
+			want: "https://gist.github.com/joeleonjr/be68e34b002e236160dbb394bbda86fb/c64bf2345256cca7d2621f9cb78401e8860f82c8/#file-test-txt-ps1-L4",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
### Description:
GitHub Gists are scanned using the `trufflehog github --repo <gist_url>` command, since a gist is just a git repo. At the moment, the `GenerateLink` function used to craft links to specific files from commit in GitHub repos containing secrets does not work properly for gists. The formatting does not include "blob" or "commit" and the fragment identifier works slightly differently (ex: `/#file-filename-txt-L5`). 

I adjusted the logic so that it generates accurate direct links to gists containing secrets.

Here are two gists to test this out on:

https://gist.github.com/joeleonjr/be68e34b002e236160dbb394bbda86fb (note two different AWS canary tokens leaked at different commits)

https://gist.github.com/joeleonjr/21b3d4460c54d4f8e18a7f71f5d4cb21 (note the file name with multiple extensions...those are converted from "." into "-" by GH)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

