### PR TITLE
Fix forks and repos counter, add metric for orgs enumerated

### DIFF
--- a/pkg/sources/github/metrics.go
+++ b/pkg/sources/github/metrics.go
@@ -39,4 +39,12 @@ var (
 		Help:      "Total number of GitHub repositories scanned.",
 	},
 		[]string{"source_name"})
+
+	githubOrgsEnumerated = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: common.MetricsNamespace,
+		Subsystem: common.MetricsSubsystem,
+		Name:      "github_orgs_enumerated",
+		Help:      "Total number of GitHub organizations enumerated.",
+	},
+		[]string{"source_name"})
 )


### PR DESCRIPTION
Fixes a counter and adds a new metric for orgs enumerated. If we used the orgs cache for enumeration with app I would have gotten the count there instead. The metric is needed to confirm that a customer integration migration is performing as expected.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

