### PR TITLE
Call Finish in SourceManager after the semaphore is released

### DIFF
--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -123,6 +123,8 @@ func (s *SourceManager) asyncRun(ctx context.Context, sourceName string, source 
 	}
 	s.wg.Add(1)
 	go func() {
+		// Call Finish after the semaphore has been released.
+		defer progress.Finish()
 		defer s.sem.Release(1)
 		defer s.wg.Done()
 		ctx := context.WithValues(ctx,
@@ -216,7 +218,6 @@ func (s *SourceManager) preflightChecks(ctx context.Context) error {
 // acquired resources. An error is returned if there was a fatal error during
 // the run. This information is also recorded in the JobProgress.
 func (s *SourceManager) run(ctx context.Context, source Source, report *JobProgress) error {
-	defer report.Finish()
 	report.Start(time.Now())
 	defer func() { report.End(time.Now()) }()
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Move the call to `Finish` to when resources have been released. This should also fix the flaky `SourceManager` test: https://github.com/trufflesecurity/trufflehog/actions/runs/6947048607/job/18899961430#step:6:321

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

