### PR TITLE
added ci scanning info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ trufflehog docker --image trufflesecurity/secrets --only-verified
 
 ## 11: Scan in CI
 
-Set the `--since-commit` flag to your default branch that people merge into (ex: "main"). Set the `--branch` flag to your PR's branch name (ex: "feature-1"). The `--fail` flag will return an 183 error code if valid credentials are found.
+Set the `--since-commit` flag to your default branch that people merge into (ex: "main"). Set the `--branch` flag to your PR's branch name (ex: "feature-1"). Depending on the CI/CD platform you use, this value can be pulled in dynamically (ex: [CIRCLE_BRANCH in Circle CI](https://circleci.com/docs/variables/) and [TRAVIS_PULL_REQUEST_BRANCH in Travis CI](https://docs.travis-ci.com/user/environment-variables/)). If the repo is cloned and the target branch is already checked out during the CI/CD workflow, then `--branch HEAD` should be sufficient. The `--fail` flag will return an 183 error code if valid credentials are found.
 
 ```bash
 trufflehog git file://. --since-commit main --branch feature-1 --only-verified --fail

--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ Use the `--image` flag multiple times to scan multiple images.
 trufflehog docker --image trufflesecurity/secrets --only-verified
 ```
 
+## 11: Scan in CI
+
+Set the `--since-commit` flag to your default branch that people merge into (ex: "main"). Set the `--branch` flag to your PR's branch name (ex: "feature-1"). The `--fail` flag will return an 183 error code if valid credentials are found.
+
+```bash
+trufflehog git file://. --since-commit main --branch feature-1 --only-verified --fail
+```
+
 # :question: FAQ
 
 - All I see is `🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷` and the program exits, what gives?


### PR DESCRIPTION
### Description:
The README doesn't detail the standard process of running TruffleHog in CI. Updated to include instructions.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

