### PR TITLE
Simplify temp dir cleaning

### DIFF
--- a/pkg/cleantemp/cleantemp.go
+++ b/pkg/cleantemp/cleantemp.go
@@ -57,7 +57,7 @@ func CleanTempDir(ctx logContext.Context) error {
 	}
 
 	tempDir := os.TempDir()
-	files, err := os.ReadDir(tempDir)
+	dirs, err := os.ReadDir(tempDir)
 	if err != nil {
 		return fmt.Errorf("Error reading temp dir: %w", err)
 	}
@@ -65,21 +65,21 @@ func CleanTempDir(ctx logContext.Context) error {
 	pattern := `^trufflehog-\d+-\d+$`
 	re := regexp.MustCompile(pattern)
 
-	for _, file := range files {
+	for _, dir := range dirs {
 		// Ensure that all directories match the pattern
-		if re.MatchString(file.Name()) {
+		if re.MatchString(dir.Name()) {
 			// Mark these directories initially as ones that should be deleted
 			shouldDelete := true
 			// If they match any live PIDs, mark as should not delete
 			for _, pidval := range pids {
-				if strings.Contains(file.Name(), fmt.Sprintf("-%s-", pidval)) {
+				if strings.Contains(dir.Name(), fmt.Sprintf("-%s-", pidval)) {
 					shouldDelete = false
 					// break out so we can still delete directories even if no other Trufflehog processes are running
 					break
 				}
 			}
 			if shouldDelete {
-				dirPath := filepath.Join(tempDir, file.Name())
+				dirPath := filepath.Join(tempDir, dir.Name())
 				if err := os.RemoveAll(dirPath); err != nil {
 					return fmt.Errorf("Error deleting temp directory: %s", dirPath)
 				}

--- a/pkg/cleantemp/cleantemp.go
+++ b/pkg/cleantemp/cleantemp.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/mitchellh/go-ps"
 
@@ -35,7 +36,13 @@ type CleanTemp interface {
 }
 
 // Deletes orphaned temp directories that do not contain running PID values
-func CleanTempDir(ctx logContext.Context, dirName string, pid int) error {
+func CleanTempDir(ctx logContext.Context) error {
+	executablePath, err := os.Executable()
+	if err != nil {
+		executablePath = "trufflehog"
+	}
+	execName := filepath.Base(executablePath)
+
 	// Finds other trufflehog PIDs that may be running
 	var pids []string
 	procs, err := ps.Processes()
@@ -44,7 +51,7 @@ func CleanTempDir(ctx logContext.Context, dirName string, pid int) error {
 	}
 
 	for _, proc := range procs {
-		if strings.Contains(proc.Executable(), dirName) {
+		if proc.Executable() == execName {
 			pids = append(pids, strconv.Itoa(proc.Pid()))
 		}
 	}
@@ -55,20 +62,17 @@ func CleanTempDir(ctx logContext.Context, dirName string, pid int) error {
 		return fmt.Errorf("Error reading temp dir: %w", err)
 	}
 
-	// Current PID
-	pidStr := strconv.Itoa(pid)
-
 	pattern := `^trufflehog-\d+-\d+$`
 	re := regexp.MustCompile(pattern)
 
 	for _, file := range files {
-		// Make sure we don't delete the working dir of the current PID
-		if file.IsDir() && re.MatchString(file.Name()) && !strings.Contains(file.Name(), pidStr) {
+		// Ensure that all directories match the pattern
+		if re.MatchString(file.Name()) {
 			// Mark these directories initially as ones that should be deleted
 			shouldDelete := true
 			// If they match any live PIDs, mark as should not delete
 			for _, pidval := range pids {
-				if strings.Contains(file.Name(), pidval) {
+				if strings.Contains(file.Name(), fmt.Sprintf("-%s-", pidval)) {
 					shouldDelete = false
 					// break out so we can still delete directories even if no other Trufflehog processes are running
 					break
@@ -84,4 +88,23 @@ func CleanTempDir(ctx logContext.Context, dirName string, pid int) error {
 		}
 	}
 	return nil
+}
+
+// RunCleanupLoop runs a loop that cleans up orphaned directories every 15 seconds
+func RunCleanupLoop(ctx logContext.Context) {
+	err := CleanTempDir(ctx)
+	if err != nil {
+		ctx.Logger().Error(err, "Error cleaning up orphaned directories ")
+	}
+
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		err := CleanTempDir(ctx)
+		if err != nil {
+			ctx.Logger().Error(err, "Error cleaning up orphaned directories ")
+		}
+	}
+
 }

--- a/pkg/cleantemp/cleantemp_test.go
+++ b/pkg/cleantemp/cleantemp_test.go
@@ -1,0 +1,16 @@
+package cleantemp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExecName(t *testing.T) {
+	executablePath, err := os.Executable()
+	assert.Nil(t, err)
+	execName := filepath.Base(executablePath)
+	assert.Equal(t, "cleantemp.test", execName)
+}

--- a/pkg/cleantemp/cleantemp_test.go
+++ b/pkg/cleantemp/cleantemp_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/mitchellh/go-ps"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,4 +14,17 @@ func TestExecName(t *testing.T) {
 	assert.Nil(t, err)
 	execName := filepath.Base(executablePath)
 	assert.Equal(t, "cleantemp.test", execName)
+
+	procs, err := ps.Processes()
+	assert.Nil(t, err)
+	assert.NotEmpty(t, procs)
+
+	found := false
+	for _, proc := range procs {
+		if proc.Executable() == execName {
+			found = true
+		}
+	}
+
+	assert.True(t, found)
 }


### PR DESCRIPTION
Simplifies the temporary directory cleaning.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

