### PR TITLE
Fix azure storage panic when invalid URL is constructed

### DIFF
--- a/pkg/detectors/azurestorage/azurestorage.go
+++ b/pkg/detectors/azurestorage/azurestorage.go
@@ -62,6 +62,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			url := "https://" + accountName + ".blob.core.windows.net/?comp=list"
 			req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+			if err != nil {
+				continue
+			}
 			req.Header.Set("x-ms-date", now)
 			req.Header.Set("x-ms-version", "2019-12-12")
 			req.Header.Set("Authorization", "SharedKey "+accountName+":"+signature)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Fix azure panic when invalid URL is constructed

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

