### PR TITLE
Check private keys concurrently

### DIFF
--- a/pkg/detectors/privatekey/ssh.go
+++ b/pkg/detectors/privatekey/ssh.go
@@ -34,7 +34,7 @@ func firstResponseFromSSH(parsedKey any, username, hostport string) (string, err
 
 	// Verify the server fingerprint to ensure that there is no MITM replay attack
 	config := &ssh.ClientConfig{
-		Timeout: 3 * time.Second,
+		Timeout: 5 * time.Second,
 		User:    username,
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This uses a [WaitGroup](https://pkg.go.dev/sync#WaitGroup) to look up private keys concurrently, rather than in sequence.

~Edit: I somehow forgot to make the actual functions go routines. I will need to correct that tomorrow.~

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

