### PR TITLE
feat(installation): Implement checksum signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ cd trufflehog; go install
 
 # Using installation script
 curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
+
+# Using installation script, verify checksum signature
+curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -v -b /usr/local/bin
+
 # Using installation script to install a specific version
 curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin <ReleaseTag like v3.56.0>
 ```
@@ -102,6 +106,8 @@ Verification steps are as follow:
    ```
 
 Replace `{version}` with the downloaded files version
+
+Alternatively, if you are using installation script, pass `-v` option to perform signature verification.
 
 # :rocket: Quick Start
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cd trufflehog; go install
 # Using installation script
 curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
 
-# Using installation script, verify checksum signature
+# Using installation script, verify checksum signature (requires cosign to be installed)
 curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -v -b /usr/local/bin
 
 # Using installation script to install a specific version
@@ -108,6 +108,7 @@ Verification steps are as follow:
 Replace `{version}` with the downloaded files version
 
 Alternatively, if you are using installation script, pass `-v` option to perform signature verification.
+This required Cosign binary to be installed prior to running installation script.
 
 # :rocket: Quick Start
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -9,6 +9,7 @@ $this: download go binaries for trufflesecurity/trufflehog
 Usage: $this [-b] bindir [-d] [tag]
   -b sets bindir or installation directory, Defaults to ./bin
   -d turns on debug logging
+  -v verify checksum signature. Require cosign binary to be installed.
    [tag] is a tag from
    https://github.com/trufflesecurity/trufflehog/releases
    If tag is missing, then the latest will be used.
@@ -22,10 +23,11 @@ parse_args() {
   # over-ridden by flag below
 
   BINDIR=${BINDIR:-./bin}
-  while getopts "b:dh?x" arg; do
+  while getopts "b:dvh?x" arg; do
     case "$arg" in
       b) BINDIR="$OPTARG" ;;
       d) log_set_priority 10 ;;
+      v) VERIFY_SIGN=true;;
       h | \?) usage "$0" ;;
       x) set -x ;;
     esac
@@ -41,8 +43,15 @@ parse_args() {
 execute() {
   tmpdir=$(mktemp -d)
   log_debug "downloading files into ${tmpdir}"
-  http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
   http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
+  
+  if [ "$VERIFY_SIGN" = true ]; then
+    http_download "${tmpdir}/${CHECKSUM}.${CERT_FORMAT}" "${CHECKSUM_URL}.${CERT_FORMAT}"
+    http_download "${tmpdir}/${CHECKSUM}.${SIG_FORMAT}" "${CHECKSUM_URL}.${SIG_FORMAT}"
+    verify_sign "${tmpdir}/${CHECKSUM}" "${tmpdir}/${CHECKSUM}.${CERT_FORMAT}" "${tmpdir}/${CHECKSUM}.${SIG_FORMAT}"
+  fi
+
+  http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
   hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
   srcdir="${tmpdir}"
   (cd "${tmpdir}" && untar "${TARBALL}")
@@ -326,6 +335,24 @@ hash_sha256_verify() {
   fi
 }
 
+check_cosign_bin() {
+  if [ "$VERIFY_SIGN" = true ]; then
+    if [ ! -x "$(command -v "$COSIGN_BINARY")" ]; then
+      log_err "Cosign binary is not installed. Follow steps from https://docs.sigstore.dev/system_config/installation/ to install it."
+      return 1
+    fi
+  fi
+}
+
+verify_sign() {
+  log_debug "Verifying artifact $1"
+  cosign verify-blob "$1" \
+  --certificate "$2" \
+  --signature "$3" \
+  --certificate-identity-regexp 'https://github\.com/trufflesecurity/trufflehog/\.github/workflows/.+' \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+}
+
 cat /dev/null <<EOF
 ------------------------------------------------------------------------
 End of functions from https://github.com/client9/shlib
@@ -341,6 +368,10 @@ ARCH=$(uname_arch)
 PREFIX="$OWNER/$REPO"
 PLATFORM="${OS}/${ARCH}"
 GITHUB_DOWNLOAD=https://github.com/${OWNER}/${REPO}/releases/download
+COSIGN_BINARY=cosign
+VERIFY_SIGN=false
+CERT_FORMAT=pem
+SIG_FORMAT=sig
 
 # use in logging routines
 log_prefix() {
@@ -352,6 +383,8 @@ uname_os_check "$OS"
 uname_arch_check "$ARCH"
 
 parse_args "$@"
+
+check_cosign_bin
 
 get_binary
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -346,7 +346,7 @@ check_cosign_bin() {
 
 verify_sign() {
   log_debug "Verifying artifact $1"
-  cosign verify-blob "$1" \
+  ${COSIGN_BINARY} verify-blob "$1" \
   --certificate "$2" \
   --signature "$3" \
   --certificate-identity-regexp "https://github\.com/${OWNER}/${REPO}/\.github/workflows/.+" \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -349,7 +349,7 @@ verify_sign() {
   cosign verify-blob "$1" \
   --certificate "$2" \
   --signature "$3" \
-  --certificate-identity-regexp 'https://github\.com/trufflesecurity/trufflehog/\.github/workflows/.+' \
+  --certificate-identity-regexp "https://github\.com/${OWNER}/${REPO}/\.github/workflows/.+" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Addresses issue: https://github.com/trufflesecurity/trufflehog/issues/2127

This PR adds an option `v` to the installation script to run checksum signature verifications. This is an optional option useful in automated systems.

If option `v` is specified, `*checksum.txt.pem` & `*checksum.txt.sig` are downloaded additional to `*checksum.txt` and signature verification is performed using cosign binary. Cosign binary installation is not part of the script. If the binary is not found, users are prompted to install it before running Trufflehog installation script. On successful verification of signature only, then installation will continue.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

