### PR TITLE
Ignore images and binaries

### DIFF
--- a/pkg/common/vars.go
+++ b/pkg/common/vars.go
@@ -7,7 +7,27 @@ import (
 
 var (
 	KB, MB, GB, TB, PB = 1e3, 1e6, 1e9, 1e12, 1e15
-	IgnoredExtensions  = []string{"mp4", "avi", "mpeg", "mpg", "mov", "wmv", "m4p", "swf", "mp2", "flv", "vob", "webm", "hdv", "3gp", "ogg", "mp3", "wav", "flac", "webp"}
+	IgnoredExtensions  = []string{
+		"mp4",
+		"avi",
+		"mpeg",
+		"mpg",
+		"mov",
+		"wmv",
+		"m4p",
+		"swf",
+		"mp2",
+		"flv",
+		"vob",
+		"webm",
+		"hdv",
+		"3gp",
+		"ogg",
+		"mp3",
+		"wav",
+		"flac",
+		"webp",
+	}
 )
 
 func SkipFile(filename string) bool {

--- a/pkg/common/vars.go
+++ b/pkg/common/vars.go
@@ -8,6 +8,7 @@ import (
 var (
 	KB, MB, GB, TB, PB = 1e3, 1e6, 1e9, 1e12, 1e15
 	IgnoredExtensions  = []string{
+		// multimedia/containers
 		"mp4",
 		"avi",
 		"mpeg",
@@ -27,6 +28,28 @@ var (
 		"wav",
 		"flac",
 		"webp",
+
+		// images
+		"png",
+		"jpg",
+		"jpeg",
+		"gif",
+		"tiff",
+
+		// binaries
+		// These can theoretically contain secrets, but need decoding for users to make sense of them, and we don't have
+		// any such decoders right now.
+		"class",
+		"dll",
+		"xsb",
+		"jdo",
+		"jar",
+		"ear",
+		"war",
+		"jks",
+		"ser",
+		"idx",
+		"hprof",
 	}
 )
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR expands the list of excluded file extensions to contain images and other binary files. These files can technically contain secrets, but need decoding to properly be handled, and we don't have any such decoding yet. Down the road if we want to add it we can.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

