### PR TITLE
[feat] - Remove go-git dependency

### DIFF
--- a/pkg/engine/git_test.go
+++ b/pkg/engine/git_test.go
@@ -106,12 +106,7 @@ func TestGitEngine(t *testing.T) {
 
 func BenchmarkGitEngine(b *testing.B) {
 	ctx := context.Background()
-	repoUrl := "https://github.com/dustin-decker/secretsandstuff.git"
-	path, _, err := git.PrepareRepo(ctx, repoUrl)
-	if err != nil {
-		b.Error(err)
-	}
-	defer os.RemoveAll(path)
+	repoUrl := "https://github.com/trufflesecurity/trufflehog.git"
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -132,11 +127,9 @@ func BenchmarkGitEngine(b *testing.B) {
 		}
 	}()
 
+	cfg := sources.GitConfig{URI: repoUrl}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		// TODO: this is measuring the time it takes to initialize the source
-		// and not to do the full scan
-		cfg := sources.GitConfig{URI: path}
 		if err := e.ScanGit(ctx, cfg); err != nil {
 			return
 		}

--- a/pkg/engine/git_test.go
+++ b/pkg/engine/git_test.go
@@ -106,7 +106,7 @@ func TestGitEngine(t *testing.T) {
 
 func BenchmarkGitEngine(b *testing.B) {
 	ctx := context.Background()
-	repoUrl := "https://github.com/trufflesecurity/trufflehog.git"
+	repoUrl := "https://github.com/dustin-decker/secretsandstuff.git"
 
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -982,9 +982,9 @@ func handleBinary(ctx context.Context, gitDir string, reporter sources.ChunkRepo
 		catFileArg = "cat-file"
 		blobArg    = "blob"
 
-		maxSize = 100 * 1024 * 1024 // 100 MB
+		maxSize = 1 * 1024 * 1024 * 1024 // 1GB
 	)
-	cmd := exec.Command("git", "--git-dir="+gitDir, catFileArg, blobArg, commitHash.String()+":"+path)
+	cmd := exec.Command("git", "-C", gitDir, catFileArg, blobArg, commitHash.String()+":"+path)
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -978,13 +978,8 @@ func handleBinary(ctx context.Context, gitDir string, reporter sources.ChunkRepo
 		return nil
 	}
 
-	const (
-		catFileArg = "cat-file"
-		blobArg    = "blob"
-
-		maxSize = 1 * 1024 * 1024 * 1024 // 1GB
-	)
-	cmd := exec.Command("git", "-C", gitDir, catFileArg, blobArg, commitHash.String()+":"+path)
+	const maxSize = 1 * 1024 * 1024 * 1024 // 1GB
+	cmd := exec.Command("git", "-C", gitDir, "cat-file", "blob", commitHash.String()+":"+path)
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -999,11 +994,11 @@ func handleBinary(ctx context.Context, gitDir string, reporter sources.ChunkRepo
 	}
 	defer func() {
 		if err := fileReader.Close(); err != nil {
-			ctx.Logger().Error(err, "Error closing fileReader")
+			ctx.Logger().Error(err, "error closing fileReader")
 		}
 		if err := cmd.Wait(); err != nil {
 			ctx.Logger().Error(
-				err, "Error waiting for command",
+				err, "error waiting for command",
 				"command", cmd.String(),
 				"stderr", stderr.String(),
 				"commit", commitHash,

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -1026,7 +1026,6 @@ func handleBinary(ctx context.Context, gitDir string, reporter sources.ChunkRepo
 
 	if fileContent.Len() == maxSize {
 		ctx.Logger().V(2).Info("Max archive size reached.", "path", path)
-		ctx.Logger().Info("Max archive size reached.", "path", path)
 	}
 
 	reader, err := diskbufferreader.New(&fileContent)

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -457,6 +457,8 @@ func (s *Git) CommitsScanned() uint64 {
 	return atomic.LoadUint64(&s.metrics.commitsScanned)
 }
 
+const gitDirName = ".git"
+
 func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string, scanOptions *ScanOptions, reporter sources.ChunkReporter) error {
 	if err := GitCmdCheck(); err != nil {
 		return err
@@ -475,7 +477,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 
 	var depth int64
 
-	gitDir := filepath.Join(path, ".git")
+	gitDir := filepath.Join(path, gitDirName)
 
 	logger := ctx.Logger().WithValues("repo", urlMetadata)
 	logger.V(1).Info("scanning repo", "base", scanOptions.BaseHash, "head", scanOptions.HeadHash)
@@ -635,7 +637,7 @@ func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string,
 
 	var depth int64
 	reachedBase := false
-	gitDir := filepath.Join(path, ".git")
+	gitDir := filepath.Join(path, gitDirName)
 
 	ctx.Logger().V(1).Info("scanning staged changes", "path", path)
 	for commit := range commitChan {
@@ -980,7 +982,7 @@ func handleBinary(ctx context.Context, gitDir string, reporter sources.ChunkRepo
 		catFileArg = "cat-file"
 		blobArg    = "blob"
 
-		maxSize = 250 * 1024 * 1024 // 20MB
+		maxSize = 100 * 1024 * 1024 // 100 MB
 	)
 	cmd := exec.Command("git", "--git-dir="+gitDir, catFileArg, blobArg, commitHash.String()+":"+path)
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Replace go-git with git cat-file for reading binary files

The go-git library loads entire file contents into memory when reading files from a commit. This causes high memory usage for large binaries.

This PR shells out to the native git cat-file command instead to retrieve file contents, which reduces memory consumption by streaming directly from the git object database rather than loading into memory.

By replacing go-git usage with git cat-file, memory usage is reduced significantly when processing large files in older commits.

Here are some profiling statistics:
Memory before:
![Screenshot 2023-12-04 at 5 20 35 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/357c98b1-181a-4b2b-8d3a-141eec3110b7)

CPU before:
![Screenshot 2023-12-04 at 5 21 01 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/4f97da8b-4d7d-40ac-8dec-430f64447823)

Memory after:
![Screenshot 2023-12-04 at 5 24 24 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/8d205fa6-5143-4164-ba04-4aa77502a4da)

CPU after.
![Screenshot 2023-12-04 at 5 24 59 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/a77a6727-3f4e-4cd4-a6c2-9f9df0ed18d1)

This entire codepath is gone:
![Screenshot 2023-12-04 at 5 03 23 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/330ab92a-af60-4ae7-987c-11aec88a1070)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

