### PR TITLE
[fixup] - Skip trying to determine MIME type for directories

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -447,7 +447,17 @@ func (a *Archive) handleExtractedFiles(ctx logContext.Context, env tempEnv, hand
 
 	var dataArchiveName string
 	for _, file := range extractedFiles {
-		name, err := handleFile(ctx, env, file.Name())
+		filename := file.Name()
+		filePath := filepath.Join(env.extractPath, filename)
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			return "", fmt.Errorf("unable to get file info for filename %s: %w", filename, err)
+		}
+		if fileInfo.IsDir() {
+			continue
+		}
+
+		name, err := handleFile(ctx, env, filename)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
When handling files within an archive, we should avoid trying to determine the MIME type for directories.

Error:
```
unable to read file for MIME type detection: read /var/folders/1m/m4kl5q2102bfr4k4566nmf800000gn/T/tmp_archive3228926043/usr: is a directory
```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

