### PR TITLE
Propagate TruffleHog context to handlers

### DIFF
--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -86,7 +86,7 @@ func TestArchiveHandler(t *testing.T) {
 		if err != nil {
 			t.Errorf("error creating reusable reader: %s", err)
 		}
-		archiveChan := archive.FromFile(context.Background(), newReader)
+		archiveChan := archive.FromFile(logContext.Background(), newReader)
 
 		count := 0
 		re := regexp.MustCompile(testCase.matchString)
@@ -110,7 +110,7 @@ func TestHandleFile(t *testing.T) {
 	reporter := sources.ChanReporter{Ch: make(chan *sources.Chunk, 2)}
 
 	// Context cancels the operation.
-	canceledCtx, cancel := context.WithCancel(context.Background())
+	canceledCtx, cancel := logContext.WithCancel(logContext.Background())
 	cancel()
 	assert.False(t, HandleFile(canceledCtx, strings.NewReader("file"), &sources.Chunk{}, reporter))
 
@@ -125,7 +125,7 @@ func TestHandleFile(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 0, len(reporter.Ch))
-	assert.True(t, HandleFile(context.Background(), reader, &sources.Chunk{}, reporter))
+	assert.True(t, HandleFile(logContext.Background(), reader, &sources.Chunk{}, reporter))
 	assert.Equal(t, 1, len(reporter.Ch))
 }
 
@@ -157,7 +157,7 @@ func TestReadToMax(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			reader := bytes.NewReader(tt.input)
-			output, err := a.ReadToMax(context.Background(), reader)
+			output, err := a.ReadToMax(logContext.Background(), reader)
 			assert.Nil(t, err)
 
 			assert.Equal(t, tt.expected, output)
@@ -173,7 +173,7 @@ func BenchmarkReadToMax(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		b.StartTimer()
-		_, _ = a.ReadToMax(context.Background(), reader)
+		_, _ = a.ReadToMax(logContext.Background(), reader)
 		b.StopTimer()
 
 		_, _ = reader.Seek(0, 0) // Reset the reader position.
@@ -204,7 +204,7 @@ func TestExtractTarContent(t *testing.T) {
 	assert.Nil(t, err)
 	defer file.Close()
 
-	ctx := context.Background()
+	ctx := logContext.Background()
 
 	chunkCh := make(chan *sources.Chunk)
 	go func() {

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -994,10 +994,11 @@ func getSafeRemoteURL(repo *git.Repository, preferred string) string {
 }
 
 func handleBinary(ctx context.Context, gitDir string, reporter sources.ChunkReporter, chunkSkel *sources.Chunk, commitHash plumbing.Hash, path string) error {
-	ctx.Logger().V(5).Info("handling binary file", "path", path)
+	fileCtx := context.WithValues(ctx, "commit", commitHash.String(), "path", path)
+	fileCtx.Logger().V(5).Info("handling binary file")
 
 	if common.SkipFile(path) {
-		ctx.Logger().V(5).Info("skipping binary file", "path", path)
+		fileCtx.Logger().V(5).Info("skipping binary file")
 		return nil
 	}
 
@@ -1043,7 +1044,7 @@ func handleBinary(ctx context.Context, gitDir string, reporter sources.ChunkRepo
 	}
 
 	if fileContent.Len() == maxSize {
-		ctx.Logger().V(2).Info("Max archive size reached.", "path", path)
+		fileCtx.Logger().V(2).Info("Max archive size reached.")
 	}
 
 	reader, err := diskbufferreader.New(&fileContent)
@@ -1052,25 +1053,25 @@ func handleBinary(ctx context.Context, gitDir string, reporter sources.ChunkRepo
 	}
 	defer reader.Close()
 
-	if handlers.HandleFile(ctx, reader, chunkSkel, reporter) {
+	if handlers.HandleFile(fileCtx, reader, chunkSkel, reporter) {
 		return nil
 	}
 
-	ctx.Logger().V(1).Info("binary file not handled, chunking raw", "path", path)
+	fileCtx.Logger().V(1).Info("binary file not handled, chunking raw")
 	if err := reader.Reset(); err != nil {
 		return err
 	}
 	reader.Stop()
 
 	chunkReader := sources.NewChunkReader()
-	chunkResChan := chunkReader(ctx, reader)
+	chunkResChan := chunkReader(fileCtx, reader)
 	for data := range chunkResChan {
 		chunk := *chunkSkel
 		chunk.Data = data.Bytes()
 		if err := data.Error(); err != nil {
 			return err
 		}
-		if err := reporter.ChunkOk(ctx, chunk); err != nil {
+		if err := reporter.ChunkOk(fileCtx, chunk); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:

Handlers currently use the built-in `context` package rather than `github.com/trufflesecurity/trufflehog/v3/pkg/context` (logContext). This results in vague errors that are impossible to trace, for instance:

```
2023-12-07T17:19:25-05:00       error   trufflehog      error unarchiving chunk.    {"error": "handling file: file1.txt: runtime error: index out of range [0] with length 0"}
```
https://github.com/trufflesecurity/trufflehog/blob/2a7813929b3a4d17c2bc6aab09ae1a95a066b4de/pkg/handlers/archive.go#L72-L81

This PR changes the code to pass logContext instead, resulting in traceable errors. Notably, it was not possible to figure out what file was causing a runtime panic (crashing TruffleHog) without this change.
```
2023-12-07T17:19:25-05:00       error   trufflehog      error unarchiving chunk.        {"source_manager_worker_id": "V1eMi", "job_id": 1, "source_id": 1, "source_name": "trufflehog - github", "source_type": "SOURCE_TYPE_GITHUB", "commit": "37ef02d1818ae263956b7c8bc702b85cdbc83d20", "path": "chromium/chrome/test/data/safe_browsing/rar/passwd.rar", "timeout": 30, "error": "handling file: file1.txt: runtime error: index out of range [0] with length 0"}
```

Two thoughts:
1. It may be easier to remove all imports of `context` and replace them with `github.com/trufflesecurity/trufflehog/v3/pkg/context`. This awkwardly changes `Handler.FromFile` but not `Handler.IsFileType`.
2. This does make the errors more verbose. Is it necessary to include all the fields or could we create pass a new context that only contains important information?

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

