### PR TITLE
Use bad json in slackwebhooks

### DIFF
--- a/pkg/detectors/slackwebhook/slackwebhook.go
+++ b/pkg/detectors/slackwebhook/slackwebhook.go
@@ -60,7 +60,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				client = defaultClient
 			}
 
-			payload := strings.NewReader(`{"text": ""}`)
+			// We don't want to actually send anything to webhooks we find. To verify them without spamming them, we
+			// send an intentionally malformed message and look for a particular expected error message.
+			payload := strings.NewReader(`intentionally malformed JSON from Trufflehog scan`)
 			req, err := http.NewRequestWithContext(ctx, "POST", resMatch, payload)
 			if err != nil {
 				continue
@@ -76,12 +78,16 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				defer res.Body.Close()
 
-				if res.StatusCode >= 200 && res.StatusCode < 300 || (res.StatusCode == 400 && (bytes.Equal(bodyBytes, []byte("no_text")) || bytes.Equal(bodyBytes, []byte("missing_text")))) {
+				if res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusMultipleChoices {
+					// Hopefully this never happens - it means we actually sent something to a channel somewhere. But
+					// we at least know the secret is verified.
 					s1.Verified = true
-				} else if res.StatusCode == 401 || res.StatusCode == 403 {
-					// The secret is determinately not verified (nothing to do)
+				} else if res.StatusCode == http.StatusBadRequest && bytes.Equal(bodyBytes, []byte("invalid_payload")) {
+					s1.Verified = true
+				} else if res.StatusCode == http.StatusNotFound {
+					// Not a real webhook or the owning app's OAuth token has been revoked or the app has been deleted
 				} else {
-					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					err = fmt.Errorf("unexpected HTTP response status %d: %s", res.StatusCode, bodyBytes)
 					s1.SetVerificationError(err, resMatch)
 				}
 			} else {

--- a/pkg/detectors/slackwebhook/slackwebhook.go
+++ b/pkg/detectors/slackwebhook/slackwebhook.go
@@ -78,15 +78,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				defer res.Body.Close()
 
-				if res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusMultipleChoices {
+				switch {
+				case res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusMultipleChoices:
 					// Hopefully this never happens - it means we actually sent something to a channel somewhere. But
 					// we at least know the secret is verified.
 					s1.Verified = true
-				} else if res.StatusCode == http.StatusBadRequest && bytes.Equal(bodyBytes, []byte("invalid_payload")) {
+				case res.StatusCode == http.StatusBadRequest && bytes.Equal(bodyBytes, []byte("invalid_payload")):
 					s1.Verified = true
-				} else if res.StatusCode == http.StatusNotFound {
+				case res.StatusCode == http.StatusNotFound:
 					// Not a real webhook or the owning app's OAuth token has been revoked or the app has been deleted
-				} else {
+					// You might want to handle this case or log it.
+				default:
 					err = fmt.Errorf("unexpected HTTP response status %d: %s", res.StatusCode, bodyBytes)
 					s1.SetVerificationError(err, resMatch)
 				}

--- a/pkg/detectors/slackwebhook/slackwebhook_test.go
+++ b/pkg/detectors/slackwebhook/slackwebhook_test.go
@@ -59,11 +59,29 @@ func TestSlackWebhook_FromChunk(t *testing.T) {
 			wantVerificationErr: false,
 		},
 		{
-			name: "deleted webhook",
+			name: "active webhook created by a deactivated user",
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a slackwebhook secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_SlackWebhook,
+					ExtraData:    map[string]string{"rotation_guide": "https://howtorotate.com/docs/tutorials/slack-webhook/"},
+					Verified:     true,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "deleted webhook",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a slackwebhook secret %s within", deletedWebhook)),
 				verify: true,
 			},
 			want: []detectors.Result{

--- a/pkg/detectors/slackwebhook/slackwebhook_test.go
+++ b/pkg/detectors/slackwebhook/slackwebhook_test.go
@@ -20,12 +20,14 @@ import (
 func TestSlackWebhook_FromChunk(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors3")
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors5")
 	if err != nil {
 		t.Fatalf("could not get test secrets from GCP: %s", err)
 	}
 	secret := testSecrets.MustGetField("SLACKWEBHOOK_TOKEN")
-	//inactiveSecret := testSecrets.MustGetField("SLACKWEBHOOK_INACTIVE")
+	inactiveSecret := testSecrets.MustGetField("SLACKWEBHOOK_INACTIVE")
+	deletedWebhook := testSecrets.MustGetField("SLACKWEBHOOK_DELETED")
+	deletedUserActiveWebhook := testSecrets.MustGetField("SLACKWEBHOOK_DELETED_USER_ACTIVE_WEBHOOK")
 
 	type args struct {
 		ctx    context.Context
@@ -63,7 +65,7 @@ func TestSlackWebhook_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a slackwebhook secret %s within", secret)),
+				data:   []byte(fmt.Sprintf("You can find a slackwebhook secret %s within", deletedUserActiveWebhook)),
 				verify: true,
 			},
 			want: []detectors.Result{
@@ -99,7 +101,7 @@ func TestSlackWebhook_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a slackwebhook secret %s within", secret)),
+				data:   []byte(fmt.Sprintf("You can find a slackwebhook secret %s within", inactiveSecret)),
 				verify: true,
 			},
 			want: []detectors.Result{

--- a/pkg/detectors/slackwebhook/slackwebhook_test.go
+++ b/pkg/detectors/slackwebhook/slackwebhook_test.go
@@ -51,6 +51,7 @@ func TestSlackWebhook_FromChunk(t *testing.T) {
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_SlackWebhook,
+					ExtraData:    map[string]string{"rotation_guide": "https://howtorotate.com/docs/tutorials/slack-webhook/"},
 					Verified:     true,
 				},
 			},
@@ -68,6 +69,7 @@ func TestSlackWebhook_FromChunk(t *testing.T) {
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_SlackWebhook,
+					ExtraData:    map[string]string{"rotation_guide": "https://howtorotate.com/docs/tutorials/slack-webhook/"},
 					Verified:     true,
 				},
 			},
@@ -85,6 +87,7 @@ func TestSlackWebhook_FromChunk(t *testing.T) {
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_SlackWebhook,
+					ExtraData:    map[string]string{"rotation_guide": "https://howtorotate.com/docs/tutorials/slack-webhook/"},
 					Verified:     true,
 				},
 			},
@@ -102,6 +105,7 @@ func TestSlackWebhook_FromChunk(t *testing.T) {
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_SlackWebhook,
+					ExtraData:    map[string]string{"rotation_guide": "https://howtorotate.com/docs/tutorials/slack-webhook/"},
 					Verified:     false,
 				},
 			},
@@ -131,6 +135,7 @@ func TestSlackWebhook_FromChunk(t *testing.T) {
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_SlackWebhook,
+					ExtraData:    map[string]string{"rotation_guide": "https://howtorotate.com/docs/tutorials/slack-webhook/"},
 					Verified:     false,
 				},
 			},
@@ -148,6 +153,7 @@ func TestSlackWebhook_FromChunk(t *testing.T) {
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_SlackWebhook,
+					ExtraData:    map[string]string{"rotation_guide": "https://howtorotate.com/docs/tutorials/slack-webhook/"},
 					Verified:     false,
 				},
 			},
@@ -165,6 +171,7 @@ func TestSlackWebhook_FromChunk(t *testing.T) {
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_SlackWebhook,
+					ExtraData:    map[string]string{"rotation_guide": "https://howtorotate.com/docs/tutorials/slack-webhook/"},
 					Verified:     false,
 				},
 			},


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We're seeing some misbehavior from the existing SlackWebhook detector. The current implementation relies on undocumented Slack API behavior, and this version relies on defined behavior instead.

HOWEVER I'm still not sure what exactly #1761 was solving, and I don't want to change things until I can make sure that my new solution solves it too. (Also this doesn't build because I need to juggle our test secrets anyway.)

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

