### PR TITLE
[fixup] - skip files in the archive handler

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -185,9 +185,8 @@ func (a *Archive) extractorHandler(archiveChan chan []byte) func(context.Context
 		if err != nil {
 			return err
 		}
-		fileContent := bytes.NewReader(fileBytes)
 
-		err = a.openArchive(ctx, depth, fileContent, archiveChan)
+		err = a.openArchive(ctx, depth, bytes.NewReader(fileBytes), archiveChan)
 		if err != nil {
 			return err
 		}

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -139,7 +139,6 @@ func (a *Archive) handleDecompressor(ctx context.Context, info decompressorInfo)
 	if err != nil {
 		return err
 	}
-
 	fileBytes, err := a.ReadToMax(ctx, compReader)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We should skip binary files that are within archived pkgs.
So we can avoid: https://console.cloud.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22thog-prod%22%0Aresource.labels.location%3D%22us-central1%22%0Aresource.labels.cluster_name%3D%22prod-c1%22%0Aresource.labels.namespace_name%3D%22capable-energetic-pearl%22%0Alabels.k8s-pod%2Fapp%3D%22scanner-api%22%20severity%3E%3DDEFAULT%0Aerror%0A--%20%22max%20archive%20depth%22%0A--%20%22Max%20archive%20size%20reached%22%0A--%20%22scanning%20repo%22%0A--%20%22Starting%20to%20scan%20repo%22%0A--%20%22Enumerated%20GitLab%20projects%22%0A--%20%22memory%20pressure%20detected,%20throttling%20concurrency%22%0A--%20error%0A--%20jsonPayload.log.source_name%3D%22MnS%20Confluence%22%0A--%20jsonPayload.log.source_name%3D%22MnS%20Sharepoint%22%0A--%20%22updating%20final%20job%20status%22%0A--%20%22falling%20back%20to%20basic%20auth%22%0A--%20error%0A--%20%22could%20not%20get%20content%22%0A--%20%22rolling%20back%22%0A--%20%22Completed%20scanning%20confluence%20space%22%0A--%20%22Restaurant%20Platform%20Engineering%22%0A--%20%22Teams%22%0A--%20%22Restaurant%22%0A--%20%22Chick%22%0A--%20%22encountered%20errors%20while%20scanning%20confluence%22%0A--%20%22TEAM%22%0A-jsonPayload.log.msg%3D%22notified%20for%20secret%22;pinnedLogId=2023-11-29T19:52:49.297222537Z%2F64w54alutkgev3d1;summaryFields=jsonPayload%252Flog%252Fsource_name:false:32:beginning;cursorTimestamp=2023-12-09T00:25:59.910110038Z;duration=PT1H?project=thog-prod

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

