### PR TITLE
[bug] - close file after reading

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -187,11 +187,7 @@ func (a *Archive) extractorHandler(archiveChan chan []byte) func(context.Context
 			return err
 		}
 
-		err = a.openArchive(lCtx, depth, bytes.NewReader(fileBytes), archiveChan)
-		if err != nil {
-			return err
-		}
-		return nil
+		return a.openArchive(lCtx, depth, bytes.NewReader(fileBytes), archiveChan)
 	}
 }
 

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -175,6 +175,8 @@ func (a *Archive) extractorHandler(archiveChan chan []byte) func(context.Context
 		if err != nil {
 			return err
 		}
+		defer fReader.Close()
+
 		if common.SkipFile(f.Name()) {
 			lCtx.Logger().V(5).Info("skipping file", "filename", f.Name())
 			return nil


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We should close the extracted file after reading to avoid leaking file handles.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

