### PR TITLE
[chore] Remove omitempty tags on JobProgressMetrics and UnitMetrics

### DIFF
--- a/pkg/sources/job_progress.go
+++ b/pkg/sources/job_progress.go
@@ -128,9 +128,9 @@ type JobProgressMetrics struct {
 	FinishedUnits uint64 `json:"finished_units,omitempty"`
 	// Total number of chunks produced. This metric updates before the
 	// chunk is sent on the output channel.
-	TotalChunks uint64 `json:"total_chunks,omitempty"`
+	TotalChunks uint64 `json:"total_chunks"`
 	// All errors encountered.
-	Errors []error `json:"errors,omitempty"`
+	Errors []error `json:"errors"`
 	// Set to true if the source supports enumeration and has finished
 	// enumerating. If the source does not support enumeration, this field
 	// is always false.

--- a/pkg/sources/job_progress_hook.go
+++ b/pkg/sources/job_progress_hook.go
@@ -174,11 +174,11 @@ type UnitMetrics struct {
 	StartTime *time.Time `json:"start_time,omitempty"`
 	EndTime   *time.Time `json:"end_time,omitempty"`
 	// Total number of chunks produced from this unit.
-	TotalChunks uint64 `json:"total_chunks,omitempty"`
+	TotalChunks uint64 `json:"total_chunks"`
 	// Total number of bytes produced from this unit.
-	TotalBytes uint64 `json:"total_bytes,omitempty"`
+	TotalBytes uint64 `json:"total_bytes"`
 	// All errors encountered by this unit.
-	Errors []error `json:"errors,omitempty"`
+	Errors []error `json:"errors"`
 	// Flag to mark that these metrics were intentionally evicted from
 	// the cache.
 	handled bool


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Removes some of the `omitempty` JSON tags.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

