### PR TITLE
Fix azurestorage detector

### DIFF
--- a/pkg/detectors/azurestorage/azurestorage.go
+++ b/pkg/detectors/azurestorage/azurestorage.go
@@ -98,13 +98,15 @@ func verifyAzureStorageKey(ctx context.Context, client *http.Client, accountName
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode == http.StatusOK {
+	switch res.StatusCode {
+	case http.StatusOK:
 		return true, nil
-	} else if res.StatusCode != http.StatusForbidden { // 403 if account id or key is invalid, or if account is disabled
+	case http.StatusForbidden:
+		// 403 if account id or key is invalid, or if the account is disabled
+		return false, nil
+	default:
 		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
 	}
-
-	return false, nil
 }
 
 func (s Scanner) Type() detectorspb.DetectorType {

--- a/pkg/detectors/azurestorage/azurestorage.go
+++ b/pkg/detectors/azurestorage/azurestorage.go
@@ -51,7 +51,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_AzureStorage,
-			Raw:          []byte(accountName),
+			Raw:          []byte(accountKey),
 		}
 
 		if verify {

--- a/pkg/detectors/azurestorage/azurestorage.go
+++ b/pkg/detectors/azurestorage/azurestorage.go
@@ -97,8 +97,7 @@ func verifyAzureStorageKey(ctx context.Context, client *http.Client, accountName
 
 	if res.StatusCode == http.StatusOK {
 		return true, nil
-	} else if res.StatusCode != 403 {
-		// 403 if account name or account key is invalid or if account is disabled
+	} else if res.StatusCode != http.StatusForbidden { // 403 if account id or key is invalid, or if account is disabled
 		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
 	}
 

--- a/pkg/detectors/azurestorage/azurestorage.go
+++ b/pkg/detectors/azurestorage/azurestorage.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
@@ -22,12 +23,19 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = http.DefaultClient
+	defaultClient = common.SaneHttpClient()
 	keyPat        = regexp.MustCompile(`DefaultEndpointsProtocol=https;AccountName=(?P<account_name>[^;]+);AccountKey=(?P<account_key>[^;]+);EndpointSuffix=core\.windows\.net`)
 )
 
 func (s Scanner) Keywords() []string {
 	return []string{"DefaultEndpointsProtocol=https;AccountName="}
+}
+
+func (s Scanner) getClient() *http.Client {
+	if s.client != nil {
+		return s.client
+	}
+	return defaultClient
 }
 
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
@@ -48,43 +56,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			client := s.client
-			if client == nil {
-				client = defaultClient
-			}
-
-			now := time.Now().UTC().Format(http.TimeFormat)
-			stringToSign := "GET\n\n\n\n\n\n\n\n\n\n\n\nx-ms-date:" + now + "\nx-ms-version:2019-12-12\n/" + accountName + "/\ncomp:list"
-			accountKeyBytes, _ := base64.StdEncoding.DecodeString(accountKey)
-			h := hmac.New(sha256.New, accountKeyBytes)
-			h.Write([]byte(stringToSign))
-			signature := base64.StdEncoding.EncodeToString(h.Sum(nil))
-
-			url := "https://" + accountName + ".blob.core.windows.net/?comp=list"
-			req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-			if err != nil {
-				continue
-			}
-			req.Header.Set("x-ms-date", now)
-			req.Header.Set("x-ms-version", "2019-12-12")
-			req.Header.Set("Authorization", "SharedKey "+accountName+":"+signature)
-
-			if err != nil {
-				continue
-			}
-			res, err := client.Do(req)
-			if err == nil {
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					s1.Verified = true
-				} else if res.StatusCode == 403 {
-				} else {
-					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
-					s1.SetVerificationError(err, accountKey)
-				}
-			} else {
-				s1.SetVerificationError(err, accountKey)
-			}
+			client := s.getClient()
+			isVerified, verificationErr := verifyAzureStorageAccount(ctx, client, accountName, accountKey)
+			s1.Verified = isVerified
+			s1.SetVerificationError(verificationErr, accountKey)
 		}
 
 		results = append(results, s1)
@@ -95,4 +70,36 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 func (s Scanner) Type() detectorspb.DetectorType {
 	return detectorspb.DetectorType_AzureStorage
+}
+
+func verifyAzureStorageAccount(ctx context.Context, client *http.Client, accountName, accountKey string) (bool, error) {
+	now := time.Now().UTC().Format(http.TimeFormat)
+	stringToSign := "GET\n\n\n\n\n\n\n\n\n\n\n\nx-ms-date:" + now + "\nx-ms-version:2019-12-12\n/" + accountName + "/\ncomp:list"
+	accountKeyBytes, _ := base64.StdEncoding.DecodeString(accountKey)
+	h := hmac.New(sha256.New, accountKeyBytes)
+	h.Write([]byte(stringToSign))
+	signature := base64.StdEncoding.EncodeToString(h.Sum(nil))
+
+	url := "https://" + accountName + ".blob.core.windows.net/?comp=list"
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("x-ms-date", now)
+	req.Header.Set("x-ms-version", "2019-12-12")
+	req.Header.Set("Authorization", "SharedKey "+accountName+":"+signature)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 200 && res.StatusCode < 300 {
+		return true, nil
+	} else if res.StatusCode == http.StatusForbidden {
+		return false, fmt.Errorf("forbidden access to Azure Storage account")
+	} else {
+		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
 }

--- a/pkg/detectors/azurestorage/azurestorage.go
+++ b/pkg/detectors/azurestorage/azurestorage.go
@@ -52,6 +52,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_AzureStorage,
 			Raw:          []byte(accountKey),
+			ExtraData: map[string]string{
+				"account_name": accountName,
+			},
 		}
 
 		if verify {

--- a/pkg/detectors/azurestorage/azurestorage_test.go
+++ b/pkg/detectors/azurestorage/azurestorage_test.go
@@ -39,12 +39,11 @@ func TestAzurestorage_FromChunk(t *testing.T) {
 		verify bool
 	}
 	tests := []struct {
-		name                string
-		s                   Scanner
-		args                args
-		want                []detectors.Result
-		wantErr             bool
-		wantVerificationErr bool
+		name    string
+		s       Scanner
+		args    args
+		want    []detectors.Result
+		wantErr bool
 	}{
 		{
 			name: "found, verified",
@@ -58,10 +57,12 @@ func TestAzurestorage_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_AzureStorage,
 					Verified:     true,
+					ExtraData: map[string]string{
+						"account_name": "teststoragebytruffle",
+					},
 				},
 			},
-			wantErr:             false,
-			wantVerificationErr: false,
+			wantErr: false,
 		},
 		{
 			name: "found, unverified",
@@ -75,10 +76,12 @@ func TestAzurestorage_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_AzureStorage,
 					Verified:     false,
+					ExtraData: map[string]string{
+						"account_name": "teststoragebytruffle",
+					},
 				},
 			},
-			wantErr:             false,
-			wantVerificationErr: false,
+			wantErr: false,
 		},
 		{
 			name: "not found",
@@ -88,9 +91,8 @@ func TestAzurestorage_FromChunk(t *testing.T) {
 				data:   []byte("You cannot find the secret within"),
 				verify: true,
 			},
-			want:                nil,
-			wantErr:             false,
-			wantVerificationErr: false,
+			want:    nil,
+			wantErr: false,
 		},
 		{
 			name: "found, would be verified if not for timeout",
@@ -104,12 +106,14 @@ func TestAzurestorage_FromChunk(t *testing.T) {
 				r := detectors.Result{
 					DetectorType: detectorspb.DetectorType_AzureStorage,
 					Verified:     false,
+					ExtraData: map[string]string{
+						"account_name": "teststoragebytruffle",
+					},
 				}
 				r.SetVerificationError(fmt.Errorf("context deadline exceeded"), secret)
 				return []detectors.Result{r}
 			}(),
-			wantErr:             false,
-			wantVerificationErr: true,
+			wantErr: false,
 		},
 		{
 			name: "found, verified but unexpected api surface",
@@ -123,12 +127,14 @@ func TestAzurestorage_FromChunk(t *testing.T) {
 				r := detectors.Result{
 					DetectorType: detectorspb.DetectorType_AzureStorage,
 					Verified:     false,
+					ExtraData: map[string]string{
+						"account_name": "teststoragebytruffle",
+					},
 				}
 				r.SetVerificationError(fmt.Errorf("unexpected HTTP response status 404"), secret)
 				return []detectors.Result{r}
 			}(),
-			wantErr:             false,
-			wantVerificationErr: true,
+			wantErr: false,
 		},
 		{
 			name: "found secret with invalid account name",
@@ -142,10 +148,12 @@ func TestAzurestorage_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_AzureStorage,
 					Verified:     false,
+					ExtraData: map[string]string{
+						"account_name": "invalid",
+					},
 				},
 			},
-			wantErr:             false,
-			wantVerificationErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/detectors/azurestorage/azurestorage_test.go
+++ b/pkg/detectors/azurestorage/azurestorage_test.go
@@ -12,9 +12,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
-
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
@@ -133,8 +132,16 @@ func TestAzurestorage_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
+				gotErr := ""
+				if got[i].VerificationError() != nil {
+					gotErr = got[i].VerificationError().Error()
+				}
+				wantErr := ""
+				if tt.want[i].VerificationError() != nil {
+					wantErr = tt.want[i].VerificationError().Error()
+				}
+				if gotErr != wantErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.want[i].VerificationError(), got[i].VerificationError())
 				}
 			}
 			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Refactoring Azure Storage detector and fixing bug
- bugfix: accountID (which is not unique) was used as raw, leading to secrets being overwritten and flipflopping; updated to use key as raw instead
- some accountIDs may no longer exist. leading to host not being found err in request. this should denote an invalid key. added check and test case for this.
- updated test secrets. all tests should be passing now
- refactor: standard refactor, pulling out verification logic, fixing verification error test cases, using http values instead of hard coded values, etc.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

