### PR TITLE
fix and refactor browserstack detector

### DIFF
--- a/pkg/detectors/browserstack/browserstack.go
+++ b/pkg/detectors/browserstack/browserstack.go
@@ -102,7 +102,6 @@ func verifyBrowserStackCredentials(ctx context.Context, client *http.Client, use
 	}
 	req.Header.Add("Content-Type", "application/json")
 	req.SetBasicAuth(username, accessKey)
-	fmt.Println(username, accessKey)
 
 	res, err := client.Do(req)
 	if err != nil {

--- a/pkg/detectors/browserstack/browserstack.go
+++ b/pkg/detectors/browserstack/browserstack.go
@@ -3,13 +3,15 @@ package browserstack
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/cookiejar"
 	"regexp"
 	"strings"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+	"golang.org/x/net/publicsuffix"
 )
 
 type Scanner struct {
@@ -22,17 +24,25 @@ var _ detectors.Detector = (*Scanner)(nil)
 const browserStackAPIURL = "https://www.browserstack.com/automate/plan.json"
 
 var (
-	defaultClient = common.SaneHttpClient()
-
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"hub-cloud.browserstack.com", "accessKey", "\"access_Key\":", "ACCESS_KEY", "key", "browserstackKey", "BS_AUTHKEY", "BROWSERSTACK_ACCESS_KEY"}) + `\b([0-9a-zA-Z]{20})\b`)
-	userPat = regexp.MustCompile(detectors.PrefixRegex([]string{"hub-cloud.browserstack.com", "userName", "\"username\":", "USER_NAME", "user", "browserstackUser", "BS_USERNAME", "BROWSERSTACK_USERNAME"}) + `\b([a-zA-Z\d]{3,18}[._-]?[a-zA-Z\d]{6,11})\b`)
+	userPat = regexp.MustCompile(detectors.PrefixRegex([]string{"hub-cloud.browserstack.com", "userName", "\"username\":", "USER_NAME", "user", "browserstackUser", "BS_USERNAME", "BROWSERSTACK_USERNAME"}) + `\b([a-zA-Z\d]{3,18}[._-]*[a-zA-Z\d]{6,11})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
 	return []string{"browserstack"}
+}
+
+func (s Scanner) getClient(cookieJar *cookiejar.Jar) *http.Client {
+	if s.client != nil {
+		s.client.Jar = cookieJar
+		return s.client
+	}
+	return &http.Client{
+		Jar: cookieJar,
+	}
 }
 
 // FromData will find and optionally verify BrowserStack secrets in a given set of bytes.
@@ -61,10 +71,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				client := s.client
-				if client == nil {
-					client = defaultClient
+				// browserstack (via cloudflare) requires cookies to be enabled
+				jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+				if err != nil {
+					return nil, err
 				}
+				client := s.getClient(jar)
 
 				isVerified, verificationErr := verifyBrowserStackCredentials(ctx, client, resUserMatch, resMatch)
 				s1.Verified = isVerified
@@ -89,6 +101,7 @@ func verifyBrowserStackCredentials(ctx context.Context, client *http.Client, use
 	}
 	req.Header.Add("Content-Type", "application/json")
 	req.SetBasicAuth(username, accessKey)
+	fmt.Println(username, accessKey)
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -96,9 +109,18 @@ func verifyBrowserStackCredentials(ctx context.Context, client *http.Client, use
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode >= 200 && res.StatusCode < 300 {
+	if res.StatusCode == http.StatusOK {
 		return true, nil
-	} else if res.StatusCode != 401 {
+	} else if res.StatusCode == http.StatusForbidden {
+		// Sometimes browserstack (via Cloudflare) will block requests for security
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return false, err
+		}
+		if strings.Contains(string(body), "blocked") {
+			return false, fmt.Errorf("blocked by browserstack")
+		}
+	} else if res.StatusCode != http.StatusUnauthorized {
 		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
 	}
 

--- a/pkg/detectors/browserstack/browserstack.go
+++ b/pkg/detectors/browserstack/browserstack.go
@@ -40,6 +40,7 @@ func (s Scanner) getClient(cookieJar *cookiejar.Jar) *http.Client {
 		s.client.Jar = cookieJar
 		return s.client
 	}
+	// Using custom HTTP client instead of common.SaneHttpClient() here because, for unknown reasons, browserstack blocks those requests even with cookie jar attached
 	return &http.Client{
 		Jar: cookieJar,
 	}

--- a/pkg/detectors/browserstack/browserstack_test.go
+++ b/pkg/detectors/browserstack/browserstack_test.go
@@ -34,12 +34,11 @@ func TestBrowserStack_FromChunk(t *testing.T) {
 		verify bool
 	}
 	tests := []struct {
-		name                string
-		s                   Scanner
-		args                args
-		want                []detectors.Result
-		wantErr             bool
-		wantVerificationErr bool
+		name    string
+		s       Scanner
+		args    args
+		want    []detectors.Result
+		wantErr bool
 	}{
 		{
 			name: "found, verified",
@@ -93,8 +92,7 @@ func TestBrowserStack_FromChunk(t *testing.T) {
 				results := []detectors.Result{r}
 				return results
 			}(),
-			wantErr:             false,
-			wantVerificationErr: true,
+			wantErr: false,
 		},
 		{
 			name: "found, verified but unexpected api surface",
@@ -114,8 +112,7 @@ func TestBrowserStack_FromChunk(t *testing.T) {
 				results := []detectors.Result{r}
 				return results
 			}(),
-			wantErr:             false,
-			wantVerificationErr: true,
+			wantErr: false,
 		},
 		{
 			name: "found, verified but blocked by browserstack",
@@ -135,8 +132,7 @@ func TestBrowserStack_FromChunk(t *testing.T) {
 				results := []detectors.Result{r}
 				return results
 			}(),
-			wantErr:             false,
-			wantVerificationErr: true,
+			wantErr: false,
 		},
 		{
 			name: "not found",

--- a/pkg/detectors/browserstack/browserstack_test.go
+++ b/pkg/detectors/browserstack/browserstack_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
@@ -83,13 +83,16 @@ func TestBrowserStack_FromChunk(t *testing.T) {
 				data:   []byte(fmt.Sprintf("You can find a BROWSERSTACK_ACCESS_KEY %s within BROWSERSTACK_USERNAME %s", secret, secretUser)),
 				verify: true,
 			},
-			want: []detectors.Result{
-				{
+			want: func() []detectors.Result {
+				r := detectors.Result{
 					DetectorType: detectorspb.DetectorType_BrowserStack,
 					RawV2:        []byte(fmt.Sprintf("%s%s", secret, secretUser)),
 					Verified:     false,
-				},
-			},
+				}
+				r.SetVerificationError(fmt.Errorf("context deadline exceeded"), secret)
+				results := []detectors.Result{r}
+				return results
+			}(),
 			wantErr:             false,
 			wantVerificationErr: true,
 		},
@@ -101,13 +104,37 @@ func TestBrowserStack_FromChunk(t *testing.T) {
 				data:   []byte(fmt.Sprintf("You can find a BROWSERSTACK_ACCESS_KEY %s within BROWSERSTACK_USERNAME %s", secret, secretUser)),
 				verify: true,
 			},
-			want: []detectors.Result{
-				{
+			want: func() []detectors.Result {
+				r := detectors.Result{
 					DetectorType: detectorspb.DetectorType_BrowserStack,
 					Verified:     false,
 					RawV2:        []byte(fmt.Sprintf("%s%s", secret, secretUser)),
-				},
+				}
+				r.SetVerificationError(fmt.Errorf("unexpected HTTP response status 404"), secret)
+				results := []detectors.Result{r}
+				return results
+			}(),
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+		{
+			name: "found, verified but blocked by browserstack",
+			s:    Scanner{client: common.SaneHttpClient()},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a BROWSERSTACK_ACCESS_KEY %s within BROWSERSTACK_USERNAME %s", secret, secretUser)),
+				verify: true,
 			},
+			want: func() []detectors.Result {
+				r := detectors.Result{
+					DetectorType: detectorspb.DetectorType_BrowserStack,
+					Verified:     false,
+					RawV2:        []byte(fmt.Sprintf("%s%s", secret, secretUser)),
+				}
+				r.SetVerificationError(fmt.Errorf("blocked by browserstack"), secret)
+				results := []detectors.Result{r}
+				return results
+			}(),
 			wantErr:             false,
 			wantVerificationErr: true,
 		},
@@ -134,8 +161,16 @@ func TestBrowserStack_FromChunk(t *testing.T) {
 				if len(got[i].Raw) == 0 {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
-				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
-					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
+				gotErr := ""
+				if got[i].VerificationError() != nil {
+					gotErr = got[i].VerificationError().Error()
+				}
+				wantErr := ""
+				if tt.want[i].VerificationError() != nil {
+					wantErr = tt.want[i].VerificationError().Error()
+				}
+				if gotErr != wantErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.want[i].VerificationError(), got[i].VerificationError())
 				}
 			}
 			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Fixing a few issues with Browserstack Detector:
- standard refactor
- Previously `[._-]+` in the user pattern was updated to `[._-]?` because some userIDs do not contain this. However it could be the case that some userIDs contain multiple such symbols in the middle, and this could be causing some users to not detect tokens. updating to use `[._-]*` instead
- Browserstack (via Cloudflare) has been blocking verification requests. Go doesn't handle cookies by default. Adding cookie jar. Adding test case to check this in the future.
- removing `common.SaneHttpClient()` bc for some reason it yields requests getting blocked even with cookiejar.
<img width="1013" alt="image" src="https://github.com/trufflesecurity/trufflehog/assets/13666360/3ce06d1c-bb2b-4058-85c8-36a40a9ec8d7">


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

