### PR TITLE
Encode '%' when generating Git URLs

### DIFF
--- a/pkg/giturl/giturl.go
+++ b/pkg/giturl/giturl.go
@@ -118,6 +118,10 @@ func NormalizeOrgRepoURL(provider provider, repoURL string) (string, error) {
 // Supports GitHub, GitLab, Bitbucket, and Azure Repos.
 // If the provider supports hyperlinks to specific lines, the line number will be included.
 func GenerateLink(repo, commit, file string, line int64) string {
+	// Some paths contain '%' which breaks |url.Parse| if not encoded.
+	// https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding
+	file = strings.Replace(file, "%", "%25", -1)
+
 	switch determineProvider(repo) {
 	case providerBitbucket:
 		return repo[:len(repo)-4] + "/commits/" + commit

--- a/pkg/giturl/giturl_test.go
+++ b/pkg/giturl/giturl_test.go
@@ -200,6 +200,16 @@ func TestGenerateLink(t *testing.T) {
 			},
 			want: "https://gist.github.com/joeleonjr/be68e34b002e236160dbb394bbda86fb/c64bf2345256cca7d2621f9cb78401e8860f82c8/#file-test-txt-ps1-L4",
 		},
+		{
+			name: "link gen - file percent in path",
+			args: args{
+				repo:   "https://github.com/GeekMasher/tree-sitter-hcl.git",
+				commit: "a7f23cc5795769262f5515e52902f86c1b768994",
+				file:   "example/real_world_stuff/coreos/coreos%tectonic-installer%installer%frontend%ui-tests%output%metal.tfvars",
+				line:   int64(1),
+			},
+			want: "https://github.com/GeekMasher/tree-sitter-hcl/blob/a7f23cc5795769262f5515e52902f86c1b768994/example/real_world_stuff/coreos/coreos%25tectonic-installer%25installer%25frontend%25ui-tests%25output%25metal.tfvars#L1",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This fixes an issue where file paths that contain `%` would cause `UpdateLinkLineNumber` to break.

Example:
```
2023-11-03T07:40:37-04:00       error   trufflehog      unable to parse link to update line number      {"detector_worker_id": "PSF2d", "timeout": 10, "link": "https://github.com/GeekMasher/tree-sitter-hcl/blob/a7f23cc5795769262f5515e52902f86c1b768994/example/real_world_stuff/coreos/coreos%tectonic-installer%installer%frontend%ui-tests%output%metal.tfvars#L1", "error": "parse \"https://github.com/GeekMasher/tree-sitter-hcl/blob/a7f23cc5795769262f5515e52902f86c1b768994/example/real_world_stuff/coreos/coreos%tectonic-installer%installer%frontend%ui-tests%output%metal.tfvars\": invalid URL escape \"%te\""}
```

### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

