### PR TITLE
Don't run 'test' workflow in forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    if: ${{ ! github.event.pull_request.head.repo.fork }}
+    if: ${{ github.repository == 'trufflesecurity/trufflehog' && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     permissions:
       actions: "read"


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This should[^1] tweak the `test` job to only run in this repository. Right now it attempts to run, [and fails](https://github.com/rgmz/trufflehog/actions/runs/7213888506/job/19654757902), every time a fork is synchronized.

[^1]: It's difficult for me to test this but I _think_ it's correct.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

