### PR TITLE
[chore] Prevent panic when ChunkError has a nil Unit

### DIFF
--- a/pkg/sources/job_progress.go
+++ b/pkg/sources/job_progress.go
@@ -94,7 +94,11 @@ type ChunkError struct {
 }
 
 func (f ChunkError) Error() string {
-	return fmt.Sprintf("error chunking unit %q: %s", f.Unit.SourceUnitID(), f.Err.Error())
+	unit := "<nil>"
+	if f.Unit != nil {
+		unit = f.Unit.SourceUnitID()
+	}
+	return fmt.Sprintf("error chunking unit %q: %s", unit, f.Err.Error())
 }
 func (f ChunkError) Unwrap() error { return f.Err }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The `Error()` method of `ChunkError` expects `Unit` to be non-nil, but that might not always be true. This PR adds a check to prevent a nil pointer dereference.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

