### PR TITLE
Don't run detector tests on forks

### DIFF
--- a/.github/workflows/detector-tests.yml
+++ b/.github/workflows/detector-tests.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   test-detectors:
+    if: ${{ github.repository == 'trufflesecurity/trufflehog' }}
     runs-on: ubuntu-latest
     permissions:
       actions: "read"


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The `test-detectors` workflow is scheduled to run via cron. It requires valid GCP credentials to succeed and will fails on forks.

https://github.com/rgmz/trufflehog/actions/runs/7230727715

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

