### PR TITLE
[feat] - Concurrent processing of binary diffs during git scans

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -49,13 +49,6 @@ type Source struct {
 	scanOptions *ScanOptions
 }
 
-type binaryDiff struct {
-	fileName  string
-	gitDir    string
-	commit    plumbing.Hash // 20 bytes
-	chunkSkel *sources.Chunk
-}
-
 type Git struct {
 	sourceType         sourcespb.SourceType
 	sourceName         string
@@ -465,6 +458,15 @@ func (s *Git) CommitsScanned() uint64 {
 }
 
 const gitDirName = ".git"
+
+// binaryDiff contains the information needed to read a binary file from a git repository.
+// It is used to send binary diffs to the binaryDiffChan for asynchronous processing.
+type binaryDiff struct {
+	fileName  string
+	gitDir    string
+	commit    plumbing.Hash // 20 bytes
+	chunkSkel *sources.Chunk
+}
 
 func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string, scanOptions *ScanOptions, reporter sources.ChunkReporter, binaryDiffChan chan<- binaryDiff) error {
 	commitChan, err := gitparse.NewParser().RepoPath(ctx, path, scanOptions.HeadHash, scanOptions.BaseHash == "", scanOptions.ExcludeGlobs, scanOptions.Bare)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Refactor Git repo scanning to use workers for asynchronous processing of binary diffs. 

- Introduce a buffered `binaryDiffChan` to distribute work
- Start N goroutine workers to handle binary diffs
- Scan commits and staged changes concurrently using WaitGroup
- Close diff channel when producers finish
- Synchronize consumer completion before exiting
- Propagate first error to cancel context
- Return early if error occurs processing diffs (this preserves existing functionality)

High level design:
![binary-diff-workers](https://github.com/trufflesecurity/trufflehog/assets/21311841/7508109e-ce06-4473-affc-3aaa8d672daf)


This refactors the scanning logic to utilize concurrency and avoid blocking on large binaries. Multiple goroutines can now process diffs asynchronously through the buffered channel.

The context cancellation allows all workers to exit cleanly if an error happens. And synchronization points ensure proper shutdown.

This should help increase overall scanning throughput, while maintaining existing control flow around error handling.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

