### PR TITLE
[chore] - leverage bufio.Peek to determine mimetype

### DIFF
--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -383,7 +383,7 @@ func TestDetermineMimeType(t *testing.T) {
 		{
 			name:       "Text file",
 			input:      bytes.NewReader(textBytes),
-			expected:   mimeType("text/plain"),
+			expected:   mimeType("text/plain; charset=utf-8"),
 			shouldFail: false,
 		},
 		{
@@ -416,7 +416,7 @@ func TestDetermineMimeType(t *testing.T) {
 			}
 
 			if !tt.shouldFail {
-				assert.Equal(t, tt.expected, mime)
+				assert.Equal(t, tt.expected, mimeType(mime.String()))
 			}
 
 			// Ensure the reader still contains all the original data.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
@mcastorina suggested using `bufio.Peek` to determine mimetype for an earlier PR which I found to be a great solution. So I've updated the existing mimetype detection function to also use bufio.Peek. Consolidated the code into that single function.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

