### PR TITLE
[fixup] - move cleanup to run

### DIFF
--- a/main.go
+++ b/main.go
@@ -216,14 +216,12 @@ func main() {
 	if err != nil {
 		logFatal(err, "error occurred with trufflehog updater 🐷")
 	}
-
-	ctx := context.Background()
-
-	go cleantemp.RunCleanupLoop(ctx)
 }
 
 func run(state overseer.State) {
 	ctx := context.Background()
+	go cleantemp.RunCleanupLoop(ctx)
+
 	logger := ctx.Logger()
 	logFatal := logFatalFunc(logger)
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We should call the cleanup loop in run in order for it to execute during the lifetime of the program.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

