### PR TITLE
[bug] - Bug archive handler memory leak

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -111,6 +111,9 @@ func (a *Archive) openArchive(ctx logContext.Context, depth int, reader io.Reade
 		if err != nil {
 			return err
 		}
+
+		defer compReader.Close()
+
 		return a.openArchive(ctx, depth+1, compReader, archiveChan)
 	case archiver.Extractor:
 		return archive.Extract(logContext.WithValue(ctx, depthKey, depth+1), arReader, nil, a.extractorHandler(archiveChan))

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -115,7 +115,9 @@ func TestHandleFile(t *testing.T) {
 	// Context cancels the operation.
 	canceledCtx, cancel := logContext.WithCancel(logContext.Background())
 	cancel()
-	assert.False(t, HandleFile(canceledCtx, strings.NewReader("file"), &sources.Chunk{}, reporter))
+	reader, err := diskbufferreader.New(strings.NewReader("file"))
+	assert.NoError(t, err)
+	assert.False(t, HandleFile(canceledCtx, reader, &sources.Chunk{}, reporter))
 
 	// Only one chunk is sent on the channel.
 	// TODO: Embed a zip without making an HTTP request.
@@ -124,12 +126,36 @@ func TestHandleFile(t *testing.T) {
 	defer resp.Body.Close()
 	archive := Archive{}
 	archive.New()
-	reader, err := diskbufferreader.New(resp.Body)
+	reader, err = diskbufferreader.New(resp.Body)
 	assert.NoError(t, err)
 
 	assert.Equal(t, 0, len(reporter.Ch))
 	assert.True(t, HandleFile(logContext.Background(), reader, &sources.Chunk{}, reporter))
 	assert.Equal(t, 1, len(reporter.Ch))
+}
+
+func BenchmarkHandleFile(b *testing.B) {
+	file, err := os.Open("testdata/dir-archive.zip")
+	assert.Nil(b, err)
+	defer file.Close()
+
+	archive := Archive{}
+	archive.New()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sourceChan := make(chan *sources.Chunk, 1)
+		reader, err := diskbufferreader.New(file)
+		assert.NoError(b, err)
+
+		go func() {
+			defer close(sourceChan)
+			HandleFile(logContext.Background(), reader, &sources.Chunk{}, sources.ChanReporter{Ch: sourceChan})
+		}()
+
+		for range sourceChan {
+		}
+	}
 }
 
 func TestHandleFileSkipBinaries(t *testing.T) {
@@ -139,13 +165,16 @@ func TestHandleFileSkipBinaries(t *testing.T) {
 	file, err := os.Open(filename)
 	assert.NoError(t, err)
 
+	reader, err := diskbufferreader.New(file)
+	assert.NoError(t, err)
+
 	ctx, cancel := logContext.WithTimeout(logContext.Background(), 5*time.Second)
 	defer cancel()
 	sourceChan := make(chan *sources.Chunk, 1)
 
 	go func() {
 		defer close(sourceChan)
-		HandleFile(ctx, file, &sources.Chunk{}, sources.ChanReporter{Ch: sourceChan}, WithSkipBinaries(true))
+		HandleFile(ctx, reader, &sources.Chunk{}, sources.ChanReporter{Ch: sourceChan}, WithSkipBinaries(true))
 	}()
 
 	count := 0
@@ -283,12 +312,15 @@ func TestExtractTarContent(t *testing.T) {
 	assert.Nil(t, err)
 	defer file.Close()
 
+	reader, err := diskbufferreader.New(file)
+	assert.NoError(t, err)
+
 	ctx := logContext.Background()
 
 	chunkCh := make(chan *sources.Chunk)
 	go func() {
 		defer close(chunkCh)
-		ok := HandleFile(ctx, file, &sources.Chunk{}, sources.ChanReporter{Ch: chunkCh})
+		ok := HandleFile(ctx, reader, &sources.Chunk{}, sources.ChanReporter{Ch: chunkCh})
 		assert.True(t, ok)
 	}()
 
@@ -335,13 +367,16 @@ func TestNestedDirArchive(t *testing.T) {
 	assert.Nil(t, err)
 	defer file.Close()
 
+	reader, err := diskbufferreader.New(file)
+	assert.NoError(t, err)
+
 	ctx, cancel := logContext.WithTimeout(logContext.Background(), 5*time.Second)
 	defer cancel()
 	sourceChan := make(chan *sources.Chunk, 1)
 
 	go func() {
 		defer close(sourceChan)
-		HandleFile(ctx, file, &sources.Chunk{}, sources.ChanReporter{Ch: sourceChan})
+		HandleFile(ctx, reader, &sources.Chunk{}, sources.ChanReporter{Ch: sourceChan})
 	}()
 
 	count := 0

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -135,7 +135,7 @@ func TestHandleFile(t *testing.T) {
 }
 
 func BenchmarkHandleFile(b *testing.B) {
-	file, err := os.Open("testdata/dir-archive.zip")
+	file, err := os.Open("testdata/test.tgz")
 	assert.Nil(b, err)
 	defer file.Close()
 

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -148,6 +148,8 @@ func BenchmarkHandleFile(b *testing.B) {
 		reader, err := diskbufferreader.New(file)
 		assert.NoError(b, err)
 
+		b.StartTimer()
+
 		go func() {
 			defer close(sourceChan)
 			HandleFile(logContext.Background(), reader, &sources.Chunk{}, sources.ChanReporter{Ch: sourceChan})
@@ -155,6 +157,8 @@ func BenchmarkHandleFile(b *testing.B) {
 
 		for range sourceChan {
 		}
+
+		b.StopTimer()
 	}
 }
 

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -48,20 +48,11 @@ type Handler interface {
 // packages them in the provided chunk skeleton, and reports them to the chunk reporter.
 // The function returns true if processing was successful and false otherwise.
 // Context is used for cancellation, and the caller is responsible for canceling it if needed.
-func HandleFile(ctx logContext.Context, file io.Reader, chunkSkel *sources.Chunk, reporter sources.ChunkReporter, opts ...Option) bool {
+func HandleFile(ctx logContext.Context, reReader *diskbufferreader.DiskBufferReader, chunkSkel *sources.Chunk, reporter sources.ChunkReporter, opts ...Option) bool {
 	for _, h := range DefaultHandlers() {
 		h.New(opts...)
 
-		// The re-reader is used to reset the file reader after checking if the handler implements SpecializedHandler.
-		// This is necessary because the archive pkg doesn't correctly determine the file type when using
-		// an io.MultiReader, which is used by the SpecializedHandler.
-		reReader, err := diskbufferreader.New(file)
-		if err != nil {
-			ctx.Logger().Error(err, "error creating reusable reader")
-			return false
-		}
-
-		if success := processHandler(ctx, h, reReader, chunkSkel, reporter); success {
+		if handled := processHandler(ctx, h, reReader, chunkSkel, reporter); handled {
 			return true
 		}
 	}
@@ -70,9 +61,6 @@ func HandleFile(ctx logContext.Context, file io.Reader, chunkSkel *sources.Chunk
 }
 
 func processHandler(ctx logContext.Context, h Handler, reReader *diskbufferreader.DiskBufferReader, chunkSkel *sources.Chunk, reporter sources.ChunkReporter) bool {
-	defer reReader.Close()
-	defer reReader.Stop()
-
 	if specialHandler, ok := h.(SpecializedHandler); ok {
 		file, isSpecial, err := specialHandler.HandleSpecialized(ctx, reReader)
 		if isSpecial {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This pull request introduces critical updates to our archive handling logic, primarily focused on improving resource management and memory usage. Below are the key changes and their implications:

1. **Ensuring Closure of Decompressed Readers**:
   - **Problem Addressed**: Previously, in our archive handling process, decompressed readers (instances of `io.ReadCloser`) were not consistently closed. This oversight potentially led to resource leaks, especially in scenarios involving large or numerous files.
   - **Solution Implemented**: We've now added definitive closure of these decompressed readers (`compReader`) across our code. This is achieved via the `defer` statement, ensuring that each reader is properly closed upon the completion of its corresponding function, thus preventing resource leaks.

2. **Avoiding Nested `DiskBufferReader` Instances**:
   - **Problem Addressed**: Analysis revealed that using nested `DiskBufferReader` instances significantly increases memory usage. This is particularly noticeable when processing large files.
   - **Solution Implemented**: We have refactored the code to avoid nesting `DiskBufferReader` instances. This change is expected to reduce the memory footprint of our archive processing routines, enhancing the overall performance and stability of our application, especially under heavy load conditions.

**Impact of Changes**:
- These updates are expected to improve the efficiency of resource usage, particularly in terms of memory management.
- By avoiding nested `DiskBufferReader` instances and ensuring the closure of decompressed readers, we anticipate a reduction in the occurrence of out-of-memory errors and other related issues in our file handling processes.

![Screenshot 2023-12-19 at 10 29 15 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/5f0aa5b2-67f4-4db1-a7d8-6c8ec171953e)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

