### PR TITLE
Dedupe some source log keys

### DIFF
--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -229,12 +229,19 @@ func (s *SourceManager) run(ctx context.Context, source Source, report *JobProgr
 	}()
 
 	report.TrackProgress(source.GetProgress())
-	ctx = context.WithValues(ctx,
-		"job_id", report.JobID,
-		"source_id", report.SourceID,
-		"source_name", report.SourceName,
-		"source_type", source.Type().String(),
-	)
+	if ctx.Value("job_id") == "" {
+		ctx = context.WithValue(ctx, "job_id", report.JobID)
+	}
+	if ctx.Value("source_id") == "" {
+		ctx = context.WithValue(ctx, "source_id", report.SourceID)
+	}
+	if ctx.Value("source_name") == "" {
+		ctx = context.WithValue(ctx, "source_name", report.SourceName)
+	}
+	if ctx.Value("source_type") == "" {
+		ctx = context.WithValue(ctx, "source_type", source.Type().String())
+	}
+
 	// Check for the preferred method of tracking source units.
 	canUseSourceUnits := len(targets) == 0 && s.useSourceUnitsFunc != nil
 	if enumChunker, ok := source.(SourceUnitEnumChunker); ok && canUseSourceUnits && s.useSourceUnitsFunc() {

--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -238,8 +238,14 @@ func (s *SourceManager) run(ctx context.Context, source Source, report *JobProgr
 	// Check for the preferred method of tracking source units.
 	canUseSourceUnits := len(targets) == 0 && s.useSourceUnitsFunc != nil
 	if enumChunker, ok := source.(SourceUnitEnumChunker); ok && canUseSourceUnits && s.useSourceUnitsFunc() {
+		ctx.Logger().Info("running source",
+			"with_units", true)
 		return s.runWithUnits(ctx, enumChunker, report)
 	}
+	ctx.Logger().Info("running source",
+		"with_units", false,
+		"target_count", len(targets),
+		"source_manager_units_configurable", s.useSourceUnitsFunc != nil)
 	return s.runWithoutUnits(ctx, source, report, targets...)
 }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The source manager attaches some context keys, but in certain circumstances, they're already present, resulting in duplicate keys. This PR changes the attachment to be conditional. It also adds some new log messages to track source startup progress.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

