### PR TITLE
[bug] - Fix Context Timeout-Induced Goroutine Leak in readInChunks

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -91,6 +91,10 @@ func (a *Archive) FromFile(originalCtx logContext.Context, data io.Reader) chan 
 
 // openArchive takes a reader and extracts the contents up to the maximum depth.
 func (a *Archive) openArchive(ctx logContext.Context, depth int, reader io.Reader, archiveChan chan []byte) error {
+	if common.IsDone(ctx) {
+		return ctx.Err()
+	}
+
 	if depth >= maxDepth {
 		return fmt.Errorf(errMaxArchiveDepthReached)
 	}
@@ -183,6 +187,11 @@ func (a *Archive) extractorHandler(archiveChan chan []byte) func(context.Context
 	return func(ctx context.Context, f archiver.File) error {
 		lCtx := logContext.AddLogger(ctx)
 		lCtx.Logger().V(5).Info("Handling extracted file.", "filename", f.Name())
+
+		if common.IsDone(ctx) {
+			return ctx.Err()
+		}
+
 		depth := 0
 		if ctxDepth, ok := ctx.Value(depthKey).(int); ok {
 			depth = ctxDepth

--- a/pkg/sources/chunker_test.go
+++ b/pkg/sources/chunker_test.go
@@ -3,9 +3,12 @@ package sources
 import (
 	"bytes"
 	"io"
+	"math/rand"
+	"runtime"
 	"strings"
 	"testing"
 	"testing/iotest"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	diskbufferreader "github.com/trufflesecurity/disk-buffer-reader"
@@ -216,4 +219,36 @@ func TestFlakyChunkReader(t *testing.T) {
 	chunk := chunks[0]
 	assert.NoError(t, chunk.Error())
 	assert.Equal(t, a+b, string(chunk.Bytes()))
+}
+
+func TestReadInChunksWithCancellation(t *testing.T) {
+	largeData := strings.Repeat("large test data ", 1024*1024) // Large data string.
+
+	for i := 0; i < 10; i++ {
+		initialGoroutines := runtime.NumGoroutine()
+
+		for j := 0; j < 5; j++ { // Call readInChunks multiple times
+			ctx, cancel := context.WithCancel(context.Background())
+
+			reader := strings.NewReader(largeData)
+			chunkReader := NewChunkReader()
+
+			chunkChan := chunkReader(ctx, reader)
+
+			if rand.Intn(2) == 0 { // Randomly decide to cancel the context
+				cancel()
+			} else {
+				for range chunkChan {
+				}
+			}
+		}
+
+		// Allow for goroutine finalization.
+		time.Sleep(time.Millisecond * 100)
+
+		// Check for goroutine leaks.
+		if runtime.NumGoroutine() > initialGoroutines {
+			t.Error("Potential goroutine leak detected")
+		}
+	}
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR addresses a discovered goroutine leak in the readInChunks function, particularly triggered by context timeouts within the Archive handler. The issue was causing a buildup of goroutines, leading to resource inefficiency and potential stability problems in long-running processes.

The goroutine leak was primarily caused by the function's inability to handle context cancellation effectively, especially under scenarios where a timeout occurred in the Archive handler. The function's internal loop was getting blocked, preventing the termination of goroutines.

I removed blocking inner loop that caused indefinite blocking when trying to send chunkRes to chunkResultChan.
Added a select statement to handle context cancellation more efficiently. This ensures that goroutines terminate properly when the context is canceled, such as during a timeout in the Archive handler.

I also included a test that should catch this moving forward.

Screenshots from goroutine profiles.

![Screenshot 2023-12-20 at 8 10 27 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/0f9b451c-ad85-4f61-87de-0e8c86ca7b0a)
![Screenshot 2023-12-20 at 8 34 48 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/61be05b6-bbc5-4a46-9170-4bef640e6c3b)
![Screenshot 2023-12-20 at 8 10 15 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/238c642b-499c-4675-b3d5-1b21f22a8dd3)



### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

