### PR TITLE
[fixup] -  Refactor to Pass Reader for Binary Diffs and Archived Data; Optimize /tmp Directory Cleanup

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,10 +5,12 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"os/signal"
 	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/felixge/fgprof"
@@ -219,7 +221,9 @@ func main() {
 }
 
 func run(state overseer.State) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
 	go func() {
 		if err := cleantemp.CleanTempArtifacts(ctx); err != nil {
 			ctx.Logger().Error(err, "error cleaning temporary artifacts")
@@ -228,6 +232,24 @@ func run(state overseer.State) {
 
 	logger := ctx.Logger()
 	logFatal := logFatalFunc(logger)
+
+	killSignal := make(chan os.Signal, 1)
+	signal.Notify(killSignal, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	go func() {
+		<-killSignal
+		logger.Info("Received signal, shutting down.")
+		cancel(fmt.Errorf("canceling context due to signal"))
+
+		if err := cleantemp.CleanTempArtifacts(ctx); err != nil {
+			logger.Error(err, "error cleaning temporary artifacts")
+		} else {
+			logger.Info("cleaned temporary artifacts")
+		}
+
+		time.Sleep(time.Second * 10)
+		logger.Info("10 seconds elapsed. Forcing shutdown.")
+		os.Exit(0)
+	}()
 
 	logger.V(2).Info(fmt.Sprintf("trufflehog %s", version.BuildVersion))
 

--- a/main.go
+++ b/main.go
@@ -220,7 +220,7 @@ func main() {
 
 func run(state overseer.State) {
 	ctx := context.Background()
-	go cleantemp.RunCleanupLoop(ctx)
+	go cleantemp.CleanTempArtifacts(ctx)
 
 	logger := ctx.Logger()
 	logFatal := logFatalFunc(logger)

--- a/main.go
+++ b/main.go
@@ -220,7 +220,11 @@ func main() {
 
 func run(state overseer.State) {
 	ctx := context.Background()
-	go cleantemp.CleanTempArtifacts(ctx)
+	go func() {
+		if err := cleantemp.CleanTempArtifacts(ctx); err != nil {
+			ctx.Logger().Error(err, "error cleaning temporary artifacts")
+		}
+	}()
 
 	logger := ctx.Logger()
 	logFatal := logFatalFunc(logger)

--- a/pkg/cleantemp/cleantemp.go
+++ b/pkg/cleantemp/cleantemp.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/mitchellh/go-ps"
 
@@ -105,28 +104,4 @@ func CleanTempArtifacts(ctx logContext.Context) error {
 	}
 
 	return nil
-}
-
-// RunCleanupLoop runs a loop that cleans up orphaned directories every 15 seconds.
-func RunCleanupLoop(ctx logContext.Context) {
-	err := CleanTempArtifacts(ctx)
-	if err != nil {
-		ctx.Logger().Error(err, "Error cleaning up orphaned directories ")
-	}
-
-	const cleanupLoopInterval = 15 * time.Second
-	ticker := time.NewTicker(cleanupLoopInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			if err := CleanTempArtifacts(ctx); err != nil {
-				ctx.Logger().Error(err, "error cleaning up orphaned directories")
-			}
-		case <-ctx.Done():
-			ctx.Logger().Info("Cleanup loop exiting due to context cancellation")
-			return
-		}
-	}
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -11,6 +11,7 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/cleantemp"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/config"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
@@ -424,6 +425,10 @@ func (e *Engine) Finish(ctx context.Context) error {
 
 	close(e.results)    // Detector workers are done, close the results channel and call it a day.
 	e.WgNotifier.Wait() // Wait for the notifier workers to finish notifying results.
+
+	if err := cleantemp.CleanTempArtifacts(ctx); err != nil {
+		ctx.Logger().Error(err, "error cleaning temp artifacts")
+	}
 
 	e.metrics.ScanDuration = time.Since(e.metrics.scanStartTime)
 

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -213,12 +213,7 @@ func (a *Archive) extractorHandler(archiveChan chan []byte) func(context.Context
 			return nil
 		}
 
-		fileBytes, err := a.ReadToMax(lCtx, fReader)
-		if err != nil {
-			return err
-		}
-
-		return a.openArchive(lCtx, depth, bytes.NewReader(fileBytes), archiveChan)
+		return a.openArchive(lCtx, depth, fReader, archiveChan)
 	}
 }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
 Streamlined the handling of binary diffs and archived data by directly passing the reader, enhancing efficiency in data processing. Additionally, we've adjusted the cleanup strategy for the /tmp directory.

Now, the cleanup occurs only at the start and end of the application's lifecycle, rather than repeatedly during operation. This change addresses the issue of loading the entire contents of the /tmp directory into memory with each scan, which was previously causing significant and unnecessary memory usage.

By implementing this optimization, we expect to see a notable reduction in memory pressure.

![Screenshot 2023-12-21 at 10 02 26 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/696fc93f-ad50-4b8a-a095-6c8ee063e91e)
![Screenshot 2023-12-21 at 10 02 31 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/c81dae5a-b9a3-4d83-895f-5fddca3038da)
![Screenshot 2023-12-21 at 10 04 40 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/708a8e1e-82bf-4b8e-8f66-5a1cae06acb4)



### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

