### PR TITLE
Update stripe detector regex

### DIFF
--- a/pkg/detectors/stripe/stripe.go
+++ b/pkg/detectors/stripe/stripe.go
@@ -18,7 +18,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 
 var (
 	//doesn't include test keys with "sk_test"
-	secretKey = regexp.MustCompile(`[rs]k_live_[a-zA-Z0-9]{20,30}`)
+	secretKey = regexp.MustCompile(`[rs]k_live_[a-zA-Z0-9]{20,247}`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The regex secretKey = regexp.MustCompile(`[rs]k_live_[a-zA-Z0-9]{20,30}`) works only for keys generated before 2019, keys created after 2019 can be of legth upto 255 characters  

https://support.stripe.com/questions/new-api-keys-are-longer-than-existing-keys#:~:text=As%20per%20our%20API%20guidelines,to%20255%20characters%20in%20length.


