### PR TITLE
Fix non-ASCII whitespace on GitHub Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ runs:
       ##########################################
       else
         if [ "${{ github.event_name }}" == "push" ]; then
-          COMMIT_LENGTH=$(printenv COMMITS | jq length)
+          COMMIT_LENGTH=$(printenv COMMITS | jq length)
           if [ $COMMIT_LENGTH == "0" ]; then
             echo "No commits to scan"
             exit 0


### PR DESCRIPTION
### Description:
Continuation of #2259, closes #2269; I don't know why this happened. 😳 I wrote a [non-breaking space](https://en.wikipedia.org/wiki/Non-breaking_space).

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

