### PR TITLE
[chore] Add test to check all versioned detectors are non-zero

### DIFF
--- a/pkg/engine/defaults_test.go
+++ b/pkg/engine/defaults_test.go
@@ -48,3 +48,20 @@ func TestDefaultDetectorTypesImplementing(t *testing.T) {
 		)
 	}
 }
+
+func TestDefaultVersionerDetectorsHaveNonZeroVersions(t *testing.T) {
+	// Loop through all our default detectors and find the ones that
+	// implement Versioner. Of those, check each version is not zero.
+	// This is required due to an implementation detail of filtering detectors.
+	// See: https://github.com/trufflesecurity/trufflehog/blob/v3.63.7/main.go#L624-L638
+	for _, detector := range DefaultDetectors() {
+		v, ok := detector.(detectors.Versioner)
+		if !ok || v.Version() != 0 {
+			continue
+		}
+		t.Errorf(
+			"detector %q implements Versioner that returns a zero version",
+			detectorspb.DetectorType_name[int32(detector.Type())],
+		)
+	}
+}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Adds a test to check all versioned detectors return a non-zero value. This assumption was used to simplify detector filtering in the engine.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

