### PR TITLE
Add Google oauth2 token detector

### DIFF
--- a/pkg/detectors/googleoauth2/googleoauth2_access_token.go
+++ b/pkg/detectors/googleoauth2/googleoauth2_access_token.go
@@ -1,0 +1,145 @@
+package googleoauth2
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"strconv"
+	"time"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+type Scanner struct {
+	client *http.Client
+}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	defaultClient = common.SaneHttpClient()
+
+	// There is conflicting information about the expected length of access tokens.
+	// 10 seems like a reasonable minimum that will weed out placeholders.
+	//
+	// https://cloud.google.com/docs/authentication/token-types#access
+	// https://github.com/GoogleChrome/developer.chrome.com/blob/51dd7dd5d510ed85d86f5a91cb8fde50b62351c7/site/en/docs/webstore/using_webstore_api/index.md?plain=1#L95
+	keyPat = regexp.MustCompile(`\b(ya29\.(?i:[a-z0-9_-]{10,}))(?:[^a-z0-9_-]|\z)`)
+)
+
+// Keywords are used for efficiently pre-filtering chunks.
+// Use identifiers in the secret preferably, or the provider name.
+func (s Scanner) Keywords() []string {
+	return []string{"ya29."}
+}
+
+// FromData will find and optionally verify Googleoauth2 secrets in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	tokens := make(map[string]struct{})
+	for _, matches := range keyPat.FindAllStringSubmatch(dataStr, -1) {
+		tokens[matches[1]] = struct{}{}
+	}
+
+	for token := range tokens {
+		s1 := detectors.Result{
+			DetectorType: s.Type(),
+			Raw:          []byte(token),
+			RawV2:        []byte(token),
+		}
+
+		if verify {
+			if s.client == nil {
+				s.client = defaultClient
+			}
+
+			verified, extraData, vErr := s.verify(ctx, token)
+			s1.Verified = verified
+			s1.ExtraData = extraData
+			s1.SetVerificationError(vErr)
+		}
+
+		// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
+		if !s1.Verified && detectors.IsKnownFalsePositive(token, detectors.DefaultFalsePositives, true) {
+			continue
+		}
+
+		results = append(results, s1)
+	}
+	return
+}
+
+func (s Scanner) verify(ctx context.Context, token string) (bool, map[string]string, error) {
+	// Based on https://stackoverflow.com/a/66957524
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.googleapis.com/oauth2/v3/tokeninfo?access_token="+token, nil)
+	if err != nil {
+		return false, nil, err
+	}
+
+	res, err := s.client.Do(req)
+	if err != nil {
+		return false, nil, err
+	}
+	defer func() {
+		_ = res.Body.Close()
+		_, _ = io.Copy(io.Discard, res.Body)
+	}()
+
+	if res.StatusCode == http.StatusOK {
+		var token tokenInfo
+		if err := json.NewDecoder(res.Body).Decode(&token); err != nil {
+			return false, nil, fmt.Errorf("failed to decode response: %w", err)
+		}
+
+		extraData := map[string]string{
+			"Google_email":   token.Email,
+			"Email_verified": token.EmailVerified,
+			"Scope":          token.Scope,
+			"Access_type":    token.AccessType,
+		}
+
+		exp, err := strconv.ParseInt(token.Expiry, 10, 64)
+		if err == nil {
+			extraData["expires_at"] = time.Unix(exp, 0).String()
+		}
+		return true, extraData, nil
+	} else if res.StatusCode == http.StatusBadRequest {
+		var errInfo errorInfo
+		if err := json.NewDecoder(res.Body).Decode(&errInfo); err != nil {
+			return false, nil, fmt.Errorf("failed to decode response: %w", err)
+		}
+
+		if errInfo.Error == "Invalid Value" {
+			// Definitively false.
+			return false, nil, nil
+		} else {
+			return false, nil, fmt.Errorf("unexpected error description '%s' for %s", errInfo.Error, req.URL)
+		}
+	} else {
+		return false, nil, fmt.Errorf("unexpected respones %d for %s", res.StatusCode, req.URL)
+	}
+}
+
+type tokenInfo struct {
+	Expiry        string `json:"exp"`
+	Scope         string `json:"scope"`
+	Email         string `json:"email"`
+	EmailVerified string `json:"email_verified"`
+	AccessType    string `json:"access_type"`
+}
+
+// {"error_description": "Invalid Value"}
+type errorInfo struct {
+	Error string `json:"error_description"`
+}
+
+func (s Scanner) Type() detectorspb.DetectorType {
+	return detectorspb.DetectorType_GoogleOauth2
+}

--- a/pkg/detectors/googleoauth2/googleoauth2_access_token.go
+++ b/pkg/detectors/googleoauth2/googleoauth2_access_token.go
@@ -52,7 +52,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: s.Type(),
 			Raw:          []byte(token),
-			RawV2:        []byte(token),
 		}
 
 		if verify {
@@ -99,10 +98,10 @@ func (s Scanner) verify(ctx context.Context, token string) (bool, map[string]str
 		}
 
 		extraData := map[string]string{
-			"Google_email":   token.Email,
-			"Email_verified": token.EmailVerified,
-			"Scope":          token.Scope,
-			"Access_type":    token.AccessType,
+			"google_email":   token.Email,
+			"email_verified": token.EmailVerified,
+			"scope":          token.Scope,
+			"access_type":    token.AccessType,
 		}
 
 		exp, err := strconv.ParseInt(token.Expiry, 10, 64)

--- a/pkg/detectors/googleoauth2/googleoauth2_access_token_test.go
+++ b/pkg/detectors/googleoauth2/googleoauth2_access_token_test.go
@@ -1,0 +1,162 @@
+//go:build detectors
+// +build detectors
+
+package googleoauth2
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+func TestGoogleoauth2_FromChunk(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors5")
+	if err != nil {
+		t.Fatalf("could not get test secrets from GCP: %s", err)
+	}
+	secret := testSecrets.MustGetField("GOOGLEOAUTH2")
+	inactiveSecret := testSecrets.MustGetField("GOOGLEOAUTH2_INACTIVE")
+
+	type args struct {
+		ctx    context.Context
+		data   []byte
+		verify bool
+	}
+	tests := []struct {
+		name                string
+		s                   Scanner
+		args                args
+		want                []detectors.Result
+		wantErr             bool
+		wantVerificationErr bool
+	}{
+		{
+			name: "found, verified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a googleoauth2 secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_GoogleOauth2,
+					Verified:     true,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "found, unverified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a googleoauth2 secret %s within but not valid", inactiveSecret)), // the secret would satisfy the regex but not pass validation
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_GoogleOauth2,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "not found",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte("You cannot find the secret within"),
+				verify: true,
+			},
+			want:                nil,
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "found, would be verified if not for timeout",
+			s:    Scanner{client: common.SaneHttpClientTimeOut(1 * time.Microsecond)},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a googleoauth2 secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_GoogleOauth2,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+		{
+			name: "found, verified but unexpected api surface",
+			s:    Scanner{client: common.ConstantResponseHttpClient(404, "")},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a googleoauth2 secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_GoogleOauth2,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Googleoauth2.FromData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if len(got[i].Raw) == 0 {
+					t.Fatalf("no raw secret present: \n %+v", got[i])
+				}
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
+				}
+			}
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
+			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
+				t.Errorf("Googleoauth2.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			}
+		})
+	}
+}
+
+func BenchmarkFromData(benchmark *testing.B) {
+	ctx := context.Background()
+	s := Scanner{}
+	for name, data := range detectors.MustGetBenchmarkData() {
+		benchmark.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				_, err := s.FromData(ctx, false, data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/engine/defaults.go
+++ b/pkg/engine/defaults.go
@@ -65,6 +65,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/azure"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/azurebatch"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/azurecontainerregistry"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/azuredevopspersonalaccesstoken"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/azurestorage"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/bannerbear"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/baremetrics"
@@ -1604,6 +1605,7 @@ func DefaultDetectors() []detectors.Detector {
 		planetscaledb.Scanner{},
 		jiratoken_v2.Scanner{},
 		&googleoauth2.Scanner{},
+		&azuredevopspersonalaccesstoken.Scanner{},
 	}
 
 }

--- a/pkg/engine/defaults.go
+++ b/pkg/engine/defaults.go
@@ -305,6 +305,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/gocanvas"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/gocardless"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/goodday"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/googleoauth2"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/grafana"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/grafanaserviceaccount"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/graphcms"
@@ -1602,6 +1603,7 @@ func DefaultDetectors() []detectors.Detector {
 		azurestorage.Scanner{},
 		planetscaledb.Scanner{},
 		jiratoken_v2.Scanner{},
+		&googleoauth2.Scanner{},
 	}
 
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Google OAuth2 access tokens are (relatively) short-lived tokens that begin with `ya29.`. It is still necessary to detect oauth2 client_id/client_secret and refresh tokens.

Example: https://github.com/hashicorp/vault/blob/066b4a18088df8eac5bcabde4c2baa4dce44a0c6/website/content/docs/secrets/gcp.mdx#L259


```sh
./trufflehog filesystem ~/.npmrc
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

2024-01-07T16:07:37-05:00	info-0	trufflehog	running source	{"source_manager_worker_id": "7iO7p", "with_units": true}
Found verified result 🐷🔑
Detector Type: GoogleOauth2
Decoder Type: PLAIN
Raw result: ya29.xxx
Expires_at: 2024-01-07 16:26:56 -0500 EST
Google_email: me@gmail.com
Email_verified: true
Scope: https://www.googleapis.com/auth/accounts.reauth https://www.googleapis.com/auth/appengine.admin https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/compute https://www.googleapis.com/auth/sqlservice.login https://www.googleapis.com/auth/userinfo.email openid
Access_type: offline
File: /home/user/.npmrc
Line: 3
```

This is auxiliary to #2264.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

