### PR TITLE
Extend memory cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -4,9 +4,9 @@ package cache
 // Cache is used to store key/value pairs.
 type Cache interface {
 	// Set stores the given key/value pair.
-	Set(string, string)
+	Set(string, any)
 	// Get returns the value for the given key and a boolean indicating if the key was found.
-	Get(string) (string, bool)
+	Get(string) (any, bool)
 	// Exists returns true if the given key exists in the cache.
 	Exists(string) bool
 	// Delete the given key from the cache.
@@ -18,7 +18,7 @@ type Cache interface {
 	// Keys returns all keys in the cache.
 	Keys() []string
 	// Values returns all values in the cache.
-	Values() []string
+	Values() []any
 	// Contents returns all keys in the cache encoded as a string.
 	Contents() string
 }

--- a/pkg/cache/memory/memory.go
+++ b/pkg/cache/memory/memory.go
@@ -71,17 +71,13 @@ func NewWithData(ctx context.Context, data []string, opts ...CacheOption) *Cache
 }
 
 // Set adds a key-value pair to the cache.
-func (c *Cache) Set(key, value string) {
+func (c *Cache) Set(key string, value any) {
 	c.c.Set(key, value, defaultExpiration)
 }
 
 // Get returns the value for the given key.
-func (c *Cache) Get(key string) (string, bool) {
-	res, ok := c.c.Get(key)
-	if !ok {
-		return "", ok
-	}
-	return res.(string), ok
+func (c *Cache) Get(key string) (any, bool) {
+	return c.c.Get(key)
 }
 
 // Exists returns true if the given key exists in the cache.
@@ -116,11 +112,11 @@ func (c *Cache) Keys() []string {
 }
 
 // Values returns all values in the cache.
-func (c *Cache) Values() []string {
+func (c *Cache) Values() []any {
 	items := c.c.Items()
-	res := make([]string, 0, len(items))
+	res := make([]any, 0, len(items))
 	for _, v := range items {
-		res = append(res, v.Object.(string))
+		res = append(res, v.Object)
 	}
 	return res
 }

--- a/pkg/cache/memory/memory.go
+++ b/pkg/cache/memory/memory.go
@@ -5,8 +5,6 @@ import (
 	"time"
 
 	"github.com/patrickmn/go-cache"
-
-	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 
 const (
@@ -41,14 +39,7 @@ func WithPurgeInterval(interval time.Duration) CacheOption {
 // By default, it sets the expiration and purge intervals to 12 and 13 hours, respectively.
 // These defaults can be overridden using the functional options: WithExpirationInterval and WithPurgeInterval.
 func New(opts ...CacheOption) *Cache {
-	configurableCache := &Cache{expiration: defaultExpirationInterval, purgeInterval: defaultPurgeInterval}
-	for _, opt := range opts {
-		opt(configurableCache)
-	}
-
-	// The underlying cache is initialized with the configured expiration and purge intervals.
-	configurableCache.c = cache.New(configurableCache.expiration, configurableCache.purgeInterval)
-	return configurableCache
+	return NewWithData(nil, opts...)
 }
 
 // CacheEntry represents a single entry in the cache, consisting of a key and its corresponding value.
@@ -61,9 +52,7 @@ type CacheEntry struct {
 
 // NewWithData constructs a new in-memory cache with existing data.
 // It also accepts CacheOption parameters to override default configuration values.
-func NewWithData(ctx context.Context, data []CacheEntry, opts ...CacheOption) *Cache {
-	ctx.Logger().V(3).Info("Loading cache", "num-items", len(data))
-
+func NewWithData(data []CacheEntry, opts ...CacheOption) *Cache {
 	instance := &Cache{expiration: defaultExpirationInterval, purgeInterval: defaultPurgeInterval}
 	for _, opt := range opts {
 		opt(instance)

--- a/pkg/cache/memory/memory.go
+++ b/pkg/cache/memory/memory.go
@@ -41,13 +41,14 @@ func WithPurgeInterval(interval time.Duration) CacheOption {
 // By default, it sets the expiration and purge intervals to 12 and 13 hours, respectively.
 // These defaults can be overridden using the functional options: WithExpirationInterval and WithPurgeInterval.
 func New(opts ...CacheOption) *Cache {
-	instance := &Cache{expiration: defaultExpirationInterval, purgeInterval: defaultPurgeInterval}
+	configurableCache := &Cache{expiration: defaultExpirationInterval, purgeInterval: defaultPurgeInterval}
 	for _, opt := range opts {
-		opt(instance)
+		opt(configurableCache)
 	}
 
-	instance.c = cache.New(instance.expiration, instance.purgeInterval)
-	return instance
+	// The underlying cache is initialized with the configured expiration and purge intervals.
+	configurableCache.c = cache.New(configurableCache.expiration, configurableCache.purgeInterval)
+	return configurableCache
 }
 
 // CacheEntry represents a single entry in the cache, consisting of a key and its corresponding value.

--- a/pkg/cache/memory/memory.go
+++ b/pkg/cache/memory/memory.go
@@ -50,9 +50,17 @@ func New(opts ...CacheOption) *Cache {
 	return instance
 }
 
+// CacheEntry represents a single entry in the cache, consisting of a key and its corresponding value.
+type CacheEntry struct {
+	// Key is the unique identifier for the entry.
+	Key string
+	// Value is the data stored in the entry.
+	Value any
+}
+
 // NewWithData constructs a new in-memory cache with existing data.
 // It also accepts CacheOption parameters to override default configuration values.
-func NewWithData(ctx context.Context, data []string, opts ...CacheOption) *Cache {
+func NewWithData(ctx context.Context, data []CacheEntry, opts ...CacheOption) *Cache {
 	ctx.Logger().V(3).Info("Loading cache", "num-items", len(data))
 
 	instance := &Cache{expiration: defaultExpirationInterval, purgeInterval: defaultPurgeInterval}
@@ -63,7 +71,7 @@ func NewWithData(ctx context.Context, data []string, opts ...CacheOption) *Cache
 	// Convert data slice to map required by go-cache.
 	items := make(map[string]cache.Item, len(data))
 	for _, d := range data {
-		items[d] = cache.Item{Object: d, Expiration: int64(defaultExpiration)}
+		items[d.Key] = cache.Item{Object: d.Value, Expiration: int64(defaultExpiration)}
 	}
 
 	instance.c = cache.NewFrom(instance.expiration, instance.purgeInterval, items)

--- a/pkg/cache/memory/memory_test.go
+++ b/pkg/cache/memory/memory_test.go
@@ -34,7 +34,7 @@ func TestCache(t *testing.T) {
 	// Test delete.
 	c.Delete("key1")
 	v, ok = c.Get("key1")
-	if ok || v != "" {
+	if ok || v != nil {
 		t.Fatalf("Unexpected value for key1 after delete: %v, %v", v, ok)
 	}
 
@@ -42,7 +42,7 @@ func TestCache(t *testing.T) {
 	c.Set("key10", "key10")
 	c.Clear()
 	v, ok = c.Get("key10")
-	if ok || v != "" {
+	if ok || v != nil {
 		t.Fatalf("Unexpected value for key10 after clear: %v, %v", v, ok)
 	}
 

--- a/pkg/cache/memory/memory_test.go
+++ b/pkg/cache/memory/memory_test.go
@@ -7,8 +7,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
-	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 
 func TestCache(t *testing.T) {
@@ -86,7 +84,7 @@ func TestCache(t *testing.T) {
 
 func TestCache_NewWithData(t *testing.T) {
 	data := []CacheEntry{{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}}
-	c := NewWithData(logContext.Background(), data)
+	c := NewWithData(data)
 
 	// Test the count.
 	if c.Count() != 3 {

--- a/pkg/cache/memory/memory_test.go
+++ b/pkg/cache/memory/memory_test.go
@@ -85,7 +85,8 @@ func TestCache(t *testing.T) {
 }
 
 func TestCache_NewWithData(t *testing.T) {
-	c := NewWithData(logContext.Background(), []string{"key1", "key2", "key3"})
+	data := []CacheEntry{{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}}
+	c := NewWithData(logContext.Background(), data)
 
 	// Test the count.
 	if c.Count() != 3 {

--- a/pkg/cache/memory/memory_test.go
+++ b/pkg/cache/memory/memory_test.go
@@ -60,7 +60,10 @@ func TestCache(t *testing.T) {
 	}
 
 	// Test getting only the values.
-	vals := c.Values()
+	vals := make([]string, 0, c.Count())
+	for _, v := range c.Values() {
+		vals = append(vals, v.(string))
+	}
 	sort.Strings(vals)
 	sort.Strings(values)
 	if !cmp.Equal(values, vals) {

--- a/pkg/sources/gcs/gcs.go
+++ b/pkg/sources/gcs/gcs.go
@@ -97,7 +97,7 @@ func newPersistableCache(increment int, cache cache.Cache, p *sources.Progress) 
 
 // Set overrides the cache Set method of the cache to enable the persistence
 // of the cache contents the Progress of the source at given increments.
-func (c *persistableCache) Set(key, val string) {
+func (c *persistableCache) Set(key string, val any) {
 	c.Cache.Set(key, val)
 	if ok, contents := c.shouldPersist(); ok {
 		c.Progress.EncodedResumeInfo = contents

--- a/pkg/sources/gcs/gcs.go
+++ b/pkg/sources/gcs/gcs.go
@@ -297,7 +297,13 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 func (s *Source) setupCache(ctx context.Context) *persistableCache {
 	var c cache.Cache
 	if s.Progress.EncodedResumeInfo != "" {
-		c = memory.NewWithData(ctx, strings.Split(s.Progress.EncodedResumeInfo, ","))
+		keys := strings.Split(s.Progress.EncodedResumeInfo, ",")
+		entries := make([]memory.CacheEntry, len(keys))
+		for i, val := range keys {
+			entries[i] = memory.CacheEntry{Key: val, Value: val}
+		}
+
+		c = memory.NewWithData(ctx, entries)
 	} else {
 		c = memory.New()
 	}

--- a/pkg/sources/gcs/gcs.go
+++ b/pkg/sources/gcs/gcs.go
@@ -303,7 +303,8 @@ func (s *Source) setupCache(ctx context.Context) *persistableCache {
 			entries[i] = memory.CacheEntry{Key: val, Value: val}
 		}
 
-		c = memory.NewWithData(ctx, entries)
+		c = memory.NewWithData(entries)
+		ctx.Logger().V(3).Info("Loaded cache", "num_entries", len(entries))
 	} else {
 		c = memory.New()
 	}

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -476,7 +476,7 @@ func (s *Source) enumerate(ctx context.Context, apiEndpoint string) (*github.Cli
 	for _, repo := range s.filteredRepoCache.Values() {
 		r, ok := repo.(string)
 		if !ok {
-			ctx.Logger().Error(fmt.Errorf("type assertion failed"), "repo not found in cache", "repo", repo)
+			ctx.Logger().Error(fmt.Errorf("type assertion failed"), "unexpected value in cache", "repo", repo)
 			continue
 		}
 		s.repos = append(s.repos, r)

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -472,7 +472,15 @@ func (s *Source) enumerate(ctx context.Context, apiEndpoint string) (*github.Cli
 		return nil, errors.Errorf("Invalid configuration given for source. Name: %s, Type: %s", s.name, s.Type())
 	}
 
-	s.repos = s.filteredRepoCache.Values()
+	s.repos = make([]string, 0, s.filteredRepoCache.Count())
+	for _, repo := range s.filteredRepoCache.Values() {
+		r, ok := repo.(string)
+		if !ok {
+			ctx.Logger().Error(fmt.Errorf("type assertion failed"), "repo not found in cache", "repo", repo)
+			continue
+		}
+		s.repos = append(s.repos, r)
+	}
 	githubReposEnumerated.WithLabelValues(s.name).Set(float64(len(s.repos)))
 	s.log.Info("Completed enumeration", "num_repos", len(s.repos), "num_orgs", s.orgsCache.Count(), "num_members", len(s.memberCache))
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR allows us to construct an in-memory cache with a custom expiration and purge interval. It additionally changes the type for values that can be stored in the cache from `string` -> `any`. These changes will be leverage in https://github.com/trufflesecurity/trufflehog/pull/2276.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

