### PR TITLE
Fix Postgres detector

### DIFF
--- a/pkg/detectors/postgres/postgres.go
+++ b/pkg/detectors/postgres/postgres.go
@@ -36,8 +36,7 @@ func (s Scanner) Keywords() []string {
 
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]detectors.Result, error) {
 	var results []detectors.Result
-	var pgURLs []url.URL
-	pgURLs = append(pgURLs, findUriMatches(string(data)))
+	pgURLs := findUriMatches(string(data))
 	pgURLs = append(pgURLs, findComponentMatches(verify, string(data))...)
 
 	for _, pgURL := range pgURLs {
@@ -80,18 +79,19 @@ func getDeadlineInSeconds(ctx context.Context) int {
 	return int(duration.Seconds())
 }
 
-func findUriMatches(dataStr string) url.URL {
-	var pgURL url.URL
-	for _, uri := range uriPattern.FindAllString(dataStr, -1) {
+func findUriMatches(dataStr string) []url.URL {
+	var results []url.URL
+	all := uriPattern.FindAllString(dataStr, -1)
+	for _, uri := range all {
 		pgURL, err := url.Parse(uri)
 		if err != nil {
 			continue
 		}
 		if pgURL.User != nil {
-			return *pgURL
+			results = append(results, *pgURL)
 		}
 	}
-	return pgURL
+	return results
 }
 
 // check if postgres is running

--- a/pkg/detectors/postgres/postgres_test.go
+++ b/pkg/detectors/postgres/postgres_test.go
@@ -26,7 +26,7 @@ const (
 	postgresUser = "postgres"
 	postgresPass = "23201dabb56ca236f3dc6736c0f9afad"
 	postgresHost = "localhost"
-	postgresPort = "5433"
+	postgresPort = "5434" // don't use 5433 because it can conflict with local development in certain cases
 
 	inactiveUser = "inactive"
 	inactivePass = "inactive"

--- a/pkg/detectors/postgres/postgres_test.go
+++ b/pkg/detectors/postgres/postgres_test.go
@@ -246,7 +246,6 @@ func TestPostgres_FromChunk(t *testing.T) {
 			}(),
 			wantErr: false,
 		},
-		// This test seems take a long time to run (70s+) even with the timeout set to 1s. It's not clear why.
 		{
 			name: "found, unverified due to error - inactive host",
 			s:    Scanner{},

--- a/pkg/detectors/postgres/postgres_test.go
+++ b/pkg/detectors/postgres/postgres_test.go
@@ -46,17 +46,19 @@ func TestPostgres_FromChunk(t *testing.T) {
 	tests := []struct {
 		name    string
 		s       Scanner
-		args    args
+		args    func() args
 		want    []detectors.Result
 		wantErr bool
 	}{
 		{
 			name: "not found",
 			s:    Scanner{},
-			args: args{
-				ctx:    context.Background(),
-				data:   []byte("You cannot find the secret within"),
-				verify: true,
+			args: func() args {
+				return args{
+					ctx:    context.Background(),
+					data:   []byte("You cannot find the secret within"),
+					verify: true,
+				}
 			},
 			want:    nil,
 			wantErr: false,
@@ -64,15 +66,17 @@ func TestPostgres_FromChunk(t *testing.T) {
 		{
 			name: "found with seperated credentials, verified",
 			s:    Scanner{},
-			args: args{
-				ctx: context.Background(),
-				data: []byte(fmt.Sprintf(`
+			args: func() args {
+				return args{
+					ctx: context.Background(),
+					data: []byte(fmt.Sprintf(`
 					POSTGRES_USER=%s
 					POSTGRES_PASSWORD=%s
 					POSTGRES_ADDRESS=%s
 					POSTGRES_PORT=%s
 					`, postgresUser, postgresPass, postgresHost, postgresPort)),
-				verify: true,
+					verify: true,
+				}
 			},
 			want: []detectors.Result{
 				{
@@ -85,10 +89,12 @@ func TestPostgres_FromChunk(t *testing.T) {
 		{
 			name: "found with single line credentials, verified",
 			s:    Scanner{},
-			args: args{
-				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf(`postgresql://%s:%s@%s:%s/postgres`, postgresUser, postgresPass, postgresHost, postgresPort)),
-				verify: true,
+			args: func() args {
+				return args{
+					ctx:    context.Background(),
+					data:   []byte(fmt.Sprintf(`postgresql://%s:%s@%s:%s/postgres`, postgresUser, postgresPass, postgresHost, postgresPort)),
+					verify: true,
+				}
 			},
 			want: []detectors.Result{
 				{
@@ -101,11 +107,13 @@ func TestPostgres_FromChunk(t *testing.T) {
 		{
 			name: "found with json credentials, verified",
 			s:    Scanner{},
-			args: args{
-				ctx: context.Background(),
-				data: []byte(fmt.Sprintf(
-					`DB_CONFIG={"user": "%s", "password": "%s", "host": "%s", "port": "%s", "database": "postgres"}`, postgresUser, postgresPass, postgresHost, postgresPort)),
-				verify: true,
+			args: func() args {
+				return args{
+					ctx: context.Background(),
+					data: []byte(fmt.Sprintf(
+						`DB_CONFIG={"user": "%s", "password": "%s", "host": "%s", "port": "%s", "database": "postgres"}`, postgresUser, postgresPass, postgresHost, postgresPort)),
+					verify: true,
+				}
 			},
 			want: []detectors.Result{
 				{
@@ -118,15 +126,17 @@ func TestPostgres_FromChunk(t *testing.T) {
 		{
 			name: "found with seperated credentials, unverified",
 			s:    Scanner{},
-			args: args{
-				ctx: context.Background(),
-				data: []byte(fmt.Sprintf(`
+			args: func() args {
+				return args{
+					ctx: context.Background(),
+					data: []byte(fmt.Sprintf(`
 					POSTGRES_USER=%s
 					POSTGRES_PASSWORD=%s
 					POSTGRES_ADDRESS=%s
 					POSTGRES_PORT=%s
 					`, postgresUser, inactivePass, postgresHost, postgresPort)),
-				verify: true,
+					verify: true,
+				}
 			},
 			want: []detectors.Result{
 				{
@@ -139,14 +149,16 @@ func TestPostgres_FromChunk(t *testing.T) {
 		{
 			name: "found with seperated credentials - no port, unverified",
 			s:    Scanner{},
-			args: args{
-				ctx: context.Background(),
-				data: []byte(fmt.Sprintf(`
+			args: func() args {
+				return args{
+					ctx: context.Background(),
+					data: []byte(fmt.Sprintf(`
 					POSTGRES_USER=%s
 					POSTGRES_PASSWORD=%s
 					POSTGRES_ADDRESS=%s
 					`, postgresUser, inactivePass, postgresHost)),
-				verify: true,
+					verify: true,
+				}
 			},
 			want: []detectors.Result{
 				{
@@ -159,10 +171,12 @@ func TestPostgres_FromChunk(t *testing.T) {
 		{
 			name: "found with single line credentials, unverified",
 			s:    Scanner{},
-			args: args{
-				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf(`postgresql://%s:%s@%s:%s/postgres`, postgresUser, inactivePass, postgresHost, postgresPort)),
-				verify: true,
+			args: func() args {
+				return args{
+					ctx:    context.Background(),
+					data:   []byte(fmt.Sprintf(`postgresql://%s:%s@%s:%s/postgres`, postgresUser, inactivePass, postgresHost, postgresPort)),
+					verify: true,
+				}
 			},
 			want: []detectors.Result{
 				{
@@ -175,11 +189,13 @@ func TestPostgres_FromChunk(t *testing.T) {
 		{
 			name: "found with json credentials, unverified - inactive password",
 			s:    Scanner{},
-			args: args{
-				ctx: context.Background(),
-				data: []byte(fmt.Sprintf(
-					`DB_CONFIG={"user": "%s", "password": "%s", "host": "%s", "port": "%s", "database": "postgres"}`, postgresUser, inactivePass, postgresHost, postgresPort)),
-				verify: true,
+			args: func() args {
+				return args{
+					ctx: context.Background(),
+					data: []byte(fmt.Sprintf(
+						`DB_CONFIG={"user": "%s", "password": "%s", "host": "%s", "port": "%s", "database": "postgres"}`, postgresUser, inactivePass, postgresHost, postgresPort)),
+					verify: true,
+				}
 			},
 			want: []detectors.Result{
 				{
@@ -192,11 +208,13 @@ func TestPostgres_FromChunk(t *testing.T) {
 		{
 			name: "found with json credentials, unverified - inactive user",
 			s:    Scanner{},
-			args: args{
-				ctx: context.Background(),
-				data: []byte(fmt.Sprintf(
-					`DB_CONFIG={"user": "%s", "password": "%s", "host": "%s", "port": "%s", "database": "postgres"}`, inactiveUser, postgresPass, postgresHost, postgresPort)),
-				verify: true,
+			args: func() args {
+				return args{
+					ctx: context.Background(),
+					data: []byte(fmt.Sprintf(
+						`DB_CONFIG={"user": "%s", "password": "%s", "host": "%s", "port": "%s", "database": "postgres"}`, inactiveUser, postgresPass, postgresHost, postgresPort)),
+					verify: true,
+				}
 			},
 			want: []detectors.Result{
 				{
@@ -209,10 +227,12 @@ func TestPostgres_FromChunk(t *testing.T) {
 		{
 			name: "found, unverified due to error - inactive port",
 			s:    Scanner{},
-			args: args{
-				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf(`postgresql://%s:%s@%s:%s/postgres`, postgresUser, postgresPass, postgresHost, inactivePort)),
-				verify: true,
+			args: func() args {
+				return args{
+					ctx:    context.Background(),
+					data:   []byte(fmt.Sprintf(`postgresql://%s:%s@%s:%s/postgres`, postgresUser, postgresPass, postgresHost, inactivePort)),
+					verify: true,
+				}
 			},
 			want: func() []detectors.Result {
 				r := detectors.Result{
@@ -234,7 +254,7 @@ func TestPostgres_FromChunk(t *testing.T) {
 					data:   []byte(fmt.Sprintf(`postgresql://%s:%s@%s:%s/postgres`, postgresUser, postgresPass, inactiveHost, postgresPort)),
 					verify: true,
 				}
-			}(),
+			},
 			want: func() []detectors.Result {
 				r := detectors.Result{
 					DetectorType: detectorspb.DetectorType_Postgres,
@@ -259,7 +279,7 @@ func TestPostgres_FromChunk(t *testing.T) {
 						postgresUser, postgresPass, postgresHost, postgresPort)),
 					verify: true,
 				}
-			}(),
+			},
 			want: func() []detectors.Result {
 				first := detectors.Result{
 					DetectorType: detectorspb.DetectorType_Postgres,
@@ -278,7 +298,8 @@ func TestPostgres_FromChunk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Scanner{}
-			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			args := tt.args()
+			got, err := s.FromData(args.ctx, args.verify, args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("postgres.FromData() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/detectors/postgres/postgres_test.go
+++ b/pkg/detectors/postgres/postgres_test.go
@@ -99,6 +99,29 @@ func TestPostgres_FromChunk(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "found with single line credentials next to invalid credentials, verified",
+			s:    Scanner{},
+			args: func() args {
+				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+				defer cancel()
+				return args{
+					ctx: ctx,
+					data: []byte(fmt.Sprintf(`
+						postgresql://user:secret@foobar.com:5432/mydb?sslmode=disable
+						postgresql://%s:%s@%s:%s/postgres`,
+						postgresUser, postgresPass, postgresHost, postgresPort)),
+					verify: true,
+				}
+			}(),
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Postgres,
+					Verified:     true,
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "found with json credentials, verified",
 			s:    Scanner{},
 			args: args{


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
* [x] Use all found URIs in a chunk, rather than just the first one
* [x] Test locally on a port other than 5433, because that one can have local dev problems
* [ ] Stop manufacturing candidate secrets with "localhost" as a candidate host
  * [ ] ignore if it it's in the chunk
  * [ ] don't conjure it up as a default
* [ ] Make it so that if "localhost" is found in a chunk, the "host" part of it doesn't trigger the host detection pattern

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

