### PR TITLE
Refactor UnitHook to block the scan if finished metrics aren't handled

### DIFF
--- a/pkg/sources/job_progress.go
+++ b/pkg/sources/job_progress.go
@@ -188,7 +188,8 @@ func (jp *JobProgress) executeHooks(todo func(hook JobProgressHook)) {
 		hooksExecTime.WithLabelValues().Observe(float64(elapsed))
 	}(time.Now())
 	for _, hook := range jp.hooks {
-		// TODO: Non-blocking?
+		// Execute hooks synchronously so they can provide
+		// back-pressure to the source.
 		todo(hook)
 	}
 }

--- a/pkg/sources/job_progress_hook.go
+++ b/pkg/sources/job_progress_hook.go
@@ -81,16 +81,16 @@ func (u *UnitHook) id(ref JobProgressRef, unit SourceUnit) string {
 	return fmt.Sprintf("%d/%d/%s", ref.SourceID, ref.JobID, unitID)
 }
 
-func (u *UnitHook) ejectFinishedMetric(metric UnitMetrics) {
+func (u *UnitHook) ejectFinishedMetrics(metrics UnitMetrics) {
 	// Intentionally block the hook from returning to supply back-pressure
 	// to the source.
 	select {
-	case u.finishedMetrics <- metric:
+	case u.finishedMetrics <- metrics:
 		return
 	default:
 		u.logBackPressure()
 	}
-	u.finishedMetrics <- metric
+	u.finishedMetrics <- metrics
 }
 
 func (u *UnitHook) StartUnitChunking(ref JobProgressRef, unit SourceUnit, start time.Time) {
@@ -113,7 +113,7 @@ func (u *UnitHook) EndUnitChunking(ref JobProgressRef, unit SourceUnit, end time
 		return
 	}
 	metrics.EndTime = &end
-	u.ejectFinishedMetric(*metrics)
+	u.ejectFinishedMetrics(*metrics)
 }
 
 func (u *UnitHook) finishUnit(id string) (*UnitMetrics, bool) {
@@ -186,7 +186,7 @@ func (u *UnitHook) Finish(ref JobProgressRef) {
 	metrics.StartTime = snap.StartTime
 	metrics.EndTime = snap.EndTime
 	metrics.Errors = snap.Errors
-	u.ejectFinishedMetric(*metrics)
+	u.ejectFinishedMetrics(*metrics)
 }
 
 // InProgressSnapshot gets all the currently active metrics across all jobs.

--- a/pkg/sources/job_progress_hook.go
+++ b/pkg/sources/job_progress_hook.go
@@ -57,6 +57,18 @@ func NewUnitHook(ctx context.Context, opts ...UnitHookOpt) (*UnitHook, <-chan Un
 	for _, opt := range opts {
 		opt(&hook)
 	}
+	go func() {
+		ticker := time.NewTicker(15 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				hooksChannelSize.WithLabelValues().Set(float64(len(hook.finishedMetrics)))
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 	return &hook, hook.finishedMetrics
 }
 

--- a/pkg/sources/job_progress_hook.go
+++ b/pkg/sources/job_progress_hook.go
@@ -3,17 +3,17 @@ package sources
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 
 // UnitHook implements JobProgressHook for tracking the progress of each
 // individual unit.
 type UnitHook struct {
-	metrics         *lru.Cache[string, *UnitMetrics]
+	metrics         map[string]*UnitMetrics
 	mu              sync.Mutex
 	finishedMetrics chan UnitMetrics
 	logBackPressure func()
@@ -32,21 +32,9 @@ func WithUnitHookFinishBufferSize(buf int) UnitHookOpt {
 }
 
 func NewUnitHook(ctx context.Context, opts ...UnitHookOpt) (*UnitHook, <-chan UnitMetrics) {
-	// lru.NewWithEvict can only fail if the size is < 0. This is the
-	// maximum number of concurrent in-progress units that this hook can
-	// handle.
-	cache, _ := lru.NewWithEvict(1024, func(key string, value *UnitMetrics) {
-		if value.handled {
-			return
-		}
-		ctx.Logger().Error(fmt.Errorf("eviction"), "dropping unit metric",
-			"id", key,
-			"metric", value,
-		)
-	})
 	var once sync.Once
 	hook := UnitHook{
-		metrics:         cache,
+		metrics:         make(map[string]*UnitMetrics, runtime.NumCPU()),
 		finishedMetrics: make(chan UnitMetrics, 1024),
 		logBackPressure: func() {
 			once.Do(func() {
@@ -98,11 +86,11 @@ func (u *UnitHook) StartUnitChunking(ref JobProgressRef, unit SourceUnit, start 
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
-	u.metrics.Add(id, &UnitMetrics{
+	u.metrics[id] = &UnitMetrics{
 		Unit:      unit,
 		Parent:    ref,
 		StartTime: &start,
-	})
+	}
 }
 
 func (u *UnitHook) EndUnitChunking(ref JobProgressRef, unit SourceUnit, end time.Time) {
@@ -120,12 +108,11 @@ func (u *UnitHook) finishUnit(id string) (*UnitMetrics, bool) {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
-	metrics, ok := u.metrics.Get(id)
+	metrics, ok := u.metrics[id]
 	if !ok {
 		return nil, false
 	}
-	metrics.handled = true
-	u.metrics.Remove(id)
+	delete(u.metrics, id)
 	return metrics, true
 }
 
@@ -134,7 +121,7 @@ func (u *UnitHook) ReportChunk(ref JobProgressRef, unit SourceUnit, chunk *Chunk
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
-	metrics, ok := u.metrics.Get(id)
+	metrics, ok := u.metrics[id]
 	if !ok && unit != nil {
 		// The unit has been evicted.
 		return
@@ -145,7 +132,7 @@ func (u *UnitHook) ReportChunk(ref JobProgressRef, unit SourceUnit, chunk *Chunk
 			Parent:    ref,
 			StartTime: ref.Snapshot().StartTime,
 		}
-		u.metrics.Add(id, metrics)
+		u.metrics[id] = metrics
 	}
 	metrics.TotalChunks++
 	metrics.TotalBytes += uint64(len(chunk.Data))
@@ -156,7 +143,7 @@ func (u *UnitHook) ReportError(ref JobProgressRef, err error) {
 	defer u.mu.Unlock()
 
 	// Always add the error to the nil unit if it exists.
-	if metrics, ok := u.metrics.Get(u.id(ref, nil)); ok {
+	if metrics, ok := u.metrics[u.id(ref, nil)]; ok {
 		metrics.Errors = append(metrics.Errors, err)
 	}
 
@@ -167,7 +154,7 @@ func (u *UnitHook) ReportError(ref JobProgressRef, err error) {
 	}
 	id := u.id(ref, chunkErr.Unit)
 
-	metrics, ok := u.metrics.Get(id)
+	metrics, ok := u.metrics[id]
 	if !ok {
 		return
 	}
@@ -193,11 +180,9 @@ func (u *UnitHook) Finish(ref JobProgressRef) {
 func (u *UnitHook) InProgressSnapshot() []UnitMetrics {
 	u.mu.Lock()
 	defer u.mu.Unlock()
-	output := make([]UnitMetrics, 0, u.metrics.Len())
-	for _, id := range u.metrics.Keys() {
-		if metrics, ok := u.metrics.Get(id); ok {
-			output = append(output, *metrics)
-		}
+	output := make([]UnitMetrics, 0, len(u.metrics))
+	for _, metrics := range u.metrics {
+		output = append(output, *metrics)
 	}
 	return output
 }
@@ -219,9 +204,6 @@ type UnitMetrics struct {
 	TotalBytes uint64 `json:"total_bytes"`
 	// All errors encountered by this unit.
 	Errors []error `json:"errors"`
-	// Flag to mark that these metrics were intentionally evicted from
-	// the cache.
-	handled bool
 }
 
 func (u UnitMetrics) IsFinished() bool {

--- a/pkg/sources/metrics.go
+++ b/pkg/sources/metrics.go
@@ -14,4 +14,11 @@ var (
 		Help:      "Time spent executing hooks (ms)",
 		Buckets:   []float64{5, 50, 500, 1000},
 	}, nil)
+
+	hooksChannelSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: common.MetricsNamespace,
+		Subsystem: common.MetricsSubsystem,
+		Name:      "hooks_channel_size",
+		Help:      "Total number of metrics waiting in the finished channel.",
+	}, nil)
 )

--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -2,6 +2,7 @@ package sources
 
 import (
 	"fmt"
+	"io"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -182,6 +183,11 @@ func (s *SourceManager) Wait() error {
 	}
 	close(s.outputChunks)
 	close(s.firstErr)
+	for _, hook := range s.hooks {
+		if hookCloser, ok := hook.(io.Closer); ok {
+			_ = hookCloser.Close()
+		}
+	}
 	return s.waitErr
 }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
`UnitHook` was originally designed to drop metrics when the producer out-paced the consumer. This changes it so the hook will block the scan until there is room to write the finished metrics to the output channel.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

