### PR TITLE
Walk directories in filesystem source enumeration

### DIFF
--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -233,7 +233,10 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 			continue
 		}
 		err = fs.WalkDir(os.DirFS(path), ".", func(relativePath string, d fs.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
+			if err != nil {
+				return reporter.UnitErr(ctx, err)
+			}
+			if d.IsDir() {
 				return nil
 			}
 			fullPath := filepath.Join(path, relativePath)

--- a/pkg/sources/filesystem/filesystem_test.go
+++ b/pkg/sources/filesystem/filesystem_test.go
@@ -115,6 +115,7 @@ func TestScanFile(t *testing.T) {
 }
 
 func TestEnumerate(t *testing.T) {
+	t.Skip("TODO: refactor to allow a virtual filesystem")
 	t.Parallel()
 	ctx := context.Background()
 

--- a/pkg/sources/filesystem/filesystem_test.go
+++ b/pkg/sources/filesystem/filesystem_test.go
@@ -2,6 +2,7 @@ package filesystem
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -115,14 +116,35 @@ func TestScanFile(t *testing.T) {
 }
 
 func TestEnumerate(t *testing.T) {
-	t.Skip("TODO: refactor to allow a virtual filesystem")
+	// TODO: refactor to allow a virtual filesystem.
 	t.Parallel()
 	ctx := context.Background()
 
 	// Setup the connection to test enumeration.
+	dir, err := os.MkdirTemp("", "trufflehog-test-enumerate")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
 	units := []string{
 		"/one", "/two", "/three",
 		"/path/to/dir/", "/path/to/another/dir/",
+	}
+	// Prefix the units with the tempdir and create files on disk.
+	for i, unit := range units {
+		fullPath := filepath.Join(dir, unit)
+		units[i] = fullPath
+		if i < 3 {
+			f, err := os.Create(fullPath)
+			assert.NoError(t, err)
+			f.Close()
+		} else {
+			assert.NoError(t, os.MkdirAll(fullPath, 0755))
+			// Create a file in the directory for enumeration to find.
+			f, err := os.CreateTemp(fullPath, "file")
+			assert.NoError(t, err)
+			units[i] = f.Name()
+			f.Close()
+		}
 	}
 	conn, err := anypb.New(&sourcespb.Filesystem{
 		Paths:       units[0:3],


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Previously the unit could be a directory, but now it is individual files. This leverages the SourceManager's concurrent units to speed up scanning of large directories.

```
» find /tmp/files -type f | wc -l
  100000

# before
» ./trufflehog filesystem /tmp/files
2024-01-18T12:48:05-08:00       info-0  trufflehog      finished scanning       {"chunks": 100000, "bytes": 588895, "verified_secrets": 0, "unverified_secrets": 0, "scan_duration": "27.942921208s"}
# 27.94s

# after
» ./trufflehog filesystem /tmp/files
2024-01-18T12:47:04-08:00       info-0  trufflehog      finished scanning       {"chunks": 100000, "bytes": 588895, "verified_secrets": 0, "unverified_secrets": 0, "scan_duration": "14.342492916s"}
# 14.34s
```



### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

