### PR TITLE
[chore] - reduce test time

### DIFF
--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -741,16 +741,6 @@ func TestIndividualCommitParsing(t *testing.T) {
 			}
 			j++
 		}
-		// for _, pass := range test.passes {
-		//	if !test.function(false, pass.latestState, pass.line) {
-		//		t.Errorf("%s: Parser did not recognize correct line. (%s)", name, string(pass.line))
-		//	}
-		// }
-		// for _, fail := range test.fails {
-		//	if test.function(false, fail.latestState, fail.line) {
-		//		t.Errorf("%s: Parser did not recognize incorrect line. (%s)", name, string(fail.line))
-		//	}
-		// }
 	}
 }
 
@@ -802,24 +792,6 @@ func TestStagedDiffParsing(t *testing.T) {
 					Content:   *bytes.NewBuffer([]byte("The Nameless is the origin of Heaven and Earth;\nThe named is the mother of all things.\n\nTherefore let there always be non-being,\n  so we may see their subtlety,\nAnd let there always be being,\n  so we may see their outcome.\nThe two are the same,\nBut after they are produced,\n  they have different names.\nThey both may be called deep and profound.\nDeeper and more profound,\nThe door of all subtleties!\n")),
 					IsBinary:  false,
 				},
-				// {
-				//	PathB:     "",
-				//	LineStart: 0,
-				//	Content:   *bytes.NewBuffer([]byte("\n")),
-				//	IsBinary:  false,
-				// },
-				// {
-				//	PathB:     "",
-				//	LineStart: 0,
-				//	Content:   *bytes.NewBuffer([]byte("\n")),
-				//	IsBinary:  false,
-				// },
-				// {
-				//	PathB:     "",
-				//	LineStart: 0,
-				//	Content:   *bytes.NewBuffer([]byte("\n")),
-				//	IsBinary:  false,
-				// },
 			},
 		},
 	}

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -741,16 +741,16 @@ func TestIndividualCommitParsing(t *testing.T) {
 			}
 			j++
 		}
-		//for _, pass := range test.passes {
+		// for _, pass := range test.passes {
 		//	if !test.function(false, pass.latestState, pass.line) {
 		//		t.Errorf("%s: Parser did not recognize correct line. (%s)", name, string(pass.line))
 		//	}
-		//}
-		//for _, fail := range test.fails {
+		// }
+		// for _, fail := range test.fails {
 		//	if test.function(false, fail.latestState, fail.line) {
 		//		t.Errorf("%s: Parser did not recognize incorrect line. (%s)", name, string(fail.line))
 		//	}
-		//}
+		// }
 	}
 }
 
@@ -802,24 +802,24 @@ func TestStagedDiffParsing(t *testing.T) {
 					Content:   *bytes.NewBuffer([]byte("The Nameless is the origin of Heaven and Earth;\nThe named is the mother of all things.\n\nTherefore let there always be non-being,\n  so we may see their subtlety,\nAnd let there always be being,\n  so we may see their outcome.\nThe two are the same,\nBut after they are produced,\n  they have different names.\nThey both may be called deep and profound.\nDeeper and more profound,\nThe door of all subtleties!\n")),
 					IsBinary:  false,
 				},
-				//{
+				// {
 				//	PathB:     "",
 				//	LineStart: 0,
 				//	Content:   *bytes.NewBuffer([]byte("\n")),
 				//	IsBinary:  false,
-				//},
-				//{
+				// },
+				// {
 				//	PathB:     "",
 				//	LineStart: 0,
 				//	Content:   *bytes.NewBuffer([]byte("\n")),
 				//	IsBinary:  false,
-				//},
-				//{
+				// },
+				// {
 				//	PathB:     "",
 				//	LineStart: 0,
 				//	Content:   *bytes.NewBuffer([]byte("\n")),
 				//	IsBinary:  false,
-				//},
+				// },
 			},
 		},
 	}
@@ -1112,27 +1112,31 @@ index 0000000..5af88a8
 
 func TestMaxDiffSize(t *testing.T) {
 	parser := NewParser()
-	bigBytes := bytes.Buffer{}
-	bigBytes.WriteString(singleCommitSingleDiff)
-	for i := 0; i <= parser.maxDiffSize/1024+10; i++ {
-		bigBytes.WriteString("+")
-		for n := 0; n < 1024; n++ {
-			bigBytes.Write([]byte("0"))
-		}
-		bigBytes.WriteString("\n")
-	}
-	bigReader := bytes.NewReader(bigBytes.Bytes())
+	builder := strings.Builder{}
+	builder.WriteString(singleCommitSingleDiff)
 
-	commitChan := make(chan Commit)
+	// Generate a diff that is larger than the maxDiffSize.
+	for i := 0; i <= parser.maxDiffSize/1024+10; i++ {
+		builder.WriteString("+" + strings.Repeat("0", 1024) + "\n")
+	}
+	bigReader := strings.NewReader(builder.String())
+
+	commitChan := make(chan Commit, 1)                                      // Buffer to prevent blocking
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // Timeout to prevent long wait
+	defer cancel()
+
 	go func() {
-		parser.FromReader(context.Background(), bigReader, commitChan, false)
+		parser.FromReader(ctx, bigReader, commitChan, false)
 	}()
 
-	commit := <-commitChan
-	if commit.Diffs[0].Content.Len() > parser.maxDiffSize+1024 {
-		t.Errorf("diff did not match MaxDiffSize. Got: %d, expected (max): %d", commit.Diffs[0].Content.Len(), parser.maxDiffSize+1024)
+	select {
+	case commit := <-commitChan:
+		if commit.Diffs[0].Content.Len() > parser.maxDiffSize+1024 {
+			t.Errorf("diff did not match MaxDiffSize. Got: %d, expected (max): %d", commit.Diffs[0].Content.Len(), parser.maxDiffSize+1024)
+		}
+	case <-ctx.Done():
+		t.Fatal("Test timed out")
 	}
-
 }
 
 func TestMaxCommitSize(t *testing.T) {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Reduce the time taken for the `TestMaxDiffSize` from `5s` -> `1s`.

![Screenshot 2024-01-20 at 2 46 17 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/2449d42a-6bf3-4c08-889c-58189953d04a)
![Screenshot 2024-01-20 at 2 46 39 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/6a4bbe38-5f7a-4224-93ff-43caab71d4e9)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

