### PR TITLE
[chore] -  max tests parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ PROTOS_IMAGE ?= trufflesecurity/protos:1.21-0
 .PHONY: protos-windows
 .PHONY: vendor
 .PHONY: dogfood
+.PHONY: test-no-cache
 
 dogfood:
 	CGO_ENABLED=0 go run . git file://. --json --debug
@@ -29,6 +30,9 @@ test-failing:
 
 test:
 	CGO_ENABLED=0 go test -timeout=5m $(shell go list ./... | grep -v /vendor/ | grep -v pkg/detectors)
+
+test-no-cache:
+	CGO_ENABLED=0 go test -count=1 -timeout=2m $(shell go list ./... | grep -v /vendor/ | grep -v pkg/detectors)
 
 test-integration:
 	CGO_ENABLED=0 go test -timeout=5m -tags=integration $(shell go list ./... | grep -v /vendor/ | grep -v pkg/detectors)

--- a/pkg/decoders/base64_test.go
+++ b/pkg/decoders/base64_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestBase64_FromChunk(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		chunk *sources.Chunk
 		want  *sources.Chunk
@@ -124,8 +125,11 @@ func TestBase64_FromChunk(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			d := &Base64{}
 			got := d.FromChunk(tt.chunk)
 			if tt.want != nil {

--- a/pkg/decoders/utf16_test.go
+++ b/pkg/decoders/utf16_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestUTF16Decoder(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name      string
 		input     []byte
@@ -42,7 +43,9 @@ func TestUTF16Decoder(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			chunk := &sources.Chunk{Data: tc.input}
 			decoder := &UTF16{}
 			decodedChunk := decoder.FromChunk(chunk)
@@ -65,6 +68,7 @@ func TestUTF16Decoder(t *testing.T) {
 }
 
 func TestDLL(t *testing.T) {
+	t.Parallel()
 	data, err := os.ReadFile("utf16_test.dll")
 	if err != nil {
 		t.Errorf("Failed to read test data: %v", err)

--- a/pkg/decoders/utf8_test.go
+++ b/pkg/decoders/utf8_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestUTF8_FromChunk(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		chunk *sources.Chunk
 	}
@@ -47,8 +48,11 @@ func TestUTF8_FromChunk(t *testing.T) {
 			wantErr: false,
 		},
 	}
+
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			d := &UTF8{}
 			got := d.FromChunk(tt.args.chunk)
 			if got != nil && tt.want != nil {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestFragmentLineOffset(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		chunk        *sources.Chunk
@@ -93,7 +94,9 @@ func TestFragmentLineOffset(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			lineOffset, isIgnored := FragmentLineOffset(tt.chunk, tt.result)
 			if lineOffset != tt.expectedLine {
 				t.Errorf("Expected line offset to be %d, got %d", tt.expectedLine, lineOffset)
@@ -145,6 +148,7 @@ func BenchmarkFragmentLineOffsetEnd(b *testing.B) {
 // Test to make sure that DefaultDecoders always returns the UTF8 decoder first.
 // Technically a decoder test but we want this to run and fail in CI
 func TestDefaultDecoders(t *testing.T) {
+	t.Parallel()
 	ds := decoders.DefaultDecoders()
 	if _, ok := ds[0].(*decoders.UTF8); !ok {
 		t.Errorf("DefaultDecoders() = %v, expected UTF8 decoder to be first", ds)
@@ -152,6 +156,7 @@ func TestDefaultDecoders(t *testing.T) {
 }
 
 func TestSupportsLineNumbers(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name          string
 		sourceType    sourcespb.SourceType
@@ -170,7 +175,9 @@ func TestSupportsLineNumbers(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			result := SupportsLineNumbers(tt.sourceType)
 			assert.Equal(t, tt.expectedValue, result)
 		})
@@ -186,6 +193,7 @@ func BenchmarkSupportsLineNumbersLoop(b *testing.B) {
 
 // TestEngine_DuplicatSecrets is a test that detects ALL duplicate secrets with the same decoder.
 func TestEngine_DuplicatSecrets(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	absPath, err := filepath.Abs("./testdata")
@@ -215,6 +223,7 @@ func TestEngine_DuplicatSecrets(t *testing.T) {
 }
 
 func TestFragmentFirstLineAndLink(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		chunk        *sources.Chunk
@@ -274,7 +283,9 @@ func TestFragmentFirstLineAndLink(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			line, linePtr, link := FragmentFirstLineAndLink(tt.chunk)
 			assert.Equal(t, tt.expectedLink, link, "Mismatch in link")
 			assert.Equal(t, tt.expectedLine, line, "Mismatch in line")
@@ -287,6 +298,7 @@ func TestFragmentFirstLineAndLink(t *testing.T) {
 }
 
 func TestSetLink(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    *source_metadatapb.MetaData
@@ -373,7 +385,9 @@ func TestSetLink(t *testing.T) {
 	ctx := context.Background()
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			err := UpdateLink(ctx, tt.input, tt.link, tt.line)
 			if err != nil && !tt.wantErr {
 				t.Errorf("Unexpected error: %v", err)

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -741,16 +741,16 @@ func TestIndividualCommitParsing(t *testing.T) {
 			}
 			j++
 		}
-		//for _, pass := range test.passes {
+		// for _, pass := range test.passes {
 		//	if !test.function(false, pass.latestState, pass.line) {
 		//		t.Errorf("%s: Parser did not recognize correct line. (%s)", name, string(pass.line))
 		//	}
-		//}
-		//for _, fail := range test.fails {
+		// }
+		// for _, fail := range test.fails {
 		//	if test.function(false, fail.latestState, fail.line) {
 		//		t.Errorf("%s: Parser did not recognize incorrect line. (%s)", name, string(fail.line))
 		//	}
-		//}
+		// }
 	}
 }
 
@@ -802,24 +802,24 @@ func TestStagedDiffParsing(t *testing.T) {
 					Content:   *bytes.NewBuffer([]byte("The Nameless is the origin of Heaven and Earth;\nThe named is the mother of all things.\n\nTherefore let there always be non-being,\n  so we may see their subtlety,\nAnd let there always be being,\n  so we may see their outcome.\nThe two are the same,\nBut after they are produced,\n  they have different names.\nThey both may be called deep and profound.\nDeeper and more profound,\nThe door of all subtleties!\n")),
 					IsBinary:  false,
 				},
-				//{
+				// {
 				//	PathB:     "",
 				//	LineStart: 0,
 				//	Content:   *bytes.NewBuffer([]byte("\n")),
 				//	IsBinary:  false,
-				//},
-				//{
+				// },
+				// {
 				//	PathB:     "",
 				//	LineStart: 0,
 				//	Content:   *bytes.NewBuffer([]byte("\n")),
 				//	IsBinary:  false,
-				//},
-				//{
+				// },
+				// {
 				//	PathB:     "",
 				//	LineStart: 0,
 				//	Content:   *bytes.NewBuffer([]byte("\n")),
 				//	IsBinary:  false,
-				//},
+				// },
 			},
 		},
 	}
@@ -1112,27 +1112,31 @@ index 0000000..5af88a8
 
 func TestMaxDiffSize(t *testing.T) {
 	parser := NewParser()
-	bigBytes := bytes.Buffer{}
-	bigBytes.WriteString(singleCommitSingleDiff)
-	for i := 0; i <= parser.maxDiffSize/1024+10; i++ {
-		bigBytes.WriteString("+")
-		for n := 0; n < 1024; n++ {
-			bigBytes.Write([]byte("0"))
-		}
-		bigBytes.WriteString("\n")
-	}
-	bigReader := bytes.NewReader(bigBytes.Bytes())
+	builder := strings.Builder{}
+	builder.WriteString(singleCommitSingleDiff)
 
-	commitChan := make(chan Commit)
+	// Generate a diff that is larger than the maxDiffSize.
+	for i := 0; i <= parser.maxDiffSize/1024+10; i++ {
+		builder.WriteString("+" + strings.Repeat("0", 1024) + "\n")
+	}
+	bigReader := strings.NewReader(builder.String())
+
+	commitChan := make(chan Commit, 1)                                      // Buffer to prevent blocking
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // Timeout to prevent long wait
+	defer cancel()
+
 	go func() {
-		parser.FromReader(context.Background(), bigReader, commitChan, false)
+		parser.FromReader(ctx, bigReader, commitChan, false)
 	}()
 
-	commit := <-commitChan
-	if commit.Diffs[0].Content.Len() > parser.maxDiffSize+1024 {
-		t.Errorf("diff did not match MaxDiffSize. Got: %d, expected (max): %d", commit.Diffs[0].Content.Len(), parser.maxDiffSize+1024)
+	select {
+	case commit := <-commitChan:
+		if commit.Diffs[0].Content.Len() > parser.maxDiffSize+1024 {
+			t.Errorf("diff did not match MaxDiffSize. Got: %d, expected (max): %d", commit.Diffs[0].Content.Len(), parser.maxDiffSize+1024)
+		}
+	case <-ctx.Done():
+		t.Fatal("Test timed out")
 	}
-
 }
 
 func TestMaxCommitSize(t *testing.T) {

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestArchiveHandler(t *testing.T) {
+	t.Parallel()
 	tests := map[string]struct {
 		archiveURL     string
 		expectedChunks int
@@ -76,7 +77,9 @@ func TestArchiveHandler(t *testing.T) {
 	}
 
 	for name, testCase := range tests {
+		name, testCase := name, testCase
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			resp, err := http.Get(testCase.archiveURL)
 			if err != nil || resp.StatusCode != http.StatusOK {
 				t.Error(err)
@@ -112,6 +115,7 @@ func TestArchiveHandler(t *testing.T) {
 }
 
 func TestHandleFile(t *testing.T) {
+	t.Parallel()
 	reporter := sources.ChanReporter{Ch: make(chan *sources.Chunk, 2)}
 
 	// Context cancels the operation.
@@ -165,6 +169,7 @@ func BenchmarkHandleFile(b *testing.B) {
 }
 
 func TestHandleFileSkipBinaries(t *testing.T) {
+	t.Parallel()
 	filename := createBinaryArchive(t)
 	defer os.Remove(filename)
 
@@ -244,6 +249,7 @@ func createBinaryArchive(t *testing.T) string {
 }
 
 func TestReadToMax(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    []byte
@@ -269,7 +275,9 @@ func TestReadToMax(t *testing.T) {
 	a := &Archive{}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			reader := bytes.NewReader(tt.input)
 			output, err := a.ReadToMax(logContext.Background(), reader)
 			assert.Nil(t, err)
@@ -296,6 +304,7 @@ func BenchmarkReadToMax(b *testing.B) {
 }
 
 func TestExtractDebContent(t *testing.T) {
+	t.Parallel()
 	// Open the sample .deb file from the testdata folder.
 	file, err := os.Open("testdata/test.deb")
 	assert.Nil(t, err)
@@ -314,6 +323,7 @@ func TestExtractDebContent(t *testing.T) {
 }
 
 func TestSkipArchive(t *testing.T) {
+	t.Parallel()
 	file, err := os.Open("testdata/test.tgz")
 	assert.Nil(t, err)
 	defer file.Close()
@@ -339,6 +349,7 @@ func TestSkipArchive(t *testing.T) {
 }
 
 func TestExtractTarContent(t *testing.T) {
+	t.Parallel()
 	file, err := os.Open("testdata/test.tgz")
 	assert.Nil(t, err)
 	defer file.Close()
@@ -364,6 +375,7 @@ func TestExtractTarContent(t *testing.T) {
 }
 
 func TestExtractRPMContent(t *testing.T) {
+	t.Parallel()
 	// Open the sample .rpm file from the testdata folder.
 	file, err := os.Open("testdata/test.rpm")
 	assert.Nil(t, err)
@@ -382,6 +394,7 @@ func TestExtractRPMContent(t *testing.T) {
 }
 
 func TestOpenInvalidArchive(t *testing.T) {
+	t.Parallel()
 	reader := strings.NewReader("invalid archive")
 
 	ctx := logContext.AddLogger(context.Background())
@@ -394,6 +407,7 @@ func TestOpenInvalidArchive(t *testing.T) {
 }
 
 func TestNestedDirArchive(t *testing.T) {
+	t.Parallel()
 	file, err := os.Open("testdata/dir-archive.zip")
 	assert.Nil(t, err)
 	defer file.Close()
@@ -419,6 +433,7 @@ func TestNestedDirArchive(t *testing.T) {
 }
 
 func TestDetermineMimeType(t *testing.T) {
+	t.Parallel()
 	filetype.AddMatcher(filetype.NewType("txt", "text/plain"), func(buf []byte) bool {
 		return strings.HasPrefix(string(buf), "text:")
 	})
@@ -472,7 +487,9 @@ func TestDetermineMimeType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			originalData, _ := io.ReadAll(io.TeeReader(tt.input, &bytes.Buffer{}))
 			tt.input = bytes.NewReader(originalData) // Reset the reader
 

--- a/pkg/sanitizer/utf8_test.go
+++ b/pkg/sanitizer/utf8_test.go
@@ -3,6 +3,7 @@ package sanitizer
 import "testing"
 
 func TestUTF8(t *testing.T) {
+	t.Parallel()
 	type args struct {
 		in string
 	}
@@ -33,8 +34,11 @@ func TestUTF8(t *testing.T) {
 			want: "no  nulls because postgres does not support it in text fields",
 		},
 	}
+
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if got := UTF8(tt.args.in); got != tt.want {
 				t.Errorf("UTF8() = %v, want %v", got, tt.want)
 			}

--- a/pkg/sources/chunker_test.go
+++ b/pkg/sources/chunker_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestChunker(t *testing.T) {
+	t.Parallel()
 	byteBuffer := bytes.NewBuffer(make([]byte, ChunkSize*9))
 	reReader, err := diskbufferreader.New(byteBuffer)
 	if err != nil {
@@ -72,6 +73,7 @@ func BenchmarkChunker(b *testing.B) {
 }
 
 func TestNewChunkedReader(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		input      string
@@ -155,7 +157,9 @@ func TestNewChunkedReader(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			readerFunc := NewChunkReader(WithChunkSize(tt.chunkSize), WithPeekSize(tt.peekSize))
 			reader := strings.NewReader(tt.input)
 			ctx := context.Background()
@@ -202,6 +206,7 @@ func BenchmarkChunkReader(b *testing.B) {
 }
 
 func TestFlakyChunkReader(t *testing.T) {
+	t.Parallel()
 	a := "aaaa"
 	b := "bbbb"
 
@@ -222,6 +227,7 @@ func TestFlakyChunkReader(t *testing.T) {
 }
 
 func TestReadInChunksWithCancellation(t *testing.T) {
+	t.Parallel()
 	largeData := strings.Repeat("large test data ", 1024*1024) // Large data string.
 
 	for i := 0; i < 10; i++ {

--- a/pkg/sources/circleci/circleci_test.go
+++ b/pkg/sources/circleci/circleci_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestSource_Scan(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
 	defer cancel()
 
@@ -60,6 +61,7 @@ func TestSource_Scan(t *testing.T) {
 			wantErr: false,
 		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Source{}

--- a/pkg/sources/errors_test.go
+++ b/pkg/sources/errors_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestNewScanErrors(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name     string
 		projects int
@@ -37,7 +38,9 @@ func TestNewScanErrors(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got := NewScanErrors()
 
 			if !errors.Is(got.Errors(), tc.want.Errors()) {
@@ -48,6 +51,7 @@ func TestNewScanErrors(t *testing.T) {
 }
 
 func TestScanErrorsAdd(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name        string
 		concurrency int
@@ -76,7 +80,9 @@ func TestScanErrorsAdd(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			se := NewScanErrors()
 
 			var wg sync.WaitGroup
@@ -99,6 +105,7 @@ func TestScanErrorsAdd(t *testing.T) {
 }
 
 func TestScanErrorsCount(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name        string
 		concurrency int
@@ -127,7 +134,9 @@ func TestScanErrorsCount(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			se := NewScanErrors()
 
 			var wg sync.WaitGroup
@@ -150,6 +159,7 @@ func TestScanErrorsCount(t *testing.T) {
 }
 
 func TestScanErrorsString(t *testing.T) {
+	t.Parallel()
 	se := NewScanErrors()
 	se.Add(nil)
 	want := "[<nil>]"

--- a/pkg/sources/gcs/gcs_manager_test.go
+++ b/pkg/sources/gcs/gcs_manager_test.go
@@ -1,11 +1,9 @@
 package gcs
 
 import (
-	"fmt"
 	"net/http"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -31,6 +29,7 @@ const (
 )
 
 func TestNewGcsManager(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -338,7 +337,9 @@ func TestNewGcsManager(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := newGCSManager(tc.projID, tc.opts...)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("newGCSManager() error = %v, wantErr %v", err, tc.wantErr)
@@ -365,6 +366,7 @@ func TestNewGcsManager(t *testing.T) {
 }
 
 func TestGCSManagerStats(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -414,7 +416,9 @@ func TestGCSManagerStats(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			gm, err := newGCSManager(tc.projectID, tc.opts...)
 			if err != nil {
 				t.Fatalf("newGCSManager() error = %v", err)
@@ -432,24 +436,8 @@ func TestGCSManagerStats(t *testing.T) {
 	}
 }
 
-func TestGCSManagerStats_Time(t *testing.T) {
-	ctx := context.Background()
-
-	opts := []gcsManagerOption{withDefaultADC(ctx)}
-	gm, err := newGCSManager(testProjectID, opts...)
-	if err != nil {
-		t.Fatalf("newGCSManager() error = %v", err)
-	}
-
-	start := time.Now()
-	var stats *attributes
-	stats, _ = gm.Attributes(ctx)
-	end := time.Since(start).Seconds()
-
-	fmt.Printf("Time taken to get %d objects: %f seconds\n", stats.numObjects, end)
-}
-
 func TestGCSManagerListObjects(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -686,7 +674,9 @@ func TestGCSManagerListObjects(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			mgr, err := newGCSManager(tc.projectID, tc.opts...)
 			assert.Nil(t, err)
 
@@ -738,6 +728,7 @@ func TestGCSManagerListObjects(t *testing.T) {
 }
 
 func TestGCSManagerListObjects_Resuming(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	testCases := []struct {
@@ -774,7 +765,9 @@ func TestGCSManagerListObjects_Resuming(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			mgr, err := newGCSManager(tc.projectID, tc.opts...)
 			assert.Nil(t, err)
 
@@ -826,6 +819,7 @@ func TestGCSManagerListObjects_Resuming(t *testing.T) {
 }
 
 func Test_isObjectTypeValid(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name    string
 		objName string
@@ -850,7 +844,9 @@ func Test_isObjectTypeValid(t *testing.T) {
 
 	ctx := context.Background()
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got := isObjectTypeValid(ctx, tc.objName)
 			assert.Equal(t, tc.want, got)
 		})
@@ -858,6 +854,7 @@ func Test_isObjectTypeValid(t *testing.T) {
 }
 
 func Test_isObjectSizeValid(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name    string
 		objSize int64
@@ -902,12 +899,15 @@ func Test_isObjectSizeValid(t *testing.T) {
 
 	ctx := context.Background()
 	for _, tc := range testCases {
-		g := &gcsManager{
-			maxObjectSize: maxObjectSizeLimit,
-		}
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			got := g.isObjectSizeValid(ctx, tc.objSize)
-			assert.Equal(t, tc.want, got)
+			t.Parallel()
+
+			g := &gcsManager{maxObjectSize: maxObjectSizeLimit}
+			t.Run(tc.name, func(t *testing.T) {
+				got := g.isObjectSizeValid(ctx, tc.objSize)
+				assert.Equal(t, tc.want, got)
+			})
 		})
 	}
 }

--- a/pkg/sources/gcs/gcs_test.go
+++ b/pkg/sources/gcs/gcs_test.go
@@ -32,6 +32,7 @@ func createTestSource(src *sourcespb.GCS) (*Source, *anypb.Any) {
 }
 
 func TestSourceInit(t *testing.T) {
+	t.Parallel()
 	source, conn := createTestSource(&sourcespb.GCS{
 		ProjectId: testProjectID,
 		IncludeBuckets: []string{
@@ -52,6 +53,7 @@ func TestSourceInit(t *testing.T) {
 }
 
 func TestConfigureGCSManager(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name    string
 		conn    *sourcespb.GCS
@@ -117,7 +119,9 @@ func TestConfigureGCSManager(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			got, err := configureGCSManager(ctx, tc.conn, 8)
 			if err != nil && !tc.wantErr {
@@ -137,6 +141,7 @@ func TestConfigureGCSManager(t *testing.T) {
 }
 
 func TestSourceOauth2Client(t *testing.T) {
+	t.Parallel()
 	testCases := []struct {
 		name    string
 		creds   *credentialspb.Oauth2
@@ -186,7 +191,9 @@ func TestSourceOauth2Client(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			ctx := context.Background()
 			got, err := oauth2Client(ctx, tc.creds)
 			if (err != nil) != tc.wantErr {
@@ -293,6 +300,7 @@ func createTestSourceChunk(id int) *sources.Chunk {
 }
 
 func TestSourceChunks_ListObjects(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	chunksCh := make(chan *sources.Chunk, 1)
 
@@ -343,6 +351,7 @@ func TestSourceChunks_ListObjects(t *testing.T) {
 }
 
 func TestSourceInit_Enumerate(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	source := &Source{gcsManager: &mockObjectManager{numObjects: 5}}
 
@@ -356,6 +365,7 @@ func TestSourceInit_Enumerate(t *testing.T) {
 }
 
 func TestSourceChunks_ListObjects_Error(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	source := &Source{gcsManager: &mockObjectManager{wantErr: true}}
 
@@ -367,6 +377,7 @@ func TestSourceChunks_ListObjects_Error(t *testing.T) {
 }
 
 func TestSourceChunks_ProgressSet(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	chunksCh := make(chan *sources.Chunk, 1)
 	source := &Source{
@@ -421,6 +432,7 @@ func TestSourceChunks_ProgressSet(t *testing.T) {
 }
 
 func TestSource_CachePersistence(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	wantObjCnt := 4 // ensure we have less objects than the cache increment

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func TestSource_Scan(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -122,10 +123,14 @@ func TestSource_Scan(t *testing.T) {
 			wantErr: false,
 		},
 	}
+
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			s := Source{}
 
+			ctx := context.Background()
 			conn, err := anypb.New(tt.init.connection)
 			if err != nil {
 				t.Fatal(err)
@@ -155,8 +160,7 @@ func TestSource_Scan(t *testing.T) {
 // We ran into an issue where upgrading a dependency caused the git patch chunking to break
 // So this test exists to make sure that when something changes, we know about it.
 func TestSource_Chunks_Integration(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	t.Parallel()
 	type init struct {
 		name       string
 		verify     bool
@@ -218,9 +222,14 @@ func TestSource_Chunks_Integration(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			s := Source{}
+
+			ctx := context.Background()
 
 			conn, err := anypb.New(tt.init.connection)
 			if err != nil {
@@ -272,6 +281,7 @@ func TestSource_Chunks_Integration(t *testing.T) {
 }
 
 func TestSource_Chunks_Edge_Cases(t *testing.T) {
+	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -360,9 +370,14 @@ func TestSource_Chunks_Edge_Cases(t *testing.T) {
 			},
 		},
 	}
+
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			s := Source{}
+
+			ctx := context.Background()
 
 			conn, err := anypb.New(tt.init.connection)
 			if err != nil {
@@ -390,6 +405,7 @@ func TestSource_Chunks_Edge_Cases(t *testing.T) {
 }
 
 func TestPrepareRepo(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		uri    string
 		path   bool
@@ -423,17 +439,21 @@ func TestPrepareRepo(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		ctx := context.Background()
-		repo, b, err := PrepareRepo(ctx, tt.uri)
-		var repoLen bool
-		if len(repo) > 0 {
-			repoLen = true
-		} else {
-			repoLen = false
-		}
-		if repoLen != tt.path || b != tt.remote {
-			t.Errorf("PrepareRepo(%v) got: %v, %v, %v want: %v, %v, %v", tt.uri, repo, b, err, tt.path, tt.remote, tt.err)
-		}
+		tt := tt
+		t.Run(tt.uri, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			repo, b, err := PrepareRepo(ctx, tt.uri)
+			var repoLen bool
+			if len(repo) > 0 {
+				repoLen = true
+			} else {
+				repoLen = false
+			}
+			if repoLen != tt.path || b != tt.remote {
+				t.Errorf("PrepareRepo(%v) got: %v, %v, %v want: %v, %v, %v", tt.uri, repo, b, err, tt.path, tt.remote, tt.err)
+			}
+		})
 	}
 }
 
@@ -446,6 +466,7 @@ func BenchmarkPrepareRepo(b *testing.B) {
 }
 
 func TestGitURLParse(t *testing.T) {
+	t.Parallel()
 	for _, tt := range []struct {
 		url      string
 		host     string

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestSource_Scan(t *testing.T) {
-	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -123,14 +122,10 @@ func TestSource_Scan(t *testing.T) {
 			wantErr: false,
 		},
 	}
-
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			s := Source{}
 
-			ctx := context.Background()
 			conn, err := anypb.New(tt.init.connection)
 			if err != nil {
 				t.Fatal(err)
@@ -160,7 +155,8 @@ func TestSource_Scan(t *testing.T) {
 // We ran into an issue where upgrading a dependency caused the git patch chunking to break
 // So this test exists to make sure that when something changes, we know about it.
 func TestSource_Chunks_Integration(t *testing.T) {
-	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	type init struct {
 		name       string
 		verify     bool
@@ -222,14 +218,9 @@ func TestSource_Chunks_Integration(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			s := Source{}
-
-			ctx := context.Background()
 
 			conn, err := anypb.New(tt.init.connection)
 			if err != nil {
@@ -281,7 +272,6 @@ func TestSource_Chunks_Integration(t *testing.T) {
 }
 
 func TestSource_Chunks_Edge_Cases(t *testing.T) {
-	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -370,14 +360,9 @@ func TestSource_Chunks_Edge_Cases(t *testing.T) {
 			},
 		},
 	}
-
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			s := Source{}
-
-			ctx := context.Background()
 
 			conn, err := anypb.New(tt.init.connection)
 			if err != nil {
@@ -405,7 +390,6 @@ func TestSource_Chunks_Edge_Cases(t *testing.T) {
 }
 
 func TestPrepareRepo(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		uri    string
 		path   bool
@@ -439,21 +423,17 @@ func TestPrepareRepo(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.uri, func(t *testing.T) {
-			t.Parallel()
-			ctx := context.Background()
-			repo, b, err := PrepareRepo(ctx, tt.uri)
-			var repoLen bool
-			if len(repo) > 0 {
-				repoLen = true
-			} else {
-				repoLen = false
-			}
-			if repoLen != tt.path || b != tt.remote {
-				t.Errorf("PrepareRepo(%v) got: %v, %v, %v want: %v, %v, %v", tt.uri, repo, b, err, tt.path, tt.remote, tt.err)
-			}
-		})
+		ctx := context.Background()
+		repo, b, err := PrepareRepo(ctx, tt.uri)
+		var repoLen bool
+		if len(repo) > 0 {
+			repoLen = true
+		} else {
+			repoLen = false
+		}
+		if repoLen != tt.path || b != tt.remote {
+			t.Errorf("PrepareRepo(%v) got: %v, %v, %v want: %v, %v, %v", tt.uri, repo, b, err, tt.path, tt.remote, tt.err)
+		}
 	}
 }
 
@@ -466,7 +446,6 @@ func BenchmarkPrepareRepo(b *testing.B) {
 }
 
 func TestGitURLParse(t *testing.T) {
-	t.Parallel()
 	for _, tt := range []struct {
 		url      string
 		host     string

--- a/pkg/sources/job_progress_test.go
+++ b/pkg/sources/job_progress_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestJobProgressFatalErrors(t *testing.T) {
+	t.Parallel()
 	var jp JobProgress
 
 	// Add a non-fatal error.
@@ -36,6 +37,7 @@ func TestJobProgressFatalErrors(t *testing.T) {
 }
 
 func TestJobProgressRef(t *testing.T) {
+	t.Parallel()
 	jp := NewJobProgress(123, 456, "source name")
 	ref := jp.Ref()
 	assert.Equal(t, JobID(123), ref.JobID)
@@ -57,6 +59,7 @@ func TestJobProgressRef(t *testing.T) {
 }
 
 func TestJobProgressHook(t *testing.T) {
+	t.Parallel()
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -108,6 +111,7 @@ func TestJobProgressHook(t *testing.T) {
 }
 
 func TestJobProgressDone(t *testing.T) {
+	t.Parallel()
 	ref := JobProgressRef{}
 	select {
 	case <-ref.Done():
@@ -117,6 +121,7 @@ func TestJobProgressDone(t *testing.T) {
 }
 
 func TestJobProgressElapsedTime(t *testing.T) {
+	t.Parallel()
 	metrics := JobProgressMetrics{}
 	assert.Equal(t, time.Duration(0), metrics.ElapsedTime())
 
@@ -130,6 +135,7 @@ func TestJobProgressElapsedTime(t *testing.T) {
 }
 
 func TestJobProgressErrorsFor(t *testing.T) {
+	t.Parallel()
 	metrics := JobProgressMetrics{
 		Errors: []error{
 			Fatal{ChunkError{

--- a/pkg/sources/resume_test.go
+++ b/pkg/sources/resume_test.go
@@ -6,6 +6,7 @@ import (
 )
 
 func TestRemoveRepoFromResumeInfo(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		startingResumeInfoSlice []string
 		repoURL                 string
@@ -29,14 +30,20 @@ func TestRemoveRepoFromResumeInfo(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		gotResumeInfoSlice := RemoveRepoFromResumeInfo(tt.startingResumeInfoSlice, tt.repoURL)
-		if !reflect.DeepEqual(gotResumeInfoSlice, tt.wantResumeInfoSlice) {
-			t.Errorf("RemoveRepoFromResumeInfo() got: %v, want: %v", gotResumeInfoSlice, tt.wantResumeInfoSlice)
-		}
+		tt := tt
+		t.Run(tt.repoURL, func(t *testing.T) {
+			t.Parallel()
+
+			gotResumeInfoSlice := RemoveRepoFromResumeInfo(tt.startingResumeInfoSlice, tt.repoURL)
+			if !reflect.DeepEqual(gotResumeInfoSlice, tt.wantResumeInfoSlice) {
+				t.Errorf("RemoveRepoFromResumeInfo() got: %v, want: %v", gotResumeInfoSlice, tt.wantResumeInfoSlice)
+			}
+		})
 	}
 }
 
 func TestEncodeResumeInfo(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		startingResumeInfoSlice []string
 		wantEncodedResumeInfo   string
@@ -52,14 +59,20 @@ func TestEncodeResumeInfo(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		gotEncodedResumeInfo := EncodeResumeInfo(tt.startingResumeInfoSlice)
-		if gotEncodedResumeInfo != tt.wantEncodedResumeInfo {
-			t.Errorf("EncodeResumeInfo() got: %q, want: %q", gotEncodedResumeInfo, tt.wantEncodedResumeInfo)
-		}
+		tt := tt
+		t.Run(tt.wantEncodedResumeInfo, func(t *testing.T) {
+			t.Parallel()
+
+			gotEncodedResumeInfo := EncodeResumeInfo(tt.startingResumeInfoSlice)
+			if gotEncodedResumeInfo != tt.wantEncodedResumeInfo {
+				t.Errorf("EncodeResumeInfo() got: %q, want: %q", gotEncodedResumeInfo, tt.wantEncodedResumeInfo)
+			}
+		})
 	}
 }
 
 func Test_decodeResumeInfo(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		resumeInfo          string
 		wantResumeInfoSlice []string
@@ -75,14 +88,19 @@ func Test_decodeResumeInfo(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		gotResumeInfoSlice := DecodeResumeInfo(tt.resumeInfo)
-		if !reflect.DeepEqual(gotResumeInfoSlice, tt.wantResumeInfoSlice) {
-			t.Errorf("DecodeResumeInfo() got: %v, want: %v", gotResumeInfoSlice, tt.wantResumeInfoSlice)
-		}
+		tt := tt
+		t.Run(tt.resumeInfo, func(t *testing.T) {
+			t.Parallel()
+			gotResumeInfoSlice := DecodeResumeInfo(tt.resumeInfo)
+			if !reflect.DeepEqual(gotResumeInfoSlice, tt.wantResumeInfoSlice) {
+				t.Errorf("DecodeResumeInfo() got: %v, want: %v", gotResumeInfoSlice, tt.wantResumeInfoSlice)
+			}
+		})
 	}
 }
 
 func Test_filterReposToResume(t *testing.T) {
+	t.Parallel()
 	startingRepos := []string{"a", "b", "c", "d", "e", "f", "g"}
 
 	tests := map[string]struct {
@@ -123,12 +141,16 @@ func Test_filterReposToResume(t *testing.T) {
 	}
 
 	for name, tt := range tests {
-		gotReposToScan, gotProgressOffsetCount := FilterReposToResume(startingRepos, tt.resumeInfo)
-		if !reflect.DeepEqual(gotReposToScan, tt.wantReposToScan) {
-			t.Errorf("FilterReposToResume() name: %q got: %v, want: %v", name, gotReposToScan, tt.wantReposToScan)
-		}
-		if gotProgressOffsetCount != tt.wantProgressOffsetCount {
-			t.Errorf("FilterReposToResume() name: %q got: %d, want: %d", name, gotProgressOffsetCount, tt.wantProgressOffsetCount)
-		}
+		name, tt := name, tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			gotReposToScan, gotProgressOffsetCount := FilterReposToResume(startingRepos, tt.resumeInfo)
+			if !reflect.DeepEqual(gotReposToScan, tt.wantReposToScan) {
+				t.Errorf("FilterReposToResume() name: %q got: %v, want: %v", name, gotReposToScan, tt.wantReposToScan)
+			}
+			if gotProgressOffsetCount != tt.wantProgressOffsetCount {
+				t.Errorf("FilterReposToResume() name: %q got: %d, want: %d", name, gotProgressOffsetCount, tt.wantProgressOffsetCount)
+			}
+		})
 	}
 }

--- a/pkg/sources/s3/s3_test.go
+++ b/pkg/sources/s3/s3_test.go
@@ -10,15 +10,19 @@ import (
 
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/anypb"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/credentialspb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
-func TestSource_Chunks(t *testing.T) {
+// NOTE: These are non-table driven tests because you can't set environment variables in a parallel subtest.
+
+func TestSourceGetChunks(t *testing.T) {
+	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
 
@@ -30,93 +34,106 @@ func TestSource_Chunks(t *testing.T) {
 	s3key := secret.MustGetField("AWS_S3_KEY")
 	s3secret := secret.MustGetField("AWS_S3_SECRET")
 
-	type init struct {
-		name       string
-		verify     bool
-		connection *sourcespb.S3
-		setEnv     map[string]string
-	}
-	tests := []struct {
-		name          string
-		init          init
-		wantErr       bool
-		wantChunkData string
-	}{
-		{
-			name: "gets chunks",
-			init: init{
-				connection: &sourcespb.S3{
-					Credential: &sourcespb.S3_AccessKey{
-						AccessKey: &credentialspb.KeySecret{
-							Key:    s3key,
-							Secret: s3secret,
-						},
-					},
-					Buckets: []string{"truffletestbucket-s3-tests"},
-				},
+	s := Source{}
+	connection := &sourcespb.S3{
+		Credential: &sourcespb.S3_AccessKey{
+			AccessKey: &credentialspb.KeySecret{
+				Key:    s3key,
+				Secret: s3secret,
 			},
-			wantErr:       false,
-			wantChunkData: `W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkID0gQUtJQTM1T0hYMkRTT1pHNjQ3TkgKYXdzX3NlY3JldF9hY2Nlc3Nfa2V5ID0gUXk5OVMrWkIvQ1dsRk50eFBBaWQ3Z0d6dnNyWGhCQjd1ckFDQUxwWgpvdXRwdXQgPSBqc29uCnJlZ2lvbiA9IHVzLWVhc3QtMg==`,
 		},
-		{
-			name: "gets chunks after assuming role",
-			// This test will attempt to scan every bucket in the account, but the role policy blocks access to every
-			// bucket except the one we want. This (expected behavior) causes errors in the test log output, but these
-			// errors shouldn't actually cause test failures.
-			init: init{
-				connection: &sourcespb.S3{
-					Roles: []string{"arn:aws:iam::619888638459:role/s3-test-assume-role"},
-				},
-				setEnv: map[string]string{
-					"AWS_ACCESS_KEY_ID":     s3key,
-					"AWS_SECRET_ACCESS_KEY": s3secret,
-				},
-			},
-			wantErr:       false,
-			wantChunkData: `W2RlZmF1bHRdCmF3c19zZWNyZXRfYWNjZXNzX2tleSA9IFF5OTlTK1pCL0NXbEZOdHhQQWlkN2dHenZzclhoQkI3dXJBQ0FMcFoKYXdzX2FjY2Vzc19rZXlfaWQgPSBBS0lBMzVPSFgyRFNPWkc2NDdOSApvdXRwdXQgPSBqc29uCnJlZ2lvbiA9IHVzLWVhc3QtMg==`,
-		},
+		Buckets: []string{"truffletestbucket-s3-tests"},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
-			var cancelOnce sync.Once
-			defer cancelOnce.Do(cancel)
-
-			for k, v := range tt.init.setEnv {
-				t.Setenv(k, v)
-			}
-
-			s := Source{}
-			conn, err := anypb.New(tt.init.connection)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, 8)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Source.Init() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			chunksCh := make(chan *sources.Chunk)
-			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				err = s.Chunks(ctx, chunksCh)
-				if (err != nil) != tt.wantErr {
-					t.Errorf("Source.Chunks() error = %v, wantErr %v", err, tt.wantErr)
-					os.Exit(1)
-				}
-			}()
-			gotChunk := <-chunksCh
-			wantData, _ := base64.StdEncoding.DecodeString(tt.wantChunkData)
-
-			if diff := pretty.Compare(gotChunk.Data, wantData); diff != "" {
-				t.Errorf("%s: Source.Chunks() diff: (-got +want)\n%s", tt.name, diff)
-			}
-			wg.Wait()
-			assert.Equal(t, "", s.GetProgress().EncodedResumeInfo)
-			assert.Equal(t, int64(100), s.GetProgress().PercentComplete)
-		})
+	conn, err := anypb.New(connection)
+	if err != nil {
+		t.Fatal(err)
 	}
+
+	err = s.Init(ctx, "gets chunks", 0, 0, true, conn, 8)
+	if err != nil {
+		t.Errorf("Source.Init() error = %v", err)
+		return
+	}
+
+	chunksCh := make(chan *sources.Chunk)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err = s.Chunks(ctx, chunksCh)
+		if err != nil {
+			t.Errorf("Source.Chunks() error = %v", err)
+			os.Exit(1)
+		}
+	}()
+
+	gotChunk := <-chunksCh
+	wantChunkData := `W2RlZmF1bHRdCmF3c19hY2Nlc3Nfa2V5X2lkID0gQUtJQTM1T0hYMkRTT1pHNjQ3TkgKYXdzX3NlY3JldF9hY2Nlc3Nfa2V5ID0gUXk5OVMrWkIvQ1dsRk50eFBBaWQ3Z0d6dnNyWGhCQjd1ckFDQUxwWgpvdXRwdXQgPSBqc29uCnJlZ2lvbiA9IHVzLWVhc3QtMg==`
+	wantData, _ := base64.StdEncoding.DecodeString(wantChunkData)
+
+	if diff := pretty.Compare(gotChunk.Data, wantData); diff != "" {
+		t.Errorf("Source.Chunks() diff: (-got +want)\n%s", diff)
+	}
+
+	wg.Wait()
+	assert.Equal(t, "", s.GetProgress().EncodedResumeInfo)
+	assert.Equal(t, int64(100), s.GetProgress().PercentComplete)
+}
+
+func TestSourceGetChunksAfterAssumingRole(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	secret, err := common.GetTestSecret(ctx)
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to access secret: %v", err))
+	}
+
+	s3key := secret.MustGetField("AWS_S3_KEY")
+	s3secret := secret.MustGetField("AWS_S3_SECRET")
+
+	os.Setenv("AWS_ACCESS_KEY_ID", s3key)
+	os.Setenv("AWS_SECRET_ACCESS_KEY", s3secret)
+	defer os.Unsetenv("AWS_ACCESS_KEY_ID")
+	defer os.Unsetenv("AWS_SECRET_ACCESS_KEY")
+
+	s := Source{}
+	connection := &sourcespb.S3{
+		Roles: []string{"arn:aws:iam::619888638459:role/s3-test-assume-role"},
+	}
+	conn, err := anypb.New(connection)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = s.Init(ctx, "gets chunks after assuming role", 0, 0, true, conn, 8)
+	if err != nil {
+		t.Errorf("Source.Init() error = %v", err)
+		return
+	}
+
+	chunksCh := make(chan *sources.Chunk)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err = s.Chunks(ctx, chunksCh)
+		if err != nil {
+			t.Errorf("Source.Chunks() error = %v", err)
+			os.Exit(1)
+		}
+	}()
+
+	gotChunk := <-chunksCh
+	wantChunkData := `W2RlZmF1bHRdCmF3c19zZWNyZXRfYWNjZXNzX2tleSA9IFF5OTlTK1pCL0NXbEZOdHhQQWlkN2dHenZzclhoQkI3dXJBQ0FMcFoKYXdzX2FjY2Vzc19rZXlfaWQgPSBBS0lBMzVPSFgyRFNPWkc2NDdOSApvdXRwdXQgPSBqc29uCnJlZ2lvbiA9IHVzLWVhc3QtMg==`
+	wantData, _ := base64.StdEncoding.DecodeString(wantChunkData)
+
+	if diff := pretty.Compare(gotChunk.Data, wantData); diff != "" {
+		t.Errorf("Source.Chunks() diff: (-got +want)\n%s", diff)
+	}
+
+	wg.Wait()
+	assert.Equal(t, "", s.GetProgress().EncodedResumeInfo)
+	assert.Equal(t, int64(100), s.GetProgress().PercentComplete)
 }

--- a/pkg/sources/source_manager_test.go
+++ b/pkg/sources/source_manager_test.go
@@ -103,6 +103,7 @@ func tryRead(ch <-chan *Chunk) (*Chunk, error) {
 }
 
 func TestSourceManagerRun(t *testing.T) {
+	t.Parallel()
 	mgr := NewManager(WithBufferedOutput(8))
 	source, err := buildDummy(&counterChunker{count: 1})
 	assert.NoError(t, err)
@@ -121,6 +122,7 @@ func TestSourceManagerRun(t *testing.T) {
 }
 
 func TestSourceManagerWait(t *testing.T) {
+	t.Parallel()
 	mgr := NewManager()
 	source, err := buildDummy(&counterChunker{count: 1})
 	assert.NoError(t, err)
@@ -139,6 +141,7 @@ func TestSourceManagerWait(t *testing.T) {
 }
 
 func TestSourceManagerError(t *testing.T) {
+	t.Parallel()
 	mgr := NewManager()
 	source, err := buildDummy(errorChunker{fmt.Errorf("oops")})
 	assert.NoError(t, err)
@@ -150,6 +153,7 @@ func TestSourceManagerError(t *testing.T) {
 }
 
 func TestSourceManagerReport(t *testing.T) {
+	t.Parallel()
 	for _, opts := range [][]func(*SourceManager){
 		{WithBufferedOutput(8)},
 		{WithBufferedOutput(8), WithSourceUnits()},
@@ -214,6 +218,7 @@ func (c *unitChunker) ChunkUnit(ctx context.Context, unit SourceUnit, rep ChunkR
 }
 
 func TestSourceManagerNonFatalError(t *testing.T) {
+	t.Parallel()
 	input := []unitChunk{
 		{unit: "one", output: "bar"},
 		{unit: "two", err: "oh no"},
@@ -234,6 +239,7 @@ func TestSourceManagerNonFatalError(t *testing.T) {
 }
 
 func TestSourceManagerContextCancelled(t *testing.T) {
+	t.Parallel()
 	mgr := NewManager(WithBufferedOutput(8))
 	source, err := buildDummy(&counterChunker{count: 100})
 	assert.NoError(t, err)
@@ -273,6 +279,7 @@ func (c callbackChunker) Enumerate(context.Context, UnitReporter) error         
 func (c callbackChunker) ChunkUnit(context.Context, SourceUnit, ChunkReporter) error { return nil }
 
 func TestSourceManagerCancelRun(t *testing.T) {
+	t.Parallel()
 	mgr := NewManager(WithBufferedOutput(8))
 	var returnedErr error
 	source, err := buildDummy(callbackChunker{func(ctx context.Context, _ chan *Chunk) error {
@@ -295,6 +302,7 @@ func TestSourceManagerCancelRun(t *testing.T) {
 }
 
 func TestSourceManagerAvailableCapacity(t *testing.T) {
+	t.Parallel()
 	mgr := NewManager(WithConcurrentSources(1337))
 	start, end := make(chan struct{}), make(chan struct{})
 	source, err := buildDummy(callbackChunker{func(context.Context, chan *Chunk) error {
@@ -316,6 +324,7 @@ func TestSourceManagerAvailableCapacity(t *testing.T) {
 }
 
 func TestSourceManagerUnitHook(t *testing.T) {
+	t.Parallel()
 	hook := NewUnitHook(context.TODO())
 
 	input := []unitChunk{
@@ -369,6 +378,7 @@ func TestSourceManagerUnitHook(t *testing.T) {
 // TestSourceManagerUnitHookNoBlock tests that the UnitHook drops metrics if
 // they aren't handled fast enough.
 func TestSourceManagerUnitHookNoBlock(t *testing.T) {
+	t.Parallel()
 	var evictedKeys []string
 	cache, _ := lru.NewWithEvict(1, func(key string, _ *UnitMetrics) {
 		evictedKeys = append(evictedKeys, key)
@@ -400,6 +410,7 @@ func TestSourceManagerUnitHookNoBlock(t *testing.T) {
 // TestSourceManagerUnitHookNoUnits tests whether the UnitHook works for
 // sources that don't support units.
 func TestSourceManagerUnitHookNoUnits(t *testing.T) {
+	t.Parallel()
 	hook := NewUnitHook(context.TODO())
 
 	mgr := NewManager(

--- a/pkg/sources/travisci/travisci_test.go
+++ b/pkg/sources/travisci/travisci_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestSource_Scan(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 
 	secret, err := common.GetTestSecret(ctx)
@@ -60,9 +61,14 @@ func TestSource_Scan(t *testing.T) {
 			wantErr: false,
 		},
 	}
+
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			s := Source{}
+
+			ctx := context.Background()
 
 			conn, err := anypb.New(tt.init.connection)
 			if err != nil {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Use parallel tests. Reduces test time from ~1m30s to 40s.

NOTE: Gitlab tests can't currently run in parallel due to account lockout. Might be worth adding the integration build tag to those tests.

![Screenshot 2024-01-20 at 3 13 50 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/3c14e47b-ad7b-4db7-bac8-839e15a538dc)
![Screenshot 2024-01-21 at 2 15 03 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/956ec6ba-5762-4a46-9357-e032387ea840)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

