### PR TITLE
fix for incorrect AWS account number identification

### DIFF
--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -61,6 +61,9 @@ func GetAccountNumFromAWSID(AWSID string) (string, error) {
 	if len(AWSID) < 4 {
 		return "", fmt.Errorf("AWSID is too short")
 	}
+	if AWSID[4] == 'I' || AWSID[4] == 'J' {
+		return "", fmt.Errorf("Can't get account number from AKIAJ/ASIAJ or AKIAI/ASIAI keys")
+	}
 	trimmedAWSID := AWSID[4:]
 	decodedBytes, err := base32.StdEncoding.WithPadding(base32.NoPadding).DecodeString(strings.ToUpper(trimmedAWSID))
 	if err != nil {


### PR DESCRIPTION
### Description:
This fix addresses #2305. Specifically, this PR adds a check for "I" or "J" as the 5th character in an AWS account ID string. During additional testing, all `AKIA*` prefixed account keys appeared to return valid account numbers from the `GetAccountNumFromAWSID` function except for `AKIAI` and `AKIAJ`. 

The verified tested values include:
```
AKIA2
AKIA3
AKIA4
AKIA5
AKIA6
AKIAQ
AKIAR
AKIAS
AKIAT
AKIAU
AKIAV
AKIAW
AKIAX
AKIAY
AKIAZ
```

If we figure out a new way to address the gap in not reporting `AKIAI*` and `AKIAJ*` access key IDs for unverified AWS keys, we'll update this logic.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

