### PR TITLE
updates to plain and json printing to include verification error

### DIFF
--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -17,6 +17,13 @@ import (
 type JSONPrinter struct{ mu sync.Mutex }
 
 func (p *JSONPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) error {
+	verificationErr := func(err error) string {
+		if err != nil {
+			return err.Error()
+		}
+		return ""
+	}(r.VerificationError())
+
 	v := &struct {
 		// SourceMetadata contains source-specific contextual information.
 		SourceMetadata *source_metadatapb.MetaData
@@ -31,8 +38,9 @@ func (p *JSONPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) 
 		// DetectorName is the string name of the DetectorType.
 		DetectorName string
 		// DecoderName is the string name of the DecoderType.
-		DecoderName string
-		Verified    bool
+		DecoderName       string
+		Verified          bool
+		VerificationError string `json:",omitempty"`
 		// Raw contains the raw secret data.
 		Raw string
 		// RawV2 contains the raw secret identifier that is a combination of both the ID and the secret.
@@ -44,19 +52,20 @@ func (p *JSONPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) 
 		ExtraData      map[string]string
 		StructuredData *detectorspb.StructuredData
 	}{
-		SourceMetadata: r.SourceMetadata,
-		SourceID:       r.SourceID,
-		SourceType:     r.SourceType,
-		SourceName:     r.SourceName,
-		DetectorType:   r.DetectorType,
-		DetectorName:   r.DetectorType.String(),
-		DecoderName:    r.DecoderType.String(),
-		Verified:       r.Verified,
-		Raw:            string(r.Raw),
-		RawV2:          string(r.RawV2),
-		Redacted:       r.Redacted,
-		ExtraData:      r.ExtraData,
-		StructuredData: r.StructuredData,
+		SourceMetadata:    r.SourceMetadata,
+		SourceID:          r.SourceID,
+		SourceType:        r.SourceType,
+		SourceName:        r.SourceName,
+		DetectorType:      r.DetectorType,
+		DetectorName:      r.DetectorType.String(),
+		DecoderName:       r.DecoderType.String(),
+		Verified:          r.Verified,
+		VerificationError: verificationErr,
+		Raw:               string(r.Raw),
+		RawV2:             string(r.RawV2),
+		Redacted:          r.Redacted,
+		ExtraData:         r.ExtraData,
+		StructuredData:    r.StructuredData,
 	}
 	out, err := json.Marshal(v)
 	if err != nil {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Same as this [PR](https://github.com/trufflesecurity/trufflehog/pull/2107) but only printer changes

Update plaintext logging to include verification error


#### Current Output
<img width="865" alt="image" src="https://github.com/trufflesecurity/trufflehog/assets/13666360/102301cd-6a2d-4b12-bf7e-8c7bdc6261ea">

#### Updated Output
<img width="1386" alt="image" src="https://github.com/trufflesecurity/trufflehog/assets/13666360/2035ad74-1702-4a0d-a623-4341910f6ecd">

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

