### PR TITLE
Add Personio detector

### DIFF
--- a/pkg/detectors/personio/personio.go
+++ b/pkg/detectors/personio/personio.go
@@ -1,0 +1,89 @@
+package personio
+
+import (
+	"context"
+	"fmt"
+	regexp "github.com/wasilibs/go-re2"
+	"net/http"
+	"strings"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+type Scanner struct {
+	client *http.Client
+}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	defaultClient = common.SaneHttpClient()
+	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"personio"}) + `\b([0-9a-zA-Z]{23}_[0-9a-zA-Z]{8})\b`)
+)
+
+// Keywords are used for efficiently pre-filtering chunks.
+// Use identifiers in the secret preferably, or the provider name.
+func (s Scanner) Keywords() []string {
+	return []string{"personio"}
+}
+
+// FromData will find and optionally verify Personio secrets in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
+
+	for _, match := range matches {
+		if len(match) != 2 {
+			continue
+		}
+		resMatch := strings.TrimSpace(match[1])
+
+		s1 := detectors.Result{
+			DetectorType: detectorspb.DetectorType_Personio,
+			Raw:          []byte(resMatch),
+		}
+
+		if verify {
+			client := s.client
+			if client == nil {
+				client = defaultClient
+			}
+			req, err := http.NewRequestWithContext(ctx, "GET", "https://eth-mainnet.g.personio.com/v2/"+resMatch+"/getNFTs/?owner=vitalik.eth", nil)
+			if err != nil {
+				continue
+			}
+			res, err := client.Do(req)
+			if err == nil {
+				defer res.Body.Close()
+				if res.StatusCode >= 200 && res.StatusCode < 300 {
+					s1.Verified = true
+				} else if res.StatusCode == 401 {
+					// The secret is determinately not verified (nothing to do)
+				} else {
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
+				}
+			} else {
+				s1.SetVerificationError(err, resMatch)
+			}
+		}
+
+		// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
+		if !s1.Verified && detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
+			continue
+		}
+
+		results = append(results, s1)
+	}
+
+	return results, nil
+}
+
+func (s Scanner) Type() detectorspb.DetectorType {
+	return detectorspb.DetectorType_Personio
+}

--- a/pkg/detectors/personio/personio_test.go
+++ b/pkg/detectors/personio/personio_test.go
@@ -26,8 +26,8 @@ func TestPersonio_FromChunk(t *testing.T) {
 		t.Fatalf("could not get test secrets from GCP: %s", err)
 	}
 	secret := testSecrets.MustGetField("PERSONIOID")
-	secret := testSecrets.MustGetField("PERSONIOKEY")
-	inactiveSecret := testSecrets.MustGetField("PERSONIO_INACTIVE")
+	key := testSecrets.MustGetField("PERSONIOKEY")
+	inactiveSecret := testSecrets.MustGetField("PERSONIOKEY_INACTIVE")
 
 	type args struct {
 		ctx    context.Context

--- a/pkg/detectors/personio/personio_test.go
+++ b/pkg/detectors/personio/personio_test.go
@@ -25,7 +25,8 @@ func TestPersonio_FromChunk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get test secrets from GCP: %s", err)
 	}
-	secret := testSecrets.MustGetField("PERSONIO")
+	secret := testSecrets.MustGetField("PERSONIOID")
+	secret := testSecrets.MustGetField("PERSONIOKEY")
 	inactiveSecret := testSecrets.MustGetField("PERSONIO_INACTIVE")
 
 	type args struct {
@@ -46,7 +47,7 @@ func TestPersonio_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a personio secret %s within", secret)),
+				data:   []byte(fmt.Sprintf("You can find a Personio secret %s within for API key ID %s", secret, key)),
 				verify: true,
 			},
 			want: []detectors.Result{
@@ -63,7 +64,7 @@ func TestPersonio_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a personio secret %s within but not valid", inactiveSecret)), // the secret would satisfy the regex but not pass validation
+				data:   []byte(fmt.Sprintf("You can find a Personio secret %s within for API key ID %s but not valid", inactiveSecret, key)), // the secret would satisfy the regex but not pass validation
 				verify: true,
 			},
 			want: []detectors.Result{
@@ -92,7 +93,7 @@ func TestPersonio_FromChunk(t *testing.T) {
 			s:    Scanner{client: common.SaneHttpClientTimeOut(1 * time.Microsecond)},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a personio secret %s within", secret)),
+				data:   []byte(fmt.Sprintf("You can find a Personio secret %s within for API key ID %s", secret, key)),
 				verify: true,
 			},
 			want: []detectors.Result{
@@ -109,7 +110,7 @@ func TestPersonio_FromChunk(t *testing.T) {
 			s:    Scanner{client: common.ConstantResponseHttpClient(404, "")},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a personio secret %s within", secret)),
+				data:   []byte(fmt.Sprintf("You can find a Personio secret %s within for API key ID %s", secret, key)),
 				verify: true,
 			},
 			want: []detectors.Result{

--- a/pkg/detectors/personio/personio_test.go
+++ b/pkg/detectors/personio/personio_test.go
@@ -1,0 +1,162 @@
+//go:build detectors
+// +build detectors
+
+package personio
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+func TestPersonio_FromChunk(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors5")
+	if err != nil {
+		t.Fatalf("could not get test secrets from GCP: %s", err)
+	}
+	secret := testSecrets.MustGetField("PERSONIO")
+	inactiveSecret := testSecrets.MustGetField("PERSONIO_INACTIVE")
+
+	type args struct {
+		ctx    context.Context
+		data   []byte
+		verify bool
+	}
+	tests := []struct {
+		name                string
+		s                   Scanner
+		args                args
+		want                []detectors.Result
+		wantErr             bool
+		wantVerificationErr bool
+	}{
+		{
+			name: "found, verified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a personio secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Personio,
+					Verified:     true,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "found, unverified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a personio secret %s within but not valid", inactiveSecret)), // the secret would satisfy the regex but not pass validation
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Personio,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "not found",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte("You cannot find the secret within"),
+				verify: true,
+			},
+			want:                nil,
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "found, would be verified if not for timeout",
+			s:    Scanner{client: common.SaneHttpClientTimeOut(1 * time.Microsecond)},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a personio secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Personio,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+		{
+			name: "found, verified but unexpected api surface",
+			s:    Scanner{client: common.ConstantResponseHttpClient(404, "")},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a personio secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Personio,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Personio.FromData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if len(got[i].Raw) == 0 {
+					t.Fatalf("no raw secret present: \n %+v", got[i])
+				}
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
+				}
+			}
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
+			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
+				t.Errorf("Personio.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			}
+		})
+	}
+}
+
+func BenchmarkFromData(benchmark *testing.B) {
+	ctx := context.Background()
+	s := Scanner{}
+	for name, data := range detectors.MustGetBenchmarkData() {
+		benchmark.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				_, err := s.FromData(ctx, false, data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/detectors/personio/personio_test.go
+++ b/pkg/detectors/personio/personio_test.go
@@ -25,8 +25,8 @@ func TestPersonio_FromChunk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get test secrets from GCP: %s", err)
 	}
-	secret := testSecrets.MustGetField("PERSONIOID")
-	key := testSecrets.MustGetField("PERSONIOKEY")
+	secret := testSecrets.MustGetField("PERSONIOKEY")
+	keyId := testSecrets.MustGetField("PERSONIOID")
 	inactiveSecret := testSecrets.MustGetField("PERSONIOKEY_INACTIVE")
 
 	type args struct {
@@ -47,7 +47,7 @@ func TestPersonio_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a Personio secret %s within for API key ID %s", secret, key)),
+				data:   []byte(fmt.Sprintf("You can find a Personio secret %s within for API key ID %s", secret, keyId)),
 				verify: true,
 			},
 			want: []detectors.Result{
@@ -64,7 +64,7 @@ func TestPersonio_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a Personio secret %s within for API key ID %s but not valid", inactiveSecret, key)), // the secret would satisfy the regex but not pass validation
+				data:   []byte(fmt.Sprintf("You can find a Personio secret %s within for API key ID %s but not valid", inactiveSecret, keyId)), // the secret would satisfy the regex but not pass validation
 				verify: true,
 			},
 			want: []detectors.Result{
@@ -93,7 +93,7 @@ func TestPersonio_FromChunk(t *testing.T) {
 			s:    Scanner{client: common.SaneHttpClientTimeOut(1 * time.Microsecond)},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a Personio secret %s within for API key ID %s", secret, key)),
+				data:   []byte(fmt.Sprintf("You can find a Personio secret %s within for API key ID %s", secret, keyId)),
 				verify: true,
 			},
 			want: []detectors.Result{
@@ -110,7 +110,7 @@ func TestPersonio_FromChunk(t *testing.T) {
 			s:    Scanner{client: common.ConstantResponseHttpClient(404, "")},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a Personio secret %s within for API key ID %s", secret, key)),
+				data:   []byte(fmt.Sprintf("You can find a Personio secret %s within for API key ID %s", secret, keyId)),
 				verify: true,
 			},
 			want: []detectors.Result{

--- a/proto/detectors.proto
+++ b/proto/detectors.proto
@@ -1035,6 +1035,7 @@ enum DetectorType {
   XAI = 1023;
   AzureDirectManagementKey = 1024;
   AzureAppConfigConnectionString = 1025;
+  Personio = 1026;
 }
 
 message Result {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This test adds support for Personio (<https://personio.com>), an HR tool containing sensitive data where a leaked key could have enormous impact. The provider expects two components, a GUID prefixed with `papi-` as well as a 48 character string prefixed with `papi-`. While API keys can be scoped to specific fields, what we can test is the authentication, which returns a bearer token. Regardless of the key's scopes the authentication will work if the credentials are still valid.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

