### PR TITLE
Update the template detector

### DIFF
--- a/hack/generate/generate.go
+++ b/hack/generate/generate.go
@@ -85,8 +85,10 @@ func mustWriteTemplates(jobs []templateJob) {
 		tmplRaw := string(tmplBytes)
 
 		for _, rplString := range job.ReplaceString {
+			rplTitle := cases.Title(language.AmericanEnglish).String(rplString)
+			tmplRaw = strings.ReplaceAll(tmplRaw, "DetectorType_"+rplTitle, "DetectorType_<<.Name>>")
 			tmplRaw = strings.ReplaceAll(tmplRaw, strings.ToLower(rplString), "<<.NameLower>>")
-			tmplRaw = strings.ReplaceAll(tmplRaw, cases.Title(language.AmericanEnglish).String(rplString), "<<.NameTitle>>")
+			tmplRaw = strings.ReplaceAll(tmplRaw, rplTitle, "<<.NameTitle>>")
 			tmplRaw = strings.ReplaceAll(tmplRaw, strings.ToUpper(rplString), "<<.NameUpper>>")
 		}
 
@@ -98,6 +100,7 @@ func mustWriteTemplates(jobs []templateJob) {
 			log.Fatal(err)
 		}
 		err = tmpl.Execute(f, templateData{
+			Name:      *name,
 			NameTitle: nameTitle,
 			NameLower: nameLower,
 			NameUpper: nameUpper,
@@ -109,6 +112,7 @@ func mustWriteTemplates(jobs []templateJob) {
 }
 
 type templateData struct {
+	Name      string
 	NameTitle string
 	NameLower string
 	NameUpper string

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -12,11 +12,70 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
-
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
+
+func TestAlchemy_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "typical pattern",
+			input: "alchemy_token = '3aBcDFE5678901234567890_1a2b3c4d'",
+			want:  []string{"3aBcDFE5678901234567890_1a2b3c4d"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			chunkSpecificDetectors := make(map[ahocorasick.DetectorKey]detectors.Detector, 2)
+			ahoCorasickCore.PopulateMatchingDetectors(test.input, chunkSpecificDetectors)
+			if len(chunkSpecificDetectors) == 0 {
+				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			if err != nil {
+				t.Errorf("error = %v", err)
+				return
+			}
+
+			if len(results) != len(test.want) {
+				if len(results) == 0 {
+					t.Errorf("did not receive result")
+				} else {
+					t.Errorf("expected %d results, only received %d", len(test.want), len(results))
+				}
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.RawV2) > 0 {
+					actual[string(r.RawV2)] = struct{}{}
+				} else {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}
 
 func TestAlchemy_FromChunk(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)

--- a/pkg/engine/ahocorasick/ahocorasickcore.go
+++ b/pkg/engine/ahocorasick/ahocorasickcore.go
@@ -1,9 +1,10 @@
-package engine
+package ahocorasick
 
 import (
 	"strings"
 
 	ahocorasick "github.com/BobuSumisu/aho-corasick"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/custom_detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"

--- a/pkg/engine/ahocorasick/ahocorasickcore_test.go
+++ b/pkg/engine/ahocorasick/ahocorasickcore_test.go
@@ -1,10 +1,11 @@
-package engine
+package ahocorasick
 
 import (
 	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/custom_detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/custom_detectorspb"

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -17,6 +17,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/decoders"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/giturl"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/output"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
@@ -65,7 +66,7 @@ type Engine struct {
 	printAvgDetectorTime bool
 
 	// ahoCorasickHandler manages the Aho-Corasick trie and related keyword lookups.
-	ahoCorasickCore *AhoCorasickCore
+	ahoCorasickCore *ahocorasick.AhoCorasickCore
 
 	// Engine synchronization primitives.
 	sourceManager        *sources.SourceManager
@@ -314,7 +315,7 @@ func (e *Engine) initialize(ctx context.Context, options ...Option) error {
 	ctx.Logger().V(4).Info("engine initialized")
 
 	ctx.Logger().V(4).Info("setting up aho-corasick core")
-	e.ahoCorasickCore = NewAhoCorasickCore(e.detectors)
+	e.ahoCorasickCore = ahocorasick.NewAhoCorasickCore(e.detectors)
 	ctx.Logger().V(4).Info("set up aho-corasick core")
 
 	return nil
@@ -463,7 +464,7 @@ func (e *Engine) detectorWorker(ctx context.Context) {
 
 	// Reuse the same map to avoid allocations.
 	const avgDetectorsPerChunk = 2
-	chunkSpecificDetectors := make(map[DetectorKey]detectors.Detector, avgDetectorsPerChunk)
+	chunkSpecificDetectors := make(map[ahocorasick.DetectorKey]detectors.Detector, avgDetectorsPerChunk)
 	for originalChunk := range e.ChunksChan() {
 		for chunk := range sources.Chunker(originalChunk) {
 			atomic.AddUint64(&e.metrics.BytesScanned, uint64(len(chunk.Data)))


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This introduces following changes to the template detector + generate script:

- Fix a bug where `generate.go` creates `DetectorType_Detectorname` instead of `DetectorType_DetectorName`
  This could be further improved by searching for the exact DetectorType casing. Matching the input name is a good enough solution for now, imo.
- De-duplicate matches prior to attempting verification, that way we don't waste time+io repeatedly verifying the same data 
- Moves verification logic out of the for loop in `FromData` and drains + closes the response body (context in #2086)
- Added a keyword+pattern test so that basic issues can be caught without having to run tests with a live secret

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

