### PR TITLE
Fix filesystem enumeration ignore paths bug

### DIFF
--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -240,6 +240,9 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 				return nil
 			}
 			fullPath := filepath.Join(path, relativePath)
+			if s.filter != nil && !s.filter.Pass(fullPath) {
+				return nil
+			}
 			item := sources.CommonSourceUnit{ID: fullPath}
 			return reporter.UnitOk(ctx, item)
 		})


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Fixes filesystem enumeration bug that did not use the provided filters. (See #2350)

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

