### PR TITLE
Make AzureDevopsPersonalAccessToken verification more robust

### DIFF
--- a/hack/snifftest/snifftest.sh
+++ b/hack/snifftest/snifftest.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 REPO_ARRAY=(
-        # "https://github.com/Netflix/Hystrix.git"
+        "https://github.com/Netflix/Hystrix.git"
         # "https://github.com/facebook/flow.git"
         # "https://github.com/Netflix/vizceral.git"
         # "https://github.com/Netflix/metaflow.git"

--- a/pkg/detectors/azuredevopspersonalaccesstoken/azuredevopspersonalaccesstoken.go
+++ b/pkg/detectors/azuredevopspersonalaccesstoken/azuredevopspersonalaccesstoken.go
@@ -69,7 +69,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				res, err := client.Do(req)
 				if err == nil {
 					defer res.Body.Close()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
+					hasVerifiedRes, _ := common.ResponseContainsSubstring(res.Body, "lastUpdateTime")
+					if res.StatusCode >= 200 && res.StatusCode < 300 && hasVerifiedRes {
 						s1.Verified = true
 					} else if res.StatusCode == 401 {
 						// The secret is determinately not verified (nothing to do)


### PR DESCRIPTION
### Description:
Adds an additional verification check on the response. In some cases the API will return a 203 response with invalid tokens.

Also should fix the broken sniff test stage in CI

### Checklist:
* [X] Tests passing (`make test-community`)?
* [X] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

