### PR TITLE
[bug] - use DetectorKey as the key in the detectorKeysWithResults map

### DIFF
--- a/pkg/engine/ahocorasick/ahocorasickcore.go
+++ b/pkg/engine/ahocorasick/ahocorasickcore.go
@@ -63,6 +63,12 @@ func NewAhoCorasickCore(allDetectors []detectors.Detector) *AhoCorasickCore {
 	}
 }
 
+// GetDetectorByKey returns the detector associated with the given key. If no detector is found, it
+// returns nil.
+func (ac *AhoCorasickCore) GetDetectorByKey(key DetectorKey) detectors.Detector {
+	return ac.detectorsByKey[key]
+}
+
 // DetectorInfo represents a detected pattern's metadata in a data chunk.
 // It encapsulates the key identifying a specific detector and the detector instance itself.
 type DetectorInfo struct {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -693,7 +693,9 @@ func (e *Engine) verificationOverlapWorker(ctx context.Context) {
 						wgDoneFn: wgDetect.Done,
 					}, res)
 
-					// Remove the detector from the list of detectors with results.
+					// Remove the detector key from the list of detector keys with results.
+					// This is to ensure that the chunk is not reprocessed with verification enabled
+					// for this detector.
 					delete(detectorKeysWithResults, detector.Key)
 				}
 				chunkSecrets[key] = struct{}{}
@@ -706,7 +708,7 @@ func (e *Engine) verificationOverlapWorker(ctx context.Context) {
 				ctx.Logger().Info("detector not found", "key", key)
 				continue
 			}
-		
+
 			wgDetect.Add(1)
 			chunk.chunk.Verify = e.verify
 			e.detectableChunksChan <- detectableChunk{

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -701,11 +701,17 @@ func (e *Engine) verificationOverlapWorker(ctx context.Context) {
 		}
 
 		for key := range detectorKeysWithResults {
+			detector := e.ahoCorasickCore.GetDetectorByKey(key)
+			if detector == nil {
+				ctx.Logger().Info("detector not found", "key", key)
+				continue
+			}
+		
 			wgDetect.Add(1)
 			chunk.chunk.Verify = e.verify
 			e.detectableChunksChan <- detectableChunk{
 				chunk:    chunk.chunk,
-				detector: e.ahoCorasickCore.GetDetectorByKey(key),
+				detector: detector,
 				decoder:  chunk.decoder,
 				wgDoneFn: wgDetect.Done,
 			}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The current map key contains unhashable fields. Use the `DetectorKey` instead as the key in the map.
[
![Screenshot 2024-02-02 at 12 37 54 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/32aaef02-e5bc-4ef3-927c-5b8c6af662f5)
](url)

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

