### PR TITLE
Implement SourceUnitEnumChunker for GitLab

### DIFF
--- a/pkg/engine/gitlab_integration_test.go
+++ b/pkg/engine/gitlab_integration_test.go
@@ -36,6 +36,6 @@ func TestGitLab(t *testing.T) {
 
 	// Check the output provided by metrics.
 	metrics := e.GetMetrics()
-	assert.GreaterOrEqual(t, metrics.ChunksScanned, uint64(36390))
-	assert.GreaterOrEqual(t, metrics.BytesScanned, uint64(92662889))
+	assert.GreaterOrEqual(t, metrics.ChunksScanned, uint64(36312))
+	assert.GreaterOrEqual(t, metrics.BytesScanned, uint64(91618854))
 }

--- a/pkg/engine/gitlab_integration_test.go
+++ b/pkg/engine/gitlab_integration_test.go
@@ -1,0 +1,41 @@
+//go:build integration
+// +build integration
+
+package engine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func TestGitLab(t *testing.T) {
+	// Run the scan.
+	ctx := context.Background()
+	e, err := Start(ctx,
+		WithDetectors(DefaultDetectors()...),
+		WithVerify(false),
+	)
+	assert.NoError(t, err)
+
+	secret, err := common.GetTestSecret(ctx)
+	if err != nil {
+		t.Fatal(fmt.Errorf("failed to access secret: %v", err))
+	}
+	err = e.ScanGitLab(ctx, sources.GitlabConfig{
+		Token: secret.MustGetField("GITLAB_TOKEN"),
+	})
+	assert.NoError(t, err)
+
+	err = e.Finish(ctx)
+	assert.NoError(t, err)
+
+	// Check the output provided by metrics.
+	metrics := e.GetMetrics()
+	assert.GreaterOrEqual(t, metrics.ChunksScanned, uint64(36390))
+	assert.GreaterOrEqual(t, metrics.BytesScanned, uint64(92662889))
+}

--- a/pkg/sources/chan_reporter.go
+++ b/pkg/sources/chan_reporter.go
@@ -18,5 +18,21 @@ func (c ChanReporter) ChunkOk(ctx context.Context, chunk Chunk) error {
 
 func (ChanReporter) ChunkErr(ctx context.Context, err error) error {
 	ctx.Logger().Error(err, "error chunking")
-	return nil
+	return ctx.Err()
+}
+
+var _ UnitReporter = (*SliceReporter)(nil)
+
+type SliceReporter struct {
+	Units []string
+}
+
+func (s *SliceReporter) UnitOk(ctx context.Context, unit SourceUnit) error {
+	s.Units = append(s.Units, unit.SourceUnitID())
+	return ctx.Err()
+}
+
+func (s *SliceReporter) UnitErr(ctx context.Context, err error) error {
+	ctx.Logger().Error(err, "error enumerating")
+	return ctx.Err()
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Implements `SourceUnitEnumChunker` in GitLab for enumerating and chunking units.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

