### PR TITLE
added hubspotv2 scanner

### DIFF
--- a/pkg/detectors/hubspotapikey/hubspotapikey.go
+++ b/pkg/detectors/hubspotapikey/hubspotapikey.go
@@ -14,8 +14,11 @@ import (
 
 type Scanner struct{}
 
+func (s Scanner) Version() int { return 1 }
+
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.Versioner = (*Scanner)(nil)
 
 var (
 	client = common.SaneHttpClient()

--- a/pkg/detectors/hubspotapikeyv2/hubspotapikeyv2.go
+++ b/pkg/detectors/hubspotapikeyv2/hubspotapikeyv2.go
@@ -15,8 +15,11 @@ import (
 
 type Scanner struct{}
 
+func (s Scanner) Version() int { return 2 }
+
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.Versioner = (*Scanner)(nil)
 
 var (
 	client = common.SaneHttpClient()

--- a/pkg/detectors/hubspotapikeyv2/hubspotapikeyv2.go
+++ b/pkg/detectors/hubspotapikeyv2/hubspotapikeyv2.go
@@ -1,0 +1,76 @@
+package hubspotapikeyv2
+
+import (
+	"context"
+	// "log"
+	regexp "github.com/wasilibs/go-re2"
+	"net/http"
+	"strings"
+	"fmt"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+type Scanner struct{}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	client = common.SaneHttpClient()
+
+	keyPat = regexp.MustCompile(`\b(pat-na1-[A-Za-z0-9]{8}\-[A-Za-z0-9]{4}\-[A-Za-z0-9]{4}\-[A-Za-z0-9]{4}\-[A-Za-z0-9]{12})\b`)
+)
+
+// Keywords are used for efficiently pre-filtering chunks.
+// Use identifiers in the secret preferably, or the provider name.
+func (s Scanner) Keywords() []string {
+	return []string{"pat-na1-"}
+}
+
+// FromData will find and optionally verify HubSpotApiKey secrets in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
+	for _, match := range matches {
+		if len(match) != 2 {
+			continue
+		}
+		resMatch := strings.TrimSpace(match[1])
+
+		s1 := detectors.Result{
+			DetectorType: detectorspb.DetectorType_HubSpotApiKey,
+			Raw:          []byte(resMatch),
+		}
+
+		if verify {
+			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.hubapi.com/account-info/v3/api-usage/daily/private-apps", nil)
+			if err != nil {
+				continue
+			}
+			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
+			res, err := client.Do(req)
+			if err == nil {
+				defer res.Body.Close()
+				if res.StatusCode >= 200 && res.StatusCode < 300 {
+					s1.Verified = true
+				} else {
+					if detectors.IsKnownFalsePositive(resMatch, detectors.DefaultFalsePositives, true) {
+						continue
+					}
+				}
+			}
+		}
+
+		results = append(results, s1)
+	}
+
+	return results, nil
+}
+
+func (s Scanner) Type() detectorspb.DetectorType {
+	return detectorspb.DetectorType_HubSpotApiKey
+}

--- a/pkg/detectors/hubspotapikeyv2/hubspotapikeyv2_test.go
+++ b/pkg/detectors/hubspotapikeyv2/hubspotapikeyv2_test.go
@@ -1,0 +1,120 @@
+//go:build detectors
+// +build detectors
+
+package hubspotapikeyv2
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+func TestHubSpotApiKey_FromChunk(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors3")
+	if err != nil {
+		t.Fatalf("could not get test secrets from GCP: %s", err)
+	}
+	secret := testSecrets.MustGetField("HUBSPOTAPIKEY_TOKEN")
+	inactiveSecret := testSecrets.MustGetField("HUBSPOTAPIKEY_INACTIVE")
+
+	type args struct {
+		ctx    context.Context
+		data   []byte
+		verify bool
+	}
+	tests := []struct {
+		name    string
+		s       Scanner
+		args    args
+		want    []detectors.Result
+		wantErr bool
+	}{
+		{
+			name: "found, verified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a hubspotapikey secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_HubSpotApiKey,
+					Verified:     true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "found, unverified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a hubspotapikey secret %s within but unverified", inactiveSecret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_HubSpotApiKey,
+					Verified:     false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "not found",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte("You cannot find the secret within"),
+				verify: true,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Scanner{}
+			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("HubSpotApiKey.FromData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if len(got[i].Raw) == 0 {
+					t.Fatalf("no raw secret present: \n %+v", got[i])
+				}
+				got[i].Raw = nil
+			}
+			if diff := pretty.Compare(got, tt.want); diff != "" {
+				t.Errorf("HubSpotApiKey.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			}
+		})
+	}
+}
+
+func BenchmarkFromData(benchmark *testing.B) {
+	ctx := context.Background()
+	s := Scanner{}
+	for name, data := range detectors.MustGetBenchmarkData() {
+		benchmark.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				_, err := s.FromData(ctx, false, data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/engine/defaults.go
+++ b/pkg/engine/defaults.go
@@ -332,6 +332,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/host"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/html2pdf"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/hubspotapikey"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/hubspotapikeyv2"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/huggingface"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/humanity"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/hunter"
@@ -1613,6 +1614,7 @@ func DefaultDetectors() []detectors.Detector {
 		&azuresearchquerykey.Scanner{},
 		jiratoken_v2.Scanner{},
 		&googleoauth2.Scanner{},
+		hubspotapikeyv2.Scanner{},
 	}
 
 }


### PR DESCRIPTION

### Description:
This PR adds the new v2 version of the hubspot API key. The older version still works.
https://developers.hubspot.com/docs/api/settings/account-information-api

https://developers.hubspot.com/changelog/upcoming-api-key-sunset

https://knowledge.hubspot.com/integrations/how-do-i-get-my-hubspot-api-key


![hubspotv2](https://github.com/trufflesecurity/trufflehog/assets/10580970/e7aa6d36-c786-421c-a596-237bd1d5109c)

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

