### PR TITLE
Make `SkipFile` case-insensitive

### DIFF
--- a/pkg/common/vars.go
+++ b/pkg/common/vars.go
@@ -7,46 +7,65 @@ import (
 
 var (
 	KB, MB, GB, TB, PB = 1e3, 1e6, 1e9, 1e12, 1e15
-	IgnoredExtensions  = []string{
-		// multimedia/containers
-		"mp4",
-		"avi",
-		"mpeg",
-		"mpg",
-		"mov",
-		"wmv",
-		"m4p",
-		"swf",
-		"mp2",
-		"flv",
-		"vob",
-		"webm",
-		"hdv",
-		"3gp",
-		"ogg",
-		"mp3",
-		"wav",
-		"flac",
-		"webp",
-		"pdf",
-
+	ignoredExtensions  = map[string]struct{}{
 		// images
-		"png",
-		"jpg",
-		"jpeg",
-		"gif",
-		"tiff",
+		"apng": {},
+		"avif": {},
+		"bmp":  {},
+		"gif":  {},
+		"icns": {}, // Apple icon image file
+		"ico":  {}, // Icon file
+		"jpg":  {},
+		"jpeg": {},
+		"png":  {},
+		"svg":  {},
+		"svgz": {}, // Compressed Scalable Vector Graphics file
+		"tga":  {},
+		"tif":  {},
+		"tiff": {},
 
-		"fnt",   // Windows font file
-		"fon",   // Generic font file
-		"ttf",   // TrueType font
-		"otf",   // OpenType font
-		"woff",  // Web Open Font Format
-		"woff2", // Web Open Font Format 2
-		"eot",   // Embedded OpenType font
-		"svgz",  // Compressed Scalable Vector Graphics file
-		"icns",  // Apple icon image file
-		"ico",   // Icon file
+		// audio
+		"fev":  {}, // video game audio
+		"fsb":  {},
+		"m2a":  {},
+		"m4a":  {},
+		"mp2":  {},
+		"mp3":  {},
+		"snag": {},
+
+		// video
+		"264":  {},
+		"3gp":  {},
+		"avi":  {},
+		"flac": {},
+		"flv":  {},
+		"hdv":  {},
+		"m4p":  {},
+		"mov":  {},
+		"mp4":  {},
+		"mpg":  {},
+		"mpeg": {},
+		"ogg":  {},
+		"qt":   {},
+		"swf":  {},
+		"vob":  {},
+		"wav":  {},
+		"webm": {},
+		"webp": {},
+		"wmv":  {},
+
+		// documents
+		"pdf": {},
+		"psd": {},
+
+		// fonts
+		"eot":   {}, // Embedded OpenType font
+		"fnt":   {}, // Windows font file
+		"fon":   {}, // Generic font file
+		"otf":   {}, // OpenType font
+		"ttf":   {}, // TrueType font
+		"woff":  {}, // Web Open Font Format
+		"woff2": {}, // Web Open Font Format 2
 	}
 
 	binaryExtensions = map[string]struct{}{
@@ -86,13 +105,11 @@ var (
 	}
 )
 
+// SkipFile returns true if the file extension is in the ignoredExtensions list.
 func SkipFile(filename string) bool {
-	for _, ext := range IgnoredExtensions {
-		if strings.TrimPrefix(filepath.Ext(filename), ".") == ext {
-			return true
-		}
-	}
-	return false
+	ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(filename), "."))
+	_, ok := ignoredExtensions[ext]
+	return ok
 }
 
 // IsBinary returns true if the file extension is in the binaryExtensions list.

--- a/pkg/common/vars_test.go
+++ b/pkg/common/vars_test.go
@@ -1,6 +1,9 @@
 package common
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestSkipFile(t *testing.T) {
 	type testCase struct {
@@ -9,10 +12,15 @@ func TestSkipFile(t *testing.T) {
 	}
 
 	// Add a test case for each ignored extension.
-	testCases := make([]testCase, 0, len(IgnoredExtensions)+1)
-	for _, ext := range IgnoredExtensions {
+	testCases := make([]testCase, 0, (len(ignoredExtensions)+1)*2)
+	for ext := range ignoredExtensions {
 		testCases = append(testCases, testCase{
 			file: "test." + ext,
+			want: true,
+		})
+
+		testCases = append(testCases, testCase{
+			file: "test." + strings.ToUpper(ext),
 			want: true,
 		})
 	}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This fixes #2382. It converts `ignoredExtensions` into a map, sorts the entries, and adds a couple new ones.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

