### PR TITLE
Fix binary file hanging bug in git sources

### DIFF
--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -375,6 +375,9 @@ func (c *Parser) executeCommand(ctx context.Context, cmd *exec.Cmd, isStaged boo
 
 	go func() {
 		c.FromReader(ctx, stdOut, commitChan, isStaged)
+		if err := stdOut.Close(); err != nil {
+			ctx.Logger().V(2).Info("Error closing git stdout pipe.", "error", err)
+		}
 		if err := cmd.Wait(); err != nil {
 			ctx.Logger().V(2).Info("Error waiting for git command to complete.", "error", err)
 		}

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -1143,6 +1143,9 @@ func (s *Git) handleBinary(ctx context.Context, gitDir string, reporter sources.
 		return err
 	}
 	defer func() {
+		if err := fileReader.Close(); err != nil {
+			ctx.Logger().Error(err, "error closing fileReader")
+		}
 		if err := cmd.Wait(); err != nil {
 			ctx.Logger().Error(
 				err, "error waiting for command",


### PR DESCRIPTION


<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Waiting for the sub-command will block until all of `stdout` has been read. In some cases, we return early due to failed chunking without reading all of the data, and thus, get stuck waiting for the command to finish. Closing the pipe will ensure `Wait` does not block on that I/O.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

