### PR TITLE
Update GitParse to handle quoted binary filenames

### DIFF
--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -716,7 +716,7 @@ func isBinaryLine(latestState ParseState, line []byte) bool {
 
 // Get the b/ file path. Ignoring the edge case of files having `and /b` in the name for simplicity.
 func pathFromBinaryLine(line []byte) (string, bool) {
-	if bytes.Index(line, []byte("and /dev/null")) != -1 {
+	if bytes.Contains(line, []byte("and /dev/null")) {
 		return "", true
 	}
 

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -591,12 +591,17 @@ func TestLineChecksNoStaged(t *testing.T) {
 
 func TestBinaryPathParse(t *testing.T) {
 	cases := map[string]string{
-		"Binary files /dev/null and b/plugin.sig differ\n":                    "plugin.sig",
-		"Binary files /dev/null and b/ Lunch and Learn - HCDiag.pdf differ\n": " Lunch and Learn - HCDiag.pdf",
+		"Binary files a/trufflehog_3.42.0_linux_arm64.tar.gz and /dev/null differ\n":                                 "",
+		"Binary files /dev/null and b/plugin.sig differ\n":                                                           "plugin.sig",
+		"Binary files /dev/null and b/ Lunch and Learn - HCDiag.pdf differ\n":                                        " Lunch and Learn - HCDiag.pdf",
+		"Binary files /dev/null and \"b/assets/retailers/ON-ikony-Platforma-ecom \\342\\200\\224 kopia.png\" differ": "assets/retailers/ON-ikony-Platforma-ecom \\342\\200\\224 kopia.png",
 	}
 
 	for name, expected := range cases {
-		filename := pathFromBinaryLine([]byte(name))
+		filename, err := pathFromBinaryLine([]byte(name))
+		if err != nil {
+			t.Errorf("Got unexpected error: %s", err)
+		}
 		if filename != expected {
 			t.Errorf("Expected: %s, Got: %s", expected, filename)
 		}

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -591,16 +591,16 @@ func TestLineChecksNoStaged(t *testing.T) {
 
 func TestBinaryPathParse(t *testing.T) {
 	cases := map[string]string{
-		"Binary files a/trufflehog_3.42.0_linux_arm64.tar.gz and /dev/null differ\n":                                 "",
-		"Binary files /dev/null and b/plugin.sig differ\n":                                                           "plugin.sig",
-		"Binary files /dev/null and b/ Lunch and Learn - HCDiag.pdf differ\n":                                        " Lunch and Learn - HCDiag.pdf",
-		"Binary files /dev/null and \"b/assets/retailers/ON-ikony-Platforma-ecom \\342\\200\\224 kopia.png\" differ": "assets/retailers/ON-ikony-Platforma-ecom \\342\\200\\224 kopia.png",
+		"Binary files a/trufflehog_3.42.0_linux_arm64.tar.gz and /dev/null differ\n":                                   "",
+		"Binary files /dev/null and b/plugin.sig differ\n":                                                             "plugin.sig",
+		"Binary files /dev/null and b/ Lunch and Learn - HCDiag.pdf differ\n":                                          " Lunch and Learn - HCDiag.pdf",
+		"Binary files /dev/null and \"b/assets/retailers/ON-ikony-Platforma-ecom \\342\\200\\224 kopia.png\" differ\n": "assets/retailers/ON-ikony-Platforma-ecom \\342\\200\\224 kopia.png",
 	}
 
 	for name, expected := range cases {
-		filename, err := pathFromBinaryLine([]byte(name))
-		if err != nil {
-			t.Errorf("Got unexpected error: %s", err)
+		filename, ok := pathFromBinaryLine([]byte(name))
+		if !ok {
+			t.Errorf("Failed to get path: %s", name)
 		}
 		if filename != expected {
 			t.Errorf("Expected: %s, Got: %s", expected, filename)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This fixes #2384. ~I figured that a regexp would be more robust than checking multiple instances of `bytes.Split`, let me know if you disagree.~

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

