### PR TITLE
Set GHA workdir

### DIFF
--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/action.yml
+++ b/action.yml
@@ -80,7 +80,7 @@ runs:
       ##########################################
       ##          Run TruffleHog              ##
       ##########################################       
-      docker run --rm -v "$REPO_PATH":/tmp \
+      docker run --rm -v "$REPO_PATH":/tmp -w /tmp \
       ghcr.io/trufflesecurity/trufflehog:latest \
       git file:///tmp/ \
       --since-commit \


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Sets the github action work dir with `-w /tmp`. _should_ fix https://github.com/trufflesecurity/trufflehog/issues/2365 and https://github.com/trufflesecurity/trufflehog/issues/2248. Adding `workflow_dispatch` to our dogfood workflow so we can easily run the gha without committing or opening a PR

### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

