### PR TITLE
[bug] - prevent concurrent map writes

### DIFF
--- a/pkg/output/github_actions.go
+++ b/pkg/output/github_actions.go
@@ -52,13 +52,13 @@ func (p *GitHubActionsPrinter) Print(_ context.Context, r *detectors.ResultWithM
 	h := sha256.New()
 	h.Write([]byte(key))
 	key = hex.EncodeToString(h.Sum(nil))
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	if _, ok := dedupeCache[key]; ok {
 		return nil
 	}
 	dedupeCache[key] = struct{}{}
 
-	p.mu.Lock()
-	defer p.mu.Unlock()
 	message := fmt.Sprintf("Found %s %s result 🐷🔑\n", verifiedStatus, out.DetectorType)
 	if r.Result.DecoderType != detectorspb.DecoderType_PLAIN {
 		message = fmt.Sprintf("Found %s %s result with %s encoding 🐷🔑\n", verifiedStatus, out.DetectorType, out.DecoderType)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Make sure we safely access the dupes cache.
![Screenshot 2024-02-07 at 2 30 24 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/ac276c45-3764-4a13-b41b-9891dfdb8e38)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

