### PR TITLE
Disable secret scans for community PRs

### DIFF
--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -12,6 +12,7 @@ on:
 
 jobs:
   test:
+    if: github.repository == 'trufflesecurity/trufflehog'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR disables community PRs (forks) for the gha secrets workflow. There might be a way where we can checkout the forked repo and run trufflehog gha against that... but iirc that has security implications and might not be possible with the controls gha exposes.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

