### PR TITLE
[cleanup] - Implement config struct for source Init

### DIFF
--- a/pkg/engine/docker.go
+++ b/pkg/engine/docker.go
@@ -1,11 +1,10 @@
 package engine
 
 import (
-	"runtime"
-
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/docker"
 )
 
@@ -14,10 +13,22 @@ func (e *Engine) ScanDocker(ctx context.Context, conn *anypb.Any) error {
 	sourceName := "trufflehog - docker"
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, docker.SourceType)
 
-	dockerSource := &docker.Source{}
-	if err := dockerSource.Init(ctx, sourceName, jobID, sourceID, true, conn, runtime.NumCPU()); err != nil {
+	src := &docker.Source{}
+	err := src.Init(
+		ctx,
+		sources.NewConfig(
+			conn,
+			sources.WithName(sourceName),
+			sources.WithSourceID(sourceID),
+			sources.WithJobID(jobID),
+			sources.WithVerify(e.verify),
+			sources.WithConcurrency(int(e.concurrency)),
+		),
+	)
+	if err != nil {
 		return err
 	}
-	_, err := e.sourceManager.Run(ctx, sourceName, dockerSource)
+
+	_, err = e.sourceManager.Run(ctx, sourceName, src)
 	return err
 }

--- a/pkg/engine/filesystem.go
+++ b/pkg/engine/filesystem.go
@@ -1,8 +1,6 @@
 package engine
 
 import (
-	"runtime"
-
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
@@ -29,10 +27,22 @@ func (e *Engine) ScanFileSystem(ctx context.Context, c sources.FilesystemConfig)
 	sourceName := "trufflehog - filesystem"
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, filesystem.SourceType)
 
-	fileSystemSource := &filesystem.Source{}
-	if err := fileSystemSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
+	src := &filesystem.Source{}
+	err = src.Init(
+		ctx,
+		sources.NewConfig(
+			&conn,
+			sources.WithName(sourceName),
+			sources.WithSourceID(sourceID),
+			sources.WithJobID(jobID),
+			sources.WithVerify(e.verify),
+			sources.WithConcurrency(int(e.concurrency)),
+		),
+	)
+	if err != nil {
 		return err
 	}
-	_, err = e.sourceManager.Run(ctx, sourceName, fileSystemSource)
+
+	_, err = e.sourceManager.Run(ctx, sourceName, src)
 	return err
 }

--- a/pkg/engine/gcs.go
+++ b/pkg/engine/gcs.go
@@ -47,11 +47,23 @@ func (e *Engine) ScanGCS(ctx context.Context, c sources.GCSConfig) error {
 	sourceName := "trufflehog - gcs"
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, gcs.SourceType)
 
-	gcsSource := &gcs.Source{}
-	if err := gcsSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, int(c.Concurrency)); err != nil {
+	src := &gcs.Source{}
+	err = src.Init(
+		ctx,
+		sources.NewConfig(
+			&conn,
+			sources.WithName(sourceName),
+			sources.WithSourceID(sourceID),
+			sources.WithJobID(jobID),
+			sources.WithVerify(e.verify),
+			sources.WithConcurrency(int(e.concurrency)),
+		),
+	)
+	if err != nil {
 		return err
 	}
-	_, err = e.sourceManager.Run(ctx, sourceName, gcsSource)
+
+	_, err = e.sourceManager.Run(ctx, sourceName, src)
 	return err
 }
 

--- a/pkg/engine/syslog.go
+++ b/pkg/engine/syslog.go
@@ -43,12 +43,23 @@ func (e *Engine) ScanSyslog(ctx context.Context, c sources.SyslogConfig) error {
 
 	sourceName := "trufflehog - syslog"
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, syslog.SourceType)
-	syslogSource := &syslog.Source{}
-	if err := syslogSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, c.Concurrency); err != nil {
+
+	src := &syslog.Source{}
+	err = src.Init(
+		ctx,
+		sources.NewConfig(
+			&conn,
+			sources.WithName(sourceName),
+			sources.WithSourceID(sourceID),
+			sources.WithJobID(jobID),
+			sources.WithVerify(e.verify),
+			sources.WithConcurrency(int(e.concurrency)),
+		),
+	)
+	if err != nil {
 		return err
 	}
-	syslogSource.InjectConnection(connection)
 
-	_, err = e.sourceManager.Run(ctx, sourceName, syslogSource)
+	_, err = e.sourceManager.Run(ctx, sourceName, src)
 	return err
 }

--- a/pkg/engine/travisci.go
+++ b/pkg/engine/travisci.go
@@ -1,13 +1,12 @@
 package engine
 
 import (
-	"runtime"
-
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/travisci"
 )
 
@@ -29,10 +28,28 @@ func (e *Engine) ScanTravisCI(ctx context.Context, token string) error {
 	sourceName := "trufflehog - Travis CI"
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, travisci.SourceType)
 
-	travisSource := &travisci.Source{}
-	if err := travisSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
+	src := &travisci.Source{}
+	err = src.Init(
+		ctx,
+		sources.NewConfig(
+			&conn,
+			sources.WithName(sourceName),
+			sources.WithSourceID(sourceID),
+			sources.WithJobID(jobID),
+			sources.WithVerify(e.verify),
+			sources.WithConcurrency(int(e.concurrency)),
+		),
+	)
+	if err != nil {
 		return err
 	}
-	_, err = e.sourceManager.Run(ctx, sourceName, travisSource)
+
+	_, err = e.sourceManager.Run(ctx, sourceName, src)
 	return err
+
+	// if err := travisSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
+	// 	return err
+	// }
+	// _, err = e.sourceManager.Run(ctx, sourceName, travisSource)
+	// return err
 }

--- a/pkg/engine/travisci.go
+++ b/pkg/engine/travisci.go
@@ -46,10 +46,4 @@ func (e *Engine) ScanTravisCI(ctx context.Context, token string) error {
 
 	_, err = e.sourceManager.Run(ctx, sourceName, src)
 	return err
-
-	// if err := travisSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
-	// 	return err
-	// }
-	// _, err = e.sourceManager.Run(ctx, sourceName, travisSource)
-	// return err
 }

--- a/pkg/sources/circleci/circleci.go
+++ b/pkg/sources/circleci/circleci.go
@@ -56,17 +56,17 @@ func (s *Source) JobID() sources.JobID {
 }
 
 // Init returns an initialized CircleCI source.
-func (s *Source) Init(_ context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
-	s.name = name
-	s.sourceId = sourceId
-	s.jobId = jobId
-	s.verify = verify
-	s.jobPool = &errgroup.Group{}
-	s.jobPool.SetLimit(concurrency)
+func (s *Source) Init(_ context.Context, cfg *sources.Config) error {
+	s.name = cfg.Name
+	s.sourceId = cfg.SourceID
+	s.jobId = cfg.JobID
+	s.verify = cfg.Verify
+	s.jobPool = new(errgroup.Group)
+	s.jobPool.SetLimit(cfg.Concurrency)
 	s.client = common.RetryableHttpClientTimeout(3)
 
 	var conn sourcespb.CircleCI
-	if err := anypb.UnmarshalTo(connection, &conn, proto.UnmarshalOptions{}); err != nil {
+	if err := anypb.UnmarshalTo(cfg.Connection, &conn, proto.UnmarshalOptions{}); err != nil {
 		return errors.WrapPrefix(err, "error unmarshalling connection", 0)
 	}
 

--- a/pkg/sources/circleci/circleci_test.go
+++ b/pkg/sources/circleci/circleci_test.go
@@ -69,7 +69,15 @@ func TestSource_Scan(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, 5)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.init.name),
+					sources.WithVerify(tt.init.verify),
+					sources.WithConcurrency(5),
+				),
+			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Source.Init() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/sources/docker/docker.go
+++ b/pkg/sources/docker/docker.go
@@ -56,18 +56,18 @@ func (s *Source) JobID() sources.JobID {
 }
 
 // Init initializes the source.
-func (s *Source) Init(_ context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
-	s.name = name
-	s.sourceId = sourceId
-	s.jobId = jobId
-	s.verify = verify
-	s.concurrency = concurrency
+func (s *Source) Init(_ context.Context, cfg *sources.Config) error {
+	s.name = cfg.Name
+	s.sourceId = cfg.SourceID
+	s.jobId = cfg.JobID
+	s.verify = cfg.Verify
+	s.concurrency = cfg.Concurrency
 
 	// Reset metrics for this source at initialization time.
 	dockerImagesScanned.WithLabelValues(s.name).Set(0)
 	dockerLayersScanned.WithLabelValues(s.name).Set(0)
 
-	if err := anypb.UnmarshalTo(connection, &s.conn, proto.UnmarshalOptions{}); err != nil {
+	if err := anypb.UnmarshalTo(cfg.Connection, &s.conn, proto.UnmarshalOptions{}); err != nil {
 		return fmt.Errorf("error unmarshalling connection: %w", err)
 	}
 

--- a/pkg/sources/docker/docker_test.go
+++ b/pkg/sources/docker/docker_test.go
@@ -26,7 +26,14 @@ func TestDockerImageScan(t *testing.T) {
 	assert.NoError(t, err)
 
 	s := &Source{}
-	err = s.Init(context.TODO(), "test source", 0, 0, false, conn, 1)
+	err = s.Init(
+		context.Background(),
+		sources.NewConfig(
+			conn,
+			sources.WithName("test source"),
+			sources.WithConcurrency(1),
+		),
+	)
 	assert.NoError(t, err)
 
 	var wg sync.WaitGroup
@@ -63,7 +70,14 @@ func TestDockerImageScanWithDigest(t *testing.T) {
 	assert.NoError(t, err)
 
 	s := &Source{}
-	err = s.Init(context.TODO(), "test source", 0, 0, false, conn, 1)
+	err = s.Init(
+		context.Background(),
+		sources.NewConfig(
+			conn,
+			sources.WithName("test source"),
+			sources.WithConcurrency(1),
+		),
+	)
 	assert.NoError(t, err)
 
 	var wg sync.WaitGroup

--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -59,17 +59,17 @@ func (s *Source) JobID() sources.JobID {
 }
 
 // Init returns an initialized Filesystem source.
-func (s *Source) Init(aCtx context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(aCtx context.Context, cfg *sources.Config) error {
 	s.log = aCtx.Logger()
 
-	s.concurrency = concurrency
-	s.name = name
-	s.sourceId = sourceId
-	s.jobId = jobId
-	s.verify = verify
+	s.concurrency = cfg.Concurrency
+	s.name = cfg.Name
+	s.sourceId = cfg.SourceID
+	s.jobId = cfg.JobID
+	s.verify = cfg.Verify
 
 	var conn sourcespb.Filesystem
-	if err := anypb.UnmarshalTo(connection, &conn, proto.UnmarshalOptions{}); err != nil {
+	if err := anypb.UnmarshalTo(cfg.Connection, &conn, proto.UnmarshalOptions{}); err != nil {
 		return errors.WrapPrefix(err, "error unmarshalling connection", 0)
 	}
 	s.paths = append(conn.Paths, conn.Directories...)

--- a/pkg/sources/filesystem/filesystem_test.go
+++ b/pkg/sources/filesystem/filesystem_test.go
@@ -63,7 +63,15 @@ func TestSource_Scan(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, 5)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.init.name),
+					sources.WithVerify(tt.init.verify),
+					sources.WithConcurrency(5),
+				),
+			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Source.Init() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -162,7 +170,15 @@ func TestEnumerate(t *testing.T) {
 
 	// Initialize the source.
 	s := Source{}
-	err = s.Init(ctx, "test enumerate", 0, 0, true, conn, 1)
+	err = s.Init(
+		ctx,
+		sources.NewConfig(
+			conn,
+			sources.WithName("test enumerate"),
+			sources.WithVerify(true),
+			sources.WithConcurrency(1),
+		),
+	)
 	assert.NoError(t, err)
 
 	reporter := sourcestest.TestReporter{}
@@ -198,7 +214,15 @@ func TestChunkUnit(t *testing.T) {
 
 	// Initialize the source.
 	s := Source{}
-	err = s.Init(ctx, "test chunk unit", 0, 0, true, conn, 1)
+	err = s.Init(
+		ctx,
+		sources.NewConfig(
+			conn,
+			sources.WithName("test chunk unit"),
+			sources.WithVerify(true),
+			sources.WithConcurrency(1),
+		),
+	)
 	assert.NoError(t, err)
 
 	// Happy path single file.
@@ -249,7 +273,15 @@ func TestEnumerateReporterErr(t *testing.T) {
 
 	// Initialize the source.
 	s := Source{}
-	err = s.Init(ctx, "test enumerate", 0, 0, true, conn, 1)
+	err = s.Init(
+		ctx,
+		sources.NewConfig(
+			conn,
+			sources.WithName("test enumerate"),
+			sources.WithVerify(true),
+			sources.WithConcurrency(1),
+		),
+	)
 	assert.NoError(t, err)
 
 	// Enumerate should always return an error if the reporter returns an
@@ -280,7 +312,15 @@ func TestChunkUnitReporterErr(t *testing.T) {
 
 	// Initialize the source.
 	s := Source{}
-	err = s.Init(ctx, "test chunk unit", 0, 0, true, conn, 1)
+	err = s.Init(
+		ctx,
+		sources.NewConfig(
+			conn,
+			sources.WithName("test chunk unit"),
+			sources.WithVerify(true),
+			sources.WithConcurrency(1),
+		),
+	)
 	assert.NoError(t, err)
 
 	// Happy path. ChunkUnit should always return an error if the reporter

--- a/pkg/sources/gcs/gcs.go
+++ b/pkg/sources/gcs/gcs.go
@@ -112,22 +112,22 @@ func (c *persistableCache) shouldPersist() (bool, string) {
 }
 
 // Init returns an initialized GCS source.
-func (s *Source) Init(aCtx context.Context, name string, id sources.JobID, sourceID sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(aCtx context.Context, cfg *sources.Config) error {
 	s.log = aCtx.Logger()
 
-	s.name = name
-	s.verify = verify
-	s.sourceId = sourceID
-	s.jobId = id
-	s.concurrency = concurrency
+	s.name = cfg.Name
+	s.verify = cfg.Verify
+	s.sourceId = cfg.SourceID
+	s.jobId = cfg.JobID
+	s.concurrency = cfg.Concurrency
 
 	var conn sourcespb.GCS
-	err := anypb.UnmarshalTo(connection, &conn, proto.UnmarshalOptions{})
+	err := anypb.UnmarshalTo(cfg.Connection, &conn, proto.UnmarshalOptions{})
 	if err != nil {
 		return errors.WrapPrefix(err, "error unmarshalling connection", 0)
 	}
 
-	gcsManager, err := configureGCSManager(aCtx, &conn, concurrency)
+	gcsManager, err := configureGCSManager(aCtx, &conn, s.concurrency)
 	if err != nil {
 		return err
 	}

--- a/pkg/sources/gcs/gcs_integration_test.go
+++ b/pkg/sources/gcs/gcs_integration_test.go
@@ -26,7 +26,15 @@ func TestChunks(t *testing.T) {
 		ExcludeBuckets: []string{perfTestBucketGlob, publicBucket},
 	})
 
-	err := source.Init(ctx, "test", 1, 1, true, conn, 8)
+	err := source.Init(
+		context.Background(),
+		sources.NewConfig(
+			conn,
+			sources.WithName("test"),
+			sources.WithVerify(true),
+			sources.WithConcurrency(9),
+		),
+	)
 	assert.Nil(t, err)
 
 	chunksCh := make(chan *sources.Chunk, 1)
@@ -66,7 +74,15 @@ func TestChunks_PublicBucket(t *testing.T) {
 		IncludeBuckets: []string{publicBucket},
 	})
 
-	err := source.Init(ctx, "test", 1, 1, true, conn, 8)
+	err := source.Init(
+		context.Background(),
+		sources.NewConfig(
+			conn,
+			sources.WithName("test"),
+			sources.WithVerify(true),
+			sources.WithConcurrency(9),
+		),
+	)
 	assert.Nil(t, err)
 
 	chunksCh := make(chan *sources.Chunk, 1)

--- a/pkg/sources/gcs/gcs_test.go
+++ b/pkg/sources/gcs/gcs_test.go
@@ -46,7 +46,15 @@ func TestSourceInit(t *testing.T) {
 		Credential: &sourcespb.GCS_Unauthenticated{},
 	})
 
-	err := source.Init(context.Background(), "test", 1, 1, true, conn, 8)
+	err := source.Init(
+		context.Background(),
+		sources.NewConfig(
+			conn,
+			sources.WithName("test"),
+			sources.WithVerify(true),
+			sources.WithConcurrency(9),
+		),
+	)
 	assert.Nil(t, err)
 	assert.NotNil(t, source.gcsManager)
 }

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -145,17 +145,17 @@ func (s *Source) withScanOptions(scanOptions *ScanOptions) {
 }
 
 // Init returns an initialized GitHub source.
-func (s *Source) Init(aCtx context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
-	s.name = name
-	s.sourceID = sourceId
-	s.jobID = jobId
-	s.verify = verify
+func (s *Source) Init(aCtx context.Context, cfg *sources.Config) error {
+	s.name = cfg.Name
+	s.sourceID = cfg.SourceID
+	s.jobID = cfg.JobID
+	s.verify = cfg.Verify
 	if s.scanOptions == nil {
 		s.scanOptions = &ScanOptions{}
 	}
 
 	var conn sourcespb.Git
-	if err := anypb.UnmarshalTo(connection, &conn, proto.UnmarshalOptions{}); err != nil {
+	if err := anypb.UnmarshalTo(cfg.Connection, &conn, proto.UnmarshalOptions{}); err != nil {
 		return fmt.Errorf("error unmarshalling connection: %w", err)
 	}
 
@@ -193,7 +193,8 @@ func (s *Source) Init(aCtx context.Context, name string, jobId sources.JobID, so
 
 	s.conn = &conn
 
-	if concurrency == 0 {
+	concurrency := cfg.Concurrency
+	if cfg.Concurrency == 0 {
 		concurrency = runtime.NumCPU()
 	}
 
@@ -201,7 +202,7 @@ func (s *Source) Init(aCtx context.Context, name string, jobId sources.JobID, so
 		return err
 	}
 
-	cfg := &Config{
+	gitCfg := &Config{
 		SourceName:   s.name,
 		JobID:        s.jobID,
 		SourceID:     s.sourceID,
@@ -226,7 +227,7 @@ func (s *Source) Init(aCtx context.Context, name string, jobId sources.JobID, so
 		},
 		UseCustomContentWriter: s.useCustomContentWriter,
 	}
-	s.git = NewGit(cfg)
+	s.git = NewGit(gitCfg)
 	return nil
 }
 

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -131,7 +131,15 @@ func TestSource_Scan(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, tt.init.concurrency)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.init.name),
+					sources.WithConcurrency(tt.init.concurrency),
+					sources.WithVerify(tt.init.verify),
+				),
+			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Source.Init() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -226,7 +234,15 @@ func TestSource_Chunks_Integration(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, 4)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.init.name),
+					sources.WithConcurrency(4),
+					sources.WithVerify(tt.init.verify),
+				),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -369,7 +385,15 @@ func TestSource_Chunks_Edge_Cases(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, 4)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.init.name),
+					sources.WithConcurrency(4),
+					sources.WithVerify(tt.init.verify),
+				),
+			)
 			if err != nil {
 				t.Errorf("Source.Init() error = %v", err)
 				return
@@ -523,7 +547,15 @@ func TestEnumerate(t *testing.T) {
 
 	// Initialize the source.
 	s := Source{}
-	err = s.Init(ctx, "test enumerate", 0, 0, true, conn, 1)
+	err = s.Init(
+		ctx,
+		sources.NewConfig(
+			conn,
+			sources.WithName("test enumerate"),
+			sources.WithConcurrency(1),
+			sources.WithVerify(true),
+		),
+	)
 	assert.NoError(t, err)
 
 	reporter := sourcestest.TestReporter{}
@@ -552,7 +584,15 @@ func TestChunkUnit(t *testing.T) {
 		Credential: &sourcespb.Git_Unauthenticated{},
 	})
 	assert.NoError(t, err)
-	err = s.Init(ctx, "test chunk", 0, 0, true, conn, 1)
+	err = s.Init(
+		ctx,
+		sources.NewConfig(
+			conn,
+			sources.WithName("test chunk"),
+			sources.WithConcurrency(1),
+			sources.WithVerify(true),
+		),
+	)
 	assert.NoError(t, err)
 
 	reporter := sourcestest.TestReporter{}

--- a/pkg/sources/github/github_integration_test.go
+++ b/pkg/sources/github/github_integration_test.go
@@ -180,7 +180,15 @@ func TestSource_ScanComments(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, 4)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.init.name),
+					sources.WithConcurrency(4),
+					sources.WithVerify(tt.init.verify),
+				),
+			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Source.Init() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -275,7 +283,15 @@ func TestSource_ScanChunks(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, 8)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.init.name),
+					sources.WithConcurrency(8),
+					sources.WithVerify(tt.init.verify),
+				),
+			)
 			assert.Nil(t, err)
 
 			chunksCh := make(chan *sources.Chunk, 1)
@@ -596,7 +612,15 @@ func TestSource_Scan(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, 4)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.init.name),
+					sources.WithConcurrency(4),
+					sources.WithVerify(tt.init.verify),
+				),
+			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Source.Init() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -737,7 +761,15 @@ func TestSource_paginateGists(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, 4)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.init.name),
+					sources.WithConcurrency(4),
+					sources.WithVerify(tt.init.verify),
+				),
+			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Source.Init() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -942,7 +974,15 @@ func TestSource_Chunks_TargetedScan(t *testing.T) {
 			conn, err := anypb.New(tt.init.connection)
 			assert.Nil(t, err)
 
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, 8)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.init.name),
+					sources.WithConcurrency(8),
+					sources.WithVerify(tt.init.verify),
+				),
+			)
 			assert.Nil(t, err)
 
 			chunksCh := make(chan *sources.Chunk, 1)

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -41,9 +41,19 @@ func createTestSource(src *sourcespb.GitHub) (*Source, *anypb.Any) {
 
 func initTestSource(src *sourcespb.GitHub) *Source {
 	s, conn := createTestSource(src)
-	if err := s.Init(context.Background(), "test - github", 0, 1337, false, conn, 1); err != nil {
+
+	err := s.Init(
+		context.Background(),
+		sources.NewConfig(
+			conn,
+			sources.WithName("test - github"),
+			sources.WithConcurrency(1),
+		),
+	)
+	if err != nil {
 		panic(err)
 	}
+
 	s.apiClient = github.NewClient(s.httpClient)
 	gock.InterceptClient(s.httpClient)
 	return s
@@ -57,7 +67,14 @@ func TestInit(t *testing.T) {
 		},
 	})
 
-	err := source.Init(context.Background(), "test - github", 0, 1337, false, conn, 1)
+	err := source.Init(
+		context.Background(),
+		sources.NewConfig(
+			conn,
+			sources.WithName("test - github"),
+			sources.WithConcurrency(1),
+		),
+	)
 	assert.Nil(t, err)
 
 	// TODO: test error case

--- a/pkg/sources/gitlab/gitlab_test.go
+++ b/pkg/sources/gitlab/gitlab_test.go
@@ -144,7 +144,15 @@ func TestSource_Scan(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, 10)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.init.name),
+					sources.WithConcurrency(10),
+					sources.WithVerify(tt.init.verify),
+				),
+			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Source.Init() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -309,7 +317,14 @@ func TestSource_Validate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = s.Init(ctx, tt.name, 0, 0, false, conn, 1)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.name),
+					sources.WithConcurrency(1),
+				),
+			)
 			if err != nil {
 				t.Fatalf("Source.Init() error: %v", err)
 			}

--- a/pkg/sources/s3/s3_integration_test.go
+++ b/pkg/sources/s3/s3_integration_test.go
@@ -10,9 +10,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/anypb"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/credentialspb"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
@@ -33,7 +34,14 @@ func TestSource_ChunksCount(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = s.Init(ctx, "test name", 0, 0, false, conn, 1)
+	err = s.Init(
+		ctx,
+		sources.NewConfig(
+			conn,
+			sources.WithName("test name"),
+			sources.WithConcurrency(1),
+		),
+	)
 	chunksCh := make(chan *sources.Chunk)
 	go func() {
 		defer close(chunksCh)
@@ -159,7 +167,14 @@ func TestSource_Validate(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = s.Init(ctx, tt.name, 0, 0, false, conn, 0)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.name),
+					sources.WithConcurrency(1),
+				),
+			)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sources/s3/s3_test.go
+++ b/pkg/sources/s3/s3_test.go
@@ -32,7 +32,6 @@ func TestSource_Chunks(t *testing.T) {
 	s3secret := secret.MustGetField("AWS_S3_SECRET")
 
 	type init struct {
-		name       string
 		verify     bool
 		connection *sourcespb.S3
 		setEnv     map[string]string

--- a/pkg/sources/s3/s3_test.go
+++ b/pkg/sources/s3/s3_test.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/anypb"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/credentialspb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 func TestSource_Chunks(t *testing.T) {
@@ -92,7 +93,15 @@ func TestSource_Chunks(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, 8)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.name),
+					sources.WithConcurrency(8),
+					sources.WithVerify(tt.init.verify),
+				),
+			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Source.Init() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"runtime"
 	"sync"
 
 	"google.golang.org/protobuf/types/known/anypb"
@@ -103,11 +104,15 @@ type Config struct {
 }
 
 // NewConfig creates a new Config with the given connection and options.
+// The connection is the only required parameter because a source cannot be initialized without it.
 func NewConfig(connection *anypb.Any, opts ...SourceConfigOption) *Config {
 	cfg := &Config{Connection: connection}
 
 	for _, opt := range opts {
 		opt(cfg)
+	}
+	if cfg.Concurrency == 0 {
+		cfg.Concurrency = runtime.NumCPU()
 	}
 
 	return cfg

--- a/pkg/sources/syslog/syslog.go
+++ b/pkg/sources/syslog/syslog.go
@@ -123,15 +123,14 @@ func (s *Source) InjectConnection(conn *sourcespb.Syslog) {
 }
 
 // Init returns an initialized Syslog source.
-func (s *Source) Init(_ context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
-
-	s.name = name
-	s.sourceId = sourceId
-	s.jobId = jobId
-	s.verify = verify
+func (s *Source) Init(_ context.Context, cfg *sources.Config) error {
+	s.name = cfg.Name
+	s.sourceId = cfg.SourceID
+	s.jobId = cfg.JobID
+	s.verify = cfg.Verify
 
 	var conn sourcespb.Syslog
-	err := anypb.UnmarshalTo(connection, &conn, proto.UnmarshalOptions{})
+	err := anypb.UnmarshalTo(cfg.Connection, &conn, proto.UnmarshalOptions{})
 	if err != nil {
 		return errors.WrapPrefix(err, "error unmarshalling connection", 0)
 	}

--- a/pkg/sources/travisci/travisci.go
+++ b/pkg/sources/travisci/travisci.go
@@ -56,11 +56,11 @@ func (s *Source) JobID() sources.JobID {
 }
 
 // Init returns an initialized TravisCI source.
-func (s *Source) Init(ctx context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
-	s.name = name
-	s.sourceId = sourceId
-	s.jobId = jobId
-	s.verify = verify
+func (s *Source) Init(ctx context.Context, cfg *sources.Config) error {
+	s.name = cfg.Name
+	s.sourceId = cfg.SourceID
+	s.jobId = cfg.JobID
+	s.verify = cfg.Verify
 	s.jobPool = &errgroup.Group{}
 	s.jobPool.SetLimit(concurrency)
 

--- a/pkg/sources/travisci/travisci.go
+++ b/pkg/sources/travisci/travisci.go
@@ -61,11 +61,11 @@ func (s *Source) Init(ctx context.Context, cfg *sources.Config) error {
 	s.sourceId = cfg.SourceID
 	s.jobId = cfg.JobID
 	s.verify = cfg.Verify
-	s.jobPool = &errgroup.Group{}
-	s.jobPool.SetLimit(concurrency)
+	s.jobPool = new(errgroup.Group)
+	s.jobPool.SetLimit(cfg.Concurrency)
 
 	var conn sourcespb.TravisCI
-	if err := anypb.UnmarshalTo(connection, &conn, proto.UnmarshalOptions{}); err != nil {
+	if err := anypb.UnmarshalTo(cfg.Connection, &conn, proto.UnmarshalOptions{}); err != nil {
 		return errors.WrapPrefix(err, "error unmarshalling connection", 0)
 	}
 

--- a/pkg/sources/travisci/travisci_test.go
+++ b/pkg/sources/travisci/travisci_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sourcestest"
 )
 
@@ -69,7 +70,15 @@ func TestSource_Scan(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = s.Init(ctx, tt.init.name, 0, 0, tt.init.verify, conn, 5)
+			err = s.Init(
+				ctx,
+				sources.NewConfig(
+					conn,
+					sources.WithName(tt.init.name),
+					sources.WithVerify(tt.init.verify),
+					sources.WithConcurrency(5),
+				),
+			)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("Source.Init() error = %v, wantErr %v", err, tt.wantErr)
 			}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Use a config struct when initializing sources. This gives us a lot more flexibility for when sources require different dependencies. For example, the use of a customContentWriter for Git based sources.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

