### PR TITLE
Partially revert #2253

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -218,7 +218,11 @@ func (a *Archive) extractorHandler(archiveChan chan []byte) func(context.Context
 			return nil
 		}
 
-		return a.openArchive(lCtx, depth, fReader, archiveChan)
+		fileBytes, err := a.ReadToMax(lCtx, fReader)
+		if err != nil {
+			return err
+		}
+		return a.openArchive(lCtx, depth, bytes.NewReader(fileBytes), archiveChan)
 	}
 }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
An optimization introduced in PR #2253 inadvertently broke scanning of nested zip archives.

Based on my testing, this fixes #2378. The changes to `pkg/sources/git/git.go`  might also need to be reverted.
https://github.com/trufflesecurity/trufflehog/pull/2253/files#diff-c2efdfa2e124674a8eaf026fee883e72f19914e765c7a99b72e4ead288bd1104

Alternatively, it's possible that this could be fixed by writing nested archives to disk instead of memory.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

