### PR TITLE
[fix] Add unit information to error returned by ChunkUnit

### DIFF
--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -355,7 +355,7 @@ func (s *SourceManager) runWithUnits(ctx context.Context, source SourceUnitEnumC
 			ctx := context.WithValue(ctx, "unit", unit.SourceUnitID())
 			ctx.Logger().V(3).Info("chunking unit")
 			if err := source.ChunkUnit(ctx, unit, chunkReporter); err != nil {
-				report.ReportError(Fatal{err})
+				report.ReportError(Fatal{ChunkError{Unit: unit, Err: err}})
 				catchFirstFatal(Fatal{err})
 			}
 			return nil


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Ensures the error returned by `ChunkUnit` is associated with the unit in the report.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

