### PR TITLE
Ignore Kubernetes GCP test credentials

### DIFF
--- a/pkg/detectors/gcp/gcp.go
+++ b/pkg/detectors/gcp/gcp.go
@@ -1,14 +1,17 @@
 package gcp
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
-	regexp "github.com/wasilibs/go-re2"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"golang.org/x/oauth2/google"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
-	"golang.org/x/oauth2/google"
 )
 
 type Scanner struct{}
@@ -77,6 +80,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		raw := []byte(creds.ClientEmail)
 		if len(raw) == 0 {
 			raw = []byte(key)
+		}
+		// This is an unprivileged service account used in Kubernetes' tests. It is intentionally public.
+		// https://github.com/kubernetes/kubernetes/blob/10a06602223eab17e02e197d1da591727c756d32/test/e2e_node/runtime_conformance_test.go#L50
+		if bytes.Equal(raw, []byte("image-pulling@authenticated-image-pulling.iam.gserviceaccount.com")) {
+			continue
 		}
 
 		credBytes, _ := json.Marshal(creds)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The `image-pulling@authenticated-image-pulling.iam.gserviceaccount.com` service account is intentionally public. It is used by Kubernetes to test image pulling, and is found in thousands of forks or k8s-related projects.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

