### PR TITLE
[chore] Increase TestMaxDiffSize timeout

### DIFF
--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -1298,8 +1298,8 @@ func TestMaxDiffSize(t *testing.T) {
 	}
 	bigReader := strings.NewReader(builder.String())
 
-	diffChan := make(chan *Diff, 1)                                         // Buffer to prevent blocking
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second) // Timeout to prevent long wait
+	diffChan := make(chan *Diff, 1)                                          // Buffer to prevent blocking
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second) // Timeout to prevent long wait
 	defer cancel()
 
 	go func() {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This test was timing out after ~5s so I increased it to 10s as a stop-gap. We should look into why the test is taking longer.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

