### PR TITLE
[chore] - use read full

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"os/exec"
@@ -624,7 +625,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 			defer reader.Close()
 
 			data := make([]byte, d.Len())
-			if _, err := reader.Read(data); err != nil {
+			if _, err := io.ReadFull(reader, data); err != nil {
 				ctx.Logger().Error(
 					err, "error reading diff content for commit",
 					"filename", fileName,


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
If the amount of data to be read is known ahead of time, it is recommended to use `io.ReadFull` as it guarantees the number of bytes to be read.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

