### PR TITLE
concurrency uint8 to int

### DIFF
--- a/main.go
+++ b/main.go
@@ -405,7 +405,7 @@ func run(state overseer.State) {
 		jobReportWriter = *jobReportFile
 	}
 	e, err := engine.Start(ctx,
-		engine.WithConcurrency(uint8(*concurrency)),
+		engine.WithConcurrency(uint16(*concurrency)),
 		engine.WithDecoders(decoders.DefaultDecoders()...),
 		engine.WithDetectors(engine.DefaultDetectors()...),
 		engine.WithDetectors(conf.Detectors...),
@@ -568,7 +568,6 @@ func run(state overseer.State) {
 	if err = e.Finish(ctx); err != nil {
 		logFatal(err, "engine failed to finish execution")
 	}
-
 	if err := cleantemp.CleanTempArtifacts(ctx); err != nil {
 		ctx.Logger().Error(err, "error cleaning temp artifacts")
 	}

--- a/main.go
+++ b/main.go
@@ -405,7 +405,7 @@ func run(state overseer.State) {
 		jobReportWriter = *jobReportFile
 	}
 	e, err := engine.Start(ctx,
-		engine.WithConcurrency(uint16(*concurrency)),
+		engine.WithConcurrency(*concurrency),
 		engine.WithDecoders(decoders.DefaultDecoders()...),
 		engine.WithDetectors(engine.DefaultDetectors()...),
 		engine.WithDetectors(conf.Detectors...),

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -59,7 +59,7 @@ type Printer interface {
 
 type Engine struct {
 	// CLI flags.
-	concurrency     uint16
+	concurrency     int
 	decoders        []decoders.Decoder
 	detectors       []detectors.Detector
 	jobReportWriter io.WriteCloser
@@ -127,7 +127,7 @@ func WithJobReportWriter(w io.WriteCloser) Option {
 	}
 }
 
-func WithConcurrency(concurrency uint16) Option {
+func WithConcurrency(concurrency int) Option {
 	return func(e *Engine) {
 		e.concurrency = concurrency
 	}
@@ -430,7 +430,7 @@ func (e *Engine) setDefaults(ctx context.Context) {
 	if e.concurrency == 0 {
 		numCPU := runtime.NumCPU()
 		ctx.Logger().Info("No concurrency specified, defaulting to max", "cpu", numCPU)
-		e.concurrency = uint16(numCPU)
+		e.concurrency = numCPU
 	}
 	ctx.Logger().V(3).Info("engine started", "workers", e.concurrency)
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -59,7 +59,7 @@ type Printer interface {
 
 type Engine struct {
 	// CLI flags.
-	concurrency     uint8
+	concurrency     uint16
 	decoders        []decoders.Decoder
 	detectors       []detectors.Detector
 	jobReportWriter io.WriteCloser
@@ -127,7 +127,7 @@ func WithJobReportWriter(w io.WriteCloser) Option {
 	}
 }
 
-func WithConcurrency(concurrency uint8) Option {
+func WithConcurrency(concurrency uint16) Option {
 	return func(e *Engine) {
 		e.concurrency = concurrency
 	}
@@ -430,7 +430,7 @@ func (e *Engine) setDefaults(ctx context.Context) {
 	if e.concurrency == 0 {
 		numCPU := runtime.NumCPU()
 		ctx.Logger().Info("No concurrency specified, defaulting to max", "cpu", numCPU)
-		e.concurrency = uint8(numCPU)
+		e.concurrency = uint16(numCPU)
 	}
 	ctx.Logger().V(3).Info("engine started", "workers", e.concurrency)
 

--- a/pkg/engine/git_test.go
+++ b/pkg/engine/git_test.go
@@ -112,7 +112,7 @@ func BenchmarkGitEngine(b *testing.B) {
 	defer cancel()
 
 	e, err := Start(ctx,
-		WithConcurrency(uint16(runtime.NumCPU())),
+		WithConcurrency(runtime.NumCPU()),
 		WithDecoders(decoders.DefaultDecoders()...),
 		WithDetectors(DefaultDetectors()...),
 		WithVerify(false),

--- a/pkg/engine/git_test.go
+++ b/pkg/engine/git_test.go
@@ -112,7 +112,7 @@ func BenchmarkGitEngine(b *testing.B) {
 	defer cancel()
 
 	e, err := Start(ctx,
-		WithConcurrency(uint8(runtime.NumCPU())),
+		WithConcurrency(uint16(runtime.NumCPU())),
 		WithDecoders(decoders.DefaultDecoders()...),
 		WithDetectors(DefaultDetectors()...),
 		WithVerify(false),


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Fixes an overflow bug described https://github.com/trufflesecurity/trufflehog/issues/2476

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

