### PR TITLE
Improve Gitlab default URL handling

### DIFF
--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -88,6 +88,10 @@ func (s *Source) Init(_ context.Context, name string, jobId sources.JobID, sourc
 	s.jobPool = &errgroup.Group{}
 	s.jobPool.SetLimit(concurrency)
 
+	if err := git.CmdCheck(); err != nil {
+		return err
+	}
+
 	var conn sourcespb.GitLab
 	err := anypb.UnmarshalTo(connection, &conn, proto.UnmarshalOptions{})
 	if err != nil {
@@ -115,7 +119,6 @@ func (s *Source) Init(_ context.Context, name string, jobId sources.JobID, sourc
 		return fmt.Errorf("invalid configuration given for source %q (%s)", name, s.Type().String())
 	}
 
-	err = git.CmdCheck()
 	s.url, err = normalizeGitlabEndpoint(conn.Endpoint)
 	if err != nil {
 		return err

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -28,7 +28,9 @@ import (
 )
 
 const SourceType = sourcespb.SourceType_SOURCE_TYPE_GITLAB
-const cloudBaseURL = "https://gitlab.com/"
+
+// This is the URL for gitlab hosted at gitlab.com
+const gitlabBaseURL = "https://gitlab.com/"
 
 type Source struct {
 	name     string
@@ -400,7 +402,7 @@ func (s *Source) getAllProjectRepos(
 		Owned:        gitlab.Ptr(false),
 	}
 
-	if s.url != cloudBaseURL {
+	if s.url != gitlabBaseURL {
 		listGroupsOptions.AllAvailable = gitlab.Ptr(true)
 	}
 
@@ -591,7 +593,7 @@ func normalizeRepos(repos []string) ([]string, []error) {
 // Otherwise, it ensures we are using https as our protocol, if none was provided.
 func normalizeGitlabEndpoint(gitlabEndpoint string) (string, error) {
 	if gitlabEndpoint == "" {
-		return cloudBaseURL, nil
+		return gitlabBaseURL, nil
 	}
 
 	gitlabURL, err := url.Parse(gitlabEndpoint)
@@ -607,20 +609,15 @@ func normalizeGitlabEndpoint(gitlabEndpoint string) (string, error) {
 		}
 	}
 
-	return normalizeGitlabEndpointURL(gitlabURL)
-}
-
-// Do not use this, only use normalizeGitlabEndpoint.
-func normalizeGitlabEndpointURL(gitlabURL *url.URL) (string, error) {
-	// If the host is gitlab.com, this is the cloud version, which only hase one valid endpoint.
+	// If the host is gitlab.com, this is the cloud version, which has only one valid endpoint.
 	if gitlabURL.Host == "gitlab.com" {
-		return cloudBaseURL, nil
+		return gitlabBaseURL, nil
 	}
 
-	// Beyond this, they are using on-prem gitlab, so we have to mostly leave what they added as-is.
+	// Beyond here, on-prem gitlab is being used, so we have to mostly leave things as-is.
 
-	if gitlabURL.Scheme == "http" {
-		return "", fmt.Errorf("http was used as URL scheme, which is insecure. Please use https instead")
+	if gitlabURL.Scheme != "https" {
+		return "", fmt.Errorf("https was not used as URL scheme, but is required. Please use https")
 	}
 
 	// The gitlab library wants trailing slashes.

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -588,7 +588,7 @@ func normalizeRepos(repos []string) ([]string, []error) {
 	return validRepos, errs
 }
 
-// normalizeGitlabEndpoint ensures that if and endpoint is going to gitlab.com, we use https://gitlab.com/ as the endpoint.
+// normalizeGitlabEndpoint ensures that if an endpoint is going to gitlab.com, we use https://gitlab.com/ as the endpoint.
 // If we see the protocol is http, we error, because this shouldn't be used.
 // Otherwise, it ensures we are using https as our protocol, if none was provided.
 func normalizeGitlabEndpoint(gitlabEndpoint string) (string, error) {

--- a/pkg/sources/gitlab/gitlab_test.go
+++ b/pkg/sources/gitlab/gitlab_test.go
@@ -443,3 +443,57 @@ func Test_scanRepos_SetProgressComplete(t *testing.T) {
 		})
 	}
 }
+
+func Test_normalizeGitlabEndpoint(t *testing.T) {
+	testCases := map[string]struct {
+		inputEndpoint  string
+		outputEndpoint string
+		wantErr        bool
+	}{
+		"the cloud url should return the cloud url": {
+			inputEndpoint:  cloudBaseURL,
+			outputEndpoint: cloudBaseURL,
+		},
+		"empty string should return the cloud url": {
+			inputEndpoint:  "",
+			outputEndpoint: cloudBaseURL,
+		},
+		"no scheme cloud url should return the cloud url": {
+			inputEndpoint:  "gitlab.com",
+			outputEndpoint: cloudBaseURL,
+		},
+		"no scheme cloud url with trailing slash should return the cloud url": {
+			inputEndpoint:  "gitlab.com/",
+			outputEndpoint: cloudBaseURL,
+		},
+		"http scheme cloud url with organization should return the cloud url": {
+			inputEndpoint:  "http://gitlab.com/trufflesec",
+			outputEndpoint: cloudBaseURL,
+		},
+		// On-prem endpoint testing.
+		"on-prem url should be unchanged": {
+			inputEndpoint:  "https://gitlab.trufflesec.com/",
+			outputEndpoint: "https://gitlab.trufflesec.com/",
+		},
+		"on-prem url without trailing slash should have trailing slash added": {
+			inputEndpoint:  "https://gitlab.trufflesec.com",
+			outputEndpoint: "https://gitlab.trufflesec.com/",
+		},
+		"on-prem url with http scheme should return an error": {
+			inputEndpoint: "http://gitlab.trufflesec.com/",
+			wantErr:       true,
+		},
+		"on-prem with gitlab.com should not rewrite to the cloud url": {
+			inputEndpoint:  "https://gitlab.com.trufflesec.com/",
+			outputEndpoint: "https://gitlab.com.trufflesec.com/",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			output, err := normalizeGitlabEndpoint(tc.inputEndpoint)
+			assert.Equal(t, tc.outputEndpoint, output)
+			assert.Equal(t, tc.wantErr, err != nil)
+		})
+	}
+}

--- a/pkg/sources/gitlab/gitlab_test.go
+++ b/pkg/sources/gitlab/gitlab_test.go
@@ -451,24 +451,24 @@ func Test_normalizeGitlabEndpoint(t *testing.T) {
 		wantErr        bool
 	}{
 		"the cloud url should return the cloud url": {
-			inputEndpoint:  cloudBaseURL,
-			outputEndpoint: cloudBaseURL,
+			inputEndpoint:  gitlabBaseURL,
+			outputEndpoint: gitlabBaseURL,
 		},
 		"empty string should return the cloud url": {
 			inputEndpoint:  "",
-			outputEndpoint: cloudBaseURL,
+			outputEndpoint: gitlabBaseURL,
 		},
 		"no scheme cloud url should return the cloud url": {
 			inputEndpoint:  "gitlab.com",
-			outputEndpoint: cloudBaseURL,
+			outputEndpoint: gitlabBaseURL,
 		},
 		"no scheme cloud url with trailing slash should return the cloud url": {
 			inputEndpoint:  "gitlab.com/",
-			outputEndpoint: cloudBaseURL,
+			outputEndpoint: gitlabBaseURL,
 		},
 		"http scheme cloud url with organization should return the cloud url": {
 			inputEndpoint:  "http://gitlab.com/trufflesec",
-			outputEndpoint: cloudBaseURL,
+			outputEndpoint: gitlabBaseURL,
 		},
 		// On-prem endpoint testing.
 		"on-prem url should be unchanged": {


### PR DESCRIPTION
### Description:
This PR does a better job handling specified gitlab URLs, particularly when they are for gitlab.com. It's currently possible wrongly specify the gitlab url, by either forgetting the protocol (https) or adding your gitlab organization to the URL. Both currently cause this source to fail, but neither should.

Additionally, if you are running against an on-prem gitlab instance, it will now fail if that instance uses http as the protocol, instead of https.

There's also a small cleanup to check for the git command earlier in the process, to prevent additional work from being done when the scan would not be successful.

Beyond those, this shouldn't change anything.

### Checklist:
* [ ] Tests passing (`make test-community`)?
      (This PR had archive test failures when running the above, looking into it)
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

