### PR TITLE
Tell git to ignore directory ownership (fixes #2495)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,8 @@ mapfile -t extra_args < <(bash -c "for arg in ${*: -1}; do echo \$arg; done")
 # Directories might be owned by a user other than root
 git config --global --add safe.directory '*'
 
-/usr/bin/trufflehog "${@: 1: $#-1}" "${extra_args[@]}" 
+if [[ $# -eq 0 ]]; then
+  /usr/bin/trufflehog --help
+else
+  /usr/bin/trufflehog "${@: 1: $#-1}" "${extra_args[@]}"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,7 @@
 # Parse the last argument into an array of extra_args.
 mapfile -t extra_args < <(bash -c "for arg in ${*: -1}; do echo \$arg; done")
 
+# Directories might be owned by a user other than root
+git config --global --add safe.directory '*'
+
 /usr/bin/trufflehog "${@: 1: $#-1}" "${extra_args[@]}" 


### PR DESCRIPTION
### Description:
When running inside docker as root with a mounted volume, we need to tell git to ignore directory ownership, which will usually not match. For more details on this fix, see https://stackoverflow.com/a/73100228/37923.

There is no security risk here, because the user actually owns the directory outside docker, and a git exploit that executes code inside the container would affect a user who made the permissions match (with `chown` or by passing `-u $UID` to docker) .

I've also included a second commit that fixes `entrypoint.sh` to show usage if no arguments are passed, instead of throwing a cryptic error. Feel free to skip this commit if you think it's wrong.

Fixes #2495.

### Checklist:
* [ ] Tests passing (`make test-community`)? No, but it doesn't without my fix either.
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?
* [x] Script passes shellcheck
