### PR TITLE
fix prefix check when returning early

### DIFF
--- a/pkg/detectors/jdbc/mysql.go
+++ b/pkg/detectors/jdbc/mysql.go
@@ -53,11 +53,11 @@ func isMySQLErrorDeterminate(err error) bool {
 func parseConnStr(connStr string) (hostAndDB, params string, err error) {
 	// expected form: [subprotocol:]//[user:password@]HOST[/DB][?key=val[&key=val]]
 	hostAndDB, params, found := strings.Cut(connStr, "?")
-	if !found {
-		return hostAndDB, "", nil
-	}
 	if !strings.HasPrefix(hostAndDB, "//") {
 		return "", "", errors.New("expected host to start with //")
+	}
+	if !found {
+		return hostAndDB, "", nil
 	}
 	splitParams := strings.Split(params, "&")
 	for i, param := range splitParams {


### PR DESCRIPTION
### Description:
While introducing a tiny optimization, I bypassed the prefix check of the host which can cause a panic in some conditions.

### Checklist:
* [X] Tests passing (`make test-community`)?
* [X] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

