### PR TITLE
Implement detectors.EndpointCustomizer on datadogtoken

### DIFF
--- a/pkg/detectors/datadogtoken/datadogtoken.go
+++ b/pkg/detectors/datadogtoken/datadogtoken.go
@@ -2,19 +2,25 @@ package datadogtoken
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{}
+type Scanner struct {
+	detectors.EndpointSetter
+}
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.EndpointCustomizer = (*Scanner)(nil)
+
+func (Scanner) DefaultEndpoint() string { return "https://api.datadoghq.com" }
 
 var (
 	client = common.SaneHttpClient()
@@ -59,23 +65,24 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-
-				req, err := http.NewRequestWithContext(ctx, "GET", "https://api.datadoghq.com/api/v2/users", nil)
-				if err != nil {
-					continue
-				}
-				req.Header.Add("Content-Type", "application/json")
-				req.Header.Add("DD-API-KEY", resApiMatch)
-				req.Header.Add("DD-APPLICATION-KEY", resAppMatch)
-				res, err := client.Do(req)
-				if err == nil {
-					defer res.Body.Close()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						s1.Verified = true
-					} else {
-						// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
-						if detectors.IsKnownFalsePositive(resApiMatch, detectors.DefaultFalsePositives, true) {
-							continue
+				for _, baseURL := range s.Endpoints(s.DefaultEndpoint()) {
+					req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/api/v2/users", nil)
+					if err != nil {
+						continue
+					}
+					req.Header.Add("Content-Type", "application/json")
+					req.Header.Add("DD-API-KEY", resApiMatch)
+					req.Header.Add("DD-APPLICATION-KEY", resAppMatch)
+					res, err := client.Do(req)
+					if err == nil {
+						defer res.Body.Close()
+						if res.StatusCode >= 200 && res.StatusCode < 300 {
+							s1.Verified = true
+						} else {
+							// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
+							if detectors.IsKnownFalsePositive(resApiMatch, detectors.DefaultFalsePositives, true) {
+								continue
+							}
 						}
 					}
 				}
@@ -96,21 +103,23 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			if verify {
 
-				req, err := http.NewRequestWithContext(ctx, "GET", "https://api.datadoghq.com/api/v1/validate", nil)
-				if err != nil {
-					continue
-				}
-				req.Header.Add("Content-Type", "application/json")
-				req.Header.Add("DD-API-KEY", resApiMatch)
-				res, err := client.Do(req)
-				if err == nil {
-					defer res.Body.Close()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						s1.Verified = true
-					} else {
-						// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
-						if detectors.IsKnownFalsePositive(resApiMatch, detectors.DefaultFalsePositives, true) {
-							continue
+				for _, baseURL := range s.Endpoints(s.DefaultEndpoint()) {
+					req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/api/v1/validate", nil)
+					if err != nil {
+						continue
+					}
+					req.Header.Add("Content-Type", "application/json")
+					req.Header.Add("DD-API-KEY", resApiMatch)
+					res, err := client.Do(req)
+					if err == nil {
+						defer res.Body.Close()
+						if res.StatusCode >= 200 && res.StatusCode < 300 {
+							s1.Verified = true
+						} else {
+							// This function will check false positives for common test words, but also it will make sure the key appears 'random' enough to be a real key.
+							if detectors.IsKnownFalsePositive(resApiMatch, detectors.DefaultFalsePositives, true) {
+								continue
+							}
 						}
 					}
 				}


### PR DESCRIPTION
### Description

As reported in #2265, Datadog API and app key verification only works if the tokens were generated in the main Datadog region (US East 1, aka `api.datadoghq.com`). This PR makes it possible to override the Datadog API endpoint at runtime.

**Please note:** when specifying a custom verifier host on the command line, trufflehog checks *both the custom host and the default host*. (See example below of when I ran this.) I wasn't expecting this, but it does appear to be the expected behaviour of `detectors.EndpointCustomizer` when using `detectors.EndpointSetter`. Please let me know if I've misunderstood anything here. (Very possible.)

Closes #2265

### Typical usage

By default, validate against https://api.datadoghq.com only:

```
trufflehog filesystem .
```

Validate against a different endpoint:

```
trufflehog filesystem . --verifier \
    datadogToken=https://api.datadoghq.eu
```

Validate against multiple endpoints:

```
trufflehog filesystem . --verifier \
    datadogToken=https://api.datadoghq.eu,https://api.us3.datadoghq.com/
```

### Sample output

I registered API and app tokens on both https://api.datadoghq.com/ and https://api.datadoghq.eu. (I gave both app tokens access to the `user_access_read` scope, since this is needed by the verifier; removing this dependency would be nice to do, but belongs in a separate PR.)

With the default verifier host:

```
$ go run . filesystem ~/misc/trufflehog-datadog-truffles/
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

2024-02-25T20:18:01Z	info-0	trufflehog	running source	{"source_manager_worker_id": "mvt4B", "with_units": true}
Found unverified result 🐷🔑❓
Detector Type: DatadogToken
Decoder Type: PLAIN
Raw result: <REDACTED>
Type: APIKeyOnly
File: /Users/simon/misc/trufflehog-datadog-truffles/datadog-eu-api-only.py

Found unverified result 🐷🔑❓
Detector Type: DatadogToken
Decoder Type: PLAIN
Raw result: <REDACTED>
Type: Application+APIKey
File: /Users/simon/misc/trufflehog-datadog-truffles/datadog-eu.py
Line: 1

✅ Found verified result 🐷🔑
Detector Type: DatadogToken
Decoder Type: PLAIN
Raw result: <REDACTED>
Type: APIKeyOnly
File: /Users/simon/misc/trufflehog-datadog-truffles/datadog-us-api-only.py

✅ Found verified result 🐷🔑
Detector Type: DatadogToken
Decoder Type: PLAIN
Raw result: <REDACTED>
Type: Application+APIKey
File: /Users/simon/misc/trufflehog-datadog-truffles/datadog-us.py
Line: 1

2024-02-25T20:18:01Z	info-0	trufflehog	finished scanning	{"chunks": 4, "bytes": 334, "verified_secrets": 2, "unverified_secrets": 2, "scan_duration": "557.51975ms"}
```

With a custom verifier host:

```
$ go run . filesystem ~/misc/trufflehog-datadog-truffles/ --verifier datadogToken=https://api.datadoghq.eu
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

2024-02-25T20:18:11Z	info-0	trufflehog	configured detector with verification urls	{"detector": "DatadogToken", "urls": ["https://api.datadoghq.eu", "https://api.datadoghq.com"]}
2024-02-25T20:18:11Z	info-0	trufflehog	running source	{"source_manager_worker_id": "IbfYG", "with_units": true}
✅ Found verified result 🐷🔑
Detector Type: DatadogToken
Decoder Type: PLAIN
Raw result: <REDACTED>
Type: APIKeyOnly
File: /Users/simon/misc/trufflehog-datadog-truffles/datadog-us-api-only.py

✅ Found verified result 🐷🔑
Detector Type: DatadogToken
Decoder Type: PLAIN
Raw result: <REDACTED>
Type: APIKeyOnly
File: /Users/simon/misc/trufflehog-datadog-truffles/datadog-eu-api-only.py

✅ Found verified result 🐷🔑
Detector Type: DatadogToken
Decoder Type: PLAIN
Raw result: <REDACTED>
Type: Application+APIKey
File: /Users/simon/misc/trufflehog-datadog-truffles/datadog-us.py
Line: 1

✅ Found verified result 🐷🔑
Detector Type: DatadogToken
Decoder Type: PLAIN
Raw result: <REDACTED>
Type: Application+APIKey
File: /Users/simon/misc/trufflehog-datadog-truffles/datadog-eu.py
Line: 1

2024-02-25T20:18:13Z	info-0	trufflehog	finished scanning	{"chunks": 4, "bytes": 334, "verified_secrets": 4, "unverified_secrets": 0, "scan_duration": "1.693135959s"}
```

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

### Notes on testing

* I did run `make test-community` but it failed, for an issue unrelated to this change.
* I would suggest also updating `datadogtoken_test.go` here, to also test Datadog credentials from an instance other than the default (`api.datadoghq.com`), but I think this needs to be done by someone with access to [the test secrets in GCP](https://github.com/trufflesecurity/trufflehog/blob/ead315dc2ec3c490c8867173250c21bd02f67238/pkg/detectors/datadogtoken/datadogtoken_test.go#L22).
