### PR TITLE
Remove one filter word

### DIFF
--- a/pkg/detectors/programmingbooks.txt
+++ b/pkg/detectors/programmingbooks.txt
@@ -1241,7 +1241,6 @@ getusermedia
 getval
 gg@allin.com
 ghastly
-github
 gitignore
 giving
 glance


### PR DESCRIPTION
Removes a problematic word from the unverified filtering while we work on a more holistic fix.
.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

