### PR TITLE
[bug] - Fix resource leak in extractDebContent and extractRpmContent function

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -355,8 +355,10 @@ func (a *Archive) extractDebContent(ctx logContext.Context, file io.Reader) (io.
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(tmpEnv.tempFileName)
-	defer os.RemoveAll(tmpEnv.extractPath)
+	defer func() {
+		os.Remove(tmpEnv.tempFileName)
+		os.RemoveAll(tmpEnv.extractPath)
+	}()
 
 	cmd := exec.Command("ar", "x", tmpEnv.tempFile.Name())
 	cmd.Dir = tmpEnv.extractPath
@@ -393,8 +395,10 @@ func (a *Archive) extractRpmContent(ctx logContext.Context, file io.Reader) (io.
 	if err != nil {
 		return nil, err
 	}
-	defer os.Remove(tmpEnv.tempFileName)
-	defer os.RemoveAll(tmpEnv.extractPath)
+	defer func() {
+		os.Remove(tmpEnv.tempFileName)
+		os.RemoveAll(tmpEnv.extractPath)
+	}()
 
 	// Use rpm2cpio to convert the RPM file to a cpio archive and then extract it using cpio command.
 	cmd := exec.Command("sh", "-c", "rpm2cpio "+tmpEnv.tempFile.Name()+" | cpio -id")


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The `extractDebContent` and `extractRpmContent` functions in the Archive type had a potential resource leak issue. The temporary file and directory created using createTempEnv were not being properly cleaned up in cases where an error occurred before reaching the defer statements responsible for their removal.

To address this issue, the defer statements for removing the temporary file and directory have been moved inside an anonymous function that is immediately invoked. This ensures that the cleanup logic is always executed, regardless of any errors that may occur during the execution of the function.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

