### PR TITLE
pull out verification logic from github detectors

### DIFF
--- a/pkg/detectors/github/v1/github_old.go
+++ b/pkg/detectors/github/v1/github_old.go
@@ -44,6 +44,11 @@ type userRes struct {
 	LdapDN string `json:"ldap_dn"`
 }
 
+type headerInfo struct {
+	Scopes string `json:"X-OAuth-Scopes"`
+	Expiry string `json:"github-authentication-token-expiration"`
+}
+
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
@@ -72,63 +77,20 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_Github,
 			Raw:          []byte(token),
-		}
-		s1.ExtraData = map[string]string{
-			"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
-			"version":        fmt.Sprintf("%d", s.Version()),
+			ExtraData: map[string]string{
+				"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
+				"version":        fmt.Sprintf("%d", s.Version()),
+			},
 		}
 
 		if verify {
 			client := common.SaneHttpClient()
-			// https://developer.github.com/v3/users/#get-the-authenticated-user
-			for _, url := range s.Endpoints(s.DefaultEndpoint()) {
-				req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/user", url), nil)
-				if err != nil {
-					continue
-				}
-				req.Header.Set("Content-Type", "application/json; charset=utf-8")
-				req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
-				res, err := client.Do(req)
-				if err == nil {
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						var userResponse userRes
-						err = json.NewDecoder(res.Body).Decode(&userResponse)
-						res.Body.Close()
-						if err == nil {
-							s1.Verified = true
 
-							if err == nil {
-								s1.Verified = true
-								s1.ExtraData["username"] = userResponse.Login
-								s1.ExtraData["url"] = userResponse.UserURL
-								s1.ExtraData["account_type"] = userResponse.Type
-								if userResponse.SiteAdmin {
-									s1.ExtraData["site_admin"] = "true"
-								}
-								if userResponse.Name != "" {
-									s1.ExtraData["name"] = userResponse.Name
-								}
-								if userResponse.Company != "" {
-									s1.ExtraData["company"] = userResponse.Company
-								}
-								if userResponse.LdapDN != "" {
-									s1.ExtraData["ldap_dn"] = userResponse.LdapDN
-								}
-
-								// GitHub does not seem to consistently return this header.
-								scopes := res.Header.Get("X-OAuth-Scopes")
-								if scopes != "" {
-									s1.ExtraData["scopes"] = scopes
-								}
-								expiry := res.Header.Get("github-authentication-token-expiration")
-								if expiry != "" {
-									s1.ExtraData["expires_at"] = expiry
-								}
-							}
-						}
-					}
-				}
-			}
+			isVerified, userResponse, headers, err := s.verifyGithub(ctx, client, token)
+			s1.Verified = isVerified
+			s1.SetVerificationError(err, token)
+			setUserResponse(userResponse, &s1)
+			setHeaderInfo(headers, &s1)
 		}
 
 		if !s1.Verified && detectors.IsKnownFalsePositive(token, detectors.DefaultFalsePositives, true) {
@@ -139,6 +101,71 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	return results, nil
+}
+
+func (s Scanner) verifyGithub(ctx context.Context, client *http.Client, token string) (bool, userRes, headerInfo, error) {
+	// https://developer.github.com/v3/users/#get-the-authenticated-user
+	var requestErr error
+	for _, url := range s.Endpoints(s.DefaultEndpoint()) {
+		requestErr = nil
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/user", url), nil)
+		if err != nil {
+			continue
+		}
+
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
+		res, err := client.Do(req)
+		if err != nil {
+			requestErr = err
+		}
+
+		if res.StatusCode >= 200 && res.StatusCode < 300 {
+			var userResponse userRes
+			err = json.NewDecoder(res.Body).Decode(&userResponse)
+			res.Body.Close()
+			if err == nil {
+				// GitHub does not seem to consistently return this header.
+				scopes := res.Header.Get("X-OAuth-Scopes")
+				expiry := res.Header.Get("github-authentication-token-expiration")
+				return true, userResponse, headerInfo{Scopes: scopes, Expiry: expiry}, nil
+			}
+		}
+	}
+	return false, userRes{}, headerInfo{}, requestErr
+}
+
+func setUserResponse(userResponse userRes, s1 *detectors.Result) {
+	if userResponse != (userRes{}) {
+		s1.ExtraData["username"] = userResponse.Login
+		s1.ExtraData["url"] = userResponse.UserURL
+		s1.ExtraData["account_type"] = userResponse.Type
+
+		if userResponse.SiteAdmin {
+			s1.ExtraData["site_admin"] = "true"
+		}
+		if userResponse.Name != "" {
+			s1.ExtraData["name"] = userResponse.Name
+		}
+		if userResponse.Company != "" {
+			s1.ExtraData["company"] = userResponse.Company
+		}
+		if userResponse.LdapDN != "" {
+			s1.ExtraData["ldap_dn"] = userResponse.LdapDN
+		}
+	}
+}
+
+func setHeaderInfo(headers headerInfo, s1 *detectors.Result) {
+	if headers != (headerInfo{}) {
+		if headers.Scopes != "" {
+			s1.ExtraData["scopes"] = headers.Scopes
+		}
+		if headers.Expiry != "" {
+			s1.ExtraData["expiry"] = headers.Expiry
+		}
+	}
 }
 
 func (s Scanner) Type() detectorspb.DetectorType {

--- a/pkg/detectors/github/v1/github_old.go
+++ b/pkg/detectors/github/v1/github_old.go
@@ -93,7 +93,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if userResponse != nil {
 				SetUserResponse(userResponse, &s1)
 			}
-
 			if headers != nil {
 				SetHeaderInfo(headers, &s1)
 			}
@@ -139,7 +138,7 @@ func (s Scanner) VerifyGithub(ctx context.Context, client *http.Client, token st
 			}
 		}
 	}
-	return false, &UserRes{}, &HeaderInfo{}, requestErr
+	return false, nil, nil, requestErr
 }
 
 func SetUserResponse(userResponse *UserRes, s1 *detectors.Result) {

--- a/pkg/detectors/github/v1/github_old_test.go
+++ b/pkg/detectors/github/v1/github_old_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestGitHub_FromChunk(t *testing.T) {
+	t.Skip("old tokens no longer valid, and no way to generate new ones")
+
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors2")

--- a/pkg/detectors/github/v2/github.go
+++ b/pkg/detectors/github/v2/github.go
@@ -2,9 +2,7 @@ package github
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 
 	regexp "github.com/wasilibs/go-re2"
 
@@ -12,16 +10,21 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	v1 "github.com/trufflesecurity/trufflehog/v3/pkg/detectors/github/v1"
 )
 
-type Scanner struct{ detectors.EndpointSetter }
+type Scanner struct {
+	v1.Scanner
+}
 
 // Ensure the Scanner satisfies the interfaces at compile time.
-var _ detectors.Detector = (*Scanner)(nil)
-var _ detectors.Versioner = (*Scanner)(nil)
-var _ detectors.EndpointCustomizer = (*Scanner)(nil)
+var _ detectors.Detector = (*v1.Scanner)(nil)
+var _ detectors.Versioner = (*v1.Scanner)(nil)
+var _ detectors.EndpointCustomizer = (*v1.Scanner)(nil)
 
-func (Scanner) Version() int            { return 2 }
+func (s Scanner) Version() int {
+	return 2
+}
 func (Scanner) DefaultEndpoint() string { return "https://api.github.com" }
 
 var (
@@ -35,23 +38,6 @@ var (
 	// TODO: Oauth2 client_id and client_secret
 	// https://developer.github.com/v3/#oauth2-keysecret
 )
-
-// TODO: Add secret context?? Information about access, ownership etc
-type userRes struct {
-	Login     string `json:"login"`
-	Type      string `json:"type"`
-	SiteAdmin bool   `json:"site_admin"`
-	Name      string `json:"name"`
-	Company   string `json:"company"`
-	UserURL   string `json:"html_url"`
-	// Included in GitHub Enterprise Server.
-	LdapDN string `json:"ldap_dn"`
-}
-
-type headerInfo struct {
-	Scopes string `json:"X-OAuth-Scopes"`
-	Expiry string `json:"github-authentication-token-expiration"`
-}
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
@@ -85,11 +71,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		if verify {
 			client := common.SaneHttpClient()
 
-			isVerified, userResponse, headers, err := s.verifyGithub(ctx, client, token)
+			isVerified, userResponse, headers, err := s.VerifyGithub(ctx, client, token)
 			s1.Verified = isVerified
 			s1.SetVerificationError(err, token)
-			setUserResponse(userResponse, &s1)
-			setHeaderInfo(headers, &s1)
+			v1.SetUserResponse(userResponse, &s1)
+			v1.SetHeaderInfo(headers, &s1)
 		}
 
 		if !s1.Verified && detectors.IsKnownFalsePositive(string(s1.Raw), detectors.DefaultFalsePositives, true) {
@@ -99,71 +85,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	return
-}
-
-func setUserResponse(userResponse userRes, s1 *detectors.Result) {
-	if userResponse != (userRes{}) {
-		s1.ExtraData["username"] = userResponse.Login
-		s1.ExtraData["url"] = userResponse.UserURL
-		s1.ExtraData["account_type"] = userResponse.Type
-
-		if userResponse.SiteAdmin {
-			s1.ExtraData["site_admin"] = "true"
-		}
-		if userResponse.Name != "" {
-			s1.ExtraData["name"] = userResponse.Name
-		}
-		if userResponse.Company != "" {
-			s1.ExtraData["company"] = userResponse.Company
-		}
-		if userResponse.LdapDN != "" {
-			s1.ExtraData["ldap_dn"] = userResponse.LdapDN
-		}
-	}
-}
-
-func (s Scanner) verifyGithub(ctx context.Context, client *http.Client, token string) (bool, userRes, headerInfo, error) {
-	// https://developer.github.com/v3/users/#get-the-authenticated-user
-	var requestErr error
-	for _, url := range s.Endpoints(s.DefaultEndpoint()) {
-		requestErr = nil
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/user", url), nil)
-		if err != nil {
-			continue
-		}
-
-		req.Header.Set("Content-Type", "application/json; charset=utf-8")
-		req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
-		res, err := client.Do(req)
-		if err != nil {
-			requestErr = err
-		}
-
-		if res.StatusCode >= 200 && res.StatusCode < 300 {
-			var userResponse userRes
-			err = json.NewDecoder(res.Body).Decode(&userResponse)
-			res.Body.Close()
-			if err == nil {
-				// GitHub does not seem to consistently return this header.
-				scopes := res.Header.Get("X-OAuth-Scopes")
-				expiry := res.Header.Get("github-authentication-token-expiration")
-				return true, userResponse, headerInfo{Scopes: scopes, Expiry: expiry}, nil
-			}
-		}
-	}
-	return false, userRes{}, headerInfo{}, requestErr
-}
-
-func setHeaderInfo(headers headerInfo, s1 *detectors.Result) {
-	if headers != (headerInfo{}) {
-		if headers.Scopes != "" {
-			s1.ExtraData["scopes"] = headers.Scopes
-		}
-		if headers.Expiry != "" {
-			s1.ExtraData["expiry"] = headers.Expiry
-		}
-	}
 }
 
 func (s Scanner) Type() detectorspb.DetectorType {

--- a/pkg/detectors/github/v2/github.go
+++ b/pkg/detectors/github/v2/github.go
@@ -48,6 +48,11 @@ type userRes struct {
 	LdapDN string `json:"ldap_dn"`
 }
 
+type headerInfo struct {
+	Scopes string `json:"X-OAuth-Scopes"`
+	Expiry string `json:"github-authentication-token-expiration"`
+}
+
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
@@ -79,64 +84,86 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 		if verify {
 			client := common.SaneHttpClient()
-			// https://developer.github.com/v3/users/#get-the-authenticated-user
-			for _, url := range s.Endpoints(s.DefaultEndpoint()) {
-				req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/user", url), nil)
-				if err != nil {
-					continue
-				}
 
-				req.Header.Set("Content-Type", "application/json; charset=utf-8")
-				req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
-				res, err := client.Do(req)
-				if err == nil {
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						var userResponse userRes
-						err = json.NewDecoder(res.Body).Decode(&userResponse)
-						res.Body.Close()
-						if err == nil {
-							s1.Verified = true
-							s1.ExtraData["username"] = userResponse.Login
-							s1.ExtraData["url"] = userResponse.UserURL
-							s1.ExtraData["account_type"] = userResponse.Type
-							if userResponse.SiteAdmin {
-								s1.ExtraData["site_admin"] = "true"
-							}
-							if userResponse.Name != "" {
-								s1.ExtraData["name"] = userResponse.Name
-							}
-							if userResponse.Company != "" {
-								s1.ExtraData["company"] = userResponse.Company
-							}
-							if userResponse.LdapDN != "" {
-								s1.ExtraData["ldap_dn"] = userResponse.LdapDN
-							}
-
-							// GitHub does not seem to consistently return this header.
-							scopes := res.Header.Get("X-OAuth-Scopes")
-							if scopes != "" {
-								s1.ExtraData["scopes"] = scopes
-							}
-							expiry := res.Header.Get("github-authentication-token-expiration")
-							if expiry != "" {
-								s1.ExtraData["expires_at"] = expiry
-							}
-						}
-					}
-				} else {
-					s1.SetVerificationError(err, token)
-				}
-			}
+			isVerified, userResponse, headers, err := s.verifyGithub(ctx, client, token)
+			s1.Verified = isVerified
+			s1.SetVerificationError(err, token)
+			setUserResponse(userResponse, &s1)
+			setHeaderInfo(headers, &s1)
 		}
 
 		if !s1.Verified && detectors.IsKnownFalsePositive(string(s1.Raw), detectors.DefaultFalsePositives, true) {
 			continue
 		}
-
 		results = append(results, s1)
 	}
 
 	return
+}
+
+func setUserResponse(userResponse userRes, s1 *detectors.Result) {
+	if userResponse != (userRes{}) {
+		s1.ExtraData["username"] = userResponse.Login
+		s1.ExtraData["url"] = userResponse.UserURL
+		s1.ExtraData["account_type"] = userResponse.Type
+
+		if userResponse.SiteAdmin {
+			s1.ExtraData["site_admin"] = "true"
+		}
+		if userResponse.Name != "" {
+			s1.ExtraData["name"] = userResponse.Name
+		}
+		if userResponse.Company != "" {
+			s1.ExtraData["company"] = userResponse.Company
+		}
+		if userResponse.LdapDN != "" {
+			s1.ExtraData["ldap_dn"] = userResponse.LdapDN
+		}
+	}
+}
+
+func (s Scanner) verifyGithub(ctx context.Context, client *http.Client, token string) (bool, userRes, headerInfo, error) {
+	// https://developer.github.com/v3/users/#get-the-authenticated-user
+	var requestErr error
+	for _, url := range s.Endpoints(s.DefaultEndpoint()) {
+		requestErr = nil
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/user", url), nil)
+		if err != nil {
+			continue
+		}
+
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		req.Header.Set("Authorization", fmt.Sprintf("token %s", token))
+		res, err := client.Do(req)
+		if err != nil {
+			requestErr = err
+		}
+
+		if res.StatusCode >= 200 && res.StatusCode < 300 {
+			var userResponse userRes
+			err = json.NewDecoder(res.Body).Decode(&userResponse)
+			res.Body.Close()
+			if err == nil {
+				// GitHub does not seem to consistently return this header.
+				scopes := res.Header.Get("X-OAuth-Scopes")
+				expiry := res.Header.Get("github-authentication-token-expiration")
+				return true, userResponse, headerInfo{Scopes: scopes, Expiry: expiry}, nil
+			}
+		}
+	}
+	return false, userRes{}, headerInfo{}, requestErr
+}
+
+func setHeaderInfo(headers headerInfo, s1 *detectors.Result) {
+	if headers != (headerInfo{}) {
+		if headers.Scopes != "" {
+			s1.ExtraData["scopes"] = headers.Scopes
+		}
+		if headers.Expiry != "" {
+			s1.ExtraData["expiry"] = headers.Expiry
+		}
+	}
 }
 
 func (s Scanner) Type() detectorspb.DetectorType {

--- a/pkg/detectors/github/v2/github.go
+++ b/pkg/detectors/github/v2/github.go
@@ -74,8 +74,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, userResponse, headers, err := s.VerifyGithub(ctx, client, token)
 			s1.Verified = isVerified
 			s1.SetVerificationError(err, token)
-			v1.SetUserResponse(userResponse, &s1)
-			v1.SetHeaderInfo(headers, &s1)
+
+			if userResponse != nil {
+				v1.SetUserResponse(userResponse, &s1)
+			}
+			if headers != nil {
+				v1.SetHeaderInfo(headers, &s1)
+			}
 		}
 
 		if !s1.Verified && detectors.IsKnownFalsePositive(string(s1.Raw), detectors.DefaultFalsePositives, true) {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
this was initially prompted by [Gomez's suggesion](https://github.com/trufflesecurity/trufflehog/pull/2471#discussion_r1493011083) that we should consolidate the verification logic for both versions of github detectors to reduce logic. but turns out according to Go's convention, each directory represents a separate package if they have different paths, even if the package declaration within the files is the same. so the detectors can't access each other's private methods. we _could_ technically make them exported but i'm not sure if that's wise.

in any case, the refactor to pull out verification was already done and should still be useful.


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

