### PR TITLE
MaxMind detector uses the right endpoint

### DIFF
--- a/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
+++ b/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
@@ -44,7 +44,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			DetectorType: detectorspb.DetectorType_MaxMindLicense,
 			Redacted:     keyRes,
 			Raw:          []byte(keyRes),
-			RawV2:        []byte(keyRes),
 			ExtraData: map[string]string{
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/maxmind/",
 				"version":        fmt.Sprintf("%d", s.Version()),

--- a/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
+++ b/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
@@ -57,9 +57,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req, err := http.NewRequestWithContext(
 				ctx, "POST", "https://secret-scanning.maxmind.com/secrets/validate-license-key",
 				strings.NewReader(data.Encode()))
-			if err != nil {
-				continue
-			}
+			r.SetVerificationError(err, keyRes)
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 			res, err := client.Do(req)

--- a/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
+++ b/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -50,13 +52,15 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "POST", "https://secret-scanning.maxmind.com/secrets/validate-license-key", nil)
+			data := url.Values{}
+			data.Add("license_key", keyRes)
+			req, err := http.NewRequestWithContext(
+				ctx, "POST", "https://secret-scanning.maxmind.com/secrets/validate-license-key",
+				strings.NewReader(data.Encode()))
 			if err != nil {
 				continue
 			}
-
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-			req.Form.Add("license_key", keyRes)
 
 			res, err := client.Do(req)
 			if err == nil {

--- a/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
+++ b/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
@@ -20,7 +20,6 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	client = common.SaneHttpClient()
 
-	idPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"maxmind", "geoip"}) + `\b([0-9]{2,7})\b`)
 	keyPat = regexp.MustCompile(`\b([0-9A-Za-z]{6}_[0-9A-Za-z]{29}_mmk)\b`)
 )
 
@@ -37,49 +36,44 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	dataStr := string(data)
 
 	keyMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
-	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, keyMatch := range keyMatches {
 		keyRes := strings.TrimSpace(keyMatch[1])
 
-		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
+		r := detectors.Result{
+			DetectorType: detectorspb.DetectorType_MaxMindLicense,
+			Redacted:     keyRes,
+			Raw:          []byte(keyRes),
+			RawV2:        []byte(keyRes),
+			ExtraData: map[string]string{
+				"rotation_guide": "https://howtorotate.com/docs/tutorials/maxmind/",
+				"version":        fmt.Sprintf("%d", s.Version()),
+			},
+		}
+
+		if verify {
+			req, err := http.NewRequestWithContext(ctx, "POST", "https://secret-scanning.maxmind.com/secrets/validate-license-key", nil)
+			if err != nil {
 				continue
 			}
-			idRes := strings.TrimSpace(idMatch[1])
 
-			s := detectors.Result{
-				DetectorType: detectorspb.DetectorType_MaxMindLicense,
-				Redacted:     idRes,
-				Raw:          []byte(keyRes),
-				RawV2:        []byte(keyRes + idRes),
-				ExtraData: map[string]string{
-					"rotation_guide": "https://howtorotate.com/docs/tutorials/maxmind/",
-					"version":        fmt.Sprintf("%d", s.Version()),
-				},
-			}
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Form.Add("license_key", keyRes)
 
-			if verify {
-				req, err := http.NewRequestWithContext(ctx, "GET", "https://geoip.maxmind.com/geoip/v2.1/country/8.8.8.8", nil)
-				if err != nil {
-					continue
-				}
-				req.SetBasicAuth(idRes, keyRes)
-				res, err := client.Do(req)
-				if err == nil {
-					defer res.Body.Close()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						s.Verified = true
-					} else {
-						if detectors.IsKnownFalsePositive(keyRes, detectors.DefaultFalsePositives, true) {
-							continue
-						}
+			res, err := client.Do(req)
+			if err == nil {
+				defer res.Body.Close()
+				if res.StatusCode >= 200 && res.StatusCode < 300 {
+					r.Verified = true
+				} else {
+					if detectors.IsKnownFalsePositive(keyRes, detectors.DefaultFalsePositives, true) {
+						continue
 					}
 				}
 			}
-
-			results = append(results, s)
 		}
+
+		results = append(results, r)
 	}
 
 	return results, nil

--- a/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
+++ b/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
-	"strings"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -38,7 +37,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	keyMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, keyMatch := range keyMatches {
-		keyRes := strings.TrimSpace(keyMatch[1])
+		keyRes := keyMatch[1]
 
 		r := detectors.Result{
 			DetectorType: detectorspb.DetectorType_MaxMindLicense,
@@ -64,10 +63,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					r.Verified = true
-				} else {
-					if detectors.IsKnownFalsePositive(keyRes, detectors.DefaultFalsePositives, true) {
-						continue
-					}
 				}
 			}
 		}

--- a/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
+++ b/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
@@ -57,15 +57,20 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			req, err := http.NewRequestWithContext(
 				ctx, "POST", "https://secret-scanning.maxmind.com/secrets/validate-license-key",
 				strings.NewReader(data.Encode()))
-			r.SetVerificationError(err, keyRes)
+			if err != nil {
+				r.SetVerificationError(err)
+				results = append(results, r)
+				continue
+			}
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 			res, err := client.Do(req)
-			if err == nil {
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					r.Verified = true
-				}
+			if err != nil {
+				r.SetVerificationError(err)
+			}
+			defer res.Body.Close()
+			if err == nil && res.StatusCode >= 200 && res.StatusCode < 300 {
+				r.Verified = true
 			}
 		}
 

--- a/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
+++ b/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go
@@ -43,7 +43,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 		r := detectors.Result{
 			DetectorType: detectorspb.DetectorType_MaxMindLicense,
-			Redacted:     keyRes,
 			Raw:          []byte(keyRes),
 			ExtraData: map[string]string{
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/maxmind/",

--- a/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2_test.go
+++ b/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-func TestMaxMindLicense_FromChunk(t *testing.T) {
+func TestMaxMindLicense(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors3")
@@ -24,7 +24,6 @@ func TestMaxMindLicense_FromChunk(t *testing.T) {
 		t.Fatalf("could not get test secrets from GCP: %s", err)
 	}
 	secret := testSecrets.MustGetField("MAXMIND_LICENSE")
-	user := testSecrets.MustGetField("MAXMIND_USER")
 	inactiveSecret := testSecrets.MustGetField("MAXMIND_LICENSE_INACTIVE")
 
 	type args struct {
@@ -44,13 +43,13 @@ func TestMaxMindLicense_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a geoip secret %s within with maxmind user %s", secret, user)),
+				data:   []byte(fmt.Sprintf("You can find a geoip secret %s", secret)),
 				verify: true,
 			},
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_MaxMindLicense,
-					Redacted:     "662034",
+					Redacted:     "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",
 					Verified:     true,
 					ExtraData: map[string]string{
 						"rotation_guide": "https://howtorotate.com/docs/tutorials/maxmind/",
@@ -65,13 +64,13 @@ func TestMaxMindLicense_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a maxmind secret %s within with maxmind user %s", inactiveSecret, user)),
+				data:   []byte(fmt.Sprintf("You can find a maxmind secret %s", inactiveSecret)),
 				verify: true,
 			},
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_MaxMindLicense,
-					Redacted:     "662034",
+					Redacted:     "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",
 					Verified:     false,
 					ExtraData: map[string]string{
 						"rotation_guide": "https://howtorotate.com/docs/tutorials/maxmind/",

--- a/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2_test.go
+++ b/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2_test.go
@@ -23,8 +23,8 @@ func TestMaxMindLicense(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get test secrets from GCP: %s", err)
 	}
-	secret := testSecrets.MustGetField("MAXMIND_LICENSE")
-	inactiveSecret := testSecrets.MustGetField("MAXMIND_LICENSE_INACTIVE")
+	secret := testSecrets.MustGetField("MAXMIND_LICENSE_V2")
+	inactiveSecret := testSecrets.MustGetField("MAXMIND_LICENSE_INACTIVE_V2")
 
 	type args struct {
 		ctx    context.Context
@@ -49,7 +49,6 @@ func TestMaxMindLicense(t *testing.T) {
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_MaxMindLicense,
-					Redacted:     "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",
 					Verified:     true,
 					ExtraData: map[string]string{
 						"rotation_guide": "https://howtorotate.com/docs/tutorials/maxmind/",
@@ -70,7 +69,6 @@ func TestMaxMindLicense(t *testing.T) {
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_MaxMindLicense,
-					Redacted:     "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",
 					Verified:     false,
 					ExtraData: map[string]string{
 						"rotation_guide": "https://howtorotate.com/docs/tutorials/maxmind/",


### PR DESCRIPTION

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The endpoint that the current detector uses fails in verifying the license key as some license keys do not have permissions to the geoip API. This commit is to make the detector use the right endpoint https://dev.maxmind.com/license-key-validation-api

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

