### PR TITLE
Fix --results not behaving as expected.

### DIFF
--- a/main.go
+++ b/main.go
@@ -616,16 +616,13 @@ func parseResults(input *string) (map[string]struct{}, error) {
 		return nil, nil
 	}
 
-
 	var (
 		values  = strings.Split(strings.ToLower(*input), ",")
 		results = make(map[string]struct{}, 3)
 	)
 	for _, value := range values {
 		switch value {
-		case "verified":
-		case "unknown":
-		case "unverified":
+		case "verified", "unknown", "unverified":
 			results[value] = struct{}{}
 		default:
 			return nil, fmt.Errorf("invalid value '%s', valid values are 'verified,unknown,unverified'", value)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:

This fixes #2580.

Go switches are not Java switches. Go switches are not Java switches. Go switches are not Java switches. Go switches are not Java switches. Go switches are not Java switches. Go switches are not Java switches. 

![QELQoU3](https://github.com/trufflesecurity/trufflehog/assets/32133502/06e49f57-47ee-4297-9227-72b58ef9c61a)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

