### PR TITLE
expand keyword checks, and add collection name to keyword

### DIFF
--- a/pkg/sources/postman/substitution_test.go
+++ b/pkg/sources/postman/substitution_test.go
@@ -145,7 +145,6 @@ func TestSource_FormatAndInjectKeywords(t *testing.T) {
 		expected := strings.Split(tc.expected, "\n")
 		sort.Strings(got)
 		sort.Strings(expected)
-		// CHATGPT CHECK HERE
 
 		if !reflect.DeepEqual(got, expected) {
 			t.Errorf("Expected result: %q, got: %q", tc.expected, result)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR loosens the constraints from an exact match to "contains" for detector keywords. e.g. "datadog-token" is a variable key in postman, but "datadog" is a detector keyword. Before this change we would not be adding "datadog" to the keywords.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

