### PR TITLE
Fix GitHub panic and test errors

### DIFF
--- a/pkg/sources/errors.go
+++ b/pkg/sources/errors.go
@@ -20,6 +20,10 @@ func NewScanErrors() *ScanErrors {
 
 // Add an error to the collection in a thread-safe manner.
 func (s *ScanErrors) Add(err error) {
+	if err == nil {
+		return
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.errors = append(s.errors, err)

--- a/pkg/sources/errors_test.go
+++ b/pkg/sources/errors_test.go
@@ -152,7 +152,7 @@ func TestScanErrorsCount(t *testing.T) {
 func TestScanErrorsString(t *testing.T) {
 	se := NewScanErrors()
 	se.Add(nil)
-	want := "[<nil>]"
+	want := "[]"
 	if got := fmt.Sprintf("%v", se); got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -417,12 +417,19 @@ func (s *Source) enumerate(ctx context.Context, apiEndpoint string) (*github.Cli
 			continue
 		}
 
-		ghRepo, _, err := s.apiClient.Repositories.Get(ctx, urlParts[1], urlParts[2])
-		if err != nil {
-			ctx.Logger().Error(err, "failed to fetch repository")
-			continue
+		// Ignore any gists in |s.filteredRepoCache|.
+		// Repos have three parts (github.com, owner, name), gists have two.
+		if len(urlParts) == 3 {
+			// Ensure that individual repos specified in --repo are cached.
+			// Gists should be cached elsewhere.
+			// https://github.com/trufflesecurity/trufflehog/pull/2379#discussion_r1487454788
+			ghRepo, _, err := s.apiClient.Repositories.Get(ctx, urlParts[1], urlParts[2])
+			if err != nil {
+				ctx.Logger().Error(err, "failed to fetch repository")
+				continue
+			}
+			s.cacheRepoInfo(ghRepo)
 		}
-		s.cacheRepoInfo(ghRepo)
 		s.repos = append(s.repos, r)
 	}
 	githubReposEnumerated.WithLabelValues(s.name).Set(float64(len(s.repos)))

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -433,18 +433,23 @@ func TestEnumerate(t *testing.T) {
 	gock.New("https://api.github.com").
 		Get("/users/super-secret-user/repos").
 		Reply(200).
-		JSON([]map[string]string{{"clone_url": "https://github.com/super-secret-repo.git", "full_name": "super-secret-repo"}})
+		JSON([]map[string]string{{"clone_url": "https://github.com/super-secret-user/super-secret-repo.git", "full_name": "super-secret-user/super-secret-repo"}})
+
+	gock.New("https://api.github.com").
+		Get("/repos/super-secret-user/super-secret-repo").
+		Reply(200).
+		JSON(`{"owner": {"login": "super-secret-user"}, "name": "super-secret-repo", "full_name": "super-secret-user/super-secret-repo", "has_wiki": false, "size": 1}`)
 
 	gock.New("https://api.github.com").
 		Get("/user/orgs").
 		MatchParam("per_page", "100").
 		Reply(200).
-		JSON([]map[string]string{{"clone_url": "https://github.com/super-secret-repo.git", "full_name": "super-secret-repo"}})
+		JSON([]map[string]string{{"clone_url": "https://github.com/super-secret-user/super-secret-repo.git", "full_name": "super-secret-user/super-secret-repo"}})
 
 	gock.New("https://api.github.com").
 		Get("/users/super-secret-user/gists").
 		Reply(200).
-		JSON([]map[string]string{{"git_pull_url": "https://github.com/super-secret-gist.git", "id": "super-secret-gist"}})
+		JSON(`[{"git_pull_url": "https://gist.github.com/2801a2b0523099d0614a951579d99ba9.git", "id": "2801a2b0523099d0614a951579d99ba9"}]`)
 
 	s := initTestSource(&sourcespb.GitHub{
 		Credential: &sourcespb.GitHub_Token{
@@ -455,9 +460,9 @@ func TestEnumerate(t *testing.T) {
 	_, err := s.enumerate(context.Background(), "https://api.github.com")
 	assert.Nil(t, err)
 	assert.Equal(t, 2, s.filteredRepoCache.Count())
-	ok := s.filteredRepoCache.Exists("super-secret-repo")
+	ok := s.filteredRepoCache.Exists("super-secret-user/super-secret-repo")
 	assert.True(t, ok)
-	ok = s.filteredRepoCache.Exists("super-secret-gist")
+	ok = s.filteredRepoCache.Exists("2801a2b0523099d0614a951579d99ba9")
 	assert.True(t, ok)
 	assert.True(t, gock.IsDone())
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This is a follow-up to #2379. It fixes a panic that could occur during enumeration, as well as some test failures.

```
2024-03-22T08:38:54-04:00       error   trufflehog      goroutine 2116 [running]:
runtime/debug.Stack()
        /home/user/sdk/go1.21.0/src/runtime/debug/stack.go:24 +0x5e
github.com/trufflesecurity/trufflehog/v3/pkg/common.Recover({0x3b3c000, 0xc0027b8030})
        /tmp/trufflehog/pkg/common/recover.go:17 +0x58
panic({0x308c1a0?, 0xc001938e10?})
        /home/user/sdk/go1.21.0/src/runtime/panic.go:914 +0x21f
github.com/trufflesecurity/trufflehog/v3/pkg/sources/github.(*Source).enumerate(0xc001dffb00, {0x3b3c000?, 0xc0027b8030?}, {0x32d2356?, 0xc0027c5c98?})
        /tmp/trufflehog/pkg/sources/github/github.go:421 +0x8b2
github.com/trufflesecurity/trufflehog/v3/pkg/sources/github.(*Source).Chunks(0xc001dffb00, {0x3b3c000, 0xc0027b8030}, 0xc002440000?, {0x0?, 0x0?, 0x0?})
        /tmp/trufflehog/pkg/sources/github/github.go:372 +0x29d
github.com/trufflesecurity/trufflehog/v3/pkg/sources.(*SourceManager).runWithoutUnits(0xc000e4a090, {0x3b3c000, 0xc0027b8030}, {0x3b3fb70?, 0xc001dffb00}, 0xc0000f9ce0, {0x0, 0x0, 0x0})
        /tmp/trufflehog/pkg/sources/source_manager.go:308 +0x204
github.com/trufflesecurity/trufflehog/v3/pkg/sources.(*SourceManager).run(0xc000e4a090, {0x3b3c000, 0xc0027b8030}, {0x3b3fb70, 0xc001dffb00}, 0xc0000f9ce0, {0x0, 0x0, 0x0})
        /tmp/trufflehog/pkg/sources/source_manager.go:283 +0x627
github.com/trufflesecurity/trufflehog/v3/pkg/sources.(*SourceManager).Run.func1()
        /tmp/trufflehog/pkg/sources/source_manager.go:159 +0x299
created by github.com/trufflesecurity/trufflehog/v3/pkg/sources.(*SourceManager).Run in goroutine 1
        /tmp/trufflehog/pkg/sources/source_manager.go:149 +0x36c
        {"source_manager_worker_id": "JjPet", "recover": "runtime error: index out of range [2] with length 2", "error": "panic"}
```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

