### PR TITLE
Fix GitHub enumeration & rate-limiting logic

### DIFF
--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -451,20 +451,17 @@ func BenchmarkEnumerateWithToken(b *testing.B) {
 func TestEnumerate(t *testing.T) {
 	defer gock.Off()
 
+	// Arrange
 	gock.New("https://api.github.com").
 		Get("/user").
 		Reply(200).
 		JSON(map[string]string{"login": "super-secret-user"})
 
+	//
 	gock.New("https://api.github.com").
 		Get("/users/super-secret-user/repos").
 		Reply(200).
-		JSON([]map[string]string{{"clone_url": "https://github.com/super-secret-user/super-secret-repo.git", "full_name": "super-secret-user/super-secret-repo"}})
-
-	gock.New("https://api.github.com").
-		Get("/repos/super-secret-user/super-secret-repo").
-		Reply(200).
-		JSON(`{"owner": {"login": "super-secret-user"}, "name": "super-secret-repo", "full_name": "super-secret-user/super-secret-repo", "has_wiki": false, "size": 1}`)
+		JSON(`[{"name": "super-secret-repo", "full_name": "super-secret-user/super-secret-repo", "owner": {"login": "super-secret-user"}, "clone_url": "https://github.com/super-secret-user/super-secret-repo.git", "has_wiki": false, "size": 1}]`)
 
 	gock.New("https://api.github.com").
 		Get("/user/orgs").
@@ -483,12 +480,50 @@ func TestEnumerate(t *testing.T) {
 		},
 	})
 
+	// Manually cache a repository to ensure that enumerate
+	// doesn't make duplicate API calls.
+	// See https://github.com/trufflesecurity/trufflehog/pull/2625
+	repo := func() *github.Repository {
+		var (
+			name     = "cached-repo"
+			fullName = "cached-user/cached-repo"
+			login    = "cached-user"
+			cloneUrl = "https://github.com/cached-user/cached-repo.git"
+			owner    = &github.User{
+				Login: &login,
+			}
+			hasWiki = false
+			size    = 1234
+		)
+		return &github.Repository{
+			Name:     &name,
+			FullName: &fullName,
+			Owner:    owner,
+			HasWiki:  &hasWiki,
+			Size:     &size,
+			CloneURL: &cloneUrl,
+		}
+	}()
+	s.cacheRepoInfo(repo)
+	s.filteredRepoCache.Set(repo.GetFullName(), repo.GetCloneURL())
+
+	// Act
 	_, err := s.enumerate(context.Background(), "https://api.github.com")
+
+	// Assert
 	assert.Nil(t, err)
-	assert.Equal(t, 2, s.filteredRepoCache.Count())
-	ok := s.filteredRepoCache.Exists("super-secret-user/super-secret-repo")
+	// Enumeration found all repos.
+	assert.Equal(t, 3, s.filteredRepoCache.Count())
+	assert.True(t, s.filteredRepoCache.Exists("super-secret-user/super-secret-repo"))
+	assert.True(t, s.filteredRepoCache.Exists("cached-user/cached-repo"))
+	assert.True(t, s.filteredRepoCache.Exists("2801a2b0523099d0614a951579d99ba9"))
+	// Enumeration cached all repos.
+	assert.Equal(t, 3, len(s.repoInfoCache.cache))
+	_, ok := s.repoInfoCache.get("https://github.com/super-secret-user/super-secret-repo.git")
 	assert.True(t, ok)
-	ok = s.filteredRepoCache.Exists("2801a2b0523099d0614a951579d99ba9")
+	_, ok = s.repoInfoCache.get("https://github.com/cached-user/cached-repo.git")
+	assert.True(t, ok)
+	_, ok = s.repoInfoCache.get("https://gist.github.com/2801a2b0523099d0614a951579d99ba9.git")
 	assert.True(t, ok)
 	assert.True(t, gock.IsDone())
 }

--- a/pkg/sources/github/repo.go
+++ b/pkg/sources/github/repo.go
@@ -297,6 +297,18 @@ func (s *Source) cacheRepoInfo(r *github.Repository) {
 	s.repoInfoCache.put(r.GetCloneURL(), info)
 }
 
+func (s *Source) cacheGistInfo(g *github.Gist) {
+	info := repoInfo{
+		owner: g.GetOwner().GetLogin(),
+	}
+	if g.GetPublic() {
+		info.visibility = source_metadatapb.Visibility_public
+	} else {
+		info.visibility = source_metadatapb.Visibility_private
+	}
+	s.repoInfoCache.put(g.GetGitPullURL(), info)
+}
+
 // wikiIsReachable returns true if https://github.com/$org/$repo/wiki is not redirected.
 // Unfortunately, this isn't 100% accurate. Some repositories have `has_wiki: true` and don't redirect their wiki page,
 // but still don't have a cloneable wiki.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This is a follow-up to #2379.

It fixes the following issues:
1. GitHub API calls missing rate-limit handling
2. The fix for https://github.com/trufflesecurity/trufflehog/pull/2379#discussion_r1487454788 inadvertently resulting in duplicate API calls

### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

