### PR TITLE
make postman source public

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,14 @@ Set the `--since-commit` flag to your default branch that people merge into (ex:
 trufflehog git file://. --since-commit main --branch feature-1 --only-verified --fail
 ```
 
+## 12: Scan a Postman workspace
+
+Use the `--workspace`, `--collection`, `--environment` flags multiple times to scan multiple targets.
+
+```bash
+trufflehog postman --token=<postman api token> --workspace=<workspace id>
+```
+
 # :question: FAQ
 
 - All I see is `🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷` and the program exits, what gives?

--- a/main.go
+++ b/main.go
@@ -155,7 +155,7 @@ var (
 	travisCiScanToken = travisCiScan.Flag("token", "TravisCI token. Can also be provided with environment variable").Envar("TRAVISCI_TOKEN").Required().String()
 
 	// Postman is hidden for now until we get more feedback from the community.
-	postmanScan                = cli.Command("postman", "Scan Postman").Hidden()
+	postmanScan                = cli.Command("postman", "Scan Postman")
 	postmanToken               = postmanScan.Flag("token", "Postman token. Can also be provided with environment variable").Envar("POSTMAN_TOKEN").String()
 	postmanWorkspaces          = postmanScan.Flag("workspace", "Postman workspace to scan. You can repeat this flag.").Strings()
 	postmanCollections         = postmanScan.Flag("collection", "Postman collection to scan. You can repeat this flag.").Strings()


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Removes the `.hidden` attribute on the `postman` command.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

