### PR TITLE
Improve handling of Gist URLs

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -433,6 +433,9 @@ RepoLoop:
 				for {
 					gistID := extractGistID(urlParts)
 					gist, _, err := s.apiClient.Gists.Get(repoCtx, gistID)
+					// Normalize the URL to the Gist's pull URL.
+					// See https://github.com/trufflesecurity/trufflehog/pull/2625#issuecomment-2025507937
+					r = gist.GetGitPullURL()
 					if s.handleRateLimit(err) {
 						continue
 					}

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -777,7 +777,7 @@ func Test_scan_SetProgressComplete(t *testing.T) {
 }
 
 func TestGetRepoURLParts(t *testing.T) {
-	tests := []string{
+	repoURLs := []string{
 		"https://github.com/trufflesecurity/trufflehog.git",
 		"git+https://github.com/trufflesecurity/trufflehog.git",
 		"ssh://github.com/trufflesecurity/trufflehog.git",
@@ -786,9 +786,31 @@ func TestGetRepoURLParts(t *testing.T) {
 		"git://github.com/trufflesecurity/trufflehog.git",
 	}
 	expected := []string{"github.com", "trufflesecurity", "trufflehog"}
-	for _, tt := range tests {
+	for _, tt := range repoURLs {
 		_, parts, err := getRepoURLParts(tt)
 		if err != nil {
+			t.Fatalf("failed: %v", err)
+		}
+		assert.Equal(t, expected, parts)
+	}
+
+	gistURLs := map[string][]string{
+		// Gists
+		"ssh://github.com/6df198861306313246466d23aa4102aa.git":                           nil,
+		"ssh://gist.github.com/6df198861306313246466d23aa4102aa.git":                      {"gist.github.com", "6df198861306313246466d23aa4102aa"},
+		"https://gist.github.com/6df198861306313246466d23aa4102aa.git":                    {"gist.github.com", "6df198861306313246466d23aa4102aa"},
+		"https://gist.github.com/john-smith/6df198861306313246466d23aa4102aa.git":         {"gist.github.com", "john-smith", "6df198861306313246466d23aa4102aa"},
+		"ssh://github.contoso.com/gist/6df198861306313246466d23aa4102aa.git":              {"github.contoso.com", "gist", "6df198861306313246466d23aa4102aa"},
+		"https://github.contoso.com/gist/6df198861306313246466d23aa4102aa.git":            {"github.contoso.com", "gist", "6df198861306313246466d23aa4102aa"},
+		"https://github.contoso.com/gist/john-smith/6df198861306313246466d23aa4102aa.git": {"github.contoso.com", "gist", "john-smith", "6df198861306313246466d23aa4102aa"},
+		"https://github.com/gist/john-smith/6df198861306313246466d23aa4102aa.git":         nil,
+	}
+	for tt, expected := range gistURLs {
+		_, parts, err := getRepoURLParts(tt)
+		if err != nil {
+			if expected == nil {
+				continue
+			}
 			t.Fatalf("failed: %v", err)
 		}
 		assert.Equal(t, expected, parts)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This is a follow-up to #2625. It fixes #2640 (at least based on my testing) and should allow scanning of gists with GHES, which was highlighted in https://github.com/trufflesecurity/trufflehog/issues/2640#issuecomment-2025398660.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

