### PR TITLE
Remove duplicate JiraToken.v2 declaration in `defaults.go`

### DIFF
--- a/pkg/engine/defaults.go
+++ b/pkg/engine/defaults.go
@@ -1593,7 +1593,6 @@ func DefaultDetectors() []detectors.Detector {
 		azuredevopspersonalaccesstoken.Scanner{},
 		azuresearchadminkey.Scanner{},
 		azuresearchquerykey.Scanner{},
-		jiratokenv2.Scanner{},
 		googleoauth2.Scanner{},
 		dockerhubv2.Scanner{},
 		&jupiterone.Scanner{},


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
It's already declared above.
https://github.com/trufflesecurity/trufflehog/blob/0ba8ae2e5f1fd3b6ff26ff7cd40eb8a41ea45fdd/pkg/engine/defaults.go#L869-L870

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

