### PR TITLE
[bug] - Add ASCII validation check for base64 decoding

### DIFF
--- a/pkg/decoders/base64_test.go
+++ b/pkg/decoders/base64_test.go
@@ -132,7 +132,6 @@ func TestBase64_FromChunk(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Parallel()
 		t.Run(tt.name, func(t *testing.T) {
 			d := &Base64{}
 			got := d.FromChunk(tt.chunk)

--- a/pkg/decoders/base64_test.go
+++ b/pkg/decoders/base64_test.go
@@ -123,8 +123,16 @@ func TestBase64_FromChunk(t *testing.T) {
 				Data: []byte(`b64urlsafe-test-secret-underscores??`),
 			},
 		},
+		{
+			name: "invalid base64 string",
+			chunk: &sources.Chunk{
+				Data: []byte(`a3d3fa7c2bb99e469ba55e5834ce79ee4853a8a3`),
+			},
+		},
 	}
+
 	for _, tt := range tests {
+		t.Parallel()
 		t.Run(tt.name, func(t *testing.T) {
 			d := &Base64{}
 			got := d.FromChunk(tt.chunk)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Previously, when decoding base64 strings using `base64.StdEncoding.DecodeString` or `base64.RawURLEncoding.DecodeString`, if the input string was not a valid base64-encoded string, the decoding process would still proceed, resulting in the inclusion of non-valid decoded strings in the output.

To address this issue, an additional validation check has been added to ensure that the decoded byte slice contains only ASCII characters. The isASCII function has been introduced to perform this check efficiently.

before:
![Screenshot 2024-04-04 at 4 12 15 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/59e47ca0-8078-4c05-94f4-8feed03b38c5)

after:
![Screenshot 2024-04-04 at 4 13 05 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/769c87e4-f9ea-42ea-ae20-88ddd0e29ee8)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

