### PR TITLE
Enrich Gitlab enumeration logging

### DIFF
--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -469,6 +469,8 @@ func (s *Source) getAllProjectRepos(
 		listGroupsOptions.AllAvailable = gitlab.Ptr(true)
 	}
 
+	ctx.Logger().Info("beginning group enumeration", "options", listGroupsOptions)
+
 	var groups []*gitlab.Group
 	for {
 		groupList, res, err := apiClient.Groups.ListGroups(&listGroupsOptions)
@@ -485,6 +487,8 @@ func (s *Source) getAllProjectRepos(
 			break
 		}
 	}
+
+	ctx.Logger().Info("got groups", "group_count", len(groups))
 
 	for _, group := range groups {
 		listGroupProjectOptions := &gitlab.ListGroupProjectsOptions{

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -202,6 +202,7 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, tar
 	}
 
 	s.repos = repos
+	gitlabReposEnumerated.WithLabelValues(s.name).Set(float64(len(repos)))
 	// We must sort the repos so we can resume later if necessary.
 	slices.Sort(s.repos)
 
@@ -729,11 +730,13 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 
 	// Report all repos if specified.
 	if len(repos) > 0 {
+		gitlabReposEnumerated.WithLabelValues(s.name).Set(0)
 		for _, repo := range repos {
 			unit := git.SourceUnit{Kind: git.UnitRepo, ID: repo}
 			if err := reporter.UnitOk(ctx, unit); err != nil {
 				return err
 			}
+			gitlabReposEnumerated.WithLabelValues(s.name).Inc()
 		}
 		return nil
 	}

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -199,10 +199,11 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, tar
 		if err := s.getAllProjectRepos(ctx, apiClient, ignoreRepo, reporter); err != nil {
 			return err
 		}
+	} else {
+		gitlabReposEnumerated.WithLabelValues(s.name).Set(float64(len(repos)))
 	}
 
 	s.repos = repos
-	gitlabReposEnumerated.WithLabelValues(s.name).Set(float64(len(repos)))
 	// We must sort the repos so we can resume later if necessary.
 	slices.Sort(s.repos)
 

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -470,6 +470,7 @@ func (s *Source) getAllProjectRepos(
 	}
 
 	ctx.Logger().Info("beginning group enumeration", "options", listGroupsOptions)
+	gitlabGroupsEnumerated.Reset()
 
 	var groups []*gitlab.Group
 	for {
@@ -482,6 +483,7 @@ func (s *Source) getAllProjectRepos(
 			break
 		}
 		groups = append(groups, groupList...)
+		gitlabGroupsEnumerated.WithLabelValues(s.name).Add(float64(len(groupList)))
 		listGroupsOptions.Page = res.NextPage
 		if res.NextPage == 0 {
 			break

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -470,7 +470,7 @@ func (s *Source) getAllProjectRepos(
 	}
 
 	ctx.Logger().Info("beginning group enumeration", "options", listGroupsOptions)
-	gitlabGroupsEnumerated.Reset()
+	gitlabGroupsEnumerated.WithLabelValues(s.name).Set(0)
 
 	var groups []*gitlab.Group
 	for {

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -471,7 +471,9 @@ func (s *Source) getAllProjectRepos(
 		listGroupsOptions.AllAvailable = gitlab.Ptr(true)
 	}
 
-	ctx.Logger().Info("beginning group enumeration", "options", listGroupsOptions)
+	ctx.Logger().Info("beginning group enumeration",
+		"list_options", listOpts,
+		"all_available", *listGroupsOptions.AllAvailable)
 	gitlabGroupsEnumerated.WithLabelValues(s.name).Set(0)
 
 	var groups []*gitlab.Group

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -491,6 +491,7 @@ func (s *Source) getAllProjectRepos(
 	}
 
 	ctx.Logger().Info("got groups", "group_count", len(groups))
+	ctx.Logger().V(2).Info("got groups", "groups", groups)
 
 	for _, group := range groups {
 		listGroupProjectOptions := &gitlab.ListGroupProjectsOptions{

--- a/pkg/sources/gitlab/metrics.go
+++ b/pkg/sources/gitlab/metrics.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	gitlabGroupsEnumerated = promauto.NewCounterVec(prometheus.CounterOpts{
+	gitlabGroupsEnumerated = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
 		Subsystem: common.MetricsSubsystem,
 		Name:      "gitlab_groups_enumerated",

--- a/pkg/sources/gitlab/metrics.go
+++ b/pkg/sources/gitlab/metrics.go
@@ -8,6 +8,14 @@ import (
 )
 
 var (
+	gitlabGroupsEnumerated = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: common.MetricsNamespace,
+		Subsystem: common.MetricsSubsystem,
+		Name:      "gitlab_groups_enumerated",
+		Help:      "Total number of GitLab groups enumerated.",
+	},
+		[]string{"source_name}"})
+
 	gitlabReposEnumerated = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
 		Subsystem: common.MetricsSubsystem,

--- a/pkg/sources/gitlab/metrics.go
+++ b/pkg/sources/gitlab/metrics.go
@@ -14,7 +14,7 @@ var (
 		Name:      "gitlab_groups_enumerated",
 		Help:      "Total number of GitLab groups enumerated.",
 	},
-		[]string{"source_name}"})
+		[]string{"source_name"})
 
 	gitlabReposEnumerated = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR modifies the GitLab source:
* emits a new "groups enumerated" metric
* logs more information about group enumeration
* emits the repo enumeration metric inside `getAllProjectRepos`, which means it will work when units are flipped on
* emits the repo enumeration metric more granularly

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

