### PR TITLE
[feat] - Introduce `readSeekCloser` for efficient and ergonomic random access reading

### DIFF
--- a/pkg/writers/buffer_writer/bufferwriter.go
+++ b/pkg/writers/buffer_writer/bufferwriter.go
@@ -112,8 +112,8 @@ func (b *BufferWriter) String() (string, error) {
 func (b *BufferWriter) Len() int { return b.size }
 
 // bufferReadSeekCloser provides random access read, seek, and close capabilities on top of the BufferWriter.
-// It combines the functionality of BufferWriter for buffered writing, bytes.Reader for random access reading and seeking,
-// and adds a close method to return the buffer to the pool.
+// It combines the functionality of BufferWriter for buffered writing, bytes.Reader for
+// random access reading and seeking, and adds a close method to return the buffer to the pool.
 type bufferReadSeekCloser struct {
 	bufWriter *BufferWriter
 	reader    *bytes.Reader

--- a/pkg/writers/buffer_writer/bufferwriter_test.go
+++ b/pkg/writers/buffer_writer/bufferwriter_test.go
@@ -1,6 +1,10 @@
 package bufferwriter
 
 import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -152,4 +156,130 @@ func TestBufferWriterString(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Create a custom reader that can simulate errors.
+type errorReader struct{}
+
+func (errorReader) Read([]byte) (n int, err error) { return 0, fmt.Errorf("error reading") }
+
+func TestNewFromReader(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		reader   io.Reader
+		wantErr  bool
+		wantData string
+	}{
+		{
+			name:     "Success case",
+			reader:   strings.NewReader("hello world"),
+			wantData: "hello world",
+		},
+		{
+			name:   "Empty reader",
+			reader: strings.NewReader(""),
+		},
+		{
+			name:    "Error reader",
+			reader:  errorReader{},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			bufWriter, err := NewFromReader(ctx, tc.reader)
+			if tc.wantErr {
+				assert.Error(t, err)
+				assert.Nil(t, bufWriter)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.NotNil(t, bufWriter)
+
+			err = bufWriter.CloseForWriting()
+			assert.NoError(t, err)
+
+			buffer := new(bytes.Buffer)
+			rdr, err := bufWriter.ReadCloser()
+			assert.NoError(t, err)
+			defer rdr.Close()
+
+			_, err = buffer.ReadFrom(rdr)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantData, buffer.String())
+		})
+	}
+}
+
+func TestBufferReadSeekCloser(t *testing.T) {
+	t.Parallel()
+
+	data := []byte("Hello, World!")
+
+	bufferReadSeekCloser, err := NewBufferReadSeekCloser(context.Background(), bytes.NewReader(data))
+	assert.NoError(t, err)
+	defer bufferReadSeekCloser.Close()
+
+	// Test Read.
+	buffer := make([]byte, len(data))
+	n, err := bufferReadSeekCloser.Read(buffer)
+	assert.NoError(t, err)
+	assert.Equal(t, len(data), n)
+	assert.Equal(t, data, buffer)
+
+	// Test Seek.
+	offset := 7
+	seekPos, err := bufferReadSeekCloser.Seek(int64(offset), io.SeekStart)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(offset), seekPos)
+
+	// Test ReadAt.
+	buffer = make([]byte, len(data)-offset)
+	n, err = bufferReadSeekCloser.ReadAt(buffer, int64(offset))
+	assert.NoError(t, err)
+	assert.Equal(t, len(data)-offset, n)
+	assert.Equal(t, data[offset:], buffer)
+
+	// Test Close.
+	err = bufferReadSeekCloser.Close()
+	assert.NoError(t, err)
+}
+
+func TestBufferReadSeekCloserClose(t *testing.T) {
+	t.Parallel()
+
+	data := []byte("Hello, World!")
+
+	bufferReadSeekCloser, err := NewBufferReadSeekCloser(context.Background(), bytes.NewReader(data))
+	assert.NoError(t, err)
+
+	err = bufferReadSeekCloser.Close()
+	assert.NoError(t, err)
+
+	// Read after closing.
+	buffer := make([]byte, len(data))
+	n, err := bufferReadSeekCloser.Read(buffer)
+	assert.NoError(t, err)
+	assert.Equal(t, len(data), n)
+	assert.Equal(t, data, buffer)
+
+	// Seek after closing.
+	offset := 7
+	seekPos, err := bufferReadSeekCloser.Seek(int64(offset), io.SeekStart)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(offset), seekPos)
+
+	// ReadAt after closing.
+	buffer = make([]byte, len(data)-offset)
+	n, err = bufferReadSeekCloser.ReadAt(buffer, int64(offset))
+	assert.NoError(t, err)
+	assert.Equal(t, len(data)-offset, n)
+	assert.Equal(t, data[offset:], buffer)
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR introduces the `bufferReadSeekCloser` type, which provides random access read, seek, and close capabilities on top of the `BufferWriter`. It serves as a drop-in replacement for `DiskBufferReader` in the `handlers` package, offering improved ergonomics and performance.

Key features and benefits:
1. Combines the functionality of `BufferWriter` for buffered writing and `bytes.Reader` for random access reading and seeking.
2. Adds a `Close` method to return the buffer to the pool when it is no longer needed.
3. Provides a more efficient and performant alternative to `DiskBufferReader`.
4. Eliminates the need to back every reader with a temporary file, reducing disk I/O and storage overhead.
5. Includes built-in metrics for monitoring and performance analysis.

The `bufferReadSeekCloser` type implements the following interfaces:
- `io.Reader`: Reads up to `len(p)` bytes into `p` from the underlying `bytes.Reader`.
- `io.Seeker`: Sets the offset for the next read or write operation on the underlying `bytes.Reader`.
- `io.ReaderAt`: Reads `len(p)` bytes from the underlying `bytes.Reader` starting at byte offset `off`.
- `io.Closer`: Releases the buffer back to the buffer pool when the `bufferReadSeekCloser` is no longer needed.

To create a new instance of `bufferReadSeekCloser`, the `NewBufferReadSeekCloser` function is introduced. It initializes a `bufferReadSeekCloser` from an `io.Reader` by using the `BufferWriter`’s functionality to read and store data, and then sets up a `bytes.Reader` for random access.

The `Close` method of `bufferReadSeekCloser` releases the buffer back to the buffer pool. It is important to note that closing the `bufferReadSeekCloser` does not affect the underlying `bytes.Reader`, which can still be used for reading, seeking, and reading at specific positions. `Close` is a no-op for the `bytes.Reader`.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

