### PR TITLE
[bug] - Correctly return the checked out buffer to the pool

### DIFF
--- a/pkg/writers/buffered_file_writer/bufferedfilewriter.go
+++ b/pkg/writers/buffered_file_writer/bufferedfilewriter.go
@@ -172,7 +172,8 @@ func (w *BufferedFileWriter) CloseForWriting() error {
 		return nil
 	}
 
-	// Return the buffer to the pool.
+	// Return the buffer to the pool since the contents have been written to the file and
+	// the writer is transitioning to read-only mode.
 	w.bufPool.Put(w.buf)
 
 	if w.buf.Len() > 0 {

--- a/pkg/writers/buffered_file_writer/bufferedfilewriter.go
+++ b/pkg/writers/buffered_file_writer/bufferedfilewriter.go
@@ -172,9 +172,11 @@ func (w *BufferedFileWriter) CloseForWriting() error {
 		return nil
 	}
 
-	// Return the buffer to the pool since the contents have been written to the file and
-	// the writer is transitioning to read-only mode.
-	w.bufPool.Put(w.buf)
+	defer func() {
+		// Return the buffer to the pool since the contents have been written to the file and
+		// the writer is transitioning to read-only mode.
+		w.bufPool.Put(w.buf)
+	}()
 
 	if w.buf.Len() > 0 {
 		_, err := w.buf.WriteTo(w.file)

--- a/pkg/writers/buffered_file_writer/bufferedfilewriter.go
+++ b/pkg/writers/buffered_file_writer/bufferedfilewriter.go
@@ -172,11 +172,9 @@ func (w *BufferedFileWriter) CloseForWriting() error {
 		return nil
 	}
 
-	defer func() {
-		// Return the buffer to the pool since the contents have been written to the file and
-		// the writer is transitioning to read-only mode.
-		w.bufPool.Put(w.buf)
-	}()
+	// Return the buffer to the pool since the contents have been written to the file and
+	// the writer is transitioning to read-only mode.
+	defer w.bufPool.Put(w.buf)
 
 	if w.buf.Len() > 0 {
 		_, err := w.buf.WriteTo(w.file)

--- a/pkg/writers/buffered_file_writer/bufferedfilewriter.go
+++ b/pkg/writers/buffered_file_writer/bufferedfilewriter.go
@@ -172,6 +172,9 @@ func (w *BufferedFileWriter) CloseForWriting() error {
 		return nil
 	}
 
+	// Return the buffer to the pool.
+	w.bufPool.Put(w.buf)
+
 	if w.buf.Len() > 0 {
 		_, err := w.buf.WriteTo(w.file)
 		if err != nil {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR ensures that the `BufferedFileWriter` returns its underlying buffer to the pool upon being closed after writing.

😅 
![Screenshot 2024-04-23 at 10 17 52 AM](https://github.com/trufflesecurity/trufflehog/assets/21311841/88651821-1577-4ee0-be60-2ed73b93d187)

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

