### PR TITLE
[bug] - Fix disk write metric and update BufferedFileWriter file field

### DIFF
--- a/pkg/writers/buffered_file_writer/bufferedfilewriter.go
+++ b/pkg/writers/buffered_file_writer/bufferedfilewriter.go
@@ -167,7 +167,6 @@ func (w *BufferedFileWriter) Write(data []byte) (int, error) {
 		return n, err
 	}
 
-	// Record the disk write metric after successfully writing to the file
 	w.metrics.recordDiskWrite(w.file)
 
 	return n, nil

--- a/pkg/writers/buffered_file_writer/bufferedfilewriter.go
+++ b/pkg/writers/buffered_file_writer/bufferedfilewriter.go
@@ -31,10 +31,8 @@ func (bufferedFileWriterMetrics) recordDiskWrite(f *os.File) {
 	diskWriteCount.Inc()
 	size, err := f.Stat()
 	if err != nil {
-		fmt.Println("Error getting file size:", err)
 		return
 	}
-	fmt.Println("File size:", size.Size())
 	fileSizeHistogram.Observe(float64(size.Size()))
 }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR fixes the disk write metric recording in the `BufferedFileWriter` and updates the `file` field type from `io.Writer` to `os.File`. I don't _feel_ like the `io.Writer` abstraction is necessary, but I'm open to differing opinions.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

