### PR TITLE
[bug] - Refactor newDiff constructor to avoid double initialization of contentWriter

### DIFF
--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -77,9 +77,13 @@ func withCustomContentWriter(cr contentWriter) diffOption {
 // The contentWriter is used to manage the diff's content, allowing for flexible handling of diff data.
 // By default, a buffer is used as the contentWriter, but this can be overridden with a custom contentWriter.
 func newDiff(ctx context.Context, commit *Commit, opts ...diffOption) *Diff {
-	diff := &Diff{Commit: commit, contentWriter: bufferwriter.New(ctx)}
+	diff := &Diff{Commit: commit}
 	for _, opt := range opts {
 		opt(diff)
+	}
+
+	if diff.contentWriter == nil {
+		diff.contentWriter = bufferwriter.New(ctx)
 	}
 
 	return diff

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -2349,12 +2349,13 @@ index 2ee133b..12b4843 100644
 +region = us-east-2
 `
 
-type mockContentWriter struct{ createCount int }
+type mockContentWriter struct{ counter int }
 
-func (m *mockContentWriter) Write(p []byte) (n int, err error) {
-	m.createCount++
-	return len(p), nil
+func newMockContentWriter() *mockContentWriter {
+	return &mockContentWriter{counter: 1}
 }
+
+func (m *mockContentWriter) Write(p []byte) (n int, err error) { return len(p), nil }
 
 func TestNewDiffContentWriterCreation(t *testing.T) {
 	testCases := []struct {
@@ -2364,12 +2365,12 @@ func TestNewDiffContentWriterCreation(t *testing.T) {
 	}{
 		{
 			name:          "Without custom contentWriter",
-			expectedCount: 0,
+			expectedCount: 1,
 		},
 		{
 			name:          "With custom contentWriter",
 			opts:          []diffOption{withCustomContentWriter(bufferwriter.New(context.Background()))},
-			expectedCount: 0,
+			expectedCount: 1,
 		},
 	}
 
@@ -2381,12 +2382,14 @@ func TestNewDiffContentWriterCreation(t *testing.T) {
 			ctx := context.Background()
 			commit := new(Commit)
 
-			mockWriter := new(mockContentWriter)
+			mockWriter := newMockContentWriter()
+			assert.NotNil(t, mockWriter, "Failed to create mockWriter")
+
 			diff := newDiff(ctx, commit, tc.opts...)
 			assert.NotNil(t, diff, "Failed to create diff")
 			assert.NotNil(t, diff.contentWriter, "Failed to create contentWriter")
 
-			assert.Equal(t, tc.expectedCount, mockWriter.createCount, "Unexpected number of contentWriter creations")
+			assert.Equal(t, tc.expectedCount, mockWriter.counter, "Unexpected number of contentWriter creations")
 		})
 	}
 }

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -3,7 +3,6 @@ package gitparse
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -2356,7 +2355,7 @@ type mockContentWriter struct{ counter int }
 func newMockContentWriter() *mockContentWriter { return &mockContentWriter{counter: 1} }
 
 func (m *mockContentWriter) ReadCloser() (io.ReadCloser, error) {
-	return ioutil.NopCloser(bytes.NewReader([]byte{})), nil
+	return io.NopCloser(bytes.NewReader([]byte{})), nil
 }
 
 func (m *mockContentWriter) CloseForWriting() error { return nil }

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -2,6 +2,8 @@ package gitparse
 
 import (
 	"bytes"
+	"io"
+	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
@@ -2351,9 +2353,17 @@ index 2ee133b..12b4843 100644
 
 type mockContentWriter struct{ counter int }
 
-func newMockContentWriter() *mockContentWriter {
-	return &mockContentWriter{counter: 1}
+func newMockContentWriter() *mockContentWriter { return &mockContentWriter{counter: 1} }
+
+func (m *mockContentWriter) ReadCloser() (io.ReadCloser, error) {
+	return ioutil.NopCloser(bytes.NewReader([]byte{})), nil
 }
+
+func (m *mockContentWriter) CloseForWriting() error { return nil }
+
+func (m *mockContentWriter) Len() int { return 0 }
+
+func (m *mockContentWriter) String() (string, error) { return "", nil }
 
 func (m *mockContentWriter) Write(p []byte) (n int, err error) { return len(p), nil }
 
@@ -2369,7 +2379,7 @@ func TestNewDiffContentWriterCreation(t *testing.T) {
 		},
 		{
 			name:          "With custom contentWriter",
-			opts:          []diffOption{withCustomContentWriter(bufferwriter.New(context.Background()))},
+			opts:          []diffOption{withCustomContentWriter(newMockContentWriter())},
 			expectedCount: 1,
 		},
 	}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR addresses an issue in the `newDiff` constructor where the `contentWriter` could potentially be double initialized, leading to duplicate resource creation and potential resource leaks.

![Screenshot 2024-04-24 at 2 01 27 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/a8b7e2ad-954c-42c9-b6bd-b4029bd21a0b)

**Suggested improvement for bufferwriter package**:
While investigating the issue with the newDiff constructor, it became apparent that the current design of the bufferwriter package could be improved to make it more ergonomic and less prone to misuse.
Instead of allocating resources (i.e., the underlying buffer) in the `New` constructor, we should consider modifying the implementation to allocate resources lazily, only when the `Write` method is called for the first time. This lazy allocation approach would prevent potential resource leaks and make it easier to use the package correctly.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

