### PR TITLE
[refactor] - lazy buffer retrieval

### DIFF
--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -315,7 +315,7 @@ func (c *Parser) FromReader(ctx context.Context, stdOut io.Reader, diffChan chan
 	}
 	if c.useCustomContentWriter {
 		diff = func(c *Commit, opts ...diffOption) *Diff {
-			opts = append(opts, withCustomContentWriter(bufferedfilewriter.New(ctx)))
+			opts = append(opts, withCustomContentWriter(bufferedfilewriter.New()))
 			return newDiff(c, opts...)
 		}
 	}

--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -76,14 +76,14 @@ func withCustomContentWriter(cr contentWriter) diffOption {
 // All Diffs must have an associated commit.
 // The contentWriter is used to manage the diff's content, allowing for flexible handling of diff data.
 // By default, a buffer is used as the contentWriter, but this can be overridden with a custom contentWriter.
-func newDiff(ctx context.Context, commit *Commit, opts ...diffOption) *Diff {
+func newDiff(commit *Commit, opts ...diffOption) *Diff {
 	diff := &Diff{Commit: commit}
 	for _, opt := range opts {
 		opt(diff)
 	}
 
 	if diff.contentWriter == nil {
-		diff.contentWriter = bufferwriter.New(ctx)
+		diff.contentWriter = bufferwriter.New()
 	}
 
 	return diff
@@ -104,9 +104,7 @@ func (d *Diff) write(p []byte) error {
 // finalize ensures proper closure of resources associated with the Diff.
 // handle the final flush in the finalize method, in case there's data remaining in the buffer.
 // This method should be called to release resources, especially when writing to a file.
-func (d *Diff) finalize() error {
-	return d.contentWriter.CloseForWriting()
-}
+func (d *Diff) finalize() error { return d.contentWriter.CloseForWriting() }
 
 // Commit contains commit header info and diffs.
 type Commit struct {
@@ -312,13 +310,13 @@ func (c *Parser) FromReader(ctx context.Context, stdOut io.Reader, diffChan chan
 	var latestState = Initial
 
 	diff := func(c *Commit, opts ...diffOption) *Diff {
-		opts = append(opts, withCustomContentWriter(bufferwriter.New(ctx)))
-		return newDiff(ctx, c, opts...)
+		opts = append(opts, withCustomContentWriter(bufferwriter.New()))
+		return newDiff(c, opts...)
 	}
 	if c.useCustomContentWriter {
 		diff = func(c *Commit, opts ...diffOption) *Diff {
 			opts = append(opts, withCustomContentWriter(bufferedfilewriter.New(ctx)))
-			return newDiff(ctx, c, opts...)
+			return newDiff(c, opts...)
 		}
 	}
 	currentDiff := diff(currentCommit)

--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -77,9 +77,13 @@ func withCustomContentWriter(cr contentWriter) diffOption {
 // The contentWriter is used to manage the diff's content, allowing for flexible handling of diff data.
 // By default, a buffer is used as the contentWriter, but this can be overridden with a custom contentWriter.
 func newDiff(ctx context.Context, commit *Commit, opts ...diffOption) *Diff {
-	diff := &Diff{Commit: commit, contentWriter: bufferwriter.New(ctx)}
+	diff := &Diff{Commit: commit}
 	for _, opt := range opts {
 		opt(diff)
+	}
+
+	if diff.contentWriter == nil {
+		diff.contentWriter = bufferwriter.New(ctx)
 	}
 
 	return diff

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -632,6 +632,10 @@ func TestToFileLinePathParse(t *testing.T) {
 func (d1 *Diff) Equal(ctx context.Context, d2 *Diff) bool {
 	// isEqualString handles the error-prone String() method calls and compares the results.
 	isEqualContentString := func(s1, s2 contentWriter) (bool, error) {
+		// If the content is nil, it's likely a binary so there won't be any content to compare.
+		if s1.Len() == 0 && s2.Len() == 0 {
+			return true, nil
+		}
 		str1, err := s1.String()
 		if err != nil {
 			return false, err

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -637,6 +637,7 @@ func (d1 *Diff) Equal(ctx context.Context, d2 *Diff) bool {
 		if s1.Len() == 0 && s2.Len() == 0 {
 			return true, nil
 		}
+
 		str1, err := s1.String()
 		if err != nil {
 			return false, err
@@ -699,8 +700,7 @@ func TestCommitParsing(t *testing.T) {
 }
 
 func newBufferedFileWriterWithContent(content []byte) *bufferedfilewriter.BufferedFileWriter {
-	ctx := context.Background()
-	b := bufferedfilewriter.New(ctx)
+	b := bufferedfilewriter.New()
 	_, err := b.Write(content) // Using Write method to add content
 	if err != nil {
 		panic(err)
@@ -1249,12 +1249,12 @@ index 239b415..2ee133b 100644
 +++ b/aws2
 !!!ERROR!!!
  blah blaj
-
+ 
 -this is the secret: AKIA2E0A8F3B244C9986
 +this is the secret: [Default]
 +Access key Id: AKIAILE3JG6KMS3HZGCA
 +Secret Access Key: 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
-
+ 
 -okay thank you bye
 \ No newline at end of file
 +okay thank you bye
@@ -1668,7 +1668,7 @@ Author: rjtmahinay <rjt.mahinay@gmail.com>
 Date:   Mon Jul 10 01:22:32 2023 +0800
 
     Add QuarkusApplication javadoc
-
+    
     * Fix #34463
 
 diff --git a/core/runtime/src/main/java/io/quarkus/runtime/QuarkusApplication.java b/core/runtime/src/main/java/io/quarkus/runtime/QuarkusApplication.java
@@ -2186,12 +2186,12 @@ index 239b415..2ee133b 100644
 +++ b/aws2
 @@ -1,5 +1,7 @@
  blah blaj
-
+ 
 -this is the secret: AKIA2E0A8F3B244C9986
 +this is the secret: [Default]
 +Access key Id: AKIAILE3JG6KMS3HZGCA
 +Secret Access Key: 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
-
+ 
 -okay thank you bye
 \ No newline at end of file
 +okay thank you bye
@@ -2317,12 +2317,12 @@ index 239b415..2ee133b 100644
 +++ b/aws
 @@ -1,5 +1,7 @@
  blah blaj
-
+ 
 -this is the secret: AKIA2E0A8F3B244C9986
 +this is the secret: [Default]
 +Access key Id: AKIAILE3JG6KMS3HZGCA
 +Secret Access Key: 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
-
+ 
 -okay thank you bye
 \ No newline at end of file
 +okay thank you bye

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -2349,12 +2349,13 @@ index 2ee133b..12b4843 100644
 +region = us-east-2
 `
 
-type mockContentWriter struct{ createCount int }
+type mockContentWriter struct{ counter int }
 
-func (m *mockContentWriter) Write(p []byte) (n int, err error) {
-	m.createCount++
-	return len(p), nil
+func newMockContentWriter() *mockContentWriter {
+	return &mockContentWriter{counter: 1}
 }
+
+func (m *mockContentWriter) Write(p []byte) (n int, err error) { return len(p), nil }
 
 func TestNewDiffContentWriterCreation(t *testing.T) {
 	testCases := []struct {
@@ -2364,12 +2365,12 @@ func TestNewDiffContentWriterCreation(t *testing.T) {
 	}{
 		{
 			name:          "Without custom contentWriter",
-			expectedCount: 0,
+			expectedCount: 1,
 		},
 		{
 			name:          "With custom contentWriter",
 			opts:          []diffOption{withCustomContentWriter(bufferwriter.New(context.Background()))},
-			expectedCount: 0,
+			expectedCount: 1,
 		},
 	}
 
@@ -2381,12 +2382,14 @@ func TestNewDiffContentWriterCreation(t *testing.T) {
 			ctx := context.Background()
 			commit := new(Commit)
 
-			mockWriter := new(mockContentWriter)
+			mockWriter := newMockContentWriter()
+			assert.NotNil(t, mockWriter, "Failed to create mockWriter")
+
 			diff := newDiff(ctx, commit, tc.opts...)
 			assert.NotNil(t, diff, "Failed to create diff")
 			assert.NotNil(t, diff.contentWriter, "Failed to create contentWriter")
 
-			assert.Equal(t, tc.expectedCount, mockWriter.createCount, "Unexpected number of contentWriter creations")
+			assert.Equal(t, tc.expectedCount, mockWriter.counter, "Unexpected number of contentWriter creations")
 		})
 	}
 }

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -704,8 +704,7 @@ func newBufferedFileWriterWithContent(content []byte) *bufferedfilewriter.Buffer
 }
 
 func newBufferWithContent(content []byte) *bufferwriter.BufferWriter {
-	ctx := context.Background()
-	b := bufferwriter.New(ctx)
+	b := bufferwriter.New()
 	_, _ = b.Write(content) // Using Write method to add content
 	return b
 }
@@ -2369,7 +2368,7 @@ func TestNewDiffContentWriterCreation(t *testing.T) {
 		},
 		{
 			name:          "With custom contentWriter",
-			opts:          []diffOption{withCustomContentWriter(bufferwriter.New(context.Background()))},
+			opts:          []diffOption{withCustomContentWriter(bufferwriter.New())},
 			expectedCount: 1,
 		},
 	}
@@ -2379,13 +2378,12 @@ func TestNewDiffContentWriterCreation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
 			commit := new(Commit)
 
 			mockWriter := newMockContentWriter()
 			assert.NotNil(t, mockWriter, "Failed to create mockWriter")
 
-			diff := newDiff(ctx, commit, tc.opts...)
+			diff := newDiff(commit, tc.opts...)
 			assert.NotNil(t, diff, "Failed to create diff")
 			assert.NotNil(t, diff.contentWriter, "Failed to create contentWriter")
 

--- a/pkg/writers/buffer/buffer.go
+++ b/pkg/writers/buffer/buffer.go
@@ -4,11 +4,8 @@ package buffer
 
 import (
 	"bytes"
-	"fmt"
 	"sync"
 	"time"
-
-	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 
 type poolMetrics struct{}
@@ -60,10 +57,9 @@ func NewBufferPool(opts ...PoolOpts) *Pool {
 }
 
 // Get returns a Buffer from the pool.
-func (p *Pool) Get(ctx context.Context) *Buffer {
+func (p *Pool) Get() *Buffer {
 	buf, ok := p.Pool.Get().(*Buffer)
 	if !ok {
-		ctx.Logger().Error(fmt.Errorf("Buffer pool returned unexpected type"), "using new Buffer")
 		buf = &Buffer{Buffer: bytes.NewBuffer(make([]byte, 0, p.bufferSize))}
 	}
 	p.metrics.recordBufferRetrival()

--- a/pkg/writers/buffer/buffer_test.go
+++ b/pkg/writers/buffer/buffer_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 
 func TestNewBufferPool(t *testing.T) {
@@ -71,12 +69,12 @@ func TestBufferPoolGetPut(t *testing.T) {
 				pool.Put(initialBuf)
 			}
 
-			buf := pool.Get(context.Background())
+			buf := pool.Get()
 			assert.Equal(t, tc.expectedCapBefore, buf.Cap())
 
 			pool.Put(buf)
 
-			bufAfter := pool.Get(context.Background())
+			bufAfter := pool.Get()
 			assert.Equal(t, tc.expectedCapAfter, bufAfter.Cap())
 		})
 	}

--- a/pkg/writers/buffer_writer/bufferwriter.go
+++ b/pkg/writers/buffer_writer/bufferwriter.go
@@ -76,6 +76,9 @@ func (b *BufferWriter) ReadCloser() (io.ReadCloser, error) {
 	if b.state != readOnly {
 		return nil, fmt.Errorf("buffer is in read-only mode")
 	}
+	if b.buf == nil {
+		return nil, fmt.Errorf("writer buffer is nil")
+	}
 
 	return buffer.ReadCloser(b.buf.Bytes(), func() { b.bufPool.Put(b.buf) }), nil
 }

--- a/pkg/writers/buffer_writer/bufferwriter_test.go
+++ b/pkg/writers/buffer_writer/bufferwriter_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 
 func TestBufferWriterWrite(t *testing.T) {
@@ -41,7 +39,7 @@ func TestBufferWriterWrite(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			writer := New(context.Background())
+			writer := New()
 			writer.state = tc.initialState
 
 			_, err := writer.Write(tc.input)
@@ -77,7 +75,7 @@ func TestBufferWriterReadCloser(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			writer := New(context.Background())
+			writer := New()
 			writer.state = tc.initialState
 
 			rc, err := writer.ReadCloser()
@@ -96,7 +94,7 @@ func TestBufferWriterReadCloser(t *testing.T) {
 }
 
 func TestBufferWriterCloseForWriting(t *testing.T) {
-	writer := New(context.Background())
+	writer := New()
 	err := writer.CloseForWriting()
 	assert.NoError(t, err)
 	assert.Equal(t, readOnly, writer.state)
@@ -140,7 +138,7 @@ func TestBufferWriterString(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			writer := New(context.Background())
+			writer := New()
 			tc.prepareBuffer(writer)
 
 			result, err := writer.String()

--- a/pkg/writers/buffer_writer/bufferwriter_test.go
+++ b/pkg/writers/buffer_writer/bufferwriter_test.go
@@ -77,6 +77,7 @@ func TestBufferWriterReadCloser(t *testing.T) {
 			t.Parallel()
 			writer := New()
 			writer.state = tc.initialState
+			writer.buf = writer.bufPool.Get()
 
 			rc, err := writer.ReadCloser()
 			if tc.expectedError {
@@ -110,8 +111,8 @@ func TestBufferWriterString(t *testing.T) {
 	}{
 		{
 			name: "String with no data",
-			prepareBuffer: func(_ *BufferWriter) {
-				// No preparation needed, buffer is empty by default
+			prepareBuffer: func(bw *BufferWriter) {
+				_, _ = bw.Write([]byte(""))
 			},
 			expectedStr:   "",
 			expectedError: false,

--- a/pkg/writers/buffered_file_writer/bufferedfilewriter.go
+++ b/pkg/writers/buffered_file_writer/bufferedfilewriter.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/cleantemp"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/writers/buffer"
 )
 
@@ -72,7 +71,7 @@ func WithThreshold(threshold uint64) Option {
 
 const defaultThreshold = 10 * 1024 * 1024 // 10MB
 // New creates a new BufferedFileWriter with the given options.
-func New(ctx context.Context, opts ...Option) *BufferedFileWriter {
+func New(opts ...Option) *BufferedFileWriter {
 	w := &BufferedFileWriter{
 		threshold: defaultThreshold,
 		state:     writeOnly,

--- a/pkg/writers/buffered_file_writer/bufferedfilewriter_test.go
+++ b/pkg/writers/buffered_file_writer/bufferedfilewriter_test.go
@@ -511,8 +511,7 @@ func BenchmarkBufferedFileWriterWriteSmall(b *testing.B) {
 func TestBufferWriterCloseForWritingWithFile(t *testing.T) {
 	bufPool := buffer.NewBufferPool()
 
-	ctx := context.Background()
-	buf := bufPool.Get(ctx)
+	buf := bufPool.Get()
 	writer := &BufferedFileWriter{
 		threshold: 10,
 		bufPool:   bufPool,
@@ -533,7 +532,7 @@ func TestBufferWriterCloseForWritingWithFile(t *testing.T) {
 	defer rdr.Close()
 
 	// Get a buffer from the pool and check if it is the same buffer used in the writer.
-	bufFromPool := bufPool.Get(ctx)
+	bufFromPool := bufPool.Get()
 	assert.Same(t, buf, bufFromPool, "Buffer should be returned to the pool")
 	bufPool.Put(bufFromPool)
 }

--- a/pkg/writers/buffered_file_writer/bufferedfilewriter_test.go
+++ b/pkg/writers/buffered_file_writer/bufferedfilewriter_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/writers/buffer"
 )
 
@@ -33,7 +32,7 @@ func TestBufferedFileWriterNewThreshold(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			writer := New(context.Background(), tc.options...)
+			writer := New(tc.options...)
 			assert.Equal(t, tc.expectedThreshold, writer.threshold)
 			// The state should always be writeOnly when created.
 			assert.Equal(t, writeOnly, writer.state)
@@ -77,8 +76,7 @@ func TestBufferedFileWriterString(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
-			writer := New(ctx, WithThreshold(tc.threshold))
+			writer := New(WithThreshold(tc.threshold))
 			// First write, should go to file if it exceeds the threshold.
 			_, err := writer.Write(tc.input)
 			assert.NoError(t, err)
@@ -109,8 +107,7 @@ const (
 func BenchmarkBufferedFileWriterString_BufferOnly_Small(b *testing.B) {
 	data := bytes.Repeat([]byte("a"), smallBuffer)
 
-	ctx := context.Background()
-	writer := New(ctx)
+	writer := New()
 
 	_, err := writer.Write(data)
 	assert.NoError(b, err)
@@ -127,8 +124,7 @@ func BenchmarkBufferedFileWriterString_BufferOnly_Small(b *testing.B) {
 
 func BenchmarkBufferedFileWriterString_BufferOnly_Medium(b *testing.B) {
 	data := bytes.Repeat([]byte("a"), mediumBuffer)
-	ctx := context.Background()
-	writer := New(ctx)
+	writer := New()
 
 	_, err := writer.Write(data)
 	assert.NoError(b, err)
@@ -146,8 +142,7 @@ func BenchmarkBufferedFileWriterString_BufferOnly_Medium(b *testing.B) {
 func BenchmarkBufferedFileWriterString_OnlyFile_Small(b *testing.B) {
 	data := bytes.Repeat([]byte("a"), smallFile)
 
-	ctx := context.Background()
-	writer := New(ctx)
+	writer := New()
 
 	_, err := writer.Write(data)
 	assert.NoError(b, err)
@@ -165,8 +160,7 @@ func BenchmarkBufferedFileWriterString_OnlyFile_Small(b *testing.B) {
 func BenchmarkBufferedFileWriterString_OnlyFile_Medium(b *testing.B) {
 	data := bytes.Repeat([]byte("a"), mediumFile)
 
-	ctx := context.Background()
-	writer := New(ctx)
+	writer := New()
 
 	_, err := writer.Write(data)
 	assert.NoError(b, err)
@@ -184,8 +178,7 @@ func BenchmarkBufferedFileWriterString_OnlyFile_Medium(b *testing.B) {
 func BenchmarkBufferedFileWriterString_BufferWithFile_Small(b *testing.B) {
 	data := bytes.Repeat([]byte("a"), smallFile)
 
-	ctx := context.Background()
-	writer := New(ctx)
+	writer := New()
 
 	_, err := writer.Write(data)
 	assert.NoError(b, err)
@@ -207,8 +200,7 @@ func BenchmarkBufferedFileWriterString_BufferWithFile_Small(b *testing.B) {
 func BenchmarkBufferedFileWriterString_BufferWithFile_Medium(b *testing.B) {
 	data := bytes.Repeat([]byte("a"), mediumFile)
 
-	ctx := context.Background()
-	writer := New(ctx)
+	writer := New()
 
 	_, err := writer.Write(data)
 	assert.NoError(b, err)
@@ -253,7 +245,7 @@ func TestBufferedFileWriterLen(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			writer := New(context.Background())
+			writer := New()
 			_, err := writer.Write(tc.input)
 			assert.NoError(t, err)
 
@@ -268,10 +260,9 @@ func TestBufferedFileWriterLen(t *testing.T) {
 func TestBufferedFileWriterWriteWithinThreshold(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
 	data := []byte("hello world")
 
-	writer := New(ctx, WithThreshold(64))
+	writer := New(WithThreshold(64))
 	_, err := writer.Write(data)
 	assert.NoError(t, err)
 
@@ -283,10 +274,9 @@ func TestBufferedFileWriterWriteWithinThreshold(t *testing.T) {
 func TestBufferedFileWriterWriteExceedsThreshold(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
 	data := []byte("hello world")
 
-	writer := New(ctx, WithThreshold(5))
+	writer := New(WithThreshold(5))
 	_, err := writer.Write(data)
 	assert.NoError(t, err)
 
@@ -307,12 +297,11 @@ func TestBufferedFileWriterWriteExceedsThreshold(t *testing.T) {
 func TestBufferedFileWriterWriteAfterFlush(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
 	initialData := []byte("initial data is longer than subsequent data")
 	subsequentData := []byte("subsequent data")
 
 	// Initialize writer with a threshold that initialData will exceed.
-	writer := New(ctx, WithThreshold(uint64(len(initialData)-1)))
+	writer := New(WithThreshold(uint64(len(initialData) - 1)))
 	_, err := writer.Write(initialData)
 	assert.NoError(t, err)
 
@@ -352,7 +341,6 @@ func TestBufferedFileWriterClose(t *testing.T) {
 	t.Parallel()
 
 	const threshold = 10
-	ctx := context.Background()
 
 	tests := []struct {
 		name              string
@@ -399,7 +387,7 @@ func TestBufferedFileWriterClose(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			writer := New(ctx, WithThreshold(threshold))
+			writer := New(WithThreshold(threshold))
 
 			tc.prepareWriter(writer)
 
@@ -421,7 +409,7 @@ func TestBufferedFileWriterClose(t *testing.T) {
 
 func TestBufferedFileWriterStateTransitionOnClose(t *testing.T) {
 	t.Parallel()
-	writer := New(context.Background())
+	writer := New()
 
 	// Initially, the writer should be in write-only mode.
 	assert.Equal(t, writeOnly, writer.state)
@@ -440,7 +428,7 @@ func TestBufferedFileWriterStateTransitionOnClose(t *testing.T) {
 
 func TestBufferedFileWriterWriteInReadOnlyState(t *testing.T) {
 	t.Parallel()
-	writer := New(context.Background())
+	writer := New()
 	_ = writer.CloseForWriting() // Transition to read-only mode
 
 	// Attempt to write in read-only mode.
@@ -449,7 +437,6 @@ func TestBufferedFileWriterWriteInReadOnlyState(t *testing.T) {
 }
 
 func BenchmarkBufferedFileWriterWriteLarge(b *testing.B) {
-	ctx := context.Background()
 	data := make([]byte, 1024*1024*10) // 10MB
 	for i := range data {
 		data[i] = byte(i % 256) // Simple pattern to avoid uniform zero data
@@ -459,7 +446,7 @@ func BenchmarkBufferedFileWriterWriteLarge(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// Threshold is smaller than the data size, data should get flushed to the file.
-		writer := New(ctx, WithThreshold(1024))
+		writer := New(WithThreshold(1024))
 
 		b.StartTimer()
 		{
@@ -479,7 +466,6 @@ func BenchmarkBufferedFileWriterWriteLarge(b *testing.B) {
 }
 
 func BenchmarkBufferedFileWriterWriteSmall(b *testing.B) {
-	ctx := context.Background()
 	data := make([]byte, 1024*1024) // 1MB
 	for i := range data {
 		data[i] = byte(i % 256) // Simple pattern to avoid uniform zero data
@@ -489,7 +475,7 @@ func BenchmarkBufferedFileWriterWriteSmall(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// Threshold is the same as the buffer size, data should always be written to the buffer.
-		writer := New(ctx, WithThreshold(1024*1024))
+		writer := New(WithThreshold(1024 * 1024))
 
 		b.StartTimer()
 		{


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR modifies the buffer retrieval strategy for `BufferWriter` and `BufferedFileWriter`. Now, rather than acquiring the buffer from the pool at instantiation, we defer this action, retrieving the buffer only when a write operation is initiated. This adjustment simplifies the usage of the package and enhances the accuracy of metrics for active buffer counts and checkout durations.

This change is related to the comment I left in [this PR](https://github.com/trufflesecurity/trufflehog/pull/2742)

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

