### PR TITLE
Remove `if len(match) != 2` check in detectors

### DIFF
--- a/pkg/detectors/abbysale/abbysale.go
+++ b/pkg/detectors/abbysale/abbysale.go
@@ -49,9 +49,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/abstract/abstract.go
+++ b/pkg/detectors/abstract/abstract.go
@@ -48,9 +48,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/abuseipdb/abuseipdb.go
+++ b/pkg/detectors/abuseipdb/abuseipdb.go
@@ -51,9 +51,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/accuweather/accuweather.go
+++ b/pkg/detectors/accuweather/accuweather.go
@@ -49,9 +49,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/adafruitio/adafruitio.go
+++ b/pkg/detectors/adafruitio/adafruitio.go
@@ -49,9 +49,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/adobeio/adobeio.go
+++ b/pkg/detectors/adobeio/adobeio.go
@@ -2,9 +2,10 @@ package adobeio
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -40,14 +41,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/adzuna/adzuna.go
+++ b/pkg/detectors/adzuna/adzuna.go
@@ -3,9 +3,10 @@ package adzuna
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -50,15 +51,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/aeroworkflow/aeroworkflow.go
+++ b/pkg/detectors/aeroworkflow/aeroworkflow.go
@@ -52,15 +52,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/agora/agora.go
+++ b/pkg/detectors/agora/agora.go
@@ -48,23 +48,14 @@ func (s Scanner) getClient() *http.Client {
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
 	dataStr := string(data)
 
-	keyMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
+	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
-	for _, keyMatch := range keyMatches {
-		if len(keyMatch) != 2 {
-			continue
-		}
+	for _, match := range matches {
+		resMatch := strings.TrimSpace(match[1])
 
-		resMatch := strings.TrimSpace(keyMatch[1])
-
-		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
-
-			resSecret := strings.TrimSpace(secretMatch[1])
-
+		for _, secret := range secretMatches {
+			resSecret := strings.TrimSpace(secret[1])
 			/*
 				as both agora key and secretMatch has same regex, the set of strings keyMatch for both probably me same.
 				we need to avoid the scenario where key is same as secretMatch. This will reduce the number of matches we process.

--- a/pkg/detectors/aha/aha.go
+++ b/pkg/detectors/aha/aha.go
@@ -49,16 +49,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	resURLMatch := "aha.io"
 	for _, URLmatch := range URLmatches {
-		if len(URLmatch) != 2 {
-			continue
-		}
 		resURLMatch = strings.TrimSpace(URLmatch[1])
 	}
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/airbrakeprojectkey/airbrakeprojectkey.go
+++ b/pkg/detectors/airbrakeprojectkey/airbrakeprojectkey.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/airbrakeuserkey/airbrakeuserkey.go
+++ b/pkg/detectors/airbrakeuserkey/airbrakeuserkey.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/airship/airship.go
+++ b/pkg/detectors/airship/airship.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/airvisual/airvisual.go
+++ b/pkg/detectors/airvisual/airvisual.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/aiven/aiven.go
+++ b/pkg/detectors/aiven/aiven.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/alconost/alconost.go
+++ b/pkg/detectors/alconost/alconost.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/aletheiaapi/aletheiaapi.go
+++ b/pkg/detectors/aletheiaapi/aletheiaapi.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/alibaba/alibaba.go
+++ b/pkg/detectors/alibaba/alibaba.go
@@ -96,15 +96,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/alienvault/alienvault.go
+++ b/pkg/detectors/alienvault/alienvault.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/allsports/allsports.go
+++ b/pkg/detectors/allsports/allsports.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/amadeus/amadeus.go
+++ b/pkg/detectors/amadeus/amadeus.go
@@ -2,10 +2,11 @@ package amadeus
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
 	"io"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -41,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecret := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/ambee/ambee.go
+++ b/pkg/detectors/ambee/ambee.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/amplitudeapikey/amplitudeapikey.go
+++ b/pkg/detectors/amplitudeapikey/amplitudeapikey.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecretMatch := strings.TrimSpace(secretMatch[1])
 
 			// regex for both key and secret are same so the set of strings could possibly be same as well

--- a/pkg/detectors/anthropic/anthropic.go
+++ b/pkg/detectors/anthropic/anthropic.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/anypoint/anypoint.go
+++ b/pkg/detectors/anypoint/anypoint.go
@@ -42,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	orgMatches := orgPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, orgMatch := range orgMatches {
-			if len(orgMatch) != 2 {
-				continue
-			}
 			orgRes := strings.TrimSpace(orgMatch[1])
 
 			// regex for both key and org are same, so to avoid same string processing

--- a/pkg/detectors/apacta/apacta.go
+++ b/pkg/detectors/apacta/apacta.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/api2cart/api2cart.go
+++ b/pkg/detectors/api2cart/api2cart.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/apideck/apideck.go
+++ b/pkg/detectors/apideck/apideck.go
@@ -3,9 +3,10 @@ package apideck
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -41,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idMatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/apifonica/apifonica.go
+++ b/pkg/detectors/apifonica/apifonica.go
@@ -40,14 +40,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	tokenMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, tokenMatch := range tokenMatches {
-			if len(tokenMatch) != 2 {
-				continue
-			}
 			resToken := strings.TrimSpace(tokenMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/apify/apify.go
+++ b/pkg/detectors/apify/apify.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/apilayer/apilayer.go
+++ b/pkg/detectors/apilayer/apilayer.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/apimetrics/apimetrics.go
+++ b/pkg/detectors/apimetrics/apimetrics.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/apitemplate/apitemplate.go
+++ b/pkg/detectors/apitemplate/apitemplate.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/apollo/apollo.go
+++ b/pkg/detectors/apollo/apollo.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/appcues/appcues.go
+++ b/pkg/detectors/appcues/appcues.go
@@ -3,9 +3,10 @@ package appcues
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -43,22 +44,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, userMatch := range userMatches {
-			if len(userMatch) != 2 {
-				continue
-			}
 
 			resUserMatch := strings.TrimSpace(userMatch[1])
 
 			for _, idMatch := range idMatches {
-				if len(idMatch) != 2 {
-					continue
-				}
 
 				resIdMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/appfollow/appfollow.go
+++ b/pkg/detectors/appfollow/appfollow.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/appointedd/appointedd.go
+++ b/pkg/detectors/appointedd/appointedd.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/appoptics/appoptics.go
+++ b/pkg/detectors/appoptics/appoptics.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/appsynergy/appsynergy.go
+++ b/pkg/detectors/appsynergy/appsynergy.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/apptivo/apptivo.go
+++ b/pkg/detectors/apptivo/apptivo.go
@@ -3,10 +3,11 @@ package apptivo
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"io"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -42,14 +43,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/artifactory/artifactory.go
+++ b/pkg/detectors/artifactory/artifactory.go
@@ -51,17 +51,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	resURLMatch := ""
 	for _, URLmatch := range URLmatches {
-		if len(URLmatch) != 2 {
-			continue
-		}
-
 		resURLMatch = strings.TrimSpace(URLmatch[1])
 	}
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		client := s.getClient()

--- a/pkg/detectors/artsy/artsy.go
+++ b/pkg/detectors/artsy/artsy.go
@@ -2,9 +2,10 @@ package artsy
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -40,16 +41,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/asanaoauth/asanaoauth.go
+++ b/pkg/detectors/asanaoauth/asanaoauth.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/asanapersonalaccesstoken/asanapersonalaccesstoken.go
+++ b/pkg/detectors/asanapersonalaccesstoken/asanapersonalaccesstoken.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/assemblyai/assemblyai.go
+++ b/pkg/detectors/assemblyai/assemblyai.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/atera/atera.go
+++ b/pkg/detectors/atera/atera.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/audd/audd.go
+++ b/pkg/detectors/audd/audd.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/auth0managementapitoken/auth0managementapitoken.go
+++ b/pkg/detectors/auth0managementapitoken/auth0managementapitoken.go
@@ -45,18 +45,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, managementApiTokenMatch := range managementAPITokenMatches {
-		if len(managementApiTokenMatch) != 2 {
-			continue
-		}
 		managementAPITokenRes := strings.TrimSpace(managementApiTokenMatch[1])
 		if len(managementAPITokenRes) < 2000 || len(managementAPITokenRes) > 5000 {
 			continue
 		}
 
 		for _, domainMatch := range domainMatches {
-			if len(domainMatch) != 2 {
-				continue
-			}
 			domainRes := strings.TrimSpace(domainMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/auth0oauth/auth0oauth.go
+++ b/pkg/detectors/auth0oauth/auth0oauth.go
@@ -43,21 +43,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, clientIdMatch := range clientIdMatches {
-		if len(clientIdMatch) != 2 {
-			continue
-		}
 		clientIdRes := strings.TrimSpace(clientIdMatch[1])
 
 		for _, clientSecretMatch := range clientSecretMatches {
-			if len(clientSecretMatch) != 2 {
-				continue
-			}
 			clientSecretRes := strings.TrimSpace(clientSecretMatch[1])
 
 			for _, domainMatch := range domainMatches {
-				if len(domainMatch) != 2 {
-					continue
-				}
 				domainRes := strings.TrimSpace(domainMatch[1])
 
 				s1 := detectors.Result{

--- a/pkg/detectors/autodesk/autodesk.go
+++ b/pkg/detectors/autodesk/autodesk.go
@@ -3,9 +3,10 @@ package autodesk
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -41,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecret := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/autoklose/autoklose.go
+++ b/pkg/detectors/autoklose/autoklose.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/autopilot/autopilot.go
+++ b/pkg/detectors/autopilot/autopilot.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/avazapersonalaccesstoken/avazapersonalaccesstoken.go
+++ b/pkg/detectors/avazapersonalaccesstoken/avazapersonalaccesstoken.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/aviationstack/aviationstack.go
+++ b/pkg/detectors/aviationstack/aviationstack.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/axonaut/axonaut.go
+++ b/pkg/detectors/axonaut/axonaut.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/aylien/aylien.go
+++ b/pkg/detectors/aylien/aylien.go
@@ -2,9 +2,10 @@ package aylien
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -39,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/ayrshare/ayrshare.go
+++ b/pkg/detectors/ayrshare/ayrshare.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/azuredevopspersonalaccesstoken/azuredevopspersonalaccesstoken.go
+++ b/pkg/detectors/azuredevopspersonalaccesstoken/azuredevopspersonalaccesstoken.go
@@ -42,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	orgMatches := orgPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, orgMatch := range orgMatches {
-			if len(orgMatch) != 2 {
-				continue
-			}
 			resOrgMatch := strings.TrimSpace(orgMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/azuresearchadminkey/azuresearchadminkey.go
+++ b/pkg/detectors/azuresearchadminkey/azuresearchadminkey.go
@@ -42,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	serviceMatches := servicePat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, serviceMatch := range serviceMatches {
-			if len(serviceMatch) != 2 {
-				continue
-			}
 			resServiceMatch := strings.TrimSpace(serviceMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/azuresearchquerykey/azuresearchquerykey.go
+++ b/pkg/detectors/azuresearchquerykey/azuresearchquerykey.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	urlMatches := urlPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, urlMatch := range urlMatches {

--- a/pkg/detectors/bannerbear/bannerbear.go
+++ b/pkg/detectors/bannerbear/bannerbear.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/baremetrics/baremetrics.go
+++ b/pkg/detectors/baremetrics/baremetrics.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/beamer/beamer.go
+++ b/pkg/detectors/beamer/beamer.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/beebole/beebole.go
+++ b/pkg/detectors/beebole/beebole.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/besnappy/besnappy.go
+++ b/pkg/detectors/besnappy/besnappy.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/besttime/besttime.go
+++ b/pkg/detectors/besttime/besttime.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/betterstack/betterstack.go
+++ b/pkg/detectors/betterstack/betterstack.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/billomat/billomat.go
+++ b/pkg/detectors/billomat/billomat.go
@@ -42,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			resId := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/bitbar/bitbar.go
+++ b/pkg/detectors/bitbar/bitbar.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/bitcoinaverage/bitcoinaverage.go
+++ b/pkg/detectors/bitcoinaverage/bitcoinaverage.go
@@ -43,9 +43,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/bitfinex/bitfinex.go
+++ b/pkg/detectors/bitfinex/bitfinex.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/bitfinexcom/bitfinex-api-go/v2/rest"
 	regexp "github.com/wasilibs/go-re2"
 
+	"github.com/bitfinexcom/bitfinex-api-go/v2/rest"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
@@ -47,9 +47,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	apiSecretMatches := apiSecretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, apiKeyMatch := range apiKeyMatches {
-		if len(apiKeyMatch) != 2 {
-			continue
-		}
 		apiKeyRes := strings.TrimSpace(apiKeyMatch[1])
 
 		s1 := detectors.Result{
@@ -58,9 +55,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		for _, apiSecretMatch := range apiSecretMatches {
-			if len(apiSecretMatch) != 2 {
-				continue
-			}
 			apiSecretRes := strings.TrimSpace(apiSecretMatch[1])
 
 			if apiKeyRes == apiSecretRes {

--- a/pkg/detectors/bitlyaccesstoken/bitlyaccesstoken.go
+++ b/pkg/detectors/bitlyaccesstoken/bitlyaccesstoken.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/bitmex/bitmex.go
+++ b/pkg/detectors/bitmex/bitmex.go
@@ -47,15 +47,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecretMatch := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/blazemeter/blazemeter.go
+++ b/pkg/detectors/blazemeter/blazemeter.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/blitapp/blitapp.go
+++ b/pkg/detectors/blitapp/blitapp.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/blocknative/blocknative.go
+++ b/pkg/detectors/blocknative/blocknative.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/blogger/blogger.go
+++ b/pkg/detectors/blogger/blogger.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/bombbomb/bombbomb.go
+++ b/pkg/detectors/bombbomb/bombbomb.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/boostnote/boostnote.go
+++ b/pkg/detectors/boostnote/boostnote.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/borgbase/borgbase.go
+++ b/pkg/detectors/borgbase/borgbase.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/braintreepayments/braintreepayments.go
+++ b/pkg/detectors/braintreepayments/braintreepayments.go
@@ -48,15 +48,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/brandfetch/brandfetch.go
+++ b/pkg/detectors/brandfetch/brandfetch.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/browserstack/browserstack.go
+++ b/pkg/detectors/browserstack/browserstack.go
@@ -55,15 +55,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	userMatches := userPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, userMatch := range userMatches {
-			if len(userMatch) != 2 {
-				continue
-			}
 
 			resUserMatch := strings.TrimSpace(userMatch[1])
 

--- a/pkg/detectors/browshot/browshot.go
+++ b/pkg/detectors/browshot/browshot.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/bscscan/bscscan.go
+++ b/pkg/detectors/bscscan/bscscan.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/buddyns/buddyns.go
+++ b/pkg/detectors/buddyns/buddyns.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/budibase/budibase.go
+++ b/pkg/detectors/budibase/budibase.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/bugherd/bugherd.go
+++ b/pkg/detectors/bugherd/bugherd.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/bugsnag/bugsnag.go
+++ b/pkg/detectors/bugsnag/bugsnag.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/buildkite/v1/buildkite.go
+++ b/pkg/detectors/buildkite/v1/buildkite.go
@@ -47,9 +47,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/buildkite/v2/buildkite.go
+++ b/pkg/detectors/buildkite/v2/buildkite.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/bulbul/bulbul.go
+++ b/pkg/detectors/bulbul/bulbul.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/buttercms/buttercms.go
+++ b/pkg/detectors/buttercms/buttercms.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/caflou/caflou.go
+++ b/pkg/detectors/caflou/caflou.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/calendarific/calendarific.go
+++ b/pkg/detectors/calendarific/calendarific.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/calendlyapikey/calendlyapikey.go
+++ b/pkg/detectors/calendlyapikey/calendlyapikey.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/calorieninja/calorieninja.go
+++ b/pkg/detectors/calorieninja/calorieninja.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/campayn/campayn.go
+++ b/pkg/detectors/campayn/campayn.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/cannyio/cannyio.go
+++ b/pkg/detectors/cannyio/cannyio.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/capsulecrm/capsulecrm.go
+++ b/pkg/detectors/capsulecrm/capsulecrm.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/captaindata/v1/captaindata.go
+++ b/pkg/detectors/captaindata/v1/captaindata.go
@@ -44,15 +44,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	projIdMatches := projIdPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, projIdMatch := range projIdMatches {
-		if len(projIdMatch) != 2 {
-			continue
-		}
 		resProjIdMatch := strings.TrimSpace(projIdMatch[1])
 
 		for _, match := range matches {
-			if len(match) != 2 {
-				continue
-			}
 			resMatch := strings.TrimSpace(match[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/carboninterface/carboninterface.go
+++ b/pkg/detectors/carboninterface/carboninterface.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/cashboard/cashboard.go
+++ b/pkg/detectors/cashboard/cashboard.go
@@ -43,15 +43,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	userMatches := userPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, userMatch := range userMatches {
-			if len(userMatch) != 2 {
-				continue
-			}
 			resUser := strings.TrimSpace(userMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/caspio/caspio.go
+++ b/pkg/detectors/caspio/caspio.go
@@ -12,7 +12,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{
+type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
 }
 
@@ -43,22 +43,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 
 			for _, domainMatch := range domainMatches {
-				if len(domainMatch) != 2 {
-					continue
-				}
 
 				resDomainMatch := strings.TrimSpace(domainMatch[1])
 

--- a/pkg/detectors/censys/censys.go
+++ b/pkg/detectors/censys/censys.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		tokenPatMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			userPatMatch := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/centralstationcrm/centralstationcrm.go
+++ b/pkg/detectors/centralstationcrm/centralstationcrm.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/cexio/cexio.go
+++ b/pkg/detectors/cexio/cexio.go
@@ -51,21 +51,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	userIdMatches := userIdPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, userIdMatch := range userIdMatches {
-		if len(userIdMatch) != 2 {
-			continue
-		}
 		resUserIdMatch := strings.TrimSpace(userIdMatch[1])
 
 		for _, keyMatch := range keyMatches {
-			if len(keyMatch) != 2 {
-				continue
-			}
 			resKeyMatch := strings.TrimSpace(keyMatch[1])
 
 			for _, secretMatch := range secretMatches {
-				if len(secretMatch) != 2 {
-					continue
-				}
 				resSecretMatch := strings.TrimSpace(secretMatch[1])
 
 				s1 := detectors.Result{

--- a/pkg/detectors/chartmogul/chartmogul.go
+++ b/pkg/detectors/chartmogul/chartmogul.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/chatbot/chatbot.go
+++ b/pkg/detectors/chatbot/chatbot.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/chatfule/chatfule.go
+++ b/pkg/detectors/chatfule/chatfule.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/checio/checio.go
+++ b/pkg/detectors/checio/checio.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/checklyhq/checklyhq.go
+++ b/pkg/detectors/checklyhq/checklyhq.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/checkout/checkout.go
+++ b/pkg/detectors/checkout/checkout.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 3 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/checkvist/checkvist.go
+++ b/pkg/detectors/checkvist/checkvist.go
@@ -47,9 +47,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for emailMatch := range uniqueEmailMatches {
 		for _, match := range matches {
-			if len(match) != 2 {
-				continue
-			}
 			resMatch := strings.TrimSpace(match[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/cicero/cicero.go
+++ b/pkg/detectors/cicero/cicero.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/clarifai/clarifai.go
+++ b/pkg/detectors/clarifai/clarifai.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/clearbit/clearbit.go
+++ b/pkg/detectors/clearbit/clearbit.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/clickhelp/clickhelp.go
+++ b/pkg/detectors/clickhelp/clickhelp.go
@@ -45,20 +45,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	keyMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range serverMatches {
-		if len(match) != 2 {
-			continue
-		}
 		resServer := strings.TrimSpace(match[1])
 
 		for _, emailMatch := range emailMatches {
-			if len(emailMatch) != 2 {
-				continue
-			}
 			resEmail := strings.TrimSpace(emailMatch[1])
 			for _, keyMatch := range keyMatches {
-				if len(keyMatch) != 2 {
-					continue
-				}
 				resKey := strings.TrimSpace(keyMatch[1])
 
 				s1 := detectors.Result{

--- a/pkg/detectors/clicksendsms/clicksendsms.go
+++ b/pkg/detectors/clicksendsms/clicksendsms.go
@@ -43,9 +43,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idMatch := range idMatches {
 			resIdMatch := strings.TrimSpace(idMatch[0][strings.LastIndex(idMatch[0], " ")+1:])

--- a/pkg/detectors/clickuppersonaltoken/clickuppersonaltoken.go
+++ b/pkg/detectors/clickuppersonaltoken/clickuppersonaltoken.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/cliengo/cliengo.go
+++ b/pkg/detectors/cliengo/cliengo.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/clinchpad/clinchpad.go
+++ b/pkg/detectors/clinchpad/clinchpad.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/clockify/clockify.go
+++ b/pkg/detectors/clockify/clockify.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/clockworksms/clockworksms.go
+++ b/pkg/detectors/clockworksms/clockworksms.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	tokenMatches := tokenPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range userKeyMatches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, tokenMatch := range tokenMatches {
-			if len(tokenMatch) != 2 {
-				continue
-			}
 			tokenRes := strings.TrimSpace(tokenMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/closecrm/close.go
+++ b/pkg/detectors/closecrm/close.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/cloudconvert/cloudconvert.go
+++ b/pkg/detectors/cloudconvert/cloudconvert.go
@@ -43,9 +43,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/cloudelements/cloudelements.go
+++ b/pkg/detectors/cloudelements/cloudelements.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	orgMatches := orgPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, orgMatch := range orgMatches {
-			if len(orgMatch) != 2 {
-				continue
-			}
 
 			resOrgMatch := strings.TrimSpace(orgMatch[1])
 

--- a/pkg/detectors/cloudflareapitoken/cloudflareapitoken.go
+++ b/pkg/detectors/cloudflareapitoken/cloudflareapitoken.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/cloudflareglobalapikey/cloudflareglobalapikey.go
+++ b/pkg/detectors/cloudflareglobalapikey/cloudflareglobalapikey.go
@@ -45,9 +45,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	for _, apiKeyMatch := range apiKeyMatches {
-		if len(apiKeyMatch) != 2 {
-			continue
-		}
 		apiKeyRes := strings.TrimSpace(apiKeyMatch[1])
 
 		for emailMatch := range uniqueEmailMatches {

--- a/pkg/detectors/cloudimage/cloudimage.go
+++ b/pkg/detectors/cloudimage/cloudimage.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/cloudmersive/cloudmersive.go
+++ b/pkg/detectors/cloudmersive/cloudmersive.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/cloudplan/cloudplan.go
+++ b/pkg/detectors/cloudplan/cloudplan.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/cloudsmith/cloudsmith.go
+++ b/pkg/detectors/cloudsmith/cloudsmith.go
@@ -42,9 +42,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/cloverly/cloverly.go
+++ b/pkg/detectors/cloverly/cloverly.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/cloze/cloze.go
+++ b/pkg/detectors/cloze/cloze.go
@@ -47,9 +47,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for emailMatch := range uniqueEmailMatches {
 		for _, match := range matches {
-			if len(match) != 2 {
-				continue
-			}
 			resMatch := strings.TrimSpace(match[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/clustdoc/clustdoc.go
+++ b/pkg/detectors/clustdoc/clustdoc.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/coda/coda.go
+++ b/pkg/detectors/coda/coda.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/codacy/codacy.go
+++ b/pkg/detectors/codacy/codacy.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/codeclimate/codeclimate.go
+++ b/pkg/detectors/codeclimate/codeclimate.go
@@ -45,9 +45,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/codemagic/codemagic.go
+++ b/pkg/detectors/codemagic/codemagic.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/codequiry/codequiry.go
+++ b/pkg/detectors/codequiry/codequiry.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/coinapi/coinapi.go
+++ b/pkg/detectors/coinapi/coinapi.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/coinbase/coinbase.go
+++ b/pkg/detectors/coinbase/coinbase.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/coinlayer/coinlayer.go
+++ b/pkg/detectors/coinlayer/coinlayer.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/coinlib/coinlib.go
+++ b/pkg/detectors/coinlib/coinlib.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/collect2/collect2.go
+++ b/pkg/detectors/collect2/collect2.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/column/column.go
+++ b/pkg/detectors/column/column.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/commercejs/commercejs.go
+++ b/pkg/detectors/commercejs/commercejs.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/commodities/commodities.go
+++ b/pkg/detectors/commodities/commodities.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/companyhub/companyhub.go
+++ b/pkg/detectors/companyhub/companyhub.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/confluent/confluent.go
+++ b/pkg/detectors/confluent/confluent.go
@@ -43,15 +43,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, secret := range secretMatches {
-			if len(secret) != 2 {
-				continue
-			}
 			resSecret := strings.TrimSpace(secret[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/contentfulpersonalaccesstoken/contentfulpersonalaccesstoken.go
+++ b/pkg/detectors/contentfulpersonalaccesstoken/contentfulpersonalaccesstoken.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	keyMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range keyMatches {
-		if len(match) != 2 {
-			continue
-		}
 		keyRes := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/conversiontools/conversiontools.go
+++ b/pkg/detectors/conversiontools/conversiontools.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/convertapi/convertapi.go
+++ b/pkg/detectors/convertapi/convertapi.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/convertkit/convertkit.go
+++ b/pkg/detectors/convertkit/convertkit.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/convier/convier.go
+++ b/pkg/detectors/convier/convier.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/copper/copper.go
+++ b/pkg/detectors/copper/copper.go
@@ -41,14 +41,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/countrylayer/countrylayer.go
+++ b/pkg/detectors/countrylayer/countrylayer.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/courier/courier.go
+++ b/pkg/detectors/courier/courier.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/coveralls/coveralls.go
+++ b/pkg/detectors/coveralls/coveralls.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/craftmypdf/craftmypdf.go
+++ b/pkg/detectors/craftmypdf/craftmypdf.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/crowdin/crowdin.go
+++ b/pkg/detectors/crowdin/crowdin.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/cryptocompare/cryptocompare.go
+++ b/pkg/detectors/cryptocompare/cryptocompare.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/currencycloud/currencycloud.go
+++ b/pkg/detectors/currencycloud/currencycloud.go
@@ -47,9 +47,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for emailmatch := range uniqueEmailMatches {

--- a/pkg/detectors/currencyfreaks/currencyfreaks.go
+++ b/pkg/detectors/currencyfreaks/currencyfreaks.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/currencylayer/currencylayer.go
+++ b/pkg/detectors/currencylayer/currencylayer.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/currencyscoop/currencyscoop.go
+++ b/pkg/detectors/currencyscoop/currencyscoop.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/currentsapi/currentsapi.go
+++ b/pkg/detectors/currentsapi/currentsapi.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/customerguru/customerguru.go
+++ b/pkg/detectors/customerguru/customerguru.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/customerio/customerio.go
+++ b/pkg/detectors/customerio/customerio.go
@@ -43,14 +43,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_CustomerIO,

--- a/pkg/detectors/d7network/d7network.go
+++ b/pkg/detectors/d7network/d7network.go
@@ -34,9 +34,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/dailyco/dailyco.go
+++ b/pkg/detectors/dailyco/dailyco.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/dandelion/dandelion.go
+++ b/pkg/detectors/dandelion/dandelion.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/dareboost/dareboost.go
+++ b/pkg/detectors/dareboost/dareboost.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/databox/databox.go
+++ b/pkg/detectors/databox/databox.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/datadogtoken/datadogtoken.go
+++ b/pkg/detectors/datadogtoken/datadogtoken.go
@@ -106,15 +106,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	apiMatches := apiPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, apiMatch := range apiMatches {
-		if len(apiMatch) != 2 {
-			continue
-		}
 		resApiMatch := strings.TrimSpace(apiMatch[1])
 		appIncluded := false
 		for _, appMatch := range appMatches {
-			if len(appMatch) != 2 {
-				continue
-			}
 			resAppMatch := strings.TrimSpace(appMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/datagov/datagov.go
+++ b/pkg/detectors/datagov/datagov.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/debounce/debounce.go
+++ b/pkg/detectors/debounce/debounce.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/deepai/deepai.go
+++ b/pkg/detectors/deepai/deepai.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/deepgram/deepgram.go
+++ b/pkg/detectors/deepgram/deepgram.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/delighted/delighted.go
+++ b/pkg/detectors/delighted/delighted.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/demio/demio.go
+++ b/pkg/detectors/demio/demio.go
@@ -41,14 +41,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	idMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idmatch := range idMatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/deputy/deputy.go
+++ b/pkg/detectors/deputy/deputy.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	urlMatches := urlPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, urlMatch := range urlMatches {
-			if len(urlMatch) != 2 {
-				continue
-			}
 			resURL := strings.TrimSpace(urlMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/detectify/detectify.go
+++ b/pkg/detectors/detectify/detectify.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/detectlanguage/detectlanguage.go
+++ b/pkg/detectors/detectlanguage/detectlanguage.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/dfuse/dfuse.go
+++ b/pkg/detectors/dfuse/dfuse.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/diffbot/diffbot.go
+++ b/pkg/detectors/diffbot/diffbot.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/diggernaut/diggernaut.go
+++ b/pkg/detectors/diggernaut/diggernaut.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/digitaloceantoken/digitaloceantoken.go
+++ b/pkg/detectors/digitaloceantoken/digitaloceantoken.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/digitaloceanv2/digitaloceanv2.go
+++ b/pkg/detectors/digitaloceanv2/digitaloceanv2.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/discordbottoken/discordbottoken.go
+++ b/pkg/detectors/discordbottoken/discordbottoken.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatch := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idMatch {
-			if len(match) != 2 {
-				continue
-			}
 			resId := strings.TrimSpace(idmatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_DiscordBotToken,

--- a/pkg/detectors/discordwebhook/discordwebhook.go
+++ b/pkg/detectors/discordwebhook/discordwebhook.go
@@ -34,9 +34,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_DiscordWebhook,

--- a/pkg/detectors/disqus/disqus.go
+++ b/pkg/detectors/disqus/disqus.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/ditto/ditto.go
+++ b/pkg/detectors/ditto/ditto.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/dnscheck/dnscheck.go
+++ b/pkg/detectors/dnscheck/dnscheck.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/docparser/docparser.go
+++ b/pkg/detectors/docparser/docparser.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/documo/documo.go
+++ b/pkg/detectors/documo/documo.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/docusign/docusign.go
+++ b/pkg/detectors/docusign/docusign.go
@@ -48,15 +48,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, idMatch := range idMatches {
-		if len(idMatch) != 2 {
-			continue
-		}
 		resIDMatch := strings.TrimSpace(idMatch[1])
 
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecretMatch := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/doppler/doppler.go
+++ b/pkg/detectors/doppler/doppler.go
@@ -55,9 +55,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/dotmailer/dotmailer.go
+++ b/pkg/detectors/dotmailer/dotmailer.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	passMatches := passPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range passMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resPassMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/dovico/dovico.go
+++ b/pkg/detectors/dovico/dovico.go
@@ -42,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	userMatches := userPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, user := range userMatches {
-			if len(user) != 2 {
-				continue
-			}
 			resUser := strings.TrimSpace(user[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/dronahq/dronahq.go
+++ b/pkg/detectors/dronahq/dronahq.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/droneci/droneci.go
+++ b/pkg/detectors/droneci/droneci.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/duply/duply.go
+++ b/pkg/detectors/duply/duply.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 			s1 := detectors.Result{

--- a/pkg/detectors/dwolla/dwolla.go
+++ b/pkg/detectors/dwolla/dwolla.go
@@ -43,16 +43,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range idMatches {
-		if len(match) != 2 {
-			continue
-		}
 
 		idMatch := strings.TrimSpace(match[1])
 
 		for _, secret := range secretMatches {
-			if len(secret) != 2 {
-				continue
-			}
 
 			secretMatch := strings.TrimSpace(secret[1])
 

--- a/pkg/detectors/dynalist/dynalist.go
+++ b/pkg/detectors/dynalist/dynalist.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/dyspatch/dyspatch.go
+++ b/pkg/detectors/dyspatch/dyspatch.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/eagleeyenetworks/eagleeyenetworks.go
+++ b/pkg/detectors/eagleeyenetworks/eagleeyenetworks.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	emailMatches := email.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, emailMatch := range emailMatches {
-			if len(emailMatch) != 2 {
-				continue
-			}
 
 			resEmailPatMatch := strings.TrimSpace(emailMatch[1])
 

--- a/pkg/detectors/ecostruxureit/ecostruxureit.go
+++ b/pkg/detectors/ecostruxureit/ecostruxureit.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/edamam/edamam.go
+++ b/pkg/detectors/edamam/edamam.go
@@ -42,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idMatch := range idMatches {
-			if len(match) != 2 {
-				continue
-			}
 			resId := strings.TrimSpace(idMatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Edamam,

--- a/pkg/detectors/edenai/edenai.go
+++ b/pkg/detectors/edenai/edenai.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/eightxeight/eightxeight.go
+++ b/pkg/detectors/eightxeight/eightxeight.go
@@ -43,15 +43,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/elasticemail/elasticemail.go
+++ b/pkg/detectors/elasticemail/elasticemail.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/enablex/enablex.go
+++ b/pkg/detectors/enablex/enablex.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		tokenPatMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			userPatMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/enigma/enigma.go
+++ b/pkg/detectors/enigma/enigma.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/envoyapikey/envoyapikey.go
+++ b/pkg/detectors/envoyapikey/envoyapikey.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/etherscan/etherscan.go
+++ b/pkg/detectors/etherscan/etherscan.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/ethplorer/ethplorer.go
+++ b/pkg/detectors/ethplorer/ethplorer.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/everhour/everhour.go
+++ b/pkg/detectors/everhour/everhour.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/exchangerateapi/exchangerateapi.go
+++ b/pkg/detectors/exchangerateapi/exchangerateapi.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/exchangeratesapi/exchangeratesapi.go
+++ b/pkg/detectors/exchangeratesapi/exchangeratesapi.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/exportsdk/exportsdk.go
+++ b/pkg/detectors/exportsdk/exportsdk.go
@@ -41,14 +41,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/extractorapi/extractorapi.go
+++ b/pkg/detectors/extractorapi/extractorapi.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/facebookoauth/facebookoauth.go
+++ b/pkg/detectors/facebookoauth/facebookoauth.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	apiSecretMatches := apiSecretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, apiIdMatch := range apiIdMatches {
-		if len(apiIdMatch) != 2 {
-			continue
-		}
 		apiIdRes := strings.TrimSpace(apiIdMatch[1])
 
 		for _, apiSecretMatch := range apiSecretMatches {
-			if len(apiSecretMatch) != 2 {
-				continue
-			}
 			apiSecretRes := strings.TrimSpace(apiSecretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/faceplusplus/faceplusplus.go
+++ b/pkg/detectors/faceplusplus/faceplusplus.go
@@ -42,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecret := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/fastforex/fastforex.go
+++ b/pkg/detectors/fastforex/fastforex.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/feedier/feedier.go
+++ b/pkg/detectors/feedier/feedier.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/fibery/fibery.go
+++ b/pkg/detectors/fibery/fibery.go
@@ -47,15 +47,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, domainMatch := range domainMatches {
-			if len(domainMatch) != 2 {
-				continue
-			}
 
 			resDomainMatch := strings.TrimSpace(domainMatch[1])
 

--- a/pkg/detectors/figmapersonalaccesstoken/v1/figmapersonalaccesstoken.go
+++ b/pkg/detectors/figmapersonalaccesstoken/v1/figmapersonalaccesstoken.go
@@ -42,9 +42,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/figmapersonalaccesstoken/v2/figmapersonalaccesstoken_v2.go
+++ b/pkg/detectors/figmapersonalaccesstoken/v2/figmapersonalaccesstoken_v2.go
@@ -46,9 +46,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/fileio/fileio.go
+++ b/pkg/detectors/fileio/fileio.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/finage/finage.go
+++ b/pkg/detectors/finage/finage.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/financialmodelingprep/financialmodelingprep.go
+++ b/pkg/detectors/financialmodelingprep/financialmodelingprep.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/findl/findl.go
+++ b/pkg/detectors/findl/findl.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/finnhub/finnhub.go
+++ b/pkg/detectors/finnhub/finnhub.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/fixerio/fixerio.go
+++ b/pkg/detectors/fixerio/fixerio.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/flatio/flatio.go
+++ b/pkg/detectors/flatio/flatio.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/fleetbase/fleetbase.go
+++ b/pkg/detectors/fleetbase/fleetbase.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/flickr/flickr.go
+++ b/pkg/detectors/flickr/flickr.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/flightapi/flightapi.go
+++ b/pkg/detectors/flightapi/flightapi.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/flightlabs/flightlabs.go
+++ b/pkg/detectors/flightlabs/flightlabs.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/flightstats/flightstats.go
+++ b/pkg/detectors/flightstats/flightstats.go
@@ -43,15 +43,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			resId := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/float/float.go
+++ b/pkg/detectors/float/float.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/flowflu/flowflu.go
+++ b/pkg/detectors/flowflu/flowflu.go
@@ -43,15 +43,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	accountMatches := accountPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, accountMatch := range accountMatches {
-			if len(accountMatch) != 2 {
-				continue
-			}
 
 			resAccount := strings.TrimSpace(accountMatch[1])
 

--- a/pkg/detectors/flutterwave/flutterwave.go
+++ b/pkg/detectors/flutterwave/flutterwave.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/fmfw/fmfw.go
+++ b/pkg/detectors/fmfw/fmfw.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		tokenPatMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			userPatMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/formbucket/formbucket.go
+++ b/pkg/detectors/formbucket/formbucket.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/formcraft/formcraft.go
+++ b/pkg/detectors/formcraft/formcraft.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/formio/formio.go
+++ b/pkg/detectors/formio/formio.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/formsite/formsite.go
+++ b/pkg/detectors/formsite/formsite.go
@@ -44,19 +44,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	userMatches := userPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, serverMatch := range serverMatches {
-			if len(serverMatch) != 2 {
-				continue
-			}
 			resServerMatch := strings.TrimSpace(serverMatch[1])
 			for _, userMatch := range userMatches {
-				if len(userMatch) != 2 {
-					continue
-				}
 				resUserMatch := strings.TrimSpace(userMatch[1])
 				s1 := detectors.Result{
 					DetectorType: detectorspb.DetectorType_Formsite,

--- a/pkg/detectors/foursquare/foursquare.go
+++ b/pkg/detectors/foursquare/foursquare.go
@@ -42,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretMatch.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecret := strings.TrimSpace(secretMatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_FourSquare,

--- a/pkg/detectors/frameio/frameio.go
+++ b/pkg/detectors/frameio/frameio.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/freshbooks/freshbooks.go
+++ b/pkg/detectors/freshbooks/freshbooks.go
@@ -42,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	uriMatches := uriPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, uriMatch := range uriMatches {
-			if len(uriMatch) != 2 {
-				continue
-			}
 			resURI := strings.TrimSpace(uriMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/freshdesk/freshdesk.go
+++ b/pkg/detectors/freshdesk/freshdesk.go
@@ -43,15 +43,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	urlMatches := urlPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, urlMatch := range urlMatches {
-			if len(urlMatch) != 2 {
-				continue
-			}
 			resURL := strings.TrimSpace(urlMatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Freshdesk,

--- a/pkg/detectors/front/front.go
+++ b/pkg/detectors/front/front.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/fulcrum/fulcrum.go
+++ b/pkg/detectors/fulcrum/fulcrum.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/fullstory/v1/fullstory.go
+++ b/pkg/detectors/fullstory/v1/fullstory.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/fullstory/v2/fullstory_v2.go
+++ b/pkg/detectors/fullstory/v2/fullstory_v2.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/fxmarket/fxmarket.go
+++ b/pkg/detectors/fxmarket/fxmarket.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/geckoboard/geckoboard.go
+++ b/pkg/detectors/geckoboard/geckoboard.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/gemini/gemini.go
+++ b/pkg/detectors/gemini/gemini.go
@@ -54,9 +54,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range idMatches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, secretMatch := range secretMatches {

--- a/pkg/detectors/gengo/gengo.go
+++ b/pkg/detectors/gengo/gengo.go
@@ -50,15 +50,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecretMatch := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/geoapify/geoapify.go
+++ b/pkg/detectors/geoapify/geoapify.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/geocode/geocode.go
+++ b/pkg/detectors/geocode/geocode.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/geocodify/geocodify.go
+++ b/pkg/detectors/geocodify/geocodify.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/geocodio/geocodio.go
+++ b/pkg/detectors/geocodio/geocodio.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	searchMatches := searchPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, searchMatch := range searchMatches {
-			if len(searchMatch) != 2 {
-				continue
-			}
 			resSearchMatch := strings.TrimSpace(searchMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/geoipifi/geoipifi.go
+++ b/pkg/detectors/geoipifi/geoipifi.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/getemail/getemail.go
+++ b/pkg/detectors/getemail/getemail.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/getemails/getemails.go
+++ b/pkg/detectors/getemails/getemails.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/getgeoapi/getgeoapi.go
+++ b/pkg/detectors/getgeoapi/getgeoapi.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/getgist/getgist.go
+++ b/pkg/detectors/getgist/getgist.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/getresponse/getresponse.go
+++ b/pkg/detectors/getresponse/getresponse.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/getsandbox/getsandbox.go
+++ b/pkg/detectors/getsandbox/getsandbox.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 			s1 := detectors.Result{

--- a/pkg/detectors/github/v1/github_old.go
+++ b/pkg/detectors/github/v1/github_old.go
@@ -70,9 +70,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for _, match := range matches {
 		// First match is entire regex, second is the first group.
-		if len(match) != 2 {
-			continue
-		}
 
 		token := match[1]
 

--- a/pkg/detectors/github/v2/github.go
+++ b/pkg/detectors/github/v2/github.go
@@ -53,9 +53,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for _, match := range matches {
 		// First match is entire regex, second is the first group.
-		if len(match) != 2 {
-			continue
-		}
 
 		token := match[1]
 

--- a/pkg/detectors/github_oauth2/github_oauth2.go
+++ b/pkg/detectors/github_oauth2/github_oauth2.go
@@ -44,13 +44,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	oauth2ClientSecretMatches := oauth2ClientSecretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, idMatch := range oauth2ClientIDMatches {
-		if len(idMatch) != 2 {
-			continue
-		}
 		for _, secretMatch := range oauth2ClientSecretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_GitHubOauth2,

--- a/pkg/detectors/githubapp/githubapp.go
+++ b/pkg/detectors/githubapp/githubapp.go
@@ -44,15 +44,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	appMatches := appPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 
 		resMatch := strings.TrimSpace(match[1])
 		for _, appMatch := range appMatches {
-			if len(appMatch) != 2 {
-				continue
-			}
 			appResMatch := strings.TrimSpace(appMatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_GitHubApp,

--- a/pkg/detectors/gitlab/v1/gitlab.go
+++ b/pkg/detectors/gitlab/v1/gitlab.go
@@ -50,9 +50,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		// ignore v2 detectors which have a prefix of `glpat-`
 		if strings.Contains(match[0], "glpat-") {
 			continue

--- a/pkg/detectors/gitlab/v2/gitlab_v2.go
+++ b/pkg/detectors/gitlab/v2/gitlab_v2.go
@@ -43,9 +43,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 
 		resMatch := strings.TrimSpace(match[1])
 		s1 := detectors.Result{

--- a/pkg/detectors/gitter/gitter.go
+++ b/pkg/detectors/gitter/gitter.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/glassnode/glassnode.go
+++ b/pkg/detectors/glassnode/glassnode.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/gocanvas/gocanvas.go
+++ b/pkg/detectors/gocanvas/gocanvas.go
@@ -50,9 +50,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for emailMatch := range uniqueEmailMatches {
 		for _, match := range matches {
-			if len(match) != 2 {
-				continue
-			}
 			resMatch := strings.TrimSpace(match[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/gocardless/gocardless.go
+++ b/pkg/detectors/gocardless/gocardless.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/goodday/goodday.go
+++ b/pkg/detectors/goodday/goodday.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/grafana/grafana.go
+++ b/pkg/detectors/grafana/grafana.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/grafanaserviceaccount/grafanaserviceaccount.go
+++ b/pkg/detectors/grafanaserviceaccount/grafanaserviceaccount.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range keyMatches {
-		if len(match) != 2 {
-			continue
-		}
 		key := strings.TrimSpace(match[1])
 
 		for _, domainMatch := range domainMatches {
-			if len(domainMatch) != 2 {
-				continue
-			}
 			domainRes := strings.TrimSpace(domainMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/graphcms/graphcms.go
+++ b/pkg/detectors/graphcms/graphcms.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/graphhopper/graphhopper.go
+++ b/pkg/detectors/graphhopper/graphhopper.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	dataStr := string(data)
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_Graphhopper,

--- a/pkg/detectors/groovehq/groovehq.go
+++ b/pkg/detectors/groovehq/groovehq.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/gtmetrix/gtmetrix.go
+++ b/pkg/detectors/gtmetrix/gtmetrix.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/guardianapi/guardianapi.go
+++ b/pkg/detectors/guardianapi/guardianapi.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/gumroad/gumroad.go
+++ b/pkg/detectors/gumroad/gumroad.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/guru/guru.go
+++ b/pkg/detectors/guru/guru.go
@@ -43,16 +43,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	keyMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range unameMatches {
-		if len(match) != 2 {
-			continue
-		}
 
 		unameMatch := strings.TrimSpace(match[1])
 
 		for _, secret := range keyMatches {
-			if len(secret) != 2 {
-				continue
-			}
 
 			keyMatch := strings.TrimSpace(secret[1])
 

--- a/pkg/detectors/gyazo/gyazo.go
+++ b/pkg/detectors/gyazo/gyazo.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/happyscribe/happyscribe.go
+++ b/pkg/detectors/happyscribe/happyscribe.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/harvest/harvest.go
+++ b/pkg/detectors/harvest/harvest.go
@@ -41,14 +41,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/hellosign/hellosign.go
+++ b/pkg/detectors/hellosign/hellosign.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/helpcrunch/helpcrunch.go
+++ b/pkg/detectors/helpcrunch/helpcrunch.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/helpscout/helpscout.go
+++ b/pkg/detectors/helpscout/helpscout.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/hereapi/hereapi.go
+++ b/pkg/detectors/hereapi/hereapi.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	dataStr := string(data)
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/heroku/heroku.go
+++ b/pkg/detectors/heroku/heroku.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/hive/hive.go
+++ b/pkg/detectors/hive/hive.go
@@ -41,16 +41,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	keyMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range idMatches {
-		if len(match) != 2 {
-			continue
-		}
 
 		idMatch := strings.TrimSpace(match[1])
 
 		for _, match := range keyMatches {
-			if len(match) != 2 {
-				continue
-			}
 			keyMatch := strings.TrimSpace(match[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/hiveage/hiveage.go
+++ b/pkg/detectors/hiveage/hiveage.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/holidayapi/holidayapi.go
+++ b/pkg/detectors/holidayapi/holidayapi.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/holistic/holistic.go
+++ b/pkg/detectors/holistic/holistic.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/honeycomb/honeycomb.go
+++ b/pkg/detectors/honeycomb/honeycomb.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/host/host.go
+++ b/pkg/detectors/host/host.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/html2pdf/html2pdf.go
+++ b/pkg/detectors/html2pdf/html2pdf.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/huggingface/huggingface.go
+++ b/pkg/detectors/huggingface/huggingface.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 1 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[0])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/humanity/humanity.go
+++ b/pkg/detectors/humanity/humanity.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/hunter/hunter.go
+++ b/pkg/detectors/hunter/hunter.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/hybiscus/hybiscus.go
+++ b/pkg/detectors/hybiscus/hybiscus.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/hypertrack/hypertrack.go
+++ b/pkg/detectors/hypertrack/hypertrack.go
@@ -41,16 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, accMatch := range accMatches {
-
-		if len(accMatch) != 2 {
-			continue
-		}
 		resAccMatch := strings.TrimSpace(accMatch[1])
 
 		for _, match := range matches {
-			if len(match) != 2 {
-				continue
-			}
 			resMatch := strings.TrimSpace(match[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/ibmclouduserkey/ibmclouduserkey.go
+++ b/pkg/detectors/ibmclouduserkey/ibmclouduserkey.go
@@ -2,9 +2,10 @@ package ibmclouduserkey
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -36,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/iconfinder/iconfinder.go
+++ b/pkg/detectors/iconfinder/iconfinder.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/iexapis/iexapis.go
+++ b/pkg/detectors/iexapis/iexapis.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/iexcloud/iexcloud.go
+++ b/pkg/detectors/iexcloud/iexcloud.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/imagekit/imagekit.go
+++ b/pkg/detectors/imagekit/imagekit.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/imagga/imagga.go
+++ b/pkg/detectors/imagga/imagga.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/impala/impala.go
+++ b/pkg/detectors/impala/impala.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/infura/infura.go
+++ b/pkg/detectors/infura/infura.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/insightly/insightly.go
+++ b/pkg/detectors/insightly/insightly.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/instabot/instabot.go
+++ b/pkg/detectors/instabot/instabot.go
@@ -35,9 +35,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/instamojo/instamojo.go
+++ b/pkg/detectors/instamojo/instamojo.go
@@ -45,15 +45,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	clientIdmatches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range secretMatches {
-		if len(match) != 2 {
-			continue
-		}
 		resSecret := strings.TrimSpace(match[1])
 
 		for _, clientIdMatch := range clientIdmatches {
-			if len(clientIdMatch) != 2 {
-				continue
-			}
 			resClientId := strings.TrimSpace(clientIdMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/intercom/intercom.go
+++ b/pkg/detectors/intercom/intercom.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		dec, err := base64.StdEncoding.DecodeString(resMatch)

--- a/pkg/detectors/interseller/interseller.go
+++ b/pkg/detectors/interseller/interseller.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/intrinio/intrinio.go
+++ b/pkg/detectors/intrinio/intrinio.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/invoiceocean/invoiceocean.go
+++ b/pkg/detectors/invoiceocean/invoiceocean.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	urlMatches := urlPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, urlMatch := range urlMatches {
-			if len(urlMatch) != 2 {
-				continue
-			}
 			resURL := strings.TrimSpace(urlMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/ip2location/ip2location.go
+++ b/pkg/detectors/ip2location/ip2location.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/ipapi/ipapi.go
+++ b/pkg/detectors/ipapi/ipapi.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/ipgeolocation/ipgeolocation.go
+++ b/pkg/detectors/ipgeolocation/ipgeolocation.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/ipinfo/ipinfo.go
+++ b/pkg/detectors/ipinfo/ipinfo.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/ipinfodb/ipinfodb.go
+++ b/pkg/detectors/ipinfodb/ipinfodb.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/ipquality/ipquality.go
+++ b/pkg/detectors/ipquality/ipquality.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/ipstack/ipstack.go
+++ b/pkg/detectors/ipstack/ipstack.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_IpStack,

--- a/pkg/detectors/jiratoken/v2/jiratoken_v2.go
+++ b/pkg/detectors/jiratoken/v2/jiratoken_v2.go
@@ -60,14 +60,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		resEmail := strings.TrimSpace(email[1])
 
 		for _, token := range tokens {
-			if len(token) != 2 {
-				continue
-			}
 			resToken := strings.TrimSpace(token[1])
 			for _, domain := range domains {
-				if len(domain) != 2 {
-					continue
-				}
 				resDomain := strings.TrimSpace(domain[1])
 
 				s1 := detectors.Result{

--- a/pkg/detectors/jotform/jotform.go
+++ b/pkg/detectors/jotform/jotform.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/jumpcloud/jumpcloud.go
+++ b/pkg/detectors/jumpcloud/jumpcloud.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_Jumpcloud,

--- a/pkg/detectors/jupiterone/jupiterone.go
+++ b/pkg/detectors/jupiterone/jupiterone.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/juro/juro.go
+++ b/pkg/detectors/juro/juro.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/kanban/kanban.go
+++ b/pkg/detectors/kanban/kanban.go
@@ -41,14 +41,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	urlMatches := urlPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, urlMatch := range urlMatches {
-			if len(urlMatch) != 2 {
-				continue
-			}
 			resURL := strings.TrimSpace(urlMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/kanbantool/kanbantool.go
+++ b/pkg/detectors/kanbantool/kanbantool.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	idMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/karmacrm/karmacrm.go
+++ b/pkg/detectors/karmacrm/karmacrm.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/keenio/keenio.go
+++ b/pkg/detectors/keenio/keenio.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/kickbox/kickbox.go
+++ b/pkg/detectors/kickbox/kickbox.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/klaviyo/klaviyo.go
+++ b/pkg/detectors/klaviyo/klaviyo.go
@@ -52,9 +52,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/klipfolio/klipfolio.go
+++ b/pkg/detectors/klipfolio/klipfolio.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/knapsackpro/knapsackpro.go
+++ b/pkg/detectors/knapsackpro/knapsackpro.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/kontent/kontent.go
+++ b/pkg/detectors/kontent/kontent.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/kraken/kraken.go
+++ b/pkg/detectors/kraken/kraken.go
@@ -50,15 +50,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	privKeyMatches := privKeyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, privKeyMatch := range privKeyMatches {
-			if len(privKeyMatch) != 2 {
-				continue
-			}
 			resPrivKeyMatch := strings.TrimSpace(privKeyMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/kucoin/kucoin.go
+++ b/pkg/detectors/kucoin/kucoin.go
@@ -47,21 +47,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	passphraseMatches := passphrasePat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, keyMatch := range keyMatches {
-		if len(keyMatch) != 2 {
-			continue
-		}
 		resKeyMatch := strings.TrimSpace(keyMatch[1])
 
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecretMatch := strings.TrimSpace(secretMatch[1])
 
 			for _, passphraseMatch := range passphraseMatches {
-				if len(passphraseMatch) != 2 {
-					continue
-				}
 				resPassphraseMatch := strings.TrimSpace(passphraseMatch[1])
 
 				s1 := detectors.Result{

--- a/pkg/detectors/kylas/kylas.go
+++ b/pkg/detectors/kylas/kylas.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/languagelayer/languagelayer.go
+++ b/pkg/detectors/languagelayer/languagelayer.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/launchdarkly/launchdarkly.go
+++ b/pkg/detectors/launchdarkly/launchdarkly.go
@@ -57,9 +57,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/leadfeeder/leadfeeder.go
+++ b/pkg/detectors/leadfeeder/leadfeeder.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/lemlist/lemlist.go
+++ b/pkg/detectors/lemlist/lemlist.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/lemonsqueezy/lemonsqueezy.go
+++ b/pkg/detectors/lemonsqueezy/lemonsqueezy.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/lendflow/lendflow.go
+++ b/pkg/detectors/lendflow/lendflow.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/lessannoyingcrm/lessannoyingcrm.go
+++ b/pkg/detectors/lessannoyingcrm/lessannoyingcrm.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/lexigram/lexigram.go
+++ b/pkg/detectors/lexigram/lexigram.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/linearapi/linearapi.go
+++ b/pkg/detectors/linearapi/linearapi.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/linemessaging/linemessaging.go
+++ b/pkg/detectors/linemessaging/linemessaging.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/linenotify/linenotify.go
+++ b/pkg/detectors/linenotify/linenotify.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/linkpreview/linkpreview.go
+++ b/pkg/detectors/linkpreview/linkpreview.go
@@ -35,9 +35,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	dataStr := string(data)
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/liveagent/liveagent.go
+++ b/pkg/detectors/liveagent/liveagent.go
@@ -45,16 +45,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, domainMatch := range domainMatches {
-			if len(domainMatch) != 2 {
-				continue
-			}
 			domainRes := strings.TrimSpace(domainMatch[0])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_LiveAgent,

--- a/pkg/detectors/livestorm/livestorm.go
+++ b/pkg/detectors/livestorm/livestorm.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/loadmill/loadmill.go
+++ b/pkg/detectors/loadmill/loadmill.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/lob/lob.go
+++ b/pkg/detectors/lob/lob.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/locationiq/locationiq.go
+++ b/pkg/detectors/locationiq/locationiq.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/loggly/loggly.go
+++ b/pkg/detectors/loggly/loggly.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range keyMatches {
-		if len(match) != 2 {
-			continue
-		}
 		key := strings.TrimSpace(match[1])
 
 		for _, domainMatch := range domainMatches {
-			if len(domainMatch) != 2 {
-				continue
-			}
 
 			domainRes := strings.TrimSpace(domainMatch[1])
 

--- a/pkg/detectors/loginradius/loginradius.go
+++ b/pkg/detectors/loginradius/loginradius.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/logzio/logzio.go
+++ b/pkg/detectors/logzio/logzio.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/lokalisetoken/lokalisetoken.go
+++ b/pkg/detectors/lokalisetoken/lokalisetoken.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/loyverse/loyverse.go
+++ b/pkg/detectors/loyverse/loyverse.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/lunchmoney/lunchmoney.go
+++ b/pkg/detectors/lunchmoney/lunchmoney.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/luno/luno.go
+++ b/pkg/detectors/luno/luno.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		tokenPatMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			userPatMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/m3o/m3o.go
+++ b/pkg/detectors/m3o/m3o.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/madkudu/madkudu.go
+++ b/pkg/detectors/madkudu/madkudu.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/magicbell/magicbell.go
+++ b/pkg/detectors/magicbell/magicbell.go
@@ -45,9 +45,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	for _, keyMatch := range apiKeyMatches {
-		if len(keyMatch) != 2 {
-			continue
-		}
 		apiKeyRes := strings.TrimSpace(keyMatch[1])
 
 		for emailMatch := range uniqueEmailMatches {

--- a/pkg/detectors/magnetic/magnetic.go
+++ b/pkg/detectors/magnetic/magnetic.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mailboxlayer/mailboxlayer.go
+++ b/pkg/detectors/mailboxlayer/mailboxlayer.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mailerlite/mailerlite.go
+++ b/pkg/detectors/mailerlite/mailerlite.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mailjetbasicauth/mailjetbasicauth.go
+++ b/pkg/detectors/mailjetbasicauth/mailjetbasicauth.go
@@ -3,9 +3,10 @@ package mailjetbasicauth
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -36,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mailjetsms/mailjetsms.go
+++ b/pkg/detectors/mailjetsms/mailjetsms.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mailmodo/mailmodo.go
+++ b/pkg/detectors/mailmodo/mailmodo.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mailsac/mailsac.go
+++ b/pkg/detectors/mailsac/mailsac.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mandrill/mandrill.go
+++ b/pkg/detectors/mandrill/mandrill.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/manifest/manifest.go
+++ b/pkg/detectors/manifest/manifest.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mapbox/mapbox.go
+++ b/pkg/detectors/mapbox/mapbox.go
@@ -42,9 +42,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		resMatch := strings.TrimSpace(match[1])
 		for i, idMatch := range idMatches {
 			if i == 11 {
-				if len(idMatch) != 2 {
-					continue
-				}
 				resId := strings.TrimSpace(idMatch[1])
 
 				s1 := detectors.Result{

--- a/pkg/detectors/mapquest/mapquest.go
+++ b/pkg/detectors/mapquest/mapquest.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/marketstack/marketstack.go
+++ b/pkg/detectors/marketstack/marketstack.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mattermostpersonaltoken/mattermostpersonaltoken.go
+++ b/pkg/detectors/mattermostpersonaltoken/mattermostpersonaltoken.go
@@ -3,9 +3,10 @@ package mattermostpersonaltoken
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -41,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	serverMatches := serverPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, serverMatch := range serverMatches {
-			if len(serverMatch) != 2 {
-				continue
-			}
 			serverRes := strings.TrimSpace(serverMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/mavenlink/mavenlink.go
+++ b/pkg/detectors/mavenlink/mavenlink.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/maxmindlicense/v1/maxmindlicense.go
+++ b/pkg/detectors/maxmindlicense/v1/maxmindlicense.go
@@ -46,9 +46,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		keyRes := strings.TrimSpace(keyMatch[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			idRes := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/meaningcloud/meaningcloud.go
+++ b/pkg/detectors/meaningcloud/meaningcloud.go
@@ -44,9 +44,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mediastack/mediastack.go
+++ b/pkg/detectors/mediastack/mediastack.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/meistertask/meistertask.go
+++ b/pkg/detectors/meistertask/meistertask.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mesibo/mesibo.go
+++ b/pkg/detectors/mesibo/mesibo.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/messagebird/messagebird.go
+++ b/pkg/detectors/messagebird/messagebird.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/metaapi/metaapi.go
+++ b/pkg/detectors/metaapi/metaapi.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	spellMatches := spellPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, spellMatch := range spellMatches {
-		if len(spellMatch) != 2 {
-			continue
-		}
 		resSpellMatch := strings.TrimSpace(spellMatch[1])
 
 		for _, match := range matches {
-			if len(match) != 2 {
-				continue
-			}
 			resMatch := strings.TrimSpace(match[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/metabase/metabase.go
+++ b/pkg/detectors/metabase/metabase.go
@@ -43,15 +43,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	urlMatches := baseURL.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, urlMatch := range urlMatches {
-			if len(urlMatch) != 2 {
-				continue
-			}
 			resURLMatch := strings.TrimSpace(urlMatch[1])
 
 			u, err := detectors.ParseURLAndStripPathAndParams(resURLMatch)

--- a/pkg/detectors/metrilo/metrilo.go
+++ b/pkg/detectors/metrilo/metrilo.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
+++ b/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mindmeister/mindmeister.go
+++ b/pkg/detectors/mindmeister/mindmeister.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/miro/miro.go
+++ b/pkg/detectors/miro/miro.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mite/mite.go
+++ b/pkg/detectors/mite/mite.go
@@ -41,14 +41,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	urlMatches := urlPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, urlMatch := range urlMatches {
-			if len(urlMatch) != 2 {
-				continue
-			}
 			resURL := strings.TrimSpace(urlMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/mixmax/mixmax.go
+++ b/pkg/detectors/mixmax/mixmax.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mixpanel/mixpanel.go
+++ b/pkg/detectors/mixpanel/mixpanel.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		tokenPatMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			userPatMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/mockaroo/mockaroo.go
+++ b/pkg/detectors/mockaroo/mockaroo.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/moderation/moderation.go
+++ b/pkg/detectors/moderation/moderation.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/monday/monday.go
+++ b/pkg/detectors/monday/monday.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/monkeylearn/monkeylearn.go
+++ b/pkg/detectors/monkeylearn/monkeylearn.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/moonclerk/moonclerk.go
+++ b/pkg/detectors/moonclerk/moonclerk.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/moosend/moosend.go
+++ b/pkg/detectors/moosend/moosend.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/moralis/moralis.go
+++ b/pkg/detectors/moralis/moralis.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/mrticktock/mrticktock.go
+++ b/pkg/detectors/mrticktock/mrticktock.go
@@ -48,9 +48,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for emailMatch := range uniqueEmailMatches {
 		for _, passwordMatch := range passwordMatches {
-			if len(passwordMatch) != 2 {
-				continue
-			}
 			resPassword := strings.TrimSpace(passwordMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/mux/mux.go
+++ b/pkg/detectors/mux/mux.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecretMatch := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/myfreshworks/myfreshworks.go
+++ b/pkg/detectors/myfreshworks/myfreshworks.go
@@ -43,14 +43,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/myintervals/myintervals.go
+++ b/pkg/detectors/myintervals/myintervals.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/nasdaqdatalink/nasdaqdatalink.go
+++ b/pkg/detectors/nasdaqdatalink/nasdaqdatalink.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/nethunt/nethunt.go
+++ b/pkg/detectors/nethunt/nethunt.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		tokenPatMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			userPatMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/netlify/netlify.go
+++ b/pkg/detectors/netlify/netlify.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/neutrinoapi/neutrinoapi.go
+++ b/pkg/detectors/neutrinoapi/neutrinoapi.go
@@ -44,15 +44,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/newrelicpersonalapikey/newrelicpersonalapikey.go
+++ b/pkg/detectors/newrelicpersonalapikey/newrelicpersonalapikey.go
@@ -2,9 +2,10 @@ package newrelicpersonalapikey
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -36,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/newsapi/newsapi.go
+++ b/pkg/detectors/newsapi/newsapi.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/newscatcher/newscatcher.go
+++ b/pkg/detectors/newscatcher/newscatcher.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/nexmoapikey/nexmoapikey.go
+++ b/pkg/detectors/nexmoapikey/nexmoapikey.go
@@ -11,7 +11,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{
+type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
 }
 
@@ -40,14 +40,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretPat := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, secretMatch := range secretPat {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecret := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/nftport/nftport.go
+++ b/pkg/detectors/nftport/nftport.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/ngc/ngc.go
+++ b/pkg/detectors/ngc/ngc.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat1.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		decode, _ := base64.StdEncoding.DecodeString(resMatch)
 

--- a/pkg/detectors/ngrok/ngrok.go
+++ b/pkg/detectors/ngrok/ngrok.go
@@ -34,9 +34,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/nicereply/nicereply.go
+++ b/pkg/detectors/nicereply/nicereply.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/nightfall/nightfall.go
+++ b/pkg/detectors/nightfall/nightfall.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/nimble/nimble.go
+++ b/pkg/detectors/nimble/nimble.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/noticeable/noticeable.go
+++ b/pkg/detectors/noticeable/noticeable.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/notion/notion.go
+++ b/pkg/detectors/notion/notion.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_Notion,

--- a/pkg/detectors/nozbeteams/nozbeteams.go
+++ b/pkg/detectors/nozbeteams/nozbeteams.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/npmtoken/npmtoken.go
+++ b/pkg/detectors/npmtoken/npmtoken.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	dataStr := string(data)
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/npmtokenv2/npmtokenv2.go
+++ b/pkg/detectors/npmtokenv2/npmtokenv2.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := match[1]
 
 		s1 := detectors.Result{

--- a/pkg/detectors/nugetapikey/nugetapikey.go
+++ b/pkg/detectors/nugetapikey/nugetapikey.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/numverify/numverify.go
+++ b/pkg/detectors/numverify/numverify.go
@@ -35,9 +35,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	dataStr := string(data)
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_Numverify,

--- a/pkg/detectors/nutritionix/nutritionix.go
+++ b/pkg/detectors/nutritionix/nutritionix.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/nylas/nylas.go
+++ b/pkg/detectors/nylas/nylas.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/oanda/oanda.go
+++ b/pkg/detectors/oanda/oanda.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/omnisend/omnisend.go
+++ b/pkg/detectors/omnisend/omnisend.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/onedesk/onedesk.go
+++ b/pkg/detectors/onedesk/onedesk.go
@@ -48,9 +48,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for emailMatch := range uniqueEmailMatches {
 		for _, pwordMatch := range pwordMatches {
-			if len(pwordMatch) != 2 {
-				continue
-			}
 			resPword := strings.TrimSpace(pwordMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/onelogin/onelogin.go
+++ b/pkg/detectors/onelogin/onelogin.go
@@ -41,13 +41,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	dataStr := string(data)
 
 	for _, clientID := range oauthClientIDPat.FindAllStringSubmatch(dataStr, -1) {
-		if len(clientID) != 2 {
-			continue
-		}
 		for _, clientSecret := range oauthClientSecretPat.FindAllStringSubmatch(dataStr, -1) {
-			if len(clientSecret) != 2 {
-				continue
-			}
 
 			result := detectors.Result{
 				DetectorType: detectorspb.DetectorType_OneLogin,

--- a/pkg/detectors/onepagecrm/onepagecrm.go
+++ b/pkg/detectors/onepagecrm/onepagecrm.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		tokenPatMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			userPatMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/onesignal/onesignal.go
+++ b/pkg/detectors/onesignal/onesignal.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/oopspam/oopspam.go
+++ b/pkg/detectors/oopspam/oopspam.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/opencagedata/opencagedata.go
+++ b/pkg/detectors/opencagedata/opencagedata.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/openuv/openuv.go
+++ b/pkg/detectors/openuv/openuv.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/openweather/openweather.go
+++ b/pkg/detectors/openweather/openweather.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/optimizely/optimizely.go
+++ b/pkg/detectors/optimizely/optimizely.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/overloop/overloop.go
+++ b/pkg/detectors/overloop/overloop.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/owlbot/owlbot.go
+++ b/pkg/detectors/owlbot/owlbot.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/packagecloud/packagecloud.go
+++ b/pkg/detectors/packagecloud/packagecloud.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pagerdutyapikey/pagerdutyapikey.go
+++ b/pkg/detectors/pagerdutyapikey/pagerdutyapikey.go
@@ -3,9 +3,10 @@ package pagerdutyapikey
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -39,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pandadoc/pandadoc.go
+++ b/pkg/detectors/pandadoc/pandadoc.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pandascore/pandascore.go
+++ b/pkg/detectors/pandascore/pandascore.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/paperform/paperform.go
+++ b/pkg/detectors/paperform/paperform.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/paralleldots/paralleldots.go
+++ b/pkg/detectors/paralleldots/paralleldots.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/parsehub/parsehub.go
+++ b/pkg/detectors/parsehub/parsehub.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/parsers/parsers.go
+++ b/pkg/detectors/parsers/parsers.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/parseur/parseur.go
+++ b/pkg/detectors/parseur/parseur.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 
 		resMatch := strings.TrimSpace(match[1])
 		s1 := detectors.Result{

--- a/pkg/detectors/partnerstack/partnerstack.go
+++ b/pkg/detectors/partnerstack/partnerstack.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pastebin/pastebin.go
+++ b/pkg/detectors/pastebin/pastebin.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/paydirtapp/paydirtapp.go
+++ b/pkg/detectors/paydirtapp/paydirtapp.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/paymoapp/paymoapp.go
+++ b/pkg/detectors/paymoapp/paymoapp.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/paymongo/paymongo.go
+++ b/pkg/detectors/paymongo/paymongo.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/paypaloauth/paypaloauth.go
+++ b/pkg/detectors/paypaloauth/paypaloauth.go
@@ -42,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, idMatch := range idmatches {
-		if len(idMatch) != 2 {
-			continue
-		}
 		resIDMatch := strings.TrimSpace(idMatch[1])
 		for _, secretMatch := range matches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecretMatch := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/paystack/paystack.go
+++ b/pkg/detectors/paystack/paystack.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pdflayer/pdflayer.go
+++ b/pkg/detectors/pdflayer/pdflayer.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pdfshift/pdfshift.go
+++ b/pkg/detectors/pdfshift/pdfshift.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/peopledatalabs/peopledatalabs.go
+++ b/pkg/detectors/peopledatalabs/peopledatalabs.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pepipost/pepipost.go
+++ b/pkg/detectors/pepipost/pepipost.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/percy/percy.go
+++ b/pkg/detectors/percy/percy.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pinata/pinata.go
+++ b/pkg/detectors/pinata/pinata.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 			s1 := detectors.Result{

--- a/pkg/detectors/pipedream/pipedream.go
+++ b/pkg/detectors/pipedream/pipedream.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pipedrive/pipedrive.go
+++ b/pkg/detectors/pipedrive/pipedrive.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pivotaltracker/pivotaltracker.go
+++ b/pkg/detectors/pivotaltracker/pivotaltracker.go
@@ -35,9 +35,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	for _, match := range matches {
 
 		// First match is entire regex, second is the first group.
-		if len(match) != 2 {
-			continue
-		}
 
 		token := match[1]
 

--- a/pkg/detectors/pixabay/pixabay.go
+++ b/pkg/detectors/pixabay/pixabay.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/plaidkey/plaidkey.go
+++ b/pkg/detectors/plaidkey/plaidkey.go
@@ -60,22 +60,19 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	for key := range uniqueKeys {
-		resMatch := strings.TrimSpace(key)
-
 		for id := range uniqueIds {
-			idresMatch := strings.TrimSpace(id)
 
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_PlaidKey,
-				Raw:          []byte(resMatch),
+				Raw:          []byte(key),
 			}
 			environments := []string{"sandbox", "production"}
 			if verify {
 				for _, env := range environments {
-					isVerified, _, verificationErr := verifyMatch(ctx, client, idresMatch, resMatch, env)
+					isVerified, _, verificationErr := verifyMatch(ctx, client, id, key, env)
 					s1.Verified = isVerified
 					s1.ExtraData = map[string]string{"environment": fmt.Sprintf("https://%s.plaid.com", env)}
-					s1.SetVerificationError(verificationErr, idresMatch, resMatch)
+					s1.SetVerificationError(verificationErr, id, key)
 				}
 				results = append(results, s1)
 				// if the environment is sandbox, we don't need to check production

--- a/pkg/detectors/planviewleankit/planviewleankit.go
+++ b/pkg/detectors/planviewleankit/planviewleankit.go
@@ -12,7 +12,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{
+type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
 }
 
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	subdomainMatches := subDomainPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, subdomainMatch := range subdomainMatches {
-		if len(subdomainMatch) != 2 {
-			continue
-		}
 		resSubdomainMatch := strings.TrimSpace(subdomainMatch[1])
 
 		for _, match := range matches {
-			if len(match) != 2 {
-				continue
-			}
 			resMatch := strings.TrimSpace(match[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/planyo/planyo.go
+++ b/pkg/detectors/planyo/planyo.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/plivo/plivo.go
+++ b/pkg/detectors/plivo/plivo.go
@@ -40,14 +40,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			id := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/podio/podio.go
+++ b/pkg/detectors/podio/podio.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pollsapi/pollsapi.go
+++ b/pkg/detectors/pollsapi/pollsapi.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/poloniex/poloniex.go
+++ b/pkg/detectors/poloniex/poloniex.go
@@ -46,15 +46,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecretMatch := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/polygon/polygon.go
+++ b/pkg/detectors/polygon/polygon.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/portainer/portainer.go
+++ b/pkg/detectors/portainer/portainer.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	endpointMatches := endpointPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, endpointMatch := range endpointMatches {

--- a/pkg/detectors/portainertoken/portainertoken.go
+++ b/pkg/detectors/portainertoken/portainertoken.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	endpointMatches := endpointPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, endpointMatch := range endpointMatches {

--- a/pkg/detectors/positionstack/positionstack.go
+++ b/pkg/detectors/positionstack/positionstack.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/postageapp/postageapp.go
+++ b/pkg/detectors/postageapp/postageapp.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/postbacks/postbacks.go
+++ b/pkg/detectors/postbacks/postbacks.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/posthog/posthog.go
+++ b/pkg/detectors/posthog/posthog.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/postman/postman.go
+++ b/pkg/detectors/postman/postman.go
@@ -42,9 +42,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/postmark/postmark.go
+++ b/pkg/detectors/postmark/postmark.go
@@ -35,9 +35,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/powrbot/powrbot.go
+++ b/pkg/detectors/powrbot/powrbot.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/prefect/prefect.go
+++ b/pkg/detectors/prefect/prefect.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/privacy/privacy.go
+++ b/pkg/detectors/privacy/privacy.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/prodpad/prodpad.go
+++ b/pkg/detectors/prodpad/prodpad.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/prospectcrm/prospectcrm.go
+++ b/pkg/detectors/prospectcrm/prospectcrm.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/protocolsio/protocolsio.go
+++ b/pkg/detectors/protocolsio/protocolsio.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/proxycrawl/proxycrawl.go
+++ b/pkg/detectors/proxycrawl/proxycrawl.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pubnubpublishkey/pubnubpublishkey.go
+++ b/pkg/detectors/pubnubpublishkey/pubnubpublishkey.go
@@ -3,9 +3,10 @@ package pubnubpublishkey
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -42,15 +43,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	subMatches := subPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, subMatch := range subMatches {
-			if len(subMatch) != 2 {
-				continue
-			}
 			ressubMatch := strings.TrimSpace(subMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/pubnubsubscriptionkey/pubnubsubscriptionkey.go
+++ b/pkg/detectors/pubnubsubscriptionkey/pubnubsubscriptionkey.go
@@ -2,9 +2,10 @@ package pubnubsubscriptionkey
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -36,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pulumi/pulumi.go
+++ b/pkg/detectors/pulumi/pulumi.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/purestake/purestake.go
+++ b/pkg/detectors/purestake/purestake.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/pushbulletapikey/pushbulletapikey.go
+++ b/pkg/detectors/pushbulletapikey/pushbulletapikey.go
@@ -2,9 +2,10 @@ package pushbulletapikey
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -36,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/qase/qase.go
+++ b/pkg/detectors/qase/qase.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/qualaroo/qualaroo.go
+++ b/pkg/detectors/qualaroo/qualaroo.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/qubole/qubole.go
+++ b/pkg/detectors/qubole/qubole.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/ramp/ramp.go
+++ b/pkg/detectors/ramp/ramp.go
@@ -3,10 +3,11 @@ package ramp
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"net/url"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -42,16 +43,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
 
-		if len(match) != 2 {
-			continue
-		}
-
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 
 			resSecret := strings.TrimSpace(secretMatch[1])
 

--- a/pkg/detectors/rapidapi/rapidapi.go
+++ b/pkg/detectors/rapidapi/rapidapi.go
@@ -35,9 +35,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/raven/raven.go
+++ b/pkg/detectors/raven/raven.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/rawg/rawg.go
+++ b/pkg/detectors/rawg/rawg.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/reachmail/reachmail.go
+++ b/pkg/detectors/reachmail/reachmail.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/readme/readme.go
+++ b/pkg/detectors/readme/readme.go
@@ -33,9 +33,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/reallysimplesystems/reallysimplesystems.go
+++ b/pkg/detectors/reallysimplesystems/reallysimplesystems.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"io"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -39,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/rebrandly/rebrandly.go
+++ b/pkg/detectors/rebrandly/rebrandly.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/refiner/refiner.go
+++ b/pkg/detectors/refiner/refiner.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/rentman/rentman.go
+++ b/pkg/detectors/rentman/rentman.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/repairshopr/repairshopr.go
+++ b/pkg/detectors/repairshopr/repairshopr.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, domainmatch := range domainMatches {
-			if len(domainmatch) != 2 {
-				continue
-			}
 			resDomainMatch := strings.TrimSpace(domainmatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Repairshopr,

--- a/pkg/detectors/replicate/replicate.go
+++ b/pkg/detectors/replicate/replicate.go
@@ -34,9 +34,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/replyio/replyio.go
+++ b/pkg/detectors/replyio/replyio.go
@@ -35,9 +35,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/requestfinance/requestfinance.go
+++ b/pkg/detectors/requestfinance/requestfinance.go
@@ -3,9 +3,10 @@ package requestfinance
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -37,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/restpackhtmltopdfapi/restpackhtmltopdfapi.go
+++ b/pkg/detectors/restpackhtmltopdfapi/restpackhtmltopdfapi.go
@@ -2,9 +2,10 @@ package restpackhtmltopdfapi
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -36,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/restpackscreenshotapi/restpackscreenshotapi.go
+++ b/pkg/detectors/restpackscreenshotapi/restpackscreenshotapi.go
@@ -2,9 +2,10 @@ package restpackscreenshotapi
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -36,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/rev/rev.go
+++ b/pkg/detectors/rev/rev.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	clientMatches := clientKeyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, userMatch := range userMatches {
-		if len(userMatch) != 2 {
-			continue
-		}
 		resUserMatch := strings.TrimSpace(userMatch[1])
 
 		for _, clientMatch := range clientMatches {
-			if len(clientMatch) != 2 {
-				continue
-			}
 			resClientMatch := strings.TrimSpace(clientMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/revampcrm/revampcrm.go
+++ b/pkg/detectors/revampcrm/revampcrm.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		tokenPatMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			userPatMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/ringcentral/ringcentral.go
+++ b/pkg/detectors/ringcentral/ringcentral.go
@@ -43,15 +43,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	uriMatches := uriPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, uriMatch := range uriMatches {
-			if len(uriMatch) != 2 {
-				continue
-			}
 			resURI := strings.TrimSpace(uriMatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_RingCentral,

--- a/pkg/detectors/ritekit/ritekit.go
+++ b/pkg/detectors/ritekit/ritekit.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/roaring/roaring.go
+++ b/pkg/detectors/roaring/roaring.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, clientMatch := range clientMatches {
-		if len(clientMatch) != 2 {
-			continue
-		}
 		resClient := strings.TrimSpace(clientMatch[1])
 
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecret := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/rocketreach/rocketreach.go
+++ b/pkg/detectors/rocketreach/rocketreach.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/roninapp/roninapp.go
+++ b/pkg/detectors/roninapp/roninapp.go
@@ -43,15 +43,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_RoninApp,

--- a/pkg/detectors/route4me/route4me.go
+++ b/pkg/detectors/route4me/route4me.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/rownd/rownd.go
+++ b/pkg/detectors/rownd/rownd.go
@@ -42,21 +42,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, idMatch := range idMatches {
-		if len(idMatch) != 2 {
-			continue
-		}
 		resId := strings.TrimSpace(idMatch[1])
 
 		for _, match := range keyMatches {
-			if len(match) != 2 {
-				continue
-			}
 			keyMatch := strings.TrimSpace(match[1])
 
 			for _, secret := range secretMatches {
-				if len(secret) != 2 {
-					continue
-				}
 
 				secretMatch := strings.TrimSpace(secret[1])
 

--- a/pkg/detectors/rubygems/rubygems.go
+++ b/pkg/detectors/rubygems/rubygems.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/runrunit/runrunit.go
+++ b/pkg/detectors/runrunit/runrunit.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	userTokenMatches := userTokenPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, userTokenMatch := range userTokenMatches {
-			if len(userTokenMatch) != 2 {
-				continue
-			}
 			resUserTokenMatch := strings.TrimSpace(userTokenMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/salesblink/salesblink.go
+++ b/pkg/detectors/salesblink/salesblink.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/salescookie/salescookie.go
+++ b/pkg/detectors/salescookie/salescookie.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/salesflare/salesflare.go
+++ b/pkg/detectors/salesflare/salesflare.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/salesforce/salesforce.go
+++ b/pkg/detectors/salesforce/salesforce.go
@@ -46,16 +46,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	tokenMatches := accessTokenPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, instance := range instanceMatches {
-		if len(instance) != 1 {
-			continue
-		}
 
 		instanceMatch := strings.TrimSpace(instance[0])
 
 		for _, token := range tokenMatches {
-			if len(token) != 1 {
-				continue
-			}
 
 			tokenMatch := strings.TrimSpace(token[0])
 

--- a/pkg/detectors/salesmate/salesmate.go
+++ b/pkg/detectors/salesmate/salesmate.go
@@ -41,14 +41,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Salesmate,

--- a/pkg/detectors/saucelabs/saucelabs.go
+++ b/pkg/detectors/saucelabs/saucelabs.go
@@ -83,7 +83,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				results = append(results, s1)
 			}
 		}
-
 	}
 
 	return results, nil

--- a/pkg/detectors/scalewaykey/scalewaykey.go
+++ b/pkg/detectors/scalewaykey/scalewaykey.go
@@ -35,9 +35,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/scalr/scalr.go
+++ b/pkg/detectors/scalr/scalr.go
@@ -41,14 +41,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Scalr,

--- a/pkg/detectors/scrapeowl/scrapeowl.go
+++ b/pkg/detectors/scrapeowl/scrapeowl.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/scraperapi/scraperapi.go
+++ b/pkg/detectors/scraperapi/scraperapi.go
@@ -35,9 +35,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	dataStr := string(data)
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/scraperbox/scraperbox.go
+++ b/pkg/detectors/scraperbox/scraperbox.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/scrapestack/scrapestack.go
+++ b/pkg/detectors/scrapestack/scrapestack.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/scrapfly/scrapfly.go
+++ b/pkg/detectors/scrapfly/scrapfly.go
@@ -42,9 +42,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/scrapingant/scrapingant.go
+++ b/pkg/detectors/scrapingant/scrapingant.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/screenshotapi/screenshotapi.go
+++ b/pkg/detectors/screenshotapi/screenshotapi.go
@@ -42,9 +42,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/screenshotlayer/screenshotlayer.go
+++ b/pkg/detectors/screenshotlayer/screenshotlayer.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/scrutinizerci/scrutinizerci.go
+++ b/pkg/detectors/scrutinizerci/scrutinizerci.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/securitytrails/securitytrails.go
+++ b/pkg/detectors/securitytrails/securitytrails.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/segmentapikey/segmentapikey.go
+++ b/pkg/detectors/segmentapikey/segmentapikey.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/selectpdf/selectpdf.go
+++ b/pkg/detectors/selectpdf/selectpdf.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/semaphore/semaphore.go
+++ b/pkg/detectors/semaphore/semaphore.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		if !detectors.HasDigit(resMatch) {

--- a/pkg/detectors/sendbird/sendbird.go
+++ b/pkg/detectors/sendbird/sendbird.go
@@ -47,15 +47,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	appIdMatches := appIdPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, appIdMatch := range appIdMatches {
-		if len(appIdMatch) != 2 {
-			continue
-		}
 		resAppIdMatch := strings.TrimSpace(appIdMatch[1])
 
 		for _, match := range matches {
-			if len(match) != 2 {
-				continue
-			}
 			resMatch := strings.TrimSpace(match[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/sendbirdorganizationapi/sendbirdorganizationapi.go
+++ b/pkg/detectors/sendbirdorganizationapi/sendbirdorganizationapi.go
@@ -3,9 +3,10 @@ package sendbirdorganizationapi
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -39,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/sendinbluev2/sendinbluev2.go
+++ b/pkg/detectors/sendinbluev2/sendinbluev2.go
@@ -35,9 +35,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/sentrytoken/sentrytoken.go
+++ b/pkg/detectors/sentrytoken/sentrytoken.go
@@ -44,9 +44,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_SentryToken,

--- a/pkg/detectors/serphouse/serphouse.go
+++ b/pkg/detectors/serphouse/serphouse.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/serpstack/serpstack.go
+++ b/pkg/detectors/serpstack/serpstack.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/sheety/sheety.go
+++ b/pkg/detectors/sheety/sheety.go
@@ -42,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/sherpadesk/sherpadesk.go
+++ b/pkg/detectors/sherpadesk/sherpadesk.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/shipday/shipday.go
+++ b/pkg/detectors/shipday/shipday.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/shodankey/shodankey.go
+++ b/pkg/detectors/shodankey/shodankey.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/shortcut/shortcut.go
+++ b/pkg/detectors/shortcut/shortcut.go
@@ -35,9 +35,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/shotstack/shotstack.go
+++ b/pkg/detectors/shotstack/shotstack.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/shutterstock/shutterstock.go
+++ b/pkg/detectors/shutterstock/shutterstock.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecretMatch := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/shutterstockoauth/shutterstockoauth.go
+++ b/pkg/detectors/shutterstockoauth/shutterstockoauth.go
@@ -3,9 +3,10 @@ package shutterstockoauth
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -37,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/signable/signable.go
+++ b/pkg/detectors/signable/signable.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := tokenPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 
 		if isCommonFalsePositive(match[0]) {
 			continue

--- a/pkg/detectors/signalwire/signalwire.go
+++ b/pkg/detectors/signalwire/signalwire.go
@@ -44,21 +44,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	urlMatches := urlPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			resID := strings.TrimSpace(idMatch[1])
 
 			for _, urlMatch := range urlMatches {
-				if len(urlMatch) != 2 {
-					continue
-				}
 				resURL := strings.TrimSpace(urlMatch[1])
 
 				s1 := detectors.Result{

--- a/pkg/detectors/signaturit/signaturit.go
+++ b/pkg/detectors/signaturit/signaturit.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/signupgenius/signupgenius.go
+++ b/pkg/detectors/signupgenius/signupgenius.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/sigopt/sigopt.go
+++ b/pkg/detectors/sigopt/sigopt.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/simfin/simfin.go
+++ b/pkg/detectors/simfin/simfin.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/simplesat/simplesat.go
+++ b/pkg/detectors/simplesat/simplesat.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/simplynoted/simplynoted.go
+++ b/pkg/detectors/simplynoted/simplynoted.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/simvoly/simvoly.go
+++ b/pkg/detectors/simvoly/simvoly.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/sinchmessage/sinchmessage.go
+++ b/pkg/detectors/sinchmessage/sinchmessage.go
@@ -41,14 +41,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/sirv/sirv.go
+++ b/pkg/detectors/sirv/sirv.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 			s1 := detectors.Result{

--- a/pkg/detectors/siteleaf/siteleaf.go
+++ b/pkg/detectors/siteleaf/siteleaf.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/skrappio/skrappio.go
+++ b/pkg/detectors/skrappio/skrappio.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/slackwebhook/slackwebhook.go
+++ b/pkg/detectors/slackwebhook/slackwebhook.go
@@ -45,9 +45,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 		for _, match := range matches {
-			if len(match) != 2 {
-				continue
-			}
 			resMatch := strings.TrimSpace(match[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/smartsheets/smartsheets.go
+++ b/pkg/detectors/smartsheets/smartsheets.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/smartystreets/smartystreets.go
+++ b/pkg/detectors/smartystreets/smartystreets.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/smooch/smooch.go
+++ b/pkg/detectors/smooch/smooch.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecret := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/snipcart/snipcart.go
+++ b/pkg/detectors/snipcart/snipcart.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/sonarcloud/sonarcloud.go
+++ b/pkg/detectors/sonarcloud/sonarcloud.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/sourcegraph/sourcegraph.go
+++ b/pkg/detectors/sourcegraph/sourcegraph.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/sourcegraphcody/sourcegraphcody.go
+++ b/pkg/detectors/sourcegraphcody/sourcegraphcody.go
@@ -3,9 +3,10 @@ package sourcegraphcody
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -38,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/sparkpost/sparkpost.go
+++ b/pkg/detectors/sparkpost/sparkpost.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/speechtextai/speechtextai.go
+++ b/pkg/detectors/speechtextai/speechtextai.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/splunkobservabilitytoken/splunkobservabilitytoken.go
+++ b/pkg/detectors/splunkobservabilitytoken/splunkobservabilitytoken.go
@@ -2,9 +2,10 @@ package splunkobservabilitytoken
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -36,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{
@@ -58,7 +56,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
-				} 
+				}
 			}
 		}
 

--- a/pkg/detectors/spoonacular/spoonacular.go
+++ b/pkg/detectors/spoonacular/spoonacular.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/sportsmonk/sportsmonk.go
+++ b/pkg/detectors/sportsmonk/sportsmonk.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/spotifykey/spotifykey.go
+++ b/pkg/detectors/spotifykey/spotifykey.go
@@ -44,14 +44,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			idresMatch := strings.TrimSpace(idMatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_SpotifyKey,

--- a/pkg/detectors/square/square.go
+++ b/pkg/detectors/square/square.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	secMatches := secretPat.FindAllStringSubmatch(dataStr, -1)
 	for _, secMatch := range secMatches {
-		if len(secMatch) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(secMatch[1])
 
 		result := detectors.Result{

--- a/pkg/detectors/squarespace/squarespace.go
+++ b/pkg/detectors/squarespace/squarespace.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/squareup/squareup.go
+++ b/pkg/detectors/squareup/squareup.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/sslmate/sslmate.go
+++ b/pkg/detectors/sslmate/sslmate.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/statuscake/statuscake.go
+++ b/pkg/detectors/statuscake/statuscake.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/statuspage/statuspage.go
+++ b/pkg/detectors/statuspage/statuspage.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/statuspal/statuspal.go
+++ b/pkg/detectors/statuspal/statuspal.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/stitchdata/stitchdata.go
+++ b/pkg/detectors/stitchdata/stitchdata.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/stockdata/stockdata.go
+++ b/pkg/detectors/stockdata/stockdata.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/storecove/storecove.go
+++ b/pkg/detectors/storecove/storecove.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/stormboard/stormboard.go
+++ b/pkg/detectors/stormboard/stormboard.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/stormglass/stormglass.go
+++ b/pkg/detectors/stormglass/stormglass.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/storyblok/storyblok.go
+++ b/pkg/detectors/storyblok/storyblok.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/storychief/storychief.go
+++ b/pkg/detectors/storychief/storychief.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/strava/strava.go
+++ b/pkg/detectors/strava/strava.go
@@ -42,21 +42,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	keyMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range idMatches {
-		if len(match) != 2 {
-			continue
-		}
 		resId := strings.TrimSpace(match[1])
 
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecret := strings.TrimSpace(secretMatch[1])
 
 			for _, keyMatch := range keyMatches {
-				if len(keyMatch) != 2 {
-					continue
-				}
 				resKey := strings.TrimSpace(keyMatch[1])
 
 				s1 := detectors.Result{

--- a/pkg/detectors/streak/streak.go
+++ b/pkg/detectors/streak/streak.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/stripo/stripo.go
+++ b/pkg/detectors/stripo/stripo.go
@@ -35,9 +35,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/stytch/stytch.go
+++ b/pkg/detectors/stytch/stytch.go
@@ -39,15 +39,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		tokenPatMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			userPatMatch := strings.TrimSpace(idMatch[1])
 			s1 := detectors.Result{

--- a/pkg/detectors/sugester/sugester.go
+++ b/pkg/detectors/sugester/sugester.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, domainmatch := range domainMatches {
-			if len(domainmatch) != 2 {
-				continue
-			}
 			resDomainMatch := strings.TrimSpace(domainmatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Sugester,

--- a/pkg/detectors/supabasetoken/supabasetoken.go
+++ b/pkg/detectors/supabasetoken/supabasetoken.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/supernotesapi/supernotesapi.go
+++ b/pkg/detectors/supernotesapi/supernotesapi.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/surveyanyplace/surveyanyplace.go
+++ b/pkg/detectors/surveyanyplace/surveyanyplace.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/surveybot/surveybot.go
+++ b/pkg/detectors/surveybot/surveybot.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/surveysparrow/surveysparrow.go
+++ b/pkg/detectors/surveysparrow/surveysparrow.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/survicate/survicate.go
+++ b/pkg/detectors/survicate/survicate.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/swell/swell.go
+++ b/pkg/detectors/swell/swell.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		tokenPatMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			userPatMatch := strings.TrimSpace(idMatch[1])
 

--- a/pkg/detectors/swiftype/swiftype.go
+++ b/pkg/detectors/swiftype/swiftype.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/tallyfy/tallyfy.go
+++ b/pkg/detectors/tallyfy/tallyfy.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/tatumio/tatumio.go
+++ b/pkg/detectors/tatumio/tatumio.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/taxjar/taxjar.go
+++ b/pkg/detectors/taxjar/taxjar.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/teamgate/teamgate.go
+++ b/pkg/detectors/teamgate/teamgate.go
@@ -39,15 +39,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	keyMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, keyMatch := range keyMatches {
-			if len(keyMatch) != 2 {
-				continue
-			}
 
 			resKeyMatch := strings.TrimSpace(keyMatch[1])
 

--- a/pkg/detectors/teamworkcrm/teamworkcrm.go
+++ b/pkg/detectors/teamworkcrm/teamworkcrm.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/teamworkdesk/teamworkdesk.go
+++ b/pkg/detectors/teamworkdesk/teamworkdesk.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/teamworkspaces/teamworkspaces.go
+++ b/pkg/detectors/teamworkspaces/teamworkspaces.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/technicalanalysisapi/technicalanalysisapi.go
+++ b/pkg/detectors/technicalanalysisapi/technicalanalysisapi.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/tefter/tefter.go
+++ b/pkg/detectors/tefter/tefter.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/telegrambottoken/telegrambottoken.go
+++ b/pkg/detectors/telegrambottoken/telegrambottoken.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 
-	//	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	//	"fmt"
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -42,9 +43,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		key := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/teletype/teletype.go
+++ b/pkg/detectors/teletype/teletype.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/telnyx/telnyx.go
+++ b/pkg/detectors/telnyx/telnyx.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/terraformcloudpersonaltoken/terraformcloudpersonaltoken.go
+++ b/pkg/detectors/terraformcloudpersonaltoken/terraformcloudpersonaltoken.go
@@ -3,9 +3,10 @@ package terraformcloudpersonaltoken
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -36,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/textmagic/textmagic.go
+++ b/pkg/detectors/textmagic/textmagic.go
@@ -13,7 +13,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{
+type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
 }
 
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	userMatches := userPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, userMatch := range userMatches {
-			if len(userMatch) != 2 {
-				continue
-			}
 			resUser := strings.TrimSpace(userMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/theoddsapi/theoddsapi.go
+++ b/pkg/detectors/theoddsapi/theoddsapi.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/thinkific/thinkific.go
+++ b/pkg/detectors/thinkific/thinkific.go
@@ -42,15 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, domainMatch := range domainMatches {
-
-			if len(domainMatch) != 2 {
-				continue
-			}
 			resDomainMatch := strings.TrimSpace(domainMatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Thinkific,

--- a/pkg/detectors/thousandeyes/thousandeyes.go
+++ b/pkg/detectors/thousandeyes/thousandeyes.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	emailMatches := email.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		tokenPatMatch := strings.TrimSpace(match[1])
 
 		for _, emailMatch := range emailMatches {
-			if len(emailMatch) != 2 {
-				continue
-			}
 
 			userPatMatch := strings.TrimSpace(emailMatch[1])
 

--- a/pkg/detectors/ticketmaster/ticketmaster.go
+++ b/pkg/detectors/ticketmaster/ticketmaster.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/tiingo/tiingo.go
+++ b/pkg/detectors/tiingo/tiingo.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/timecamp/timecamp.go
+++ b/pkg/detectors/timecamp/timecamp.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/timezoneapi/timezoneapi.go
+++ b/pkg/detectors/timezoneapi/timezoneapi.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/tineswebhook/tineswebhook.go
+++ b/pkg/detectors/tineswebhook/tineswebhook.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/tly/tly.go
+++ b/pkg/detectors/tly/tly.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/tmetric/tmetric.go
+++ b/pkg/detectors/tmetric/tmetric.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/todoist/todoist.go
+++ b/pkg/detectors/todoist/todoist.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/toggltrack/toggltrack.go
+++ b/pkg/detectors/toggltrack/toggltrack.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/tokeet/tokeet.go
+++ b/pkg/detectors/tokeet/tokeet.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/tomorrowio/tomorrowio.go
+++ b/pkg/detectors/tomorrowio/tomorrowio.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/tomtom/tomtom.go
+++ b/pkg/detectors/tomtom/tomtom.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/tradier/tradier.go
+++ b/pkg/detectors/tradier/tradier.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/transferwise/transferwise.go
+++ b/pkg/detectors/transferwise/transferwise.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/travelpayouts/travelpayouts.go
+++ b/pkg/detectors/travelpayouts/travelpayouts.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/travisci/travisci.go
+++ b/pkg/detectors/travisci/travisci.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/trelloapikey/trelloapikey.go
+++ b/pkg/detectors/trelloapikey/trelloapikey.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		if i == 0 {
 			resMatch := strings.TrimSpace(match[1])
 			for _, tokenMatch := range tokenMatches {
-				if len(tokenMatch) != 2 {
-					continue
-				}
 
 				token := strings.TrimSpace(tokenMatch[1])
 

--- a/pkg/detectors/tru/tru.go
+++ b/pkg/detectors/tru/tru.go
@@ -42,14 +42,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	secretMatches := secrePat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, secretMatch := range secretMatches {
-			if len(secretMatch) != 2 {
-				continue
-			}
 			resSecret := strings.TrimSpace(secretMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/trufflehogenterprise/trufflehogenterprise.go
+++ b/pkg/detectors/trufflehogenterprise/trufflehogenterprise.go
@@ -43,21 +43,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	hostnameMatches := hostnamePat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, keyMatch := range keyMatches {
-		if len(keyMatch) != 1 {
-			continue
-		}
 		resKeyMatch := strings.TrimSpace(keyMatch[0])
 		for _, secretMatch := range secretMatches {
-
-			if len(secretMatch) != 1 {
-				continue
-			}
 			resSecretMatch := strings.TrimSpace(secretMatch[0])
 
 			for _, hostnameMatch := range hostnameMatches {
-				if len(hostnameMatch) != 1 {
-					continue
-				}
 
 				resHostnameMatch := strings.TrimSpace(hostnameMatch[0])
 

--- a/pkg/detectors/twelvedata/twelvedata.go
+++ b/pkg/detectors/twelvedata/twelvedata.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/twist/twist.go
+++ b/pkg/detectors/twist/twist.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := accessToken.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		setAuth := resMatch
 

--- a/pkg/detectors/twitch/twitch.go
+++ b/pkg/detectors/twitch/twitch.go
@@ -47,15 +47,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/tyntec/tyntec.go
+++ b/pkg/detectors/tyntec/tyntec.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/typeform/v1/typeform.go
+++ b/pkg/detectors/typeform/v1/typeform.go
@@ -41,9 +41,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/typetalk/typetalk.go
+++ b/pkg/detectors/typetalk/typetalk.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idMatch := range idMatches {
-			if len(idMatch) != 2 {
-				continue
-			}
 
 			resIdMatch := strings.TrimSpace(idMatch[1])
 			s1 := detectors.Result{

--- a/pkg/detectors/ubidots/ubidots.go
+++ b/pkg/detectors/ubidots/ubidots.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/uclassify/uclassify.go
+++ b/pkg/detectors/uclassify/uclassify.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/unifyid/unifyid.go
+++ b/pkg/detectors/unifyid/unifyid.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/unplugg/unplugg.go
+++ b/pkg/detectors/unplugg/unplugg.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/unsplash/unsplash.go
+++ b/pkg/detectors/unsplash/unsplash.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/upcdatabase/upcdatabase.go
+++ b/pkg/detectors/upcdatabase/upcdatabase.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/uplead/uplead.go
+++ b/pkg/detectors/uplead/uplead.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/uploadcare/uploadcare.go
+++ b/pkg/detectors/uploadcare/uploadcare.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	publicMatches := publicKeyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, publicMatch := range publicMatches {
-			if len(publicMatch) != 2 {
-				continue
-			}
 			publicKeyMatch := strings.TrimSpace(publicMatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_UploadCare,

--- a/pkg/detectors/uptimerobot/uptimerobot.go
+++ b/pkg/detectors/uptimerobot/uptimerobot.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/upwave/upwave.go
+++ b/pkg/detectors/upwave/upwave.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/urlscan/urlscan.go
+++ b/pkg/detectors/urlscan/urlscan.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/user/user.go
+++ b/pkg/detectors/user/user.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/userflow/userflow.go
+++ b/pkg/detectors/userflow/userflow.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/userstack/userstack.go
+++ b/pkg/detectors/userstack/userstack.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/vagrantcloudpersonaltoken/vagrantcloudpersonaltoken.go
+++ b/pkg/detectors/vagrantcloudpersonaltoken/vagrantcloudpersonaltoken.go
@@ -3,9 +3,10 @@ package vagrantcloudpersonaltoken
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -38,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/vatlayer/vatlayer.go
+++ b/pkg/detectors/vatlayer/vatlayer.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/vbout/vbout.go
+++ b/pkg/detectors/vbout/vbout.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/vercel/vercel.go
+++ b/pkg/detectors/vercel/vercel.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/verifier/verifier.go
+++ b/pkg/detectors/verifier/verifier.go
@@ -46,9 +46,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for emailMatch := range uniqueEmailMatches {

--- a/pkg/detectors/verimail/verimail.go
+++ b/pkg/detectors/verimail/verimail.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/veriphone/veriphone.go
+++ b/pkg/detectors/veriphone/veriphone.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/versioneye/versioneye.go
+++ b/pkg/detectors/versioneye/versioneye.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/viewneo/viewneo.go
+++ b/pkg/detectors/viewneo/viewneo.go
@@ -42,9 +42,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/virustotal/virustotal.go
+++ b/pkg/detectors/virustotal/virustotal.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/visualcrossing/visualcrossing.go
+++ b/pkg/detectors/visualcrossing/visualcrossing.go
@@ -3,9 +3,10 @@ package visualcrossing
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -37,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/voiceflow/voiceflow.go
+++ b/pkg/detectors/voiceflow/voiceflow.go
@@ -42,9 +42,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/voicegain/voicegain.go
+++ b/pkg/detectors/voicegain/voicegain.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/voodoosms/voodoosms.go
+++ b/pkg/detectors/voodoosms/voodoosms.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/vouchery/vouchery.go
+++ b/pkg/detectors/vouchery/vouchery.go
@@ -41,15 +41,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	subMatches := subPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, subMatch := range subMatches {
-			if len(subMatch) != 2 {
-				continue
-			}
 
 			subMatch := strings.TrimSpace(subMatch[1])
 

--- a/pkg/detectors/vpnapi/vpnapi.go
+++ b/pkg/detectors/vpnapi/vpnapi.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/vultrapikey/vultrapikey.go
+++ b/pkg/detectors/vultrapikey/vultrapikey.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/vyte/vyte.go
+++ b/pkg/detectors/vyte/vyte.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/walkscore/walkscore.go
+++ b/pkg/detectors/walkscore/walkscore.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/weatherbit/weatherbit.go
+++ b/pkg/detectors/weatherbit/weatherbit.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/weatherstack/weatherstack.go
+++ b/pkg/detectors/weatherstack/weatherstack.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/web3storage/web3storage.go
+++ b/pkg/detectors/web3storage/web3storage.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/webex/webex.go
+++ b/pkg/detectors/webex/webex.go
@@ -39,15 +39,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idMatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		for _, idMatch := range idMatches {
-
-			if len(idMatch) != 2 {
-				continue
-			}
 			id := strings.TrimSpace(idMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/webflow/webflow.go
+++ b/pkg/detectors/webflow/webflow.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/webscraper/webscraper.go
+++ b/pkg/detectors/webscraper/webscraper.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/webscraping/webscraping.go
+++ b/pkg/detectors/webscraping/webscraping.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/websitepulse/websitepulse.go
+++ b/pkg/detectors/websitepulse/websitepulse.go
@@ -42,15 +42,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdMatch := strings.TrimSpace(idmatch[1])
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Websitepulse,

--- a/pkg/detectors/wepay/wepay.go
+++ b/pkg/detectors/wepay/wepay.go
@@ -42,16 +42,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	resAppIDMatch := ""
 	for _, appIDMatch := range appIDmatches {
-		if len(appIDMatch) != 2 {
-			continue
-		}
 		resAppIDMatch = strings.TrimSpace(appIDMatch[1])
 	}
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_WePay,

--- a/pkg/detectors/whoxy/whoxy.go
+++ b/pkg/detectors/whoxy/whoxy.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/wistia/wistia.go
+++ b/pkg/detectors/wistia/wistia.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/wit/wit.go
+++ b/pkg/detectors/wit/wit.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/worksnaps/worksnaps.go
+++ b/pkg/detectors/worksnaps/worksnaps.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/workstack/workstack.go
+++ b/pkg/detectors/workstack/workstack.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/worldcoinindex/worldcoinindex.go
+++ b/pkg/detectors/worldcoinindex/worldcoinindex.go
@@ -39,9 +39,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/worldweather/worldweather.go
+++ b/pkg/detectors/worldweather/worldweather.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/wrike/wrike.go
+++ b/pkg/detectors/wrike/wrike.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/yandex/yandex.go
+++ b/pkg/detectors/yandex/yandex.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/yelp/yelp.go
+++ b/pkg/detectors/yelp/yelp.go
@@ -40,9 +40,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/youneedabudget/youneedabudget.go
+++ b/pkg/detectors/youneedabudget/youneedabudget.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/yousign/yousign.go
+++ b/pkg/detectors/yousign/yousign.go
@@ -42,9 +42,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/youtubeapikey/youtubeapikey.go
+++ b/pkg/detectors/youtubeapikey/youtubeapikey.go
@@ -40,15 +40,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	idmatches := idPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		for _, idmatch := range idmatches {
-			if len(idmatch) != 2 {
-				continue
-			}
 			resIdmatch := strings.TrimSpace(idmatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/zapierwebhook/zapierwebhook.go
+++ b/pkg/detectors/zapierwebhook/zapierwebhook.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/zendeskapi/zendeskapi.go
+++ b/pkg/detectors/zendeskapi/zendeskapi.go
@@ -43,22 +43,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	emails := email.FindAllStringSubmatch(dataStr, -1)
 
 	for _, token := range tokens {
-		if len(token) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(token[1])
 
 		var resDomain string
 		for _, domain := range domains {
-			if len(domain) != 2 {
-				continue
-			}
 			resDomain = strings.TrimSpace(domain[1])
 
 			for _, email := range emails {
-				if len(email) != 2 {
-					continue
-				}
 				resEmail := strings.TrimSpace(email[1])
 
 				s1 := detectors.Result{

--- a/pkg/detectors/zenkitapi/zenkitapi.go
+++ b/pkg/detectors/zenkitapi/zenkitapi.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/zenrows/zenrows.go
+++ b/pkg/detectors/zenrows/zenrows.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/zenscrape/zenscrape.go
+++ b/pkg/detectors/zenscrape/zenscrape.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/zenserp/zenserp.go
+++ b/pkg/detectors/zenserp/zenserp.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/zeplin/zeplin.go
+++ b/pkg/detectors/zeplin/zeplin.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/zerobounce/zerobounce.go
+++ b/pkg/detectors/zerobounce/zerobounce.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/zerotier/zerotier.go
+++ b/pkg/detectors/zerotier/zerotier.go
@@ -38,9 +38,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/zipbooks/zipbooks.go
+++ b/pkg/detectors/zipbooks/zipbooks.go
@@ -47,9 +47,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for emailMatch := range uniqueEmailMatches {
 		for _, pwordMatch := range pwordMatches {
-			if len(pwordMatch) != 2 {
-				continue
-			}
 			resPword := strings.TrimSpace(pwordMatch[1])
 
 			s1 := detectors.Result{

--- a/pkg/detectors/zipcodeapi/zipcodeapi.go
+++ b/pkg/detectors/zipcodeapi/zipcodeapi.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/zipcodebase/zipcodebase.go
+++ b/pkg/detectors/zipcodebase/zipcodebase.go
@@ -37,9 +37,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{

--- a/pkg/detectors/zonkafeedback/zonkafeedback.go
+++ b/pkg/detectors/zonkafeedback/zonkafeedback.go
@@ -36,9 +36,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
-		if len(match) != 2 {
-			continue
-		}
 		resMatch := strings.TrimSpace(match[1])
 
 		s1 := detectors.Result{


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
I believe the intention behind this code was to make sure that a given pattern matched, but it doesn't actually do this. A while ago, I explained in a PR comment how the `if len(match) != 2` check doesn't necessarily do what it appears to, and how it can actually silently break detectors.

In short, `FindAllStringSubmatch` only returns results that match the given pattern. The number of match groups in a specific match is static, meaning that the pattern `(fo.)bar(.?)` will always have 3 groups even if the group after `bar` is empty. If the number of match groups in a pattern is changed and the if statement isn't, it will cause matches to be silently discarded.

https://go.dev/play/p/TXYh1bQItaO

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

