### PR TITLE
[bug] - fix buffer size metric

### DIFF
--- a/pkg/writers/buffer/buffer.go
+++ b/pkg/writers/buffer/buffer.go
@@ -23,7 +23,7 @@ func (poolMetrics) recordBufferRetrival() {
 
 func (poolMetrics) recordBufferReturn(buf *Buffer) {
 	activeBufferCount.Dec()
-	totalBufferSize.Add(float64(buf.Len()))
+	totalBufferSize.Add(float64(buf.Cap()))
 	totalBufferLength.Add(float64(buf.Len()))
 	buf.recordMetric()
 }

--- a/pkg/writers/buffer_writer/bufferwriter.go
+++ b/pkg/writers/buffer_writer/bufferwriter.go
@@ -62,8 +62,7 @@ func (b *BufferWriter) Write(data []byte) (int, error) {
 	b.size += size
 	start := time.Now()
 	defer func(start time.Time) {
-		bufferLength := int64(b.buf.Len())
-		b.metrics.recordDataProcessed(bufferLength, time.Since(start))
+		b.metrics.recordDataProcessed(int64(size), time.Since(start))
 
 	}(start)
 	return b.buf.Write(data)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR updates the buffer metric calculation by using the `Cap()` method instead of `Len()` to more accurately represent the buffer size.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

