### PR TITLE
[bug] - Fix the metric for buffered file writer writes

### DIFF
--- a/pkg/writers/buffered_file_writer/bufferedfilewriter.go
+++ b/pkg/writers/buffered_file_writer/bufferedfilewriter.go
@@ -27,6 +27,7 @@ func (bufferedFileWriterMetrics) recordDataProcessed(size uint64, dur time.Durat
 }
 
 func (bufferedFileWriterMetrics) recordDiskWrite(size int64) {
+	diskWriteCount.Inc()
 	fileSizeHistogram.Observe(float64(size))
 }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR ensures the `bufferedfilewriter` accurately counts the number of bytes written to a file.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

