### PR TITLE
Update postman flags to be less confusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ---
 
-# :mag_right: _Now Scanning_
+# :mag*right: \_Now Scanning*
 
 <div align="center">
 
@@ -54,7 +54,7 @@ brew install trufflehog
 
 ### Docker:
 
-<sub><i>*Ensure Docker engine is running before executing the following commands:*</i></sub>
+<sub><i>_Ensure Docker engine is running before executing the following commands:_</i></sub>
 
 #### &nbsp;&nbsp;&nbsp;&nbsp;Unix
 
@@ -251,10 +251,10 @@ trufflehog git file://. --since-commit main --branch feature-1 --only-verified -
 
 ## 12: Scan a Postman workspace
 
-Use the `--workspace`, `--collection`, `--environment` flags multiple times to scan multiple targets.
+Use the `--workspace-id`, `--collection-id`, `--environment` flags multiple times to scan multiple targets.
 
 ```bash
-trufflehog postman --token=<postman api token> --workspace=<workspace id>
+trufflehog postman --token=<postman api token> --workspace-id=<workspace id>
 ```
 
 # :question: FAQ
@@ -487,7 +487,7 @@ If you'd like to specify specific `base` and `head` refs, you can use the `base`
 ```yaml
 stages:
   - security
-  
+
 security-secrets:
   stage: security
   allow_failure: false
@@ -616,7 +616,7 @@ class Verifier(BaseHTTPRequestHandler):
             self.log_message("%s", request)
 
             # check the match, you'll need to implement validateToken, which takes an array of ID's and Secrets
-            if not validateTokens(request['HogTokenDetector']['hogID'], request['HogTokenDetector']['hogSecret']): 
+            if not validateTokens(request['HogTokenDetector']['hogID'], request['HogTokenDetector']['hogSecret']):
                 self.send_response(200)
                 self.end_headers()
             else:

--- a/main.go
+++ b/main.go
@@ -158,11 +158,11 @@ var (
 	postmanScan  = cli.Command("postman", "Scan Postman")
 	postmanToken = postmanScan.Flag("token", "Postman token. Can also be provided with environment variable").Envar("POSTMAN_TOKEN").String()
 
-	postmanWorkspaces    = postmanScan.Flag("workspace", "Postman workspace to scan. You can repeat this flag. Deprecated flag.").Hidden().Strings()
-	postmanCollectionIDs = postmanScan.Flag("collection-id", "Postman collection ID to scan. You can repeat this flag.").Strings()
-
-	postmanCollections  = postmanScan.Flag("collection", "Postman collection to scan. You can repeat this flag. Deprecated flag.").Hidden().Strings()
+	postmanWorkspaces   = postmanScan.Flag("workspace", "Postman workspace to scan. You can repeat this flag. Deprecated flag.").Hidden().Strings()
 	postmanWorkspaceIDs = postmanScan.Flag("workspace-id", "Postman workspace ID to scan. You can repeat this flag.").Strings()
+
+	postmanCollections   = postmanScan.Flag("collection", "Postman collection to scan. You can repeat this flag. Deprecated flag.").Hidden().Strings()
+	postmanCollectionIDs = postmanScan.Flag("collection-id", "Postman collection ID to scan. You can repeat this flag.").Strings()
 
 	postmanEnvironments = postmanScan.Flag("environment", "Postman environment to scan. You can repeat this flag.").Strings()
 

--- a/main.go
+++ b/main.go
@@ -155,14 +155,25 @@ var (
 	travisCiScanToken = travisCiScan.Flag("token", "TravisCI token. Can also be provided with environment variable").Envar("TRAVISCI_TOKEN").Required().String()
 
 	// Postman is hidden for now until we get more feedback from the community.
-	postmanScan                = cli.Command("postman", "Scan Postman")
-	postmanToken               = postmanScan.Flag("token", "Postman token. Can also be provided with environment variable").Envar("POSTMAN_TOKEN").String()
-	postmanWorkspaces          = postmanScan.Flag("workspace", "Postman workspace to scan. You can repeat this flag.").Strings()
-	postmanCollections         = postmanScan.Flag("collection", "Postman collection to scan. You can repeat this flag.").Strings()
-	postmanEnvironments        = postmanScan.Flag("environment", "Postman environment to scan. You can repeat this flag.").Strings()
-	postmanIncludeCollections  = postmanScan.Flag("include-collections", "Collections to include in scan. You can repeat this flag.").Strings()
+	postmanScan  = cli.Command("postman", "Scan Postman")
+	postmanToken = postmanScan.Flag("token", "Postman token. Can also be provided with environment variable").Envar("POSTMAN_TOKEN").String()
+
+	postmanWorkspaces    = postmanScan.Flag("workspace", "Postman workspace to scan. You can repeat this flag. Deprecated flag.").Hidden().Strings()
+	postmanCollectionIDs = postmanScan.Flag("collection-id", "Postman collection ID to scan. You can repeat this flag.").Strings()
+
+	postmanCollections  = postmanScan.Flag("collection", "Postman collection to scan. You can repeat this flag. Deprecated flag.").Hidden().Strings()
+	postmanWorkspaceIDs = postmanScan.Flag("workspace-id", "Postman workspace ID to scan. You can repeat this flag.").Strings()
+
+	postmanEnvironments = postmanScan.Flag("environment", "Postman environment to scan. You can repeat this flag.").Strings()
+
+	postmanIncludeCollections   = postmanScan.Flag("include-collections", "Collections to include in scan. You can repeat this flag. Deprecated flag.").Hidden().Strings()
+	postmanIncludeCollectionIDs = postmanScan.Flag("include-collection-id", "Collection ID to include in scan. You can repeat this flag.").Strings()
+
 	postmanIncludeEnvironments = postmanScan.Flag("include-environments", "Environments to include in scan. You can repeat this flag.").Strings()
-	postmanExcludeCollections  = postmanScan.Flag("exclude-collections", "Collections to exclude from scan. You can repeat this flag.").Strings()
+
+	postmanExcludeCollections   = postmanScan.Flag("exclude-collections", "Collections to exclude from scan. You can repeat this flag. Deprecated flag.").Hidden().Strings()
+	postmanExcludeCollectionIDs = postmanScan.Flag("exclude-collection-id", "Collection ID to exclude from scan. You can repeat this flag.").Strings()
+
 	postmanExcludeEnvironments = postmanScan.Flag("exclude-environments", "Environments to exclude from scan. You can repeat this flag.").Strings()
 	postmanWorkspacePaths      = postmanScan.Flag("workspace-paths", "Path to Postman workspaces.").Strings()
 	postmanCollectionPaths     = postmanScan.Flag("collection-paths", "Path to Postman collections.").Strings()
@@ -592,14 +603,34 @@ func run(state overseer.State) {
 			logFatal(err, "Failed to scan Docker.")
 		}
 	case postmanScan.FullCommand():
+		// handle deprecated flag
+		workspaceIDs := make([]string, 0, len(*postmanWorkspaceIDs)+len(*postmanWorkspaces))
+		workspaceIDs = append(workspaceIDs, *postmanWorkspaceIDs...)
+		workspaceIDs = append(workspaceIDs, *postmanWorkspaces...)
+
+		// handle deprecated flag
+		collectionIDs := make([]string, 0, len(*postmanCollectionIDs)+len(*postmanCollections))
+		collectionIDs = append(collectionIDs, *postmanCollectionIDs...)
+		collectionIDs = append(collectionIDs, *postmanCollections...)
+
+		// handle deprecated flag
+		includeCollectionIDs := make([]string, 0, len(*postmanIncludeCollectionIDs)+len(*postmanIncludeCollections))
+		includeCollectionIDs = append(includeCollectionIDs, *postmanIncludeCollectionIDs...)
+		includeCollectionIDs = append(includeCollectionIDs, *postmanIncludeCollections...)
+
+		// handle deprecated flag
+		excludeCollectionIDs := make([]string, 0, len(*postmanExcludeCollectionIDs)+len(*postmanExcludeCollections))
+		excludeCollectionIDs = append(excludeCollectionIDs, *postmanExcludeCollectionIDs...)
+		excludeCollectionIDs = append(excludeCollectionIDs, *postmanExcludeCollections...)
+
 		cfg := sources.PostmanConfig{
 			Token:               *postmanToken,
-			Workspaces:          *postmanWorkspaces,
-			Collections:         *postmanCollections,
+			Workspaces:          workspaceIDs,
+			Collections:         collectionIDs,
 			Environments:        *postmanEnvironments,
-			IncludeCollections:  *postmanIncludeCollections,
+			IncludeCollections:  includeCollectionIDs,
 			IncludeEnvironments: *postmanIncludeEnvironments,
-			ExcludeCollections:  *postmanExcludeCollections,
+			ExcludeCollections:  excludeCollectionIDs,
 			ExcludeEnvironments: *postmanExcludeEnvironments,
 			CollectionPaths:     *postmanCollectionPaths,
 			WorkspacePaths:      *postmanWorkspacePaths,


### PR DESCRIPTION
### Description:
Addresses #2753 

A number of flags require IDs rather than names and are not clearly specified. This change makes those flags hidden (they still work) and replaces them with more clearly defined flags.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

