### PR TITLE
[bug] - Improve BufferedFileReader Close Behavior

### DIFF
--- a/pkg/readers/bufferedfilereader_test.go
+++ b/pkg/readers/bufferedfilereader_test.go
@@ -15,7 +15,6 @@ func TestBufferedFileReader(t *testing.T) {
 
 	bufferReadSeekCloser, err := NewBufferedFileReader(bytes.NewReader(data))
 	assert.NoError(t, err)
-	defer bufferReadSeekCloser.Close()
 
 	// Test Read.
 	buffer := make([]byte, len(data))

--- a/pkg/readers/bufferedfilereader_test.go
+++ b/pkg/readers/bufferedfilereader_test.go
@@ -53,25 +53,11 @@ func TestBufferedFileReaderClose(t *testing.T) {
 	err = bufferReadSeekCloser.Close()
 	assert.NoError(t, err)
 
-	// Read after closing.
+	// Read should NOT return any data after closing the reader.
 	buffer := make([]byte, len(data))
 	n, err := bufferReadSeekCloser.Read(buffer)
-	assert.NoError(t, err)
-	assert.Equal(t, len(data), n)
-	assert.Equal(t, data, buffer)
-
-	// Seek after closing.
-	offset := 7
-	seekPos, err := bufferReadSeekCloser.Seek(int64(offset), io.SeekStart)
-	assert.NoError(t, err)
-	assert.Equal(t, int64(offset), seekPos)
-
-	// ReadAt after closing.
-	buffer = make([]byte, len(data)-offset)
-	n, err = bufferReadSeekCloser.ReadAt(buffer, int64(offset))
-	assert.NoError(t, err)
-	assert.Equal(t, len(data)-offset, n)
-	assert.Equal(t, data[offset:], buffer)
+	assert.ErrorIs(t, err, io.EOF)
+	assert.Equal(t, 0, n)
 }
 
 func TestBufferedFileReaderReadFromFile(t *testing.T) {

--- a/pkg/writers/buffer/buffer.go
+++ b/pkg/writers/buffer/buffer.go
@@ -172,9 +172,8 @@ func (brc *readCloser) Close() error {
 
 // Read reads up to len(p) bytes into p from the underlying reader.
 // It returns the number of bytes read and any error encountered.
-// If the reader reaches the end of the available data, Read returns 0, io.EOF.
-// It ensures that Read should not be called after the reader is closed.
-// It implements the io.Reader interface.
+// On reaching the end of the available data, it returns 0 and io.EOF.
+// Calling Read on a closed reader will also return 0 and io.EOF.
 func (brc *readCloser) Read(p []byte) (int, error) {
 	if brc.Reader == nil {
 		return 0, io.EOF

--- a/pkg/writers/buffer/buffer.go
+++ b/pkg/writers/buffer/buffer.go
@@ -166,5 +166,19 @@ func (brc *readCloser) Close() error {
 	}
 
 	brc.onClose() // Return the buffer to the pool
+	brc.Reader = nil
 	return nil
+}
+
+// Read reads up to len(p) bytes into p from the underlying reader.
+// It returns the number of bytes read and any error encountered.
+// If the reader reaches the end of the available data, Read returns 0, io.EOF.
+// It ensures that Read should not be called after the reader is closed.
+// It implements the io.Reader interface.
+func (brc *readCloser) Read(p []byte) (int, error) {
+	if brc.Reader == nil {
+		return 0, io.EOF
+	}
+
+	return brc.Reader.Read(p)
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This pull request introduces changes to the `TestBufferedFileReaderClose` test and the underlying logic of the `BufferedFileReader` to ensure proper behavior when closing the reader.

Key changes:

1. Updated `TestBufferedFileReaderClose` test:
   - Modified the test to check that `Read` returns `io.EOF` and reads 0 bytes after closing the reader.
   - Removed assertions for `Seek` and `ReadAt` operations after closing, as they are no longer valid.
2. Update `Close` method on `readCloser`:
   - The `Close` sets the underlying `Reader` to `nil` after returning the buffer to the pool.
3. Enhanced `Read` method of `readCloser`:
   - Modified the `Read` method to return `io.EOF` and read 0 bytes if called after the reader is closed.
   - This ensures that `Read` cannot be called after closing the reader.
4. Updated `TestBufferedFileReader` test:
   - Removed the defered close since we manually close the reader at the end of the test.


![Screenshot 2024-04-30 at 8 42 42 AM](https://github.com/trufflesecurity/trufflehog/assets/21311841/397f1a63-7704-4cdf-8ef0-3de3468b663a)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

