### PR TITLE
fix for infinite recursion in Postman var sub

### DIFF
--- a/pkg/sources/postman/substitution.go
+++ b/pkg/sources/postman/substitution.go
@@ -74,8 +74,7 @@ func (s *Source) buildSubstitution(data string, metadata Metadata, combos *map[s
 			// to ensure we don't infinitely recurse, we will trim all `{{}}` from the values before replacement.
 			// this is to prevent the case where a variable is replaced with a value that contains the same variable causing
 			// an infinite loop
-			removedBrackets := strings.ReplaceAll(slice.value, "{{", "")
-			removedBrackets = strings.ReplaceAll(removedBrackets, "}}", "")
+			removedBrackets := strings.ReplaceAll(strings.ReplaceAll(slice.value, "{{", ""), "}}", "")
 
 			d := strings.ReplaceAll(data, match, removedBrackets)
 			s.buildSubstitution(d, metadata, combos)

--- a/pkg/sources/postman/substitution.go
+++ b/pkg/sources/postman/substitution.go
@@ -70,8 +70,14 @@ func (s *Source) buildSubstitution(data string, metadata Metadata, combos *map[s
 			if slice.Metadata.CollectionInfo.PostmanID != "" && slice.Metadata.CollectionInfo.PostmanID != metadata.CollectionInfo.PostmanID {
 				continue
 			}
-			// to ensure we don't infinitely recurse, we will trim all `{{}}` from the values before replacement
-			d := strings.ReplaceAll(data, match, strings.Trim(slice.value, "{}"))
+
+			// to ensure we don't infinitely recurse, we will trim all `{{}}` from the values before replacement.
+			// this is to prevent the case where a variable is replaced with a value that contains the same variable causing
+			// an infinite loop
+			removedBrackets := strings.ReplaceAll(slice.value, "{{", "")
+			removedBrackets = strings.ReplaceAll(removedBrackets, "}}", "")
+
+			d := strings.ReplaceAll(data, match, removedBrackets)
 			s.buildSubstitution(d, metadata, combos)
 		}
 	}

--- a/pkg/sources/postman/substitution_test.go
+++ b/pkg/sources/postman/substitution_test.go
@@ -68,6 +68,9 @@ func TestSource_BuildSubstituteSet(t *testing.T) {
 	}
 	s.sub.add(Metadata{Type: GLOBAL_TYPE}, "var1", "value1")
 	s.sub.add(Metadata{Type: GLOBAL_TYPE}, "var2", "value2")
+	s.sub.add(Metadata{Type: GLOBAL_TYPE}, "", "value2")
+	s.sub.add(Metadata{Type: GLOBAL_TYPE}, "continuation_token", "'{{continuation_token}}'")     // this caused an infinite loop in the original implementation
+	s.sub.add(Metadata{Type: GLOBAL_TYPE}, "continuation_token2", "'{{{continuation_token2}}}'") // this caused an infinite loop in the original implementation
 
 	metadata := Metadata{
 		Type: GLOBAL_TYPE,
@@ -81,6 +84,8 @@ func TestSource_BuildSubstituteSet(t *testing.T) {
 		{"{{var2}}", []string{"value2"}},
 		{"{{var1}}:{{var2}}", []string{"value1:value2"}},
 		{"no variables", []string{"no variables"}},
+		{"{{var1}}:{{continuation_token}}", []string{"value1:'continuation_token'"}},
+		{"{{var1}}:{{continuation_token2}}", []string{"value1:'{continuation_token2}'"}},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
There was a bug in the variable substitution code for Postman that caused infinite recursion which happened when a variable value referenced itself. This is a stopgap solution. More investigation needs to be done but this at least relieves the infinite recursion bug. 

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

