### PR TITLE
[bug] - Ignore FP check for the private key detector

### DIFF
--- a/pkg/detectors/privatekey/privatekey.go
+++ b/pkg/detectors/privatekey/privatekey.go
@@ -25,6 +25,7 @@ type Scanner struct {
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.CustomFalsePositiveChecker = (*Scanner)(nil)
 
 var (
 	// TODO: add base64 encoded key support
@@ -144,6 +145,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	return results, nil
 }
+
+func (s Scanner) IsFalsePositive(_ detectors.Result) bool { return false }
 
 type result struct {
 	CertificateURLs []string


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR fixes a regression introduced in [this PR](https://github.com/trufflesecurity/trufflehog/pull/2643), where we moved the false positive check to the engine. Unfortunately, the private key detector didn’t originally have a false positive check, so the default check was mistakenly added. This PR ensures the private key detector does _not_ run the false positive check on its results.
### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

