### PR TITLE
Updating Enterprise Readme Link from Contact to Product Info Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To learn more about about TruffleHog and its features and capabilities, visit ou
 
 # :money_with_wings: TruffleHog Enterprise
 
-Are you interested in continuously monitoring **Git, Jira, Slack, Confluence, Microsoft Teams, Sharepoint, and more..** for credentials? We have an enterprise product that can help! Reach out here to learn more at <https://trufflesecurity.com/contact/>
+Are you interested in continuously monitoring **Git, Jira, Slack, Confluence, Microsoft Teams, Sharepoint, and more..** for credentials? We have an enterprise product that can help! Learn more at <https://trufflesecurity.com/trufflehog-enterprise>.
 
 We take the revenue from the enterprise product to fund more awesome open source projects that the whole community can benefit from.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To learn more about about TruffleHog and its features and capabilities, visit ou
 
 </div>
 
-# :money_with_wings: TruffleHog Enterprise
+# :globe_with_meridians: TruffleHog Enterprise
 
 Are you interested in continuously monitoring **Git, Jira, Slack, Confluence, Microsoft Teams, Sharepoint, and more..** for credentials? We have an enterprise product that can help! Learn more at <https://trufflesecurity.com/trufflehog-enterprise>.
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Updated the Readme Enterprise section to lead to the enterprise product info page instead of the contact us page

### Checklist:
* [x] Tests passing (`make test-community`)?
* [X] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

