### PR TITLE
[bug] - Fix case-sensitivity issue in PrefixRegex function

### DIFF
--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -156,9 +156,9 @@ func CleanResults(results []Result) []Result {
 // 40 characters of the capturing group that follows.
 // This can help prevent false positives.
 func PrefixRegex(keywords []string) string {
-	pre := `(?i)(?:`
+	pre := `(?i:`
 	middle := strings.Join(keywords, "|")
-	post := `)(?:.|[\n\r]){0,40}?(?-i)`
+	post := `)(?:.|[\n\r]){0,40}?`
 	return pre + middle + post
 }
 

--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -3,12 +3,11 @@ package detectors
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"math/big"
 	"net/url"
 	"strings"
 	"unicode"
-
-	"errors"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
@@ -154,12 +153,12 @@ func CleanResults(results []Result) []Result {
 }
 
 // PrefixRegex ensures that at least one of the given keywords is within
-// 20 characters of the capturing group that follows.
+// 40 characters of the capturing group that follows.
 // This can help prevent false positives.
 func PrefixRegex(keywords []string) string {
 	pre := `(?i)(?:`
 	middle := strings.Join(keywords, "|")
-	post := `)(?:.|[\n\r]){0,40}?`
+	post := `)(?:.|[\n\r]){0,40}?(?-i)`
 	return pre + middle + post
 }
 

--- a/pkg/detectors/detectors_test.go
+++ b/pkg/detectors/detectors_test.go
@@ -3,7 +3,11 @@
 
 package detectors
 
-import "testing"
+import (
+	"testing"
+
+	regexp "github.com/wasilibs/go-re2"
+)
 
 func TestPrefixRegex(t *testing.T) {
 	tests := []struct {
@@ -27,6 +31,38 @@ func TestPrefixRegex(t *testing.T) {
 		got := PrefixRegex(tt.keywords)
 		if got != tt.expected {
 			t.Errorf("PrefixRegex(%v) got: %v want: %v", tt.keywords, got, tt.expected)
+		}
+	}
+}
+
+func TestPrefixRegexKeywords(t *testing.T) {
+	keywords := []string{"keyword1", "keyword2", "keyword3"}
+
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		{"keyword1 1234c4aabceeff4444442131444aab44", true},
+		{"keyword1 1234567890ABCDEF1234567890ABBBCA", false},
+		{"KEYWORD1 1234567890abcdef1234567890ababcd", true},
+		{"KEYWORD1 1234567890ABCDEF1234567890ABdaba", false},
+		{"keyword2 1234567890abcdef1234567890abeeff", true},
+		{"keyword2 1234567890ABCDEF1234567890ABadbd", false},
+		{"KEYWORD2 1234567890abcdef1234567890ababca", true},
+		{"KEYWORD2 1234567890ABCDEF1234567890ABBBBs", false},
+		{"keyword3 1234567890abcdef1234567890abccea", true},
+		{"KEYWORD3 1234567890abcdef1234567890abaabb", true},
+		{"keyword4 1234567890abcdef1234567890abzzzz", false},
+		{"keyword3 1234567890ABCDEF1234567890AB", false},
+		{"keyword4 1234567890ABCDEF1234567890AB", false},
+	}
+
+	keyPat := regexp.MustCompile(PrefixRegex(keywords) + `\b([0-9a-f]{32})\b`)
+
+	for _, tc := range testCases {
+		match := keyPat.MatchString(tc.input)
+		if match != tc.expected {
+			t.Errorf("Input: %s, Expected: %v, Got: %v", tc.input, tc.expected, match)
 		}
 	}
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The `PrefixRegex` function is used to ensure that at least one of the given keywords is within 40 characters of the capturing group that follows. This helps prevent false positives in regex matching.

However, there was an issue with the case-sensitivity handling in the function. The `(?i)` flag was used to make the keyword matching case-insensitive, but it inadvertently made the entire regex, including the capturing group, case-insensitive as well.

To fix this issue, the `pre` variable in the `PrefixRegex` function has been updated to `(?i:`. This limits the case-insensitivity to only the keyword matching portion of the regex. The capture group that follows will be matched case-sensitively.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

