### PR TITLE
Adding postman to sub-commands list

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ TruffleHog has a sub-command for each source of data that you may want to scan:
 - circleci
 - travisci
 - GCS (Google Cloud Storage)
+- postman
 
 Each subcommand can have options that you can see with the `--help` flag provided to the sub command:
 

--- a/README.md
+++ b/README.md
@@ -300,12 +300,12 @@ TruffleHog has a sub-command for each source of data that you may want to scan:
 - github
 - gitlab
 - docker
-- S3
+- s3
 - filesystem (files and directories)
 - syslog
 - circleci
 - travisci
-- GCS (Google Cloud Storage)
+- gcs (Google Cloud Storage)
 - postman
 
 Each subcommand can have options that you can see with the `--help` flag provided to the sub command:


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Postman source [was made public](https://github.com/trufflesecurity/trufflehog/commit/20dd450e0b6d62a5380b96e8151bb82e56315693) so it can now be added to the sub-command list for completeness.
Not creating Issue since this is a simple documentation update.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

