### PR TITLE
Prevent panic from flaky test

### DIFF
--- a/pkg/common/http_test.go
+++ b/pkg/common/http_test.go
@@ -24,6 +24,10 @@ func TestRetryableHTTPClientCheckRetry(t *testing.T) {
 			name:           "Retry on 500 status, give up after 3 retries",
 			responseStatus: http.StatusInternalServerError, // Server error status
 			checkRetry: func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+				if err != nil {
+					t.Errorf("expected response with 500 status, got error: %v", err)
+					return false, err
+				}
 				// The underlying transport will retry on 500 status.
 				if resp.StatusCode == http.StatusInternalServerError {
 					return true, nil
@@ -45,6 +49,10 @@ func TestRetryableHTTPClientCheckRetry(t *testing.T) {
 			name:           "Retry on 429 status, give up after 3 retries",
 			responseStatus: http.StatusTooManyRequests,
 			checkRetry: func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+				if err != nil {
+					t.Errorf("expected response with 429 status, got error: %v", err)
+					return false, err
+				}
 				// The underlying transport will retry on 429 status.
 				if resp.StatusCode == http.StatusTooManyRequests {
 					return true, nil
@@ -79,7 +87,7 @@ func TestRetryableHTTPClientCheckRetry(t *testing.T) {
 
 			// Bad linter, there is no body to close.
 			_, err = client.Do(req) //nolint:bodyclose
-			if err != nil && slices.Contains([]int{http.StatusInternalServerError, http.StatusTooManyRequests}, tc.responseStatus) {
+			if slices.Contains([]int{http.StatusInternalServerError, http.StatusTooManyRequests}, tc.responseStatus) {
 				// The underlying transport will retry on 500 and 429 status.
 				assert.Error(t, err)
 			}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Context: https://trufflehog-community.slack.com/archives/CK5PWLESK/p1715263905872769

> This test is failing intermittently because the http.Response passed to checkRetry is nil. No idea why it's happening; my best guess is that t.Parallel is creating a race condition in the test or the [github.com/hashicorp/go-retryablehttp](http://github.com/hashicorp/go-retryablehttp) library.
> https://github.com/trufflesecurity/trufflehog/blob/c7b72b98677722afac24a2bafe84bd98074129b4/pkg/common/http_test.go#L26
> 
> ```
> --- FAIL: TestRetryableHTTPClientCheckRetry (0.24s)
>     --- FAIL: TestRetryableHTTPClientCheckRetry/Retry_on_500_status,_give_up_after_3_retries (0.24s)
> panic: runtime error: invalid memory address or nil pointer dereference [recovered]
>         panic: runtime error: invalid memory address or nil pointer dereference
> [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xae436a]
> 
> goroutine 22 [running]:
> testing.tRunner.func1.2({0xb9e260, 0x12f94a0})
>         /home/user/sdk/go1.22.1/src/testing/testing.go:1631 +0x24a
> testing.tRunner.func1()
>         /home/user/sdk/go1.22.1/src/testing/testing.go:1634 +0x377
> panic({0xb9e260?, 0x12f94a0?})
>         /home/user/sdk/go1.22.1/src/runtime/panic.go:770 +0x132
> github.com/trufflesecurity/trufflehog/v3/pkg/common.TestRetryableHTTPClientCheckRetry.func1({0xc0003f3830?, 0xc0004a4120?}, 0x0?, {0x0?, 0x0?})
>         /tmp/trufflehog/pkg/common/http_test.go:32 +0x4a
> github.com/hashicorp/go-retryablehttp.(*Client).Do(0xc00041a770, 0xc000131aa0)
>         /home/user/go/pkg/mod/github.com/hashicorp/go-retryablehttp@v0.7.5/client.go:656 +0x335
> github.com/hashicorp/go-retryablehttp.(*RoundTripper).RoundTrip(0xc000131a88, 0xc00037f9e0?)
>         /home/user/go/pkg/mod/github.com/hashicorp/go-retryablehttp@v0.7.5/roundtripper.go:47 +0x72
> net/http.send(0xc00037f9e0, {0xdc1020, 0xc000131a88}, {0xc00011bc01?, 0x41a525?, 0x0?})
>         /home/user/sdk/go1.22.1/src/net/http/client.go:259 +0x5e4
> net/http.(*Client).send(0xc0003f3860, 0xc00037f9e0, {0x41217b?, 0x1?, 0x0?})
>         /home/user/sdk/go1.22.1/src/net/http/client.go:180 +0x98
> net/http.(*Client).do(0xc0003f3860, 0xc00037f9e0)
>         /home/user/sdk/go1.22.1/src/net/http/client.go:724 +0x8dc
> net/http.(*Client).Do(...)
>         /home/user/sdk/go1.22.1/src/net/http/client.go:590
> github.com/trufflesecurity/trufflehog/v3/pkg/common.TestRetryableHTTPClientCheckRetry.func4(0xc0003fe340)
>         /tmp/trufflehog/pkg/common/http_test.go:88 +0x28a
> testing.tRunner(0xc0003fe340, 0xc0003f35f0)
>         /home/user/sdk/go1.22.1/src/testing/testing.go:1689 +0xfb
> created by testing.(*T).Run in goroutine 21
>         /home/user/sdk/go1.22.1/src/testing/testing.go:1742 +0x390
> ```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

