### PR TITLE
Docker scan errors should be surfaced to the user beyond just logs

### DIFF
--- a/pkg/sources/docker/docker.go
+++ b/pkg/sources/docker/docker.go
@@ -132,6 +132,7 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 	_ = workers.Wait()
 	if scanErrs.Count() > 0 {
 		ctx.Logger().V(2).Info("scan errors", "errors", scanErrs.String())
+		return errors.New(scanErrs.String())
 	}
 
 	return nil


### PR DESCRIPTION
### Description:
Currently if a Docker image scan fails due to invalid auth in TruffleHog Enterprise, the source integration is still showing as healthy because the error is not surfaced. This PR returns the errors.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

