### PR TITLE
Add "Intra42" detector

### DIFF
--- a/pkg/detectors/intra42/intra42.go
+++ b/pkg/detectors/intra42/intra42.go
@@ -35,7 +35,7 @@ var (
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"intra", "intra42", "secret", "s-s4t2ud-", "s-s4t2af-"}
+	return []string{"s-s4t2ud-", "s-s4t2af-"}
 }
 
 // FromData will find and optionally verify Intra42 secrets in a given set of bytes.

--- a/pkg/detectors/intra42/intra42.go
+++ b/pkg/detectors/intra42/intra42.go
@@ -28,8 +28,8 @@ var (
 	defaultClient = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"intra", "intra42", "client", "secret"}) + `\b(s-s4t2(?:ud|af)-[abcdef0123456789]{64})\b`)
-	idPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"intra", "intra42", "client", "id"}) + `\b(u-s4t2(?:ud|af)-[abcdef0123456789]{64})\b`)
+	keyPat = regexp.MustCompile(`\b(s-s4t2(?:ud|af)-[abcdef0123456789]{64})\b`)
+	idPat  = regexp.MustCompile(`\b(u-s4t2(?:ud|af)-[abcdef0123456789]{64})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/intra42/intra42.go
+++ b/pkg/detectors/intra42/intra42.go
@@ -28,8 +28,8 @@ var (
 	defaultClient = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(`\b(s-s4t2(?:ud|af)-[abcdef0123456789]{64})\b`)
-	idPat  = regexp.MustCompile(`\b(u-s4t2(?:ud|af)-[abcdef0123456789]{64})\b`)
+	keyPat = regexp.MustCompile(`\b(s-s4t2(?:ud|af)-[a-f0-9]{64})\b`)
+	idPat  = regexp.MustCompile(`\b(u-s4t2(?:ud|af)-[a-f0-9]{64})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/intra42/intra42.go
+++ b/pkg/detectors/intra42/intra42.go
@@ -28,8 +28,8 @@ var (
 	defaultClient = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"intra", "intra42", "secret"}) + `\b(s-s4t2(?:ud|af)-[abcdef0123456789]{64})\b`)
-	idPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"intra", "intra42", "secret"}) + `\b(u-s4t2(?:ud|af)-[abcdef0123456789]{64})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"intra", "intra42", "client", "secret"}) + `\b(s-s4t2(?:ud|af)-[abcdef0123456789]{64})\b`)
+	idPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"intra", "intra42", "client", "id"}) + `\b(u-s4t2(?:ud|af)-[abcdef0123456789]{64})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/intra42/intra42.go
+++ b/pkg/detectors/intra42/intra42.go
@@ -1,0 +1,96 @@
+package intra42
+
+import (
+	"context"
+	"net/http"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+type Scanner struct {
+	client *http.Client
+}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	defaultClient = common.SaneHttpClient()
+	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"intra", "intra42", "token", "client"}) + `\b(s-s4t2(?:ud|af)-[abcdef0123456789]{64})\b`)
+)
+
+// Keywords are used for efficiently pre-filtering chunks.
+// Use identifiers in the secret preferably, or the provider name.
+func (s Scanner) Keywords() []string {
+	return []string{"intra", "intra42", "token", "client"}
+}
+
+// FromData will find and optionally verify Intra42 secrets in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	uniqueMatches := make(map[string]struct{})
+	for _, match := range keyPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueMatches[match[1]] = struct{}{}
+	}
+
+	for match := range uniqueMatches {
+		s1 := detectors.Result{
+			DetectorType: detectorspb.DetectorType_Intra42,
+			Raw:          []byte(match),
+		}
+
+		if verify {
+			client := s.client
+			if client == nil {
+				client = defaultClient
+			}
+
+			isVerified, extraData, verificationErr := verifyMatch(ctx, client, match)
+			s1.Verified = isVerified
+			s1.ExtraData = extraData
+			s1.SetVerificationError(verificationErr, match)
+		}
+
+		results = append(results, s1)
+	}
+
+	return
+}
+
+func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, map[string]string, error) {
+	return false, nil, nil
+	// req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://eth-mainnet.g.intra42.com/v2/"+token+"/getNFTs/?owner=vitalik.eth", nil)
+	// if err != nil {
+	// 	return false, nil, nil
+	// }
+	//
+	// res, err := client.Do(req)
+	// if err != nil {
+	// 	return false, nil, err
+	// }
+	// defer func() {
+	// 	_, _ = io.Copy(io.Discard, res.Body)
+	// 	_ = res.Body.Close()
+	// }()
+	//
+	// switch res.StatusCode {
+	// case http.StatusOK:
+	// 	// If the endpoint returns useful information, we can return it as a map.
+	// 	return true, nil, nil
+	// case http.StatusUnauthorized:
+	// 	// The secret is determinately not verified (nothing to do)
+	// 	return false, nil, nil
+	// default:
+	// 	return false, nil, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	// }
+}
+
+func (s Scanner) Type() detectorspb.DetectorType {
+	return detectorspb.DetectorType_Intra42
+}

--- a/pkg/detectors/intra42/intra42.go
+++ b/pkg/detectors/intra42/intra42.go
@@ -21,13 +21,13 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	defaultClient = common.SaneHttpClient()
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"intra", "intra42", "token", "client"}) + `\b(s-s4t2(?:ud|af)-[abcdef0123456789]{64})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"intra", "intra42", "secret"}) + `\b(s-s4t2(?:ud|af)-[abcdef0123456789]{64})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"intra", "intra42", "token", "client"}
+	return []string{"intra", "intra42", "secret", "s-s4t2ud-", "s-s4t2af-"}
 }
 
 // FromData will find and optionally verify Intra42 secrets in a given set of bytes.

--- a/pkg/detectors/intra42/intra42_test.go
+++ b/pkg/detectors/intra42/intra42_test.go
@@ -1,0 +1,221 @@
+//go:build detectors
+// +build detectors
+
+package intra42
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+func TestIntra42_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "typical pattern",
+			input: "intra_client_secret = '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'",
+			want:  []string{"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"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			chunkSpecificDetectors := make(map[ahocorasick.DetectorKey]detectors.Detector, 2)
+			ahoCorasickCore.PopulateMatchingDetectors(test.input, chunkSpecificDetectors)
+			if len(chunkSpecificDetectors) == 0 {
+				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			if err != nil {
+				t.Errorf("error = %v", err)
+				return
+			}
+
+			if len(results) != len(test.want) {
+				if len(results) == 0 {
+					t.Errorf("did not receive result")
+				} else {
+					t.Errorf("expected %d results, only received %d", len(test.want), len(results))
+				}
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.RawV2) > 0 {
+					actual[string(r.RawV2)] = struct{}{}
+				} else {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}
+
+func TestIntra42_FromChunk(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors5")
+	if err != nil {
+		t.Fatalf("could not get test secrets from GCP: %s", err)
+	}
+	secret := testSecrets.MustGetField("INTRA42")
+	inactiveSecret := testSecrets.MustGetField("INTRA42_INACTIVE")
+
+	type args struct {
+		ctx    context.Context
+		data   []byte
+		verify bool
+	}
+	tests := []struct {
+		name                string
+		s                   Scanner
+		args                args
+		want                []detectors.Result
+		wantErr             bool
+		wantVerificationErr bool
+	}{
+		{
+			name: "found, verified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a intra42 secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Intra42,
+					Verified:     true,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "found, unverified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a intra42 secret %s within but not valid", inactiveSecret)), // the secret would satisfy the regex but not pass validation
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Intra42,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "not found",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte("You cannot find the secret within"),
+				verify: true,
+			},
+			want:                nil,
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "found, would be verified if not for timeout",
+			s:    Scanner{client: common.SaneHttpClientTimeOut(1 * time.Microsecond)},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a intra42 secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Intra42,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+		{
+			name: "found, verified but unexpected api surface",
+			s:    Scanner{client: common.ConstantResponseHttpClient(404, "")},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a intra42 secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Intra42,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Intra42.FromData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if len(got[i].Raw) == 0 {
+					t.Fatalf("no raw secret present: \n %+v", got[i])
+				}
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
+				}
+			}
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
+			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
+				t.Errorf("Intra42.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			}
+		})
+	}
+}
+
+func BenchmarkFromData(benchmark *testing.B) {
+	ctx := context.Background()
+	s := Scanner{}
+	for name, data := range detectors.MustGetBenchmarkData() {
+		benchmark.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				_, err := s.FromData(ctx, false, data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/engine/defaults.go
+++ b/pkg/engine/defaults.go
@@ -347,6 +347,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/integromat"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/intercom"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/interseller"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/intra42"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/intrinio"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/invoiceocean"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/ip2location"
@@ -1604,6 +1605,7 @@ func DefaultDetectors() []detectors.Detector {
 		gcpapplicationdefaultcredentials.Scanner{},
 		wiz.Scanner{},
 		onfleet.Scanner{},
+		intra42.Scanner{},
 	}
 }
 

--- a/pkg/pb/detectorspb/detectors.pb.go
+++ b/pkg/pb/detectorspb/detectors.pb.go
@@ -7,10 +7,11 @@
 package detectorspb
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -1085,6 +1086,7 @@ const (
 	DetectorType_Wiz                                     DetectorType = 984
 	DetectorType_Pagarme                                 DetectorType = 985
 	DetectorType_Onfleet                                 DetectorType = 986
+	DetectorType_Intra42                                 DetectorType = 987
 )
 
 // Enum value maps for DetectorType.
@@ -3058,6 +3060,7 @@ var (
 		"Wiz":                              984,
 		"Pagarme":                          985,
 		"Onfleet":                          986,
+		"Intra42":                          987,
 	}
 )
 
@@ -4538,18 +4541,21 @@ func file_detectors_proto_rawDescGZIP() []byte {
 	return file_detectors_proto_rawDescData
 }
 
-var file_detectors_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_detectors_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
-var file_detectors_proto_goTypes = []interface{}{
-	(DecoderType)(0),          // 0: detectors.DecoderType
-	(DetectorType)(0),         // 1: detectors.DetectorType
-	(*Result)(nil),            // 2: detectors.Result
-	(*FalsePositiveInfo)(nil), // 3: detectors.FalsePositiveInfo
-	(*StructuredData)(nil),    // 4: detectors.StructuredData
-	(*TlsPrivateKey)(nil),     // 5: detectors.TlsPrivateKey
-	(*GitHubSSHKey)(nil),      // 6: detectors.GitHubSSHKey
-	nil,                       // 7: detectors.Result.ExtraDataEntry
-}
+var (
+	file_detectors_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+	file_detectors_proto_msgTypes  = make([]protoimpl.MessageInfo, 6)
+	file_detectors_proto_goTypes   = []interface{}{
+		(DecoderType)(0),          // 0: detectors.DecoderType
+		(DetectorType)(0),         // 1: detectors.DetectorType
+		(*Result)(nil),            // 2: detectors.Result
+		(*FalsePositiveInfo)(nil), // 3: detectors.FalsePositiveInfo
+		(*StructuredData)(nil),    // 4: detectors.StructuredData
+		(*TlsPrivateKey)(nil),     // 5: detectors.TlsPrivateKey
+		(*GitHubSSHKey)(nil),      // 6: detectors.GitHubSSHKey
+		nil,                       // 7: detectors.Result.ExtraDataEntry
+	}
+)
+
 var file_detectors_proto_depIdxs = []int32{
 	7, // 0: detectors.Result.extra_data:type_name -> detectors.Result.ExtraDataEntry
 	4, // 1: detectors.Result.structured_data:type_name -> detectors.StructuredData

--- a/pkg/pb/detectorspb/detectors.pb.go
+++ b/pkg/pb/detectorspb/detectors.pb.go
@@ -7,11 +7,10 @@
 package detectorspb
 
 import (
-	reflect "reflect"
-	sync "sync"
-
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	reflect "reflect"
+	sync "sync"
 )
 
 const (
@@ -4541,21 +4540,18 @@ func file_detectors_proto_rawDescGZIP() []byte {
 	return file_detectors_proto_rawDescData
 }
 
-var (
-	file_detectors_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-	file_detectors_proto_msgTypes  = make([]protoimpl.MessageInfo, 6)
-	file_detectors_proto_goTypes   = []interface{}{
-		(DecoderType)(0),          // 0: detectors.DecoderType
-		(DetectorType)(0),         // 1: detectors.DetectorType
-		(*Result)(nil),            // 2: detectors.Result
-		(*FalsePositiveInfo)(nil), // 3: detectors.FalsePositiveInfo
-		(*StructuredData)(nil),    // 4: detectors.StructuredData
-		(*TlsPrivateKey)(nil),     // 5: detectors.TlsPrivateKey
-		(*GitHubSSHKey)(nil),      // 6: detectors.GitHubSSHKey
-		nil,                       // 7: detectors.Result.ExtraDataEntry
-	}
-)
-
+var file_detectors_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_detectors_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_detectors_proto_goTypes = []interface{}{
+	(DecoderType)(0),          // 0: detectors.DecoderType
+	(DetectorType)(0),         // 1: detectors.DetectorType
+	(*Result)(nil),            // 2: detectors.Result
+	(*FalsePositiveInfo)(nil), // 3: detectors.FalsePositiveInfo
+	(*StructuredData)(nil),    // 4: detectors.StructuredData
+	(*TlsPrivateKey)(nil),     // 5: detectors.TlsPrivateKey
+	(*GitHubSSHKey)(nil),      // 6: detectors.GitHubSSHKey
+	nil,                       // 7: detectors.Result.ExtraDataEntry
+}
 var file_detectors_proto_depIdxs = []int32{
 	7, // 0: detectors.Result.extra_data:type_name -> detectors.Result.ExtraDataEntry
 	4, // 1: detectors.Result.structured_data:type_name -> detectors.StructuredData

--- a/pkg/pb/detectorspb/detectors.pb.go
+++ b/pkg/pb/detectorspb/detectors.pb.go
@@ -2074,6 +2074,7 @@ var (
 		984: "Wiz",
 		985: "Pagarme",
 		986: "Onfleet",
+		987: "Intra42",
 	}
 	DetectorType_value = map[string]int32{
 		"Alibaba":                               0,

--- a/proto/detectors.proto
+++ b/proto/detectors.proto
@@ -996,6 +996,7 @@ enum DetectorType {
   Wiz = 984;
   Pagarme = 985;
   Onfleet = 986;
+  Intra42 = 987;
 }
 
 message Result {


### PR DESCRIPTION
### Description:
This PR adds a new detector: `Intra42` (987)
Intra42 is the intranet and API of "42 School", a Computer-Science school.  
The API is open to all students in 57 campus around the world. It is thus often subject to credentials leaks on GitHub.  
Sensitive data is available, like administrative information, scolarship, exam grades, etc. Actions are also possible on the account of the leaked secret. If the app has elevated rights and is leaked (which happened), it can read AND modify all students data, administrative or pedagogical. The Intellectual Property (pedagogical content) may also be retrieved from the API.

OAuth2 verification is implemented, and tests with simple pattern test and some verification tests, all passing.

Test repo (with revoked secret): https://github.com/zoirj0n/42_AbuDhabi
![Screenshot from 2024-05-13 01-49-35](https://github.com/trufflesecurity/trufflehog/assets/10067226/629bea40-b248-4396-bcdc-743c6134dd73)
I noticed that on this screen, "Detector Type" appears as "987" instead of the text value "Intra42", is it normal? It seems that other detectors get their text name correctly.

Public website: https://42.fr
API doc: https://api.intra.42.fr/ (OAuth2)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

