### PR TITLE
[feat] - Support bearer auth for docker scans

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ var (
 
 	dockerScan       = cli.Command("docker", "Scan Docker Image")
 	dockerScanImages = dockerScan.Flag("image", "Docker image to scan. Use the file:// prefix to point to a local tarball, otherwise a image registry is assumed.").Required().Strings()
-	dockerScanToken  = dockerScan.Flag("token", "Docker token. Can also be provided with environment variable").Envar("DOCKER_TOKEN").String()
+	dockerScanToken  = dockerScan.Flag("token", "Docker bearer token. Can also be provided with environment variable").Envar("DOCKER_TOKEN").String()
 
 	travisCiScan      = cli.Command("travisci", "Scan TravisCI")
 	travisCiScanToken = travisCiScan.Flag("token", "TravisCI token. Can also be provided with environment variable").Envar("TRAVISCI_TOKEN").Required().String()

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/jpillora/overseer"
 	"github.com/mattn/go-isatty"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/cleantemp"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
@@ -30,7 +29,6 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/handlers"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/output"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/tui"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/updater"
@@ -150,6 +148,7 @@ var (
 
 	dockerScan       = cli.Command("docker", "Scan Docker Image")
 	dockerScanImages = dockerScan.Flag("image", "Docker image to scan. Use the file:// prefix to point to a local tarball, otherwise a image registry is assumed.").Required().Strings()
+	dockerScanToken  = dockerScan.Flag("token", "Docker token. Can also be provided with environment variable").Envar("DOCKER_TOKEN").String()
 
 	travisCiScan      = cli.Command("travisci", "Scan TravisCI")
 	travisCiScanToken = travisCiScan.Flag("token", "TravisCI token. Can also be provided with environment variable").Envar("TRAVISCI_TOKEN").Required().String()
@@ -589,17 +588,12 @@ func run(state overseer.State) {
 			logFatal(err, "Failed to scan GCS.")
 		}
 	case dockerScan.FullCommand():
-		dockerConn := sourcespb.Docker{
-			Images: *dockerScanImages,
-			Credential: &sourcespb.Docker_DockerKeychain{
-				DockerKeychain: true,
-			},
+		cfg := sources.DockerConfig{
+			BearerToken:       *dockerScanToken,
+			Images:            *dockerScanImages,
+			UseDockerKeychain: *dockerScanToken == "",
 		}
-		anyConn, err := anypb.New(&dockerConn)
-		if err != nil {
-			logFatal(err, "Failed to marshal Docker connection")
-		}
-		if err := e.ScanDocker(ctx, anyConn); err != nil {
+		if err := e.ScanDocker(ctx, cfg); err != nil {
 			logFatal(err, "Failed to scan Docker.")
 		}
 	case postmanScan.FullCommand():

--- a/pkg/engine/docker.go
+++ b/pkg/engine/docker.go
@@ -1,7 +1,6 @@
 package engine
 
 import (
-	"fmt"
 	"runtime"
 
 	"google.golang.org/protobuf/proto"
@@ -23,7 +22,7 @@ func (e *Engine) ScanDocker(ctx context.Context, c sources.DockerConfig) error {
 	case len(c.BearerToken) > 0:
 		connection.Credential = &sourcespb.Docker_BearerToken{BearerToken: c.BearerToken}
 	default:
-		return fmt.Errorf("must provide docker keychain or bearer token")
+		connection.Credential = &sourcespb.Docker_Unauthenticated{}
 	}
 
 	var conn anypb.Any

--- a/pkg/engine/docker.go
+++ b/pkg/engine/docker.go
@@ -1,23 +1,45 @@
 package engine
 
 import (
+	"fmt"
 	"runtime"
 
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/docker"
 )
 
 // ScanDocker scans a given docker connection.
-func (e *Engine) ScanDocker(ctx context.Context, conn *anypb.Any) error {
+func (e *Engine) ScanDocker(ctx context.Context, c sources.DockerConfig) error {
+	connection := &sourcespb.Docker{Images: c.Images}
+
+	switch {
+	case c.UseDockerKeychain:
+		connection.Credential = &sourcespb.Docker_DockerKeychain{DockerKeychain: true}
+	case len(c.BearerToken) > 0:
+		connection.Credential = &sourcespb.Docker_BearerToken{BearerToken: c.BearerToken}
+	default:
+		return fmt.Errorf("must provide docker keychain or bearer token")
+	}
+
+	var conn anypb.Any
+	err := anypb.MarshalFrom(&conn, connection, proto.MarshalOptions{})
+	if err != nil {
+		ctx.Logger().Error(err, "failed to marshal gitlab connection")
+		return err
+	}
+
 	sourceName := "trufflehog - docker"
 	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, docker.SourceType)
 
 	dockerSource := &docker.Source{}
-	if err := dockerSource.Init(ctx, sourceName, jobID, sourceID, true, conn, runtime.NumCPU()); err != nil {
+	if err := dockerSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return err
 	}
-	_, err := e.sourceManager.Run(ctx, sourceName, dockerSource)
+	_, err = e.sourceManager.Run(ctx, sourceName, dockerSource)
 	return err
 }

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -144,6 +144,16 @@ type SourceUnit interface {
 	Display() string
 }
 
+// DockerConfig defines the optional configuration for a Docker source.
+type DockerConfig struct {
+	// Images is the list of images to scan.
+	Images []string
+	// BearerToken is the token to use to authenticate with the source.
+	BearerToken string
+	// UseDockerKeychain determines whether to use the Docker keychain.
+	UseDockerKeychain bool
+}
+
 // GCSConfig defines the optional configuration for a GCS source.
 type GCSConfig struct {
 	// CloudCred determines whether to use cloud credentials.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR introduces a `token` CLI flag for authentication during docker scans.
### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

