### PR TITLE
add tolower to all keywords, and remove return on error for global vars

### DIFF
--- a/pkg/sources/postman/substitution_test.go
+++ b/pkg/sources/postman/substitution_test.go
@@ -46,9 +46,9 @@ func TestSource_KeywordCombinations(t *testing.T) {
 		},
 		keywords: make(map[string]struct{}),
 	}
-	s.addKeyword("keyword1")
-	s.addKeyword("keyword2")
-	s.addKeyword("keyword3")
+	s.attemptToAddKeyword("keyword1")
+	s.attemptToAddKeyword("keyword2")
+	s.attemptToAddKeyword("keyword3")
 
 	// remove that \n from the end of the string
 	got := strings.Split(strings.TrimSuffix(s.keywordCombinations("test"), "\n"), "\n")
@@ -122,9 +122,9 @@ func TestSource_FormatAndInjectKeywords(t *testing.T) {
 		},
 		keywords: make(map[string]struct{}),
 	}
-	s.addKeyword("keyword1")
-	s.addKeyword("keyword2")
-	s.addKeyword("keyword3")
+	s.attemptToAddKeyword("keyword1")
+	s.attemptToAddKeyword("keyword2")
+	s.attemptToAddKeyword("keyword3")
 
 	testCases := []struct {
 		input    []string


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Add `tolower` to all keywords, and remove return on error for global vars. This was causing issues like prematurely returning and not scanning workspaces because of the finicky global var api. Also added more "attempts" to add keywords for things like variable and auth data to support unique tokens, like Postman with `PMAK-` as the prefix.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

