### PR TITLE
Remove "finished verificationOverlap chunks" log line

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -794,7 +794,6 @@ func (e *Engine) verificationOverlapWorker(ctx context.Context) {
 	}
 
 	wgDetect.Wait()
-	ctx.Logger().V(4).Info("finished verificationOverlap chunks")
 }
 
 func (e *Engine) detectChunks(ctx context.Context) {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This log line creates a significant amount of noise when `--trace` is enabled and doesn't seem to provide any meaningful insight, as far as I can tell.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

