### PR TITLE
Update regex for Organization in Azure Devops detector

### DIFF
--- a/pkg/detectors/azuredevopspersonalaccesstoken/azuredevopspersonalaccesstoken.go
+++ b/pkg/detectors/azuredevopspersonalaccesstoken/azuredevopspersonalaccesstoken.go
@@ -24,7 +24,7 @@ var (
 	defaultClient = common.SaneHttpClient()
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"azure"}) + `\b([0-9a-z]{52})\b`)
-	orgPat = regexp.MustCompile(detectors.PrefixRegex([]string{"azure"}) + `\b([0-9a-z]{7,40})\b`)
+	orgPat = regexp.MustCompile(detectors.PrefixRegex([]string{"azure"}) + `\b([0-9a-zA-Z][0-9a-zA-Z-]{5,48}[0-9a-zA-Z])\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.


### PR DESCRIPTION
### Description:
As per [AzureDevOps documentation](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/rename-organization?view=azure-devops) about Organization renaming, The old regex is not accommodating hyphens and length conditions. This PR allows to detect correct naming of organization.

Here are some key-points from documentation about organization renaming:

      Adhere to the following guidelines when you create an organization name.

      - Use only letters from the English alphabet
      - Start your organization name with a letter or number
      - Use letters, numbers, or hyphens after the initial character
      - Ensure that your organization doesn't exceed 50 Unicode characters
      - End with a letter or number

      If you use any of the disallowed characters, you get the following error message: VS850015: The specified name is not allowed to be used: {Organization name}.


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

