### PR TITLE
Update regex for OpenAI's API key 

### DIFF
--- a/pkg/detectors/openai/openai.go
+++ b/pkg/detectors/openai/openai.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strconv"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
@@ -20,7 +21,7 @@ type Scanner struct{}
 var _ detectors.Detector = (*Scanner)(nil)
 
 // The magic string T3BlbkFJ is the base64-encoded string: OpenAI
-var keyPat = regexp.MustCompile(`\b(sk-[[:alnum:]]{20}T3BlbkFJ[[:alnum:]]{20})\b`)
+var keyPat = regexp.MustCompile(`\b(sk-[a-zA-Z0-9-]{0,50}[[:alnum:]]{20}T3BlbkFJ[[:alnum:]]{20})\b`)
 
 // TODO: Add secret context?? Information about access, ownership etc
 type orgResponse struct {


### PR DESCRIPTION
### Description:
Recently for testing I generated two kind of OpenAI’s api keys, user and service based. Both of them were not detected with the current regex.

I could not find any documentation but This is what I observed:

> 1) for user based api keys, sk-proj- is being used as prefix in keys.
> 2) for service based keys, sk-{service_name} is being used as prefix. The service name can have letters, numbers & hyphen. I manually hit and try for the length. on more than 42 characters, I got invalid service ID error. under 42, portal generated the service api key. To be on safe side, Regex allows at max 50 characters. 

To support old key format, minimum 0 is set {0,50}.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

