### PR TITLE
Update metadata for DataDog for API + APPKey

### DIFF
--- a/pkg/detectors/datadogtoken/datadogtoken.go
+++ b/pkg/detectors/datadogtoken/datadogtoken.go
@@ -36,7 +36,6 @@ type userServiceResponse struct {
 }
 
 type user struct {
-	Type       string     `json:"type"`
 	Attributes attributes `json:"attributes"`
 }
 


### PR DESCRIPTION
### Description:
In case of API + APP keys, the [API](https://docs.datadoghq.com/api/latest/users/#list-all-users) returns list of user belongs to organization with their emails along with optional information of organization.

This PR includes following information in metadata:
- Email addresses of user which are verified, not disabled and not service account. If there is no user exists of this kind then includes the email of first user.
- If there is organization information then include name and url in metadata.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

