### PR TITLE
feat: support docker image history scanning

### DIFF
--- a/pkg/sources/docker/docker.go
+++ b/pkg/sources/docker/docker.go
@@ -220,11 +220,7 @@ func (s *Source) processHistoryEntry(ctx context.Context, entryIndex int, entry 
 
 	ctx.Logger().V(2).Info("scanning image history entry", "index", entryIndex)
 
-	if err := common.CancellableWrite(ctx, chunksChan, chunk); err != nil {
-		return err
-	}
-
-	return nil
+	return common.CancellableWrite(ctx, chunksChan, chunk)
 }
 
 // processLayer processes an individual layer of an image.

--- a/pkg/sources/docker/metrics.go
+++ b/pkg/sources/docker/metrics.go
@@ -16,6 +16,14 @@ var (
 	},
 		[]string{"source_name"})
 
+	dockerHistoryEntriesScanned = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: common.MetricsNamespace,
+		Subsystem: common.MetricsSubsystem,
+		Name:      "docker_history_entries_scanned",
+		Help:      "Total number of Docker image history entries scanned.",
+	},
+		[]string{"source_name"})
+
 	dockerImagesScanned = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
 		Subsystem: common.MetricsSubsystem,


### PR DESCRIPTION
### Description

> [!NOTE]
> This PR has been created to help illustrate a possible fix for #2881. I'd be grateful for any feedback, and if this is useful, I'll follow the guidance to ready it for merge.

Enables the `docker` scanner to send image history records to the scanner. These records are generally the commands that were run to build each image layer. The entries look similar to:

```json
    {
      "created": "2024-05-24T05:26:37.56186972Z",
      "created_by": "RUN |8 PNPM_VERSION=v8.15.5 GITHUB_REGISTRY_TOKEN=ghp_ohmygodnessaleakedvalue /bin/sh -c unwise-command '${GITHUB_REGISTRY_TOKEN}' ",
      "comment": "buildkit.dockerfile.v0"
    },
```

In this example, the secret is leaked from a build argument, but it could equally be from a command line literal.

Fixes #2881 

### Questions

1. I'm currently using `image://config-file/history/index` as the filename for each history entry ([see diff](https://github.com/trufflesecurity/trufflehog/pull/2882/files#diff-ebf4fb4c65aea8ffed27f07423b39278c65970e7ea9e6905065745c3068313caR210)). Is this sufficient for identification? It doesn't look particularly flash, but I'm not sure what would be better.
2. The `Layer` in the Docker metadata is [entered as the empty string](https://github.com/trufflesecurity/trufflehog/pull/2882/files#diff-ebf4fb4c65aea8ffed27f07423b39278c65970e7ea9e6905065745c3068313caR213). If this isn't OK, I'd welcome suggestions on fixing it.
3. I [added a new metric](https://github.com/trufflesecurity/trufflehog/pull/2882/files#diff-7c3859b918ec2dbd4e563b9b02e631efc12fda1373dde17de99a8a58ed2c452aR19-R25) `docker_history_entries_scanned` for this, assuming this is the right thing to do.

### Checklist

* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

