### PR TITLE
Consistent docker image of MSSQL for integration testing.

### DIFF
--- a/pkg/detectors/jdbc/jdbc_integration_test.go
+++ b/pkg/detectors/jdbc/jdbc_integration_test.go
@@ -80,7 +80,7 @@ func TestJdbcVerified(t *testing.T) {
 	sqlServerDatabase := "master"
 
 	mssqlContainer, err := mssql.RunContainer(ctx,
-		testcontainers.WithImage("mcr.microsoft.com/mssql/server:2022-RTM-GDR1-ubuntu-20.04"),
+		testcontainers.WithImage("mcr.microsoft.com/azure-sql-edge"),
 		mssql.WithAcceptEULA(),
 		mssql.WithPassword(sqlServerPass),
 	)

--- a/pkg/detectors/jdbc/sqlserver_integration_test.go
+++ b/pkg/detectors/jdbc/sqlserver_integration_test.go
@@ -22,7 +22,7 @@ func TestSqlServer(t *testing.T) {
 	sqlServerDB := "master"
 
 	mssqlContainer, err := mssql.RunContainer(ctx,
-		testcontainers.WithImage("mcr.microsoft.com/mssql/server:2022-RTM-GDR1-ubuntu-20.04"),
+		testcontainers.WithImage("mcr.microsoft.com/azure-sql-edge"),
 		mssql.WithAcceptEULA(),
 		mssql.WithPassword(sqlServerPass),
 	)


### PR DESCRIPTION
### Description:
In [integration testing of SQL Server](https://github.com/trufflesecurity/trufflehog/blob/793231370e6ce9530fc1a302fe375c1874c5aaff/pkg/detectors/sqlserver/sqlserver_integration_test.go#L29), official Microsoft image was being used 'azure-sql-edge' and on that test case PASS. But in JDBC detector, different image was being used. To achieve consistency, This PR replaced images for MsSQL in jdbc detector by 'azure-sql-edge' in them. 

Azure-sql-edge : https://learn.microsoft.com/en-us/azure/azure-sql-edge/overview


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

