### PR TITLE
Add a flag to disable ssl verify

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ var (
 	includeDetectors     = cli.Flag("include-detectors", "Comma separated list of detector types to include. Protobuf name or IDs may be used, as well as ranges.").Default("all").String()
 	excludeDetectors     = cli.Flag("exclude-detectors", "Comma separated list of detector types to exclude. Protobuf name or IDs may be used, as well as ranges. IDs defined here take precedence over the include list.").String()
 	jobReportFile        = cli.Flag("output-report", "Write a scan report to the provided path.").Hidden().OpenFile(os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	SslVerify            = cli.Flag("ssl-verify", "Whether to verify the SSL certificates when making requests.").Default("true").Bool()
 
 	noVerificationCache = cli.Flag("no-verification-cache", "Disable verification caching").Bool()
 
@@ -300,7 +301,7 @@ func init() {
 
 	cmd = kingpin.MustParse(cli.Parse(os.Args[1:]))
 
-	// Configure logging.
+	// Configure log level.
 	switch {
 	case *trace:
 		log.SetLevel(5)
@@ -324,6 +325,10 @@ func init() {
 
 	if *noColor || *noColour {
 		color.NoColor = true // disables colorized output
+	}
+	// Disable certificate validation, if specified.
+	if !*SslVerify {
+		feature.NoVerifySsl.Store(true)
 	}
 }
 

--- a/pkg/common/http.go
+++ b/pkg/common/http.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/feature"
 )
 
@@ -208,23 +209,31 @@ func RetryableHTTPClientTimeout(timeOutSeconds int64, opts ...ClientOption) *htt
 
 const DefaultResponseTimeout = 5 * time.Second
 
-var saneTransport = &http.Transport{
-	Proxy: http.ProxyFromEnvironment,
-	DialContext: (&net.Dialer{
-		Timeout:   2 * time.Second,
-		KeepAlive: 5 * time.Second,
-	}).DialContext,
-	MaxIdleConns:          5,
-	IdleConnTimeout:       5 * time.Second,
-	TLSHandshakeTimeout:   3 * time.Second,
-	ExpectContinueTimeout: 1 * time.Second,
+func saneTransport() *http.Transport {
+	t := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   2 * time.Second,
+			KeepAlive: 5 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          5,
+		IdleConnTimeout:       5 * time.Second,
+		TLSHandshakeTimeout:   3 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	// Disable TLS certificate validation.
+	if feature.NoVerifySsl.Load() {
+		t.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+	return t
 }
 
 func SaneHttpClient() *http.Client {
-	httpClient := &http.Client{}
-	httpClient.Timeout = DefaultResponseTimeout
-	httpClient.Transport = NewCustomTransport(saneTransport)
-	return httpClient
+	client := &http.Client{}
+	client.Timeout = DefaultResponseTimeout
+	client.Transport = NewCustomTransport(saneTransport())
+	return client
 }
 
 // SaneHttpClientTimeOut adds a custom timeout for some scanners

--- a/pkg/detectors/azure_storage/storage.go
+++ b/pkg/detectors/azure_storage/storage.go
@@ -26,8 +26,6 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = detectors.DetectorHttpClientWithNoLocalAddresses
-
 	namePat = regexp.MustCompile(`(?i:Account[_.-]?Name|Storage[_.-]?(?:Account|Name))(?:.|\s){0,20}?\b([a-z0-9]{3,24})\b|([a-z0-9]{3,24})(?i:\.blob\.core\.windows\.net)`) // Names can only be lowercase alphanumeric.
 	keyPat  = regexp.MustCompile(`(?i:(?:Access|Account|Storage)[_.-]?Key)(?:.|\s){0,25}?([a-zA-Z0-9+\/-]{86,88}={0,2})`)
 
@@ -105,12 +103,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				client := s.client
-				if client == nil {
-					client = defaultClient
+				if s.client == nil {
+					s.client = detectors.GetHttpClientWithNoLocalAddresses()
 				}
 
-				isVerified, verificationErr := s.verifyMatch(ctx, client, name, key, s1.ExtraData)
+				isVerified, verificationErr := s.verifyMatch(ctx, s.client, name, key, s1.ExtraData)
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr, key)
 			}

--- a/pkg/detectors/databrickstoken/databrickstoken.go
+++ b/pkg/detectors/databrickstoken/databrickstoken.go
@@ -22,8 +22,6 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = detectors.DetectorHttpClientWithNoLocalAddresses
-
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	domain = regexp.MustCompile(`\b([a-z0-9-]+(?:\.[a-z0-9-]+)*\.(cloud\.databricks\.com|gcp\.databricks\.com|azuredatabricks\.net))\b`)
 	keyPat = regexp.MustCompile(`\b(dapi[0-9a-f]{32}(-\d)?)\b`)
@@ -57,12 +55,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				client := s.client
-				if client == nil {
-					client = defaultClient
+				if s.client == nil {
+					s.client = detectors.GetHttpClientWithNoLocalAddresses()
 				}
 
-				isVerified, verificationErr := verifyDatabricksToken(client, domain, token)
+				isVerified, verificationErr := verifyDatabricksToken(s.client, domain, token)
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr)
 

--- a/pkg/detectors/deputy/deputy.go
+++ b/pkg/detectors/deputy/deputy.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Scanner struct {
+	client *http.Client
 	detectors.DefaultMultiPartCredentialProvider
 }
 
@@ -20,8 +21,6 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = detectors.DetectorHttpClientWithNoLocalAddresses
-
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"deputy"}) + `\b([0-9a-z]{32})\b`)
 	urlPat = regexp.MustCompile(`\b([0-9a-z]{1,}\.as\.deputy\.com)\b`)
@@ -52,13 +51,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
+				if s.client == nil {
+					s.client = detectors.GetHttpClientWithNoLocalAddresses()
+				}
+
 				req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://%s/api/v1/me", resURL), nil)
 				if err != nil {
 					continue
 				}
 				req.Header.Add("Content-Type", "application/json")
 				req.Header.Add("Authorization", fmt.Sprintf("OAuth %s", resMatch))
-				res, err := client.Do(req)
+				res, err := s.client.Do(req)
 				if err == nil {
 					defer res.Body.Close()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {

--- a/pkg/detectors/jdbc/postgres.go
+++ b/pkg/detectors/jdbc/postgres.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/feature"
 
 	"github.com/lib/pq"
 )
@@ -90,7 +91,9 @@ func parsePostgres(_ logContext.Context, subname string) (jdbc, error) {
 		}
 	}
 
-	if v := u.Query()["sslmode"]; len(v) > 0 {
+	if feature.NoVerifySsl.Load() {
+		params["sslmode"] = "disable"
+	} else if v := u.Query()["sslmode"]; len(v) > 0 {
 		switch v[0] {
 		// https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION
 		case "disable", "allow", "prefer",

--- a/pkg/detectors/jdbc/sqlserver.go
+++ b/pkg/detectors/jdbc/sqlserver.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/feature"
 
 	mssql "github.com/microsoft/go-mssqldb"
 )
@@ -69,7 +70,7 @@ func parseSqlServer(ctx logContext.Context, subname string) (jdbc, error) {
 		}
 	}
 
-	urlStr := fmt.Sprintf("sqlserver://sa:%s@%s:%s?database=master&connection+timeout=5", password, host, port)
+	urlStr := fmt.Sprintf("sqlserver://sa:%s@%s:%s?database=master&connection+timeout=5&TrustServerCertificate=%t", password, host, port, !feature.NoVerifySsl.Load())
 	jdbcUrl, err := url.Parse(urlStr)
 	if err != nil {
 		ctx.Logger().WithName("jdbc").

--- a/pkg/detectors/loggly/loggly.go
+++ b/pkg/detectors/loggly/loggly.go
@@ -21,7 +21,6 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = detectors.DetectorHttpClientWithNoLocalAddresses
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	domainPat = regexp.MustCompile(`\b([a-zA-Z0-9-]+\.loggly\.com)\b`)
 	keyPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"loggly"}) + `\b([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\b`)
@@ -54,16 +53,15 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				client := s.client
-				if client == nil {
-					client = defaultClient
+				if s.client == nil {
+					s.client = detectors.GetHttpClientWithNoLocalAddresses()
 				}
 				req, err := http.NewRequestWithContext(ctx, "GET", "https://"+domainRes+"/apiv2/customer", nil)
 				if err != nil {
 					continue
 				}
 				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", key))
-				res, err := client.Do(req)
+				res, err := s.client.Do(req)
 				if err == nil {
 					defer res.Body.Close()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {

--- a/pkg/detectors/metabase/metabase.go
+++ b/pkg/detectors/metabase/metabase.go
@@ -13,7 +13,8 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{
+type Scanner struct {
+	client *http.Client
 	detectors.DefaultMultiPartCredentialProvider
 }
 
@@ -21,8 +22,6 @@ type Scanner struct{
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = detectors.DetectorHttpClientWithLocalAddresses
-
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"metabase"}) + `\b([a-zA-Z0-9-]{36})\b`)
 
@@ -61,13 +60,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
+				if s.client == nil {
+					s.client = detectors.GetHttpClientWithLocalAddresses()
+				}
+
 				u.Path = "/api/user/current"
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 				if err != nil {
 					continue
 				}
 				req.Header.Add("X-Metabase-Session", resMatch)
-				res, err := client.Do(req)
+				res, err := s.client.Do(req)
 				if err == nil {
 					defer res.Body.Close()
 					body, err := io.ReadAll(res.Body)

--- a/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
+++ b/pkg/detectors/microsoftteamswebhook/microsoftteamswebhook.go
@@ -22,8 +22,6 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = detectors.DetectorHttpClientWithNoLocalAddresses
-
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(`(https:\/\/[a-zA-Z-0-9]+\.webhook\.office\.com\/webhookb2\/[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12}\@[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12}\/IncomingWebhook\/[a-zA-Z-0-9]{32}\/[a-zA-Z-0-9]{8}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{4}-[a-zA-Z-0-9]{12})`)
 )
@@ -52,12 +50,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			client := s.client
-			if client == nil {
-				client = defaultClient
+			if s.client == nil {
+				s.client = detectors.GetHttpClientWithNoLocalAddresses()
 			}
 
-			isVerified, verificationErr := verifyWebhook(ctx, client, resMatch)
+			isVerified, verificationErr := verifyWebhook(ctx, s.client, resMatch)
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr, resMatch)
 		}

--- a/pkg/detectors/mongodb/mongodb.go
+++ b/pkg/detectors/mongodb/mongodb.go
@@ -9,6 +9,7 @@ import (
 
 	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/feature"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 
 	regexp "github.com/wasilibs/go-re2"
@@ -129,6 +130,11 @@ func verifyUri(ctx context.Context, connStr string, timeout time.Duration) (bool
 	clientOptions := options.Client().SetTimeout(timeout).ApplyURI(connStr)
 	if err := clientOptions.Validate(); err != nil {
 		return false, err
+	}
+
+	// Disable TLS certificate validation.
+	if feature.NoVerifySsl.Load() {
+		clientOptions.TLSConfig.InsecureSkipVerify = true
 	}
 
 	client, err := mongo.Connect(ctx, clientOptions)

--- a/pkg/detectors/okta/okta.go
+++ b/pkg/detectors/okta/okta.go
@@ -20,9 +20,8 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = detectors.DetectorHttpClientWithNoLocalAddresses
-	domainPat     = regexp.MustCompile(`\b[a-z0-9-]{1,40}\.okta(?:preview|-emea){0,1}\.com\b`)
-	tokenPat      = regexp.MustCompile(`\b00[a-zA-Z0-9_-]{40}\b`)
+	domainPat = regexp.MustCompile(`\b[a-z0-9-]{1,40}\.okta(?:preview|-emea){0,1}\.com\b`)
+	tokenPat  = regexp.MustCompile(`\b00[a-zA-Z0-9_-]{40}\b`)
 	// TODO: Oauth client secrets
 )
 
@@ -56,8 +55,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			if verify {
 				client := s.client
-				if client == nil {
-					client = defaultClient
+				if s.client == nil {
+					s.client = detectors.GetHttpClientWithNoLocalAddresses()
 				}
 
 				isVerified, verificationErr := verifyOktaToken(ctx, client, domain, token)

--- a/pkg/detectors/portainer/portainer.go
+++ b/pkg/detectors/portainer/portainer.go
@@ -21,7 +21,6 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = detectors.DetectorHttpClientWithLocalAddresses
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	endpointPat = regexp.MustCompile(detectors.PrefixRegex([]string{"portainer"}) + `\b(https?:\/\/\S+(:[0-9]{4,5})?)\b`)
 	tokenPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"portainer"}) + `\b(eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[0-9A-Za-z]{50,310}\.[0-9A-Z-a-z\-_]{43})\b`)
@@ -60,16 +59,15 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				client := s.client
-				if client == nil {
-					client = defaultClient
+				if s.client == nil {
+					s.client = detectors.GetHttpClientWithLocalAddresses()
 				}
 				req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 				if err != nil {
 					continue
 				}
 				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
-				res, err := client.Do(req)
+				res, err := s.client.Do(req)
 				if err == nil {
 					defer res.Body.Close()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {

--- a/pkg/detectors/repairshopr/repairshopr.go
+++ b/pkg/detectors/repairshopr/repairshopr.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Scanner struct {
+	client *http.Client
 	detectors.DefaultMultiPartCredentialProvider
 }
 
@@ -20,8 +21,6 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = detectors.DetectorHttpClientWithNoLocalAddresses
-
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat    = regexp.MustCompile(detectors.PrefixRegex([]string{"repairshopr"}) + `\b([a-zA-Z0-9-]{51})\b`)
 	domainPat = regexp.MustCompile(detectors.PrefixRegex([]string{"repairshopr"}) + `\b([a-zA-Z0-9_.!+$#^*]{3,32})\b`)
@@ -51,6 +50,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
+				if s.client == nil {
+					s.client = detectors.GetHttpClientWithNoLocalAddresses()
+				}
+
 				req, err := http.NewRequestWithContext(ctx, "GET", "https://"+resDomainMatch+".repairshopr.com/api/v1/appointment_types", nil)
 				if err != nil {
 					continue
@@ -58,7 +61,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				req.Header.Add("Accept", "application/vnd.sugester+json; version=3")
 				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
 
-				res, err := client.Do(req)
+				res, err := s.client.Do(req)
 				if err == nil {
 					defer res.Body.Close()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {

--- a/pkg/detectors/salesforce/salesforce.go
+++ b/pkg/detectors/salesforce/salesforce.go
@@ -26,7 +26,6 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = detectors.DetectorHttpClientWithNoLocalAddresses
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	accessTokenPat = regexp.MustCompile(`\b00[a-zA-Z0-9]{13}![a-zA-Z0-9_.]{96}\b`)
 	instancePat    = regexp.MustCompile(`\bhttps://[0-9a-zA-Z-\.]{1,100}\.my\.salesforce\.com\b`)
@@ -59,9 +58,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				client := s.client
-				if client == nil {
-					client = defaultClient
+				if s.client == nil {
+					s.client = detectors.GetHttpClientWithNoLocalAddresses()
 				}
 
 				req, err := http.NewRequestWithContext(ctx, "GET", instanceMatch+"/services/data/v"+currentVersion+"/query?q=SELECT+name+from+Account", nil)
@@ -70,7 +68,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				req.Header.Set("Authorization", "Bearer "+tokenMatch)
 
-				res, err := client.Do(req)
+				res, err := s.client.Do(req)
 
 				if err != nil {
 					// End execution, append Detector Result if request fails to prevent panic on response body checks

--- a/pkg/detectors/uri/uri.go
+++ b/pkg/detectors/uri/uri.go
@@ -32,9 +32,6 @@ var _ interface {
 var (
 	keyPat = regexp.MustCompile(`\bhttps?:\/\/[\w!#$%&()*+,\-./;<=>?@[\\\]^_{|}~]{0,50}:([\w!#$%&()*+,\-./:;<=>?[\\\]^_{|}~]{3,50})@[a-zA-Z0-9.-]+(?:\.[a-zA-Z]{2,})?(?::\d{1,5})?[\w/]+\b`)
 
-	// TODO: make local addr opt-out
-	defaultClient = detectors.DetectorHttpClientWithNoLocalAddresses
-
 	hostNotFoundCache = simple.NewCache[struct{}]()
 )
 
@@ -111,8 +108,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				continue
 			}
 
+			// TODO: make local addr opt-out
 			if s.client == nil {
-				s.client = defaultClient
+				s.client = detectors.GetHttpClientWithNoLocalAddresses()
 			}
 			isVerified, vErr := verifyURL(ctx, s.client, parsedURL)
 			r.Verified = isVerified

--- a/pkg/detectors/zulipchat/zulipchat.go
+++ b/pkg/detectors/zulipchat/zulipchat.go
@@ -23,8 +23,6 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = detectors.DetectorHttpClientWithNoLocalAddresses
-
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat    = regexp.MustCompile(common.BuildRegex(common.AlphaNumPattern, "", 32))
 	idPat     = regexp.MustCompile(`\b([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})\b`)
@@ -68,11 +66,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 
 				if verify {
-					client := s.client
-					if client == nil {
-						client = defaultClient
+					if s.client == nil {
+						s.client = detectors.GetHttpClientWithNoLocalAddresses()
 					}
-					verified, verificationErr := verifyResult(ctx, client, domain, id, key)
+					verified, verificationErr := verifyResult(ctx, s.client, domain, id, key)
 					s1.Verified = verified
 					s1.SetVerificationError(verificationErr)
 				}

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -8,6 +8,8 @@ var (
 	SkipAdditionalRefs atomic.Bool
 	EnableAPKHandler   atomic.Bool
 	UserAgentSuffix    AtomicString
+	// NoVerifySsl instructs supported detectors to skip SSL/TLS certificate verification.
+	NoVerifySsl atomic.Bool
 )
 
 type AtomicString struct {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This creates an experimental flag to disable SSL verification for detectors. This is useful in corporate environments where [MITMing SSL traffic is common](https://security.stackexchange.com/questions/107542/is-it-common-practice-for-companies-to-mitm-https-traffic) and certificates are replaced with self-signed ones.

This implementation is an incomplete POC.

- [ ] There may not be total coverage for http clients
- [ ] Detectors that rely on third-party libraries likely need to be configured separately. 

### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

