### PR TITLE
Make the github action work with a path as input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,8 +30,8 @@ runs:
   using: "composite"
   steps:
   - shell: bash
+    working-directory: ${{ inputs.path }}
     env:
-      REPO_PATH: ${{ inputs.path }}
       BASE: ${{ inputs.base }}
       HEAD: ${{ inputs.head }}
       ARGS: ${{ inputs.extra_args }}
@@ -43,6 +43,7 @@ runs:
       ## Scan by BASE & HEAD user inputs      ##
       ## If BASE == HEAD, exit with error     ##
       ##########################################
+      git status >/dev/null  # make sure we are in a git repostiory
       if [ -n "$BASE" ] || [ -n "$HEAD" ]; then
         if [ -n "$BASE" ]; then
           base_commit=$(git rev-parse "$BASE" 2>/dev/null) || true
@@ -54,7 +55,7 @@ runs:
         else
           head_commit=""
         fi
-        if [ $base_commit == $head_commit ] ; then
+        if [ "$base_commit" == "$head_commit" ] ; then
           echo "::error::BASE and HEAD commits are the same. TruffleHog won't scan anything. Please see documentation (https://github.com/trufflesecurity/trufflehog#octocat-trufflehog-github-action)."
           exit 1
         fi
@@ -85,7 +86,7 @@ runs:
       ##########################################
       ##          Run TruffleHog              ##
       ##########################################
-      docker run --rm -v "$REPO_PATH":/tmp -w /tmp \
+      docker run --rm -v .:/tmp -w /tmp \
       ghcr.io/trufflesecurity/trufflehog:${VERSION} \
       git file:///tmp/ \
       --since-commit \


### PR DESCRIPTION

### Description:
This change executes all shell commands relative to `path`, and makes sure that `git` is always working by running `git status` first. If the `path` is not a git repository, `git status` should give a clear error message about this.

When passing `path` as input before this change, trufflehog would:

- scan nothing (when not passing `head` or `base`)
- fail to run (when passing either or both)

I'm happy to close this PR and raise this as an issue of that is the preferred way to handle this.


### Checklist:
* [X] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

Note: `make lint` fails for me, but I have not touched any go related files. I have not investigated why this fails on my machine yet