### PR TITLE
[chore] Always log git repositories being scanned

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -550,7 +550,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 
 	gitDir := filepath.Join(path, gitDirName)
 
-	logger.V(1).Info("scanning repo", logValues...)
+	logger.Info("scanning repo", logValues...)
 
 	var depth int64
 	var lastCommitHash string
@@ -790,7 +790,7 @@ func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string,
 	if scanOptions.MaxDepth > 0 {
 		logValues = append(logValues, "max_depth", scanOptions.MaxDepth)
 	}
-	logger.V(1).Info("scanning repo", logValues...)
+	logger.Info("scanning repo", logValues...)
 
 	ctx.Logger().V(1).Info("scanning staged changes", "path", path)
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Always logs the git repositories that are being scanned for users to see.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

