### PR TITLE
Improve GitHub wiki scan errs

### DIFF
--- a/pkg/sources/github/repo.go
+++ b/pkg/sources/github/repo.go
@@ -68,12 +68,12 @@ func (s *Source) cloneRepo(
 	case *sourcespb.GitHub_BasicAuth:
 		path, repo, err = git.CloneRepoUsingToken(ctx, s.conn.GetBasicAuth().GetPassword(), repoURL, s.conn.GetBasicAuth().GetUsername())
 		if err != nil {
-			return "", nil, fmt.Errorf("error cloning repo %s: %w", repoURL, err)
+			return "", nil, err
 		}
 	case *sourcespb.GitHub_Unauthenticated:
 		path, repo, err = git.CloneRepoUsingUnauthenticated(ctx, repoURL)
 		if err != nil {
-			return "", nil, fmt.Errorf("error cloning repo %s: %w", repoURL, err)
+			return "", nil, err
 		}
 
 	case *sourcespb.GitHub_GithubApp:
@@ -84,7 +84,7 @@ func (s *Source) cloneRepo(
 
 		path, repo, err = git.CloneRepoUsingToken(ctx, s.githubToken, repoURL, s.githubUser)
 		if err != nil {
-			return "", nil, fmt.Errorf("error cloning repo %s: %w", repoURL, err)
+			return "", nil, err
 		}
 
 	case *sourcespb.GitHub_Token:
@@ -93,10 +93,10 @@ func (s *Source) cloneRepo(
 		}
 		path, repo, err = git.CloneRepoUsingToken(ctx, s.githubToken, repoURL, s.githubUser)
 		if err != nil {
-			return "", nil, fmt.Errorf("error cloning repo %s: %w", repoURL, err)
+			return "", nil, err
 		}
 	default:
-		return "", nil, fmt.Errorf("unhandled credential type for repo %s", repoURL)
+		return "", nil, fmt.Errorf("unhandled credential type for repo %s: %T", repoURL, s.conn.GetCredential())
 	}
 	return path, repo, nil
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This handles a not-uncommon edge case where GitHub's API says a repo has a wiki, and the wiki page resolves, but the repository is empty ([example](https://github.com/watson-developer-cloud/text-to-speech-nodejs/wiki)). When scanning a large org with `--include-wikis` enabled this could produce a bunch of 'false' scan errors.

It also removes redundant wrapping of clone errors to make the errors more clear.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

