### PR TITLE
[feat] - Add Support for `compareDetectionStrategies` Mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -468,27 +468,27 @@ func run(state overseer.State) {
 		if err != nil {
 			logFatal(err, "error comparing span calculators")
 		}
-	} else {
-		fmt.Println(*scanEntireChunk)
-		metrics, err := runSingleScan(ctx, scanConfig, *scanEntireChunk)
-		if err != nil {
-			logFatal(err, "error running scan")
-		}
+		return
+	}
 
-		// Print results.
-		logger.Info("finished scanning",
-			"chunks", metrics.ChunksScanned,
-			"bytes", metrics.BytesScanned,
-			"verified_secrets", metrics.VerifiedSecretsFound,
-			"unverified_secrets", metrics.UnverifiedSecretsFound,
-			"scan_duration", metrics.ScanDuration.String(),
-			"trufflehog_version", version.BuildVersion,
-		)
+	metrics, err := runSingleScan(ctx, scanConfig, *scanEntireChunk)
+	if err != nil {
+		logFatal(err, "error running scan")
+	}
 
-		if metrics.hasFoundResults && *fail {
-			logger.V(2).Info("exiting with code 183 because results were found")
-			os.Exit(183)
-		}
+	// Print results.
+	logger.Info("finished scanning",
+		"chunks", metrics.ChunksScanned,
+		"bytes", metrics.BytesScanned,
+		"verified_secrets", metrics.VerifiedSecretsFound,
+		"unverified_secrets", metrics.UnverifiedSecretsFound,
+		"scan_duration", metrics.ScanDuration.String(),
+		"trufflehog_version", version.BuildVersion,
+	)
+
+	if metrics.hasFoundResults && *fail {
+		logger.V(2).Info("exiting with code 183 because results were found")
+		os.Exit(183)
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ var (
 	allowVerificationOverlap   = cli.Flag("allow-verification-overlap", "Allow verification of similar credentials across detectors").Bool()
 	filterUnverified           = cli.Flag("filter-unverified", "Only output first unverified result per chunk per detector if there are more than one results.").Bool()
 	filterEntropy              = cli.Flag("filter-entropy", "Filter unverified results with Shannon entropy. Start with 3.0.").Float64()
-	scanEntireChunk            = cli.Flag("scan-entire-chunk", "Scan the entire chunk for secrets.").Hidden().Default("true").Bool()
+	scanEntireChunk            = cli.Flag("scan-entire-chunk", "Scan the entire chunk for secrets.").Hidden().Default("false").Bool()
 	compareDetectionStrategies = cli.Flag("compare-detection-strategies", "Compare different detection strategies for matching spans").Hidden().Default("false").Bool()
 	configFilename             = cli.Flag("config", "Path to configuration file.").ExistingFile()
 	// rules = cli.Flag("rules", "Path to file with custom rules.").String()


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR introduces a new feature, `compareDetectionStrategies` mode, which allows for the comparison of two span calculation strategies used in our detection process: the custom span calculator and the entire chunk span calculator.

When the `--compare-detection-strategies` flag is enabled, we run the scan multiple times using different engine configurations. We opted not to run the scans concurrently as this mode is intended for regression checking to identify any missed secrets, rather than for performance.

### Summary

These changes enable users to compare the effectiveness of different span calculation strategies.

Note: I'm aware there might be a more elegant solution, but this seemed like the best balance between time and effort.

![Screenshot 2024-06-04 at 6 47 33 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/6b2d1362-a95f-4c35-9c8e-7d8c150dd6cc)
![Screenshot 2024-06-04 at 6 48 33 PM](https://github.com/trufflesecurity/trufflehog/assets/21311841/89dfe979-4901-4af8-8695-6ad197f9925a)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

