### PR TITLE
Compare detection strategies per chunk/detector

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 
 	"github.com/alecthomas/kingpin/v2"
@@ -518,115 +517,67 @@ func run(state overseer.State) {
 		// default detectors, which can be further filtered by the
 		// user. The filters are applied by the engine and are only
 		// subtractive.
-		Detectors:                append(defaults.DefaultDetectors(), conf.Detectors...),
-		Verify:                   !*noVerification,
-		IncludeDetectors:         *includeDetectors,
-		ExcludeDetectors:         *excludeDetectors,
-		CustomVerifiersOnly:      *customVerifiersOnly,
-		VerifierEndpoints:        *verifiers,
-		Dispatcher:               engine.NewPrinterDispatcher(printer),
-		FilterUnverified:         *filterUnverified,
-		FilterEntropy:            *filterEntropy,
-		VerificationOverlap:      *allowVerificationOverlap,
-		Results:                  parsedResults,
-		PrintAvgDetectorTime:     *printAvgDetectorTime,
-		ShouldScanEntireChunk:    *scanEntireChunk,
-		VerificationCacheMetrics: &verificationCacheMetrics,
+		Detectors:                  append(defaults.DefaultDetectors(), conf.Detectors...),
+		Verify:                     !*noVerification,
+		IncludeDetectors:           *includeDetectors,
+		ExcludeDetectors:           *excludeDetectors,
+		CustomVerifiersOnly:        *customVerifiersOnly,
+		VerifierEndpoints:          *verifiers,
+		Dispatcher:                 engine.NewPrinterDispatcher(printer),
+		FilterUnverified:           *filterUnverified,
+		FilterEntropy:              *filterEntropy,
+		VerificationOverlap:        *allowVerificationOverlap,
+		Results:                    parsedResults,
+		PrintAvgDetectorTime:       *printAvgDetectorTime,
+		ShouldScanEntireChunk:      *scanEntireChunk,
+		CompareDetectionStrategies: *compareDetectionStrategies,
+		VerificationCacheMetrics:   &verificationCacheMetrics,
 	}
 
 	if !*noVerificationCache {
 		engConf.VerificationResultCache = simple.NewCache[detectors.Result]()
 	}
 
-	if *compareDetectionStrategies {
-		if err := compareScans(ctx, cmd, engConf); err != nil {
-			logFatal(err, "error comparing detection strategies")
-		}
-		return
-	}
-
-	metrics, err := runSingleScan(ctx, cmd, engConf)
-	if err != nil {
-		logFatal(err, "error running scan")
-	}
-
-	verificationCacheMetricsSnapshot := struct {
-		Hits                    int32
-		Misses                  int32
-		HitsWasted              int32
-		AttemptsSaved           int32
-		VerificationTimeSpentMS int64
-	}{
-		Hits:                    verificationCacheMetrics.ResultCacheHits.Load(),
-		Misses:                  verificationCacheMetrics.ResultCacheMisses.Load(),
-		HitsWasted:              verificationCacheMetrics.ResultCacheHitsWasted.Load(),
-		AttemptsSaved:           verificationCacheMetrics.CredentialVerificationsSaved.Load(),
-		VerificationTimeSpentMS: verificationCacheMetrics.FromDataVerifyTimeSpentMS.Load(),
-	}
-
-	// Print results.
-	logger.Info("finished scanning",
-		"chunks", metrics.ChunksScanned,
-		"bytes", metrics.BytesScanned,
-		"verified_secrets", metrics.VerifiedSecretsFound,
-		"unverified_secrets", metrics.UnverifiedSecretsFound,
-		"scan_duration", metrics.ScanDuration.String(),
-		"trufflehog_version", version.BuildVersion,
-		"verification_caching", verificationCacheMetricsSnapshot,
-	)
-
-	if metrics.hasFoundResults && *fail {
-		logger.V(2).Info("exiting with code 183 because results were found")
-		os.Exit(183)
-	}
-}
-
-func compareScans(ctx context.Context, cmd string, cfg engine.Config) error {
-	var (
-		entireMetrics    metrics
-		maxLengthMetrics metrics
-		err              error
-	)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	go func() {
-		defer wg.Done()
-		// Run scan with entire chunk span calculator.
-		cfg.ShouldScanEntireChunk = true
-		entireMetrics, err = runSingleScan(ctx, cmd, cfg)
+	topLevelSubCommand, _, _ := strings.Cut(cmd, " ")
+	switch topLevelSubCommand {
+	case analyzeCmd.FullCommand():
+		analyzer.Run(cmd)
+	default:
+		metrics, err := runSingleScan(ctx, cmd, engConf)
 		if err != nil {
-			ctx.Logger().Error(err, "error running scan with entire chunk span calculator")
+			logFatal(err, "error running scan")
 		}
-	}()
 
-	// Run scan with max-length span calculator.
-	maxLengthMetrics, err = runSingleScan(ctx, cmd, cfg)
-	if err != nil {
-		return fmt.Errorf("error running scan with custom span calculator: %v", err)
+		verificationCacheMetricsSnapshot := struct {
+			Hits                    int32
+			Misses                  int32
+			HitsWasted              int32
+			AttemptsSaved           int32
+			VerificationTimeSpentMS int64
+		}{
+			Hits:                    verificationCacheMetrics.ResultCacheHits.Load(),
+			Misses:                  verificationCacheMetrics.ResultCacheMisses.Load(),
+			HitsWasted:              verificationCacheMetrics.ResultCacheHitsWasted.Load(),
+			AttemptsSaved:           verificationCacheMetrics.CredentialVerificationsSaved.Load(),
+			VerificationTimeSpentMS: verificationCacheMetrics.FromDataVerifyTimeSpentMS.Load(),
+		}
+
+		// Print results.
+		logger.Info("finished scanning",
+			"chunks", metrics.ChunksScanned,
+			"bytes", metrics.BytesScanned,
+			"verified_secrets", metrics.VerifiedSecretsFound,
+			"unverified_secrets", metrics.UnverifiedSecretsFound,
+			"scan_duration", metrics.ScanDuration.String(),
+			"trufflehog_version", version.BuildVersion,
+			"verification_caching", verificationCacheMetricsSnapshot,
+		)
+
+		if metrics.hasFoundResults && *fail {
+			logger.V(2).Info("exiting with code 183 because results were found")
+			os.Exit(183)
+		}
 	}
-
-	wg.Wait()
-
-	return compareMetrics(maxLengthMetrics.Metrics, entireMetrics.Metrics)
-}
-
-func compareMetrics(customMetrics, entireMetrics engine.Metrics) error {
-	fmt.Printf("Comparison of scan results: \n")
-	fmt.Printf("Custom span - Chunks: %d, Bytes: %d, Verified Secrets: %d, Unverified Secrets: %d, Duration: %s\n",
-		customMetrics.ChunksScanned, customMetrics.BytesScanned, customMetrics.VerifiedSecretsFound, customMetrics.UnverifiedSecretsFound, customMetrics.ScanDuration.String())
-	fmt.Printf("Entire chunk - Chunks: %d, Bytes: %d, Verified Secrets: %d, Unverified Secrets: %d, Duration: %s\n",
-		entireMetrics.ChunksScanned, entireMetrics.BytesScanned, entireMetrics.VerifiedSecretsFound, entireMetrics.UnverifiedSecretsFound, entireMetrics.ScanDuration.String())
-
-	// Check for differences in scan metrics.
-	if customMetrics.ChunksScanned != entireMetrics.ChunksScanned ||
-		customMetrics.BytesScanned != entireMetrics.BytesScanned ||
-		customMetrics.VerifiedSecretsFound != entireMetrics.VerifiedSecretsFound {
-		return fmt.Errorf("scan metrics do not match")
-	}
-
-	return nil
 }
 
 type metrics struct {

--- a/pkg/engine/ahocorasick/ahocorasickcore.go
+++ b/pkg/engine/ahocorasick/ahocorasickcore.go
@@ -52,16 +52,6 @@ type spanCalculationParams struct {
 	detector   detectors.Detector
 }
 
-// EntireChunkSpanCalculator is a strategy that calculates the match span to use the entire chunk data.
-// This is used when we want to match against the full length of the provided chunk.
-type EntireChunkSpanCalculator struct{}
-
-// calculateSpan returns the match span as the length of the chunk data,
-// effectively using the entire chunk for matching.
-func (e *EntireChunkSpanCalculator) calculateSpan(params spanCalculationParams) matchSpan {
-	return matchSpan{startOffset: 0, endOffset: int64(len(params.chunkData))}
-}
-
 // adjustableSpanCalculator is a strategy that calculates match spans. It uses a default offset magnitude
 // or values provided by specific detectors to adjust the start and end indices of the span, allowing
 // for more granular control over the match.

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -152,6 +152,8 @@ type Config struct {
 
 	VerificationResultCache  verificationcache.ResultCache
 	VerificationCacheMetrics verificationcache.MetricsReporter
+
+	CompareDetectionStrategies bool
 }
 
 // Engine represents the core scanning engine responsible for detecting secrets in input data.
@@ -182,6 +184,12 @@ type Engine struct {
 	// By default, the engine will only scan a subset of the chunk if a detector matches the chunk.
 	// If this flag is set to true, the engine will scan the entire chunk.
 	scanEntireChunk bool
+	// If this flag is set to true, the engine will run two scans per chunk:
+	//  1. the entire chunk (old)
+	//  2. a subset of the chunk (new)
+	//
+	// Any discrepancies between methods will be logged.
+	compareScanStrategies bool
 
 	// ahoCorasickHandler manages the Aho-Corasick trie and related keyword lookups.
 	AhoCorasickCore *ahocorasick.Core
@@ -244,6 +252,7 @@ func NewEngine(ctx context.Context, cfg *Config) (*Engine, error) {
 		detectorWorkerMultiplier:            cfg.DetectorWorkerMultiplier,
 		notificationWorkerMultiplier:        cfg.NotificationWorkerMultiplier,
 		verificationOverlapWorkerMultiplier: cfg.VerificationOverlapWorkerMultiplier,
+		compareScanStrategies:               cfg.CompareDetectionStrategies,
 	}
 	if engine.sourceManager == nil {
 		return nil, fmt.Errorf("source manager is required")
@@ -520,14 +529,8 @@ func (e *Engine) initialize(ctx context.Context) error {
 	e.dedupeCache = cache
 	ctx.Logger().V(4).Info("engine initialized")
 
-	// Configure the EntireChunkSpanCalculator if the engine is set to scan the entire chunk.
-	var ahoCOptions []ahocorasick.CoreOption
-	if e.scanEntireChunk {
-		ahoCOptions = append(ahoCOptions, ahocorasick.WithSpanCalculator(new(ahocorasick.EntireChunkSpanCalculator)))
-	}
-
 	ctx.Logger().V(4).Info("setting up aho-corasick core")
-	e.AhoCorasickCore = ahocorasick.NewAhoCorasickCore(e.detectors, ahoCOptions...)
+	e.AhoCorasickCore = ahocorasick.NewAhoCorasickCore(e.detectors)
 	ctx.Logger().V(4).Info("set up aho-corasick core")
 
 	return nil
@@ -1036,12 +1039,25 @@ func (e *Engine) verificationOverlapWorker(ctx context.Context) {
 func (e *Engine) detectorWorker(ctx context.Context) {
 	for data := range e.detectableChunksChan {
 		start := time.Now()
-		e.detectChunk(ctx, data)
+
+		if !e.compareScanStrategies {
+			// Typical use case: scan the chunk.
+			_ = e.detectChunk(ctx, data, e.scanEntireChunk)
+		} else {
+			// --compare-detection-strategies is enabled, scan with both methods and compare results.
+			customSpanResultCount := e.detectChunk(ctx, data, false)
+			entireChunkResultCount := e.detectChunk(ctx, data, true)
+
+			if customSpanResultCount != entireChunkResultCount {
+				err := fmt.Errorf("mismatch between custom span and entire chunk: %d vs %d", customSpanResultCount, entireChunkResultCount)
+				ctx.Logger().Error(err, "Scan results do not match", "detector", data.detector.Type().String())
+			}
+		}
 		chunksDetectedLatency.Observe(float64(time.Since(start).Milliseconds()))
 	}
 }
 
-func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
+func (e *Engine) detectChunk(ctx context.Context, data detectableChunk, scanEntireChunk bool) int {
 	var start time.Time
 	if e.printAvgDetectorTime {
 		start = time.Now()
@@ -1065,8 +1081,14 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 	// The matches field of the DetectorMatch struct contains the
 	// relevant portions of the chunk data that were matched.
 	// This avoids the need for additional regex processing on the entire chunk data.
-	matches := data.detector.Matches()
-	for _, matchBytes := range matches {
+	var matchedBytes [][]byte
+	if scanEntireChunk {
+		matchedBytes = [][]byte{data.chunk.Data}
+	} else {
+		matchedBytes = data.detector.Matches()
+	}
+	resultCount := 0
+	for _, matchBytes := range matchedBytes {
 		matchCount++
 		detectBytesPerMatch.Observe(float64(len(matchBytes)))
 
@@ -1099,13 +1121,23 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 		if e.printAvgDetectorTime && len(results) > 0 {
 			elapsed := time.Since(start)
 			detectorName := results[0].DetectorType.String()
+
 			avgTimeI, ok := e.metrics.detectorAvgTime.Load(detectorName)
-			var avgTime []time.Duration
-			if ok {
-				avgTime, ok = avgTimeI.([]time.Duration)
-				if !ok {
-					return
-				}
+			if !ok {
+				ctx.Logger().Error(
+					errors.New("failed to load metric"),
+					"Unable to track detector time",
+					"detector", detectorName)
+				goto HandleResults
+			}
+
+			avgTime, ok := avgTimeI.([]time.Duration)
+			if !ok {
+				ctx.Logger().Error(
+					errors.New("failed to cast metric as []time.Duration"),
+					"Unable to track detector time",
+					"detector", detectorName)
+				goto HandleResults
 			}
 			avgTime = append(avgTime, elapsed)
 			e.metrics.detectorAvgTime.Store(detectorName, avgTime)
@@ -1120,6 +1152,10 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 			results = e.filterResults(ctx, data.detector, results)
 		}
 
+	HandleResults:
+		results = e.filterResults(ctx, data.detector, results)
+
+		resultCount += len(results)
 		for _, res := range results {
 			e.processResult(ctx, data, res, isFalsePositive)
 		}
@@ -1127,9 +1163,15 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 
 	matchesPerChunk.Observe(float64(matchCount))
 
-	ctx.Logger().V(5).Info("Finished detecting chunk")
+	// If `e.compareScanStrategies` is enabled, two scans will be run.
+	// Don't decrement the WaitGroup until both have been completed.
+	if (!e.compareScanStrategies) || (e.compareScanStrategies && !scanEntireChunk) {
+		ctx.Logger().V(5).Info("Finished detecting chunk")
 
-	data.wgDoneFn()
+		data.wgDoneFn()
+	}
+
+	return resultCount
 }
 
 func (e *Engine) filterResults(


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This is an alternative implementation to #2918, with two main advantages:

1. It only requires the data to be downloaded and parsed/chunked once
2. It provides specific context about the affected detector(s) and chunk(s), rather than vague high-level metrics which are hard to action.

**Note:** Anything I deleted wasn't necessarily because I didn't think it was useful, it was just the easiest way to implement this.

### Example

**Compare per chunk/detector**

When testing #2894 against a known true positive, it provides immediate and unambiguous feedback that there's a discrepancy. 
```sh
$ ./trufflehog github --repo="..." --token="..." --compare-detection-strategies  --allow-verification-overlap
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

2024-06-05T19:11:32-04:00       info-0  trufflehog      running source  {"source_manager_worker_id": "XlWGy", "with_units": false, "target_count": 0, "source_manager_units_configurable": true}
...
2024-06-05T19:11:34-04:00       error   trufflehog      Scan results do not match       {"detector_worker_id": "vMNq4", "chunk": {"Github":{"link":"...","repository":"...","commit":"...","email":"...","file":"...","timestamp":"2019-05-06 16:03:25 +0000","line":709}}, "detector": "KubeConfig", "error": "mismatch between custom span and entire chunk: 0 vs 1"}
```

**Compare per scan**

Information is only logged at the end, and doesn't provide any insight to _which_ chunk(s) or detector(s) were affected.
```
$ ./trufflehog github --repo="..." --token="..." --compare-detection-strategies  --allow-verification-overlap
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

2024-06-05T19:22:41-04:00       info-0  trufflehog      running source  {"source_manager_worker_id": "2xLZv", "with_units": false, "target_count": 0, "source_manager_units_configurable": true}
2024-06-05T19:22:41-04:00       info-0  trufflehog      running source  {"source_manager_worker_id": "lzBGQ", "with_units": false, "target_count": 0, "source_manager_units_configurable": true}
2024-06-05T19:22:41-04:00       info-0  trufflehog      Completed enumeration   {"num_repos": 1, "num_orgs": 0, "num_members": 0}
2024-06-05T19:22:41-04:00       info-0  trufflehog      Completed enumeration   {"num_repos": 1, "num_orgs": 0, "num_members": 0}
2024-06-05T19:22:42-04:00       info-0  trufflehog      scanning repo   {"source_manager_worker_id": "2xLZv", "repo": "..."}
2024-06-05T19:22:42-04:00       info-0  trufflehog      scanning repo   {"source_manager_worker_id": "2xLZv", "repo": "..."}
2024-06-05T19:23:39-04:00       info-0  trufflehog      scanning repo   {"source_manager_worker_id": "lzBGQ", "repo": "..."}
2024-06-05T19:23:39-04:00       info-0  trufflehog      scanning repo   {"source_manager_worker_id": "lzBGQ", "repo": "..."}
Comparison of scan results:
Custom span - Chunks: 169, Bytes: 706634, Verified Secrets: 0, Unverified Secrets: 0, Duration: 1.453095634s
Entire chunk - Chunks: 169, Bytes: 706634, Verified Secrets: 0, Unverified Secrets: 3, Duration: 1.637307744s
```

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

