### PR TITLE
Add explicit warning when an overlap is detected

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -993,7 +993,7 @@ func TestLikelyDuplicate(t *testing.T) {
 			name:     "empty strings",
 			val:      chunkSecretKey{"", detectorA.Key},
 			dupes:    map[chunkSecretKey]struct{}{{"", detectorB.Key}: {}},
-			expected: true,
+			expected: false,
 		},
 		{
 			name: "similar within threshold same detector",
@@ -1008,7 +1008,7 @@ func TestLikelyDuplicate(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			result := likelyDuplicate(ctx, tc.val, tc.dupes)
+			result, _ := likelyDuplicate(ctx, tc.val, tc.dupes)
 			if result != tc.expected {
 				t.Errorf("expected %v, got %v", tc.expected, result)
 			}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Similar to #2922, the goal of this change is to provide clear and actionable information if a detection is impacted.

The problem is currently that "verification overlap" doesn't provide useful feedback. Even if you use `--results=unknown` to see the error, it doesn't tell you which detectors overlapped.

```
2024-06-06T08:27:05-04:00       info-0  trufflehog      WARNING: A result will not be verified because more than one detector matches. You can override this behavior by using the --allow-verification-overlap flag    {"verification_overlap_worker_id": "2hlPu", "detectors": ["AzureSearchAdminKey", "AzureDevopsPersonalAccessToken"]}
```


### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

