### PR TITLE
Add `*.dia` to ignored extensions list

### DIFF
--- a/pkg/common/vars.go
+++ b/pkg/common/vars.go
@@ -12,6 +12,7 @@ var (
 		"apng": {},
 		"avif": {},
 		"bmp":  {},
+		"dia":  {}, // Open-source Visio clone
 		"gif":  {},
 		"icns": {}, // Apple icon image file
 		"ico":  {}, // Icon file


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Dia is a program similar to Visio.
https://gitlab.gnome.org/GNOME/dia


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

