### PR TITLE
[bug] - Ensure BufferedFileWriter Flushes Buffer Contents to File Correctly

### DIFF
--- a/pkg/writers/buffered_file_writer/bufferedfilewriter.go
+++ b/pkg/writers/buffered_file_writer/bufferedfilewriter.go
@@ -285,7 +285,6 @@ func (w *BufferedFileWriter) CloseForWriting() error {
 			return err
 		}
 	}
-
 	return w.file.Close()
 }
 
@@ -312,7 +311,6 @@ func (w *BufferedFileWriter) ReadSeekCloser() (io.ReadSeekCloser, error) {
 		if err != nil {
 			return nil, err
 		}
-
 		return newAutoDeletingFileReader(file), nil
 	}
 

--- a/pkg/writers/buffered_file_writer/bufferedfilewriter.go
+++ b/pkg/writers/buffered_file_writer/bufferedfilewriter.go
@@ -205,7 +205,6 @@ func (w *BufferedFileWriter) Write(data []byte) (int, error) {
 				}
 				return 0, err
 			}
-			w.buf.Reset()
 		}
 	}
 
@@ -214,7 +213,6 @@ func (w *BufferedFileWriter) Write(data []byte) (int, error) {
 		if _, err := w.buf.WriteTo(w.file); err != nil {
 			return 0, fmt.Errorf("error flushing buffer to file: %w", err)
 		}
-		w.buf.Reset()
 	}
 
 	n, err := w.file.Write(data)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
**Problem:**
The `BufferedFileWriter` was not correctly flushing the buffer contents to the file once the buffer threshold was exceeded and a file was created. This caused subsequent writes that exceeded the threshold to bypass the buffer without flushing it, leading to incorrect data in the file.

**Fix:**
Ensure that any remaining data in the buffer is always flushed to the file once a file is created, before writing new data. This guarantees that the file contains the correct data.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

