### PR TITLE
[fix] - Refactor Filtering Logic to Fix Known False Positive Handling in Overlapping Cases

### DIFF
--- a/pkg/engine/testdata/verificationoverlap_detectors_fp.yaml
+++ b/pkg/engine/testdata/verificationoverlap_detectors_fp.yaml
@@ -1,0 +1,13 @@
+# config.yaml
+detectors:
+  - name: detector1
+    keywords:
+      - sample
+    regex:
+      api_key: \b(sample-[a-zA-Z-0-9]{59})\b
+
+  - name: detector2
+    keywords:
+      - ample
+    regex:
+      api_key: \b(ssample-[a-zA-Z-0-9]{59})\b

--- a/pkg/engine/testdata/verificationoverlap_secrets_fp.txt
+++ b/pkg/engine/testdata/verificationoverlap_secrets_fp.txt
@@ -1,0 +1,2 @@
+
+POSTMAN_API_KEY="ssample-qnwfsLyRSyfCwfpHaQP1UzDhrgpWvHjbYzjpRCMshjt417zWcrzyHUArs7r"


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR fixes issue [#2888](https://github.com/trufflesecurity/trufflehog/issues/2888), where TruffleHog does not filter out known false positives in overlapping detection scenarios.

**Changes:**
1. **Extracted Filtering Logic:** Moved filtering logic into a new `filterResults` method in the `Engine` struct for reusability.
2. **Enhanced Filtering:** `filterResults` handles known false positives, cleans results, and applies entropy-based filtering.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

