### PR TITLE
Fix panic in MaxMind detector

### DIFF
--- a/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2_test.go
+++ b/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2_test.go
@@ -9,12 +9,91 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/kylelemons/godebug/pretty"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
+
+func TestMaxMind_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name: "key in URL",
+			input: `#cd /home/xtreamcodes/iptv_xtream_codes/
+#wget "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=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&suffix=tar.gz" -qO /home/xtreamcodes/iptv_xtream_codes/GeoLite2-City.mmdb.tar.gz
+#tar -xf /home/xtreamcodes/iptv_xtream_codes/GeoLite2-City.mmdb.tar.gz`,
+			want: []string{"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"},
+		},
+		{
+			name: "ENV VAR",
+			input: `BASE_URL=https://plausible.example.com
+SECRET_KEY_BASE=GLVzDZW04FzuS1gMcmBRVhwgd4Gu9YmSl/k/TqfTUXti7FLBd7aflXeQDdwCj6Cz
+TOTP_VAULT_KEY=dsxvbn3jxDd16az2QpsX5B8O+llxjQ2SJE2i5Bzx38I=
+MAXMIND_LICENSE_KEY=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
+MAXMIND_EDITION=GeoLite2-City
+GOOGLE_CLIENT_ID=...`,
+			want: []string{"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"},
+		},
+		{
+			name: "Random .conf",
+			input: `# LicenseKey is from your MaxMind account
+LicenseKey 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`,
+			want: []string{"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"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(matchedDetectors) == 0 {
+				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			if err != nil {
+				t.Errorf("error = %v", err)
+				return
+			}
+
+			if len(results) != len(test.want) {
+				if len(results) == 0 {
+					t.Errorf("did not receive result")
+				} else {
+					t.Errorf("expected %d results, only received %d", len(test.want), len(results))
+				}
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.RawV2) > 0 {
+					actual[string(r.RawV2)] = struct{}{}
+				} else {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}
 
 func TestMaxMindLicense(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This fixes a panic in the MaxMind v2 detector.

```
2024-06-09T11:08:31-04:00       error   trufflehog      goroutine 586 [running]:
runtime/debug.Stack()
        /home/user/sdk/go1.22.1/src/runtime/debug/stack.go:24 +0x5e
github.com/trufflesecurity/trufflehog/v3/pkg/common.Recover({0x4c70b80, 0xc0093b7b30})
        /tmp/trufflehog/pkg/common/recover.go:17 +0x5b
panic({0x394c4e0?, 0x6b3d500?})
        /home/user/sdk/go1.22.1/src/runtime/panic.go:770 +0x132
github.com/trufflesecurity/trufflehog/v3/pkg/detectors/maxmindlicense/v2.Scanner.FromData({}, {0x7fb5e053cca8, 0xc0093b7b30}, 0x1, {0xc008b5efd2?, 0xc0093ba460?, 0xc001cc1980?})
        /tmp/trufflehog/pkg/detectors/maxmindlicense/v2/maxmindlicense_v2.go:71 +0x653
github.com/trufflesecurity/trufflehog/v3/pkg/engine.(*Engine).detectChunk(0xc0006a2780, {0x4c70b80?, 0xc001cc1a10?}, {0xc009391320, {{0xc008b5efa0, 0x95, 0x95}, {0x3fb85b9, 0x13}, 0x1, ...}, ...})
        /tmp/trufflehog/pkg/engine/engine.go:826 +0x1b8
github.com/trufflesecurity/trufflehog/v3/pkg/engine.(*Engine).detectChunks(...)
        /tmp/trufflehog/pkg/engine/engine.go:806
github.com/trufflesecurity/trufflehog/v3/pkg/engine.(*Engine).startWorkers.func2()
        /tmp/trufflehog/pkg/engine/engine.go:527 +0x230
created by github.com/trufflesecurity/trufflehog/v3/pkg/engine.(*Engine).startWorkers in goroutine 1
        /tmp/trufflehog/pkg/engine/engine.go:523 +0x2af
        {"detector_worker_id": "wK4BB", "timeout": 10, "recover": "runtime error: invalid memory address or nil pointer dereference", "error": "panic"}
2024-06-09T11:08:31-04:00       info-0  trufflehog      sentry flush failed     {"detector_worker_id": "wK4BB", "timeout": 10}
```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

