### PR TITLE
[fix] - implement MaxSecretSizeProvider for `auth0managementapitoken` detector

### DIFF
--- a/pkg/detectors/auth0managementapitoken/auth0managementapitoken.go
+++ b/pkg/detectors/auth0managementapitoken/auth0managementapitoken.go
@@ -3,9 +3,10 @@ package auth0managementapitoken
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -18,35 +19,38 @@ type Scanner struct {
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.MaxSecretSizeProvider = (*Scanner)(nil)
 
 var (
 	client = common.SaneHttpClient()
 
 	// long jwt token but note this is default 8640000 seconds = 24 hours but could be set to maximum 2592000 seconds = 720 hours = 30 days
 	// at https://manage.auth0.com/dashboard/us/dev-63memjo3/apis/management/explorer
-	managementApiTokenPat = regexp.MustCompile(detectors.PrefixRegex([]string{"auth0"}) + `\b(ey[a-zA-Z0-9._-]+)\b`)
+	managementAPITokenPat = regexp.MustCompile(`\b(ey[a-zA-Z0-9._-]+)\b`)
 	domainPat             = regexp.MustCompile(`([a-zA-Z0-9\-]{2,16}\.[a-zA-Z0-9_-]{2,3}\.auth0\.com)`) // could be part of url
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
-func (s Scanner) Keywords() []string {
-	return []string{"auth0"}
-}
+func (s Scanner) Keywords() []string { return []string{"auth0", "ey"} }
+
+const maxSecretSize = 5000
+
+func (Scanner) MaxSecretSize() int64 { return maxSecretSize }
 
 // FromData will find and optionally verify Auth0ManagementApiToken secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
 	dataStr := string(data)
 
-	managementApiTokenMatches := managementApiTokenPat.FindAllStringSubmatch(dataStr, -1)
+	managementAPITokenMatches := managementAPITokenPat.FindAllStringSubmatch(dataStr, -1)
 	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 
-	for _, managementApiTokenMatch := range managementApiTokenMatches {
+	for _, managementApiTokenMatch := range managementAPITokenMatches {
 		if len(managementApiTokenMatch) != 2 {
 			continue
 		}
-		managementApiTokenRes := strings.TrimSpace(managementApiTokenMatch[1])
-		if len(managementApiTokenRes) < 2000 || len(managementApiTokenRes) > 5000 {
+		managementAPITokenRes := strings.TrimSpace(managementApiTokenMatch[1])
+		if len(managementAPITokenRes) < 2000 || len(managementAPITokenRes) > 5000 {
 			continue
 		}
 
@@ -59,8 +63,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_Auth0ManagementApiToken,
 				Redacted:     domainRes,
-				Raw:          []byte(managementApiTokenRes),
-				RawV2:        []byte(managementApiTokenRes + domainRes),
+				Raw:          []byte(managementAPITokenRes),
+				RawV2:        []byte(managementAPITokenRes + domainRes),
 			}
 
 			if verify {
@@ -72,7 +76,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err != nil {
 					continue
 				}
-				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", managementApiTokenRes))
+				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", managementAPITokenRes))
 				res, err := client.Do(req)
 				if err == nil {
 					defer res.Body.Close()

--- a/pkg/detectors/auth0managementapitoken/auth0managementapitoken.go
+++ b/pkg/detectors/auth0managementapitoken/auth0managementapitoken.go
@@ -32,7 +32,7 @@ var (
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
-func (s Scanner) Keywords() []string { return []string{"auth0", "ey"} }
+func (s Scanner) Keywords() []string { return []string{"auth0"} }
 
 const maxSecretSize = 5000
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR introduces the MaxSecretSizeProvider for the `auth0managementapitoken` detector. Additionally, it updates the keyword list to include `ey`, the prefix of the API token.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

