### PR TITLE
[chore] - Update `discordwebhook` detector keyword

### DIFF
--- a/pkg/detectors/discordwebhook/discordwebhook.go
+++ b/pkg/detectors/discordwebhook/discordwebhook.go
@@ -45,7 +45,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", resMatch, nil)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, resMatch, nil)
 			if err != nil {
 				continue
 			}

--- a/pkg/detectors/discordwebhook/discordwebhook.go
+++ b/pkg/detectors/discordwebhook/discordwebhook.go
@@ -2,9 +2,10 @@ package discordwebhook
 
 import (
 	"context"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -25,9 +26,7 @@ var (
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
-func (s Scanner) Keywords() []string {
-	return []string{"discord"}
-}
+func (s Scanner) Keywords() []string { return []string{"https://discord.com/api/webhooks/"} }
 
 // FromData will find and optionally verify DiscordWebhook secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
@@ -60,7 +59,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		results = append(results, s1)
-
 	}
 
 	return results, nil


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR updates the keyword for the `discordwebhook` detector to `ttps://discord.com/api/webhooks/`. This more specific keyword should reduce the number of regex matches the detector needs to process.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

