### PR TITLE
[feat] - Adding StartOffsetProvider Interface and Implementing for Specific Detectors

### DIFF
--- a/pkg/detectors/aha/aha.go
+++ b/pkg/detectors/aha/aha.go
@@ -20,7 +20,9 @@ type Scanner struct {
 
 var (
 	// Ensure the Scanner satisfies the interface at compile time.
-	_ detectors.Detector = (*Scanner)(nil)
+	_ detectors.Detector                    = (*Scanner)(nil)
+	_ detectors.MultiPartCredentialProvider = (*Scanner)(nil)
+	_ detectors.StartOffsetProvider         = (*Scanner)(nil)
 
 	defaultClient = common.SaneHttpClient()
 
@@ -31,9 +33,11 @@ var (
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
-func (s Scanner) Keywords() []string {
-	return []string{"aha"}
-}
+func (s Scanner) Keywords() []string { return []string{"aha"} }
+
+const startOffset = 512
+
+func (Scanner) StartOffset() int64 { return startOffset }
 
 func (s Scanner) getClient() *http.Client {
 	if s.client != nil {

--- a/pkg/detectors/databrickstoken/databrickstoken.go
+++ b/pkg/detectors/databrickstoken/databrickstoken.go
@@ -33,7 +33,7 @@ var (
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
-func (s Scanner) Keywords() []string { return []string{"cloud.databricks.com", "dapi"} }
+func (s Scanner) Keywords() []string { return []string{"databricks", "dapi"} }
 
 const startOffset = 512
 

--- a/pkg/detectors/databrickstoken/databrickstoken.go
+++ b/pkg/detectors/databrickstoken/databrickstoken.go
@@ -3,9 +3,10 @@ package databrickstoken
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -19,6 +20,8 @@ type Scanner struct {
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.MultiPartCredentialProvider = (*Scanner)(nil)
+var _ detectors.StartOffsetProvider = (*Scanner)(nil)
 
 var (
 	defaultClient = common.SaneHttpClient()
@@ -30,9 +33,11 @@ var (
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
-func (s Scanner) Keywords() []string {
-	return []string{"databricks", "dapi"}
-}
+func (s Scanner) Keywords() []string { return []string{"cloud.databricks.com", "dapi"} }
+
+const startOffset = 512
+
+func (Scanner) StartOffset() int64 { return startOffset }
 
 // FromData will find and optionally verify Databrickstoken secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {

--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -38,6 +38,12 @@ type MaxSecretSizeProvider interface {
 	MaxSecretSize() int64
 }
 
+// StartOffsetProvider is an optional interface that a detector can implement to
+// provide a custom start offset for the secret it finds.
+type StartOffsetProvider interface {
+	StartOffset() int64
+}
+
 // MultiPartCredentialProvider is an optional interface that a detector can implement
 // to indicate its compatibility with multi-part credentials and provide the maximum
 // secret size for the credential it finds.

--- a/pkg/detectors/gcp/gcp.go
+++ b/pkg/detectors/gcp/gcp.go
@@ -20,6 +20,7 @@ type Scanner struct{}
 var _ detectors.Detector = (*Scanner)(nil)
 var _ detectors.CustomFalsePositiveChecker = (*Scanner)(nil)
 var _ detectors.MaxSecretSizeProvider = (*Scanner)(nil)
+var _ detectors.StartOffsetProvider = (*Scanner)(nil)
 
 var (
 	keyPat = regexp.MustCompile(`\{[^{]+auth_provider_x509_cert_url[^}]+\}`)
@@ -50,10 +51,14 @@ func (s Scanner) Keywords() []string {
 	return []string{"provider_x509"}
 }
 
-const maxGCPKeySize = 4096
+const maxGCPKeySize = 2048
 
-// ProvideMaxSecretSize returns the maximum size of a secret that this detector can find.
+// MaxSecretSize returns the maximum size of a secret that this detector can find.
 func (s Scanner) MaxSecretSize() int64 { return maxGCPKeySize }
+
+const startOffset = 4096
+
+func (Scanner) StartOffset() int64 { return startOffset }
 
 // FromData will find and optionally verify GCP secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {

--- a/pkg/detectors/gcpapplicationdefaultcredentials/gcpapplicationdefaultcredentials.go
+++ b/pkg/detectors/gcpapplicationdefaultcredentials/gcpapplicationdefaultcredentials.go
@@ -26,6 +26,7 @@ type Scanner struct {
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 var _ detectors.MaxSecretSizeProvider = (*Scanner)(nil)
+var _ detectors.StartOffsetProvider = (*Scanner)(nil)
 
 var (
 	defaultClient = common.SaneHttpClient()
@@ -48,8 +49,12 @@ func (s Scanner) Keywords() []string {
 
 const maxGCPADCKeySize = 1024
 
-// ProvideMaxSecretSize returns the maximum size of a secret that this detector can find.
+// MaxSecretSize returns the maximum size of a secret that this detector can find.
 func (s Scanner) MaxSecretSize() int64 { return maxGCPADCKeySize }
+
+const startOffset = maxGCPADCKeySize
+
+func (Scanner) StartOffset() int64 { return startOffset }
 
 // FromData will find and optionally verify Gcpapplicationdefaultcredentials secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {

--- a/pkg/detectors/grafanaserviceaccount/grafanaserviceaccount.go
+++ b/pkg/detectors/grafanaserviceaccount/grafanaserviceaccount.go
@@ -3,9 +3,10 @@ package grafanaserviceaccount
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -19,6 +20,8 @@ type Scanner struct {
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.MultiPartCredentialProvider = (*Scanner)(nil)
+var _ detectors.StartOffsetProvider = (*Scanner)(nil)
 
 var (
 	defaultClient = common.SaneHttpClient()
@@ -29,9 +32,11 @@ var (
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
-func (s Scanner) Keywords() []string {
-	return []string{"glsa_"}
-}
+func (s Scanner) Keywords() []string { return []string{"glsa_", "grafana.net"} }
+
+const startOffset = 256
+
+func (Scanner) StartOffset() int64 { return startOffset }
 
 // FromData will find and optionally verify Grafanaserviceaccount secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {

--- a/pkg/detectors/liveagent/liveagent.go
+++ b/pkg/detectors/liveagent/liveagent.go
@@ -3,21 +3,24 @@ package liveagent
 import (
 	"context"
 	"encoding/json"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{
+type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
 }
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.MultiPartCredentialProvider = (*Scanner)(nil)
+var _ detectors.StartOffsetProvider = (*Scanner)(nil)
 
 var (
 	client = common.SaneHttpClient()
@@ -30,8 +33,12 @@ var (
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"liveagent", "ladesk"}
+	return []string{"liveagent", "ladesk.com"}
 }
+
+const startOffset = 256
+
+func (Scanner) StartOffset() int64 { return startOffset }
 
 type response struct {
 	Message string `json:"message"`

--- a/pkg/detectors/loggly/loggly.go
+++ b/pkg/detectors/loggly/loggly.go
@@ -3,9 +3,10 @@ package loggly
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -19,6 +20,8 @@ type Scanner struct {
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.MultiPartCredentialProvider = (*Scanner)(nil)
+var _ detectors.StartOffsetProvider = (*Scanner)(nil)
 
 var (
 	defaultClient = common.SaneHttpClient()
@@ -32,6 +35,10 @@ var (
 func (s Scanner) Keywords() []string {
 	return []string{"loggly"}
 }
+
+const startOffset = 512
+
+func (Scanner) StartOffset() int64 { return startOffset }
 
 // FromData will find and optionally verify Loggly secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {

--- a/pkg/detectors/okta/okta.go
+++ b/pkg/detectors/okta/okta.go
@@ -14,12 +14,14 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{
+type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
 }
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.MultiPartCredentialProvider = (*Scanner)(nil)
+var _ detectors.StartOffsetProvider = (*Scanner)(nil)
 
 var (
 	domainPat = regexp.MustCompile(`\b[a-z0-9-]{1,40}\.okta(?:preview|-emea){0,1}\.com\b`)
@@ -32,6 +34,10 @@ var (
 func (s Scanner) Keywords() []string {
 	return []string{".okta"}
 }
+
+const startOffset = 1024
+
+func (Scanner) StartOffset() int64 { return startOffset }
 
 // FromData will find and optionally verify Okta secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {

--- a/pkg/detectors/openvpn/openvpn.go
+++ b/pkg/detectors/openvpn/openvpn.go
@@ -21,6 +21,8 @@ type Scanner struct {
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.MultiPartCredentialProvider = (*Scanner)(nil)
+var _ detectors.StartOffsetProvider = (*Scanner)(nil)
 
 var (
 	defaultClient = common.SaneHttpClient()
@@ -32,9 +34,11 @@ var (
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
-func (s Scanner) Keywords() []string {
-	return []string{"openvpn"}
-}
+func (s Scanner) Keywords() []string { return []string{"api.openvpn.com"} }
+
+const startOffset = 512
+
+func (Scanner) StartOffset() int64 { return startOffset }
 
 // FromData will find and optionally verify Openvpn secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {

--- a/pkg/detectors/signable/signable.go
+++ b/pkg/detectors/signable/signable.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -20,6 +21,7 @@ type Scanner struct {
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.MultiPartCredentialProvider = (*Scanner)(nil)
 
 var (
 	defaultClient = common.SaneHttpClient()

--- a/pkg/detectors/zulipchat/zulipchat.go
+++ b/pkg/detectors/zulipchat/zulipchat.go
@@ -3,9 +3,10 @@ package zulipchat
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -19,6 +20,8 @@ type Scanner struct {
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.MultiPartCredentialProvider = (*Scanner)(nil)
+var _ detectors.StartOffsetProvider = (*Scanner)(nil)
 
 var (
 	defaultClient = common.SaneHttpClient()
@@ -31,9 +34,11 @@ var (
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
-func (s Scanner) Keywords() []string {
-	return []string{"zulip"}
-}
+func (s Scanner) Keywords() []string { return []string{"zulip"} }
+
+const startOffset = 1024
+
+func (Scanner) StartOffset() int64 { return startOffset }
 
 // FromData will find and optionally verify ZulipChat secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {

--- a/pkg/engine/ahocorasick/ahocorasickcore_test.go
+++ b/pkg/engine/ahocorasick/ahocorasickcore_test.go
@@ -63,6 +63,64 @@ func (testDetectorV3) Type() detectorspb.DetectorType {
 
 func (testDetectorV3) Version() int { return 1 }
 
+var _ detectors.Detector = (*testDetectorV4)(nil)
+var _ detectors.MultiPartCredentialProvider = (*testDetectorV4)(nil)
+var _ detectors.StartOffsetProvider = (*testDetectorV4)(nil)
+
+type testDetectorV4 struct{}
+
+func (testDetectorV4) FromData(context.Context, bool, []byte) ([]detectors.Result, error) {
+	return make([]detectors.Result, 0), nil
+}
+
+func (testDetectorV4) Keywords() []string { return []string{"password"} }
+
+func (testDetectorV4) Type() detectorspb.DetectorType { return TestDetectorType }
+
+func (testDetectorV4) Version() int { return 1 }
+
+func (testDetectorV4) MaxCredentialSpan() int64 { return 15 }
+
+func (testDetectorV4) StartOffset() int64 { return 5 }
+
+var _ detectors.Detector = (*testDetectorV5)(nil)
+var _ detectors.MaxSecretSizeProvider = (*testDetectorV5)(nil)
+var _ detectors.StartOffsetProvider = (*testDetectorV5)(nil)
+
+type testDetectorV5 struct{}
+
+func (testDetectorV5) FromData(context.Context, bool, []byte) ([]detectors.Result, error) {
+	return make([]detectors.Result, 0), nil
+}
+
+func (testDetectorV5) Keywords() []string { return []string{"password"} }
+
+func (testDetectorV5) Type() detectorspb.DetectorType { return TestDetectorType }
+
+func (testDetectorV5) Version() int { return 1 }
+
+func (testDetectorV5) MaxSecretSize() int64 { return 10 }
+
+func (testDetectorV5) StartOffset() int64 { return 3 }
+
+var _ detectors.Detector = (*testDetectorV6)(nil)
+var _ detectors.Detector = (*testDetectorV6)(nil)
+var _ detectors.StartOffsetProvider = (*testDetectorV6)(nil)
+
+type testDetectorV6 struct{}
+
+func (testDetectorV6) FromData(context.Context, bool, []byte) ([]detectors.Result, error) {
+	return make([]detectors.Result, 0), nil
+}
+
+func (testDetectorV6) Keywords() []string { return []string{"password"} }
+
+func (testDetectorV6) Type() detectorspb.DetectorType { return TestDetectorType }
+
+func (testDetectorV6) Version() int { return 1 }
+
+func (testDetectorV6) StartOffset() int64 { return 1 }
+
 var _ detectors.Detector = (*testDetectorV1)(nil)
 var _ detectors.Detector = (*testDetectorV2)(nil)
 var _ detectors.Versioner = (*testDetectorV1)(nil)
@@ -217,6 +275,106 @@ func TestFindDetectorMatches(t *testing.T) {
                  c libero molestie, nec mlesud ugue ugue eget. This is the second occurrence of the letter a.`,
 			expectedResult: map[DetectorKey][][]int64{
 				CreateDetectorKey(testDetectorV2{}): {{0, 856}},
+			},
+		},
+		{
+			name: "keyword in the middle of the credential; MultiPartCredentialProvider, StartOffsetProvider",
+			detectors: []detectors.Detector{
+				testDetectorV4{},
+			},
+			sampleData: "This is a password in the middle of some data; MultiPartCredentialProvider, StartOffsetProvider",
+			expectedResult: map[DetectorKey][][]int64{
+				CreateDetectorKey(testDetectorV4{}): {{5, 25}},
+			},
+		},
+		{
+			name: "keyword at the end of the credential; MultiPartCredentialProvider, StartOffsetProvider",
+			detectors: []detectors.Detector{
+				testDetectorV4{},
+			},
+			sampleData: "This data ends with a password",
+			expectedResult: map[DetectorKey][][]int64{
+				CreateDetectorKey(testDetectorV4{}): {{17, 30}},
+			},
+		},
+		{
+			name: "keyword near the start of the data; MultiPartCredentialProvider, StartOffsetProvider",
+			detectors: []detectors.Detector{
+				testDetectorV4{},
+			},
+			sampleData: "a password at the start",
+			expectedResult: map[DetectorKey][][]int64{
+				CreateDetectorKey(testDetectorV4{}): {{0, 17}},
+			},
+		},
+		{
+			name: "keyword in the middle of the credential; MaxSecretSizeProvider, StartOffsetProvider",
+			detectors: []detectors.Detector{
+				testDetectorV5{},
+			},
+			sampleData: "This is a password in the middle of some data",
+			expectedResult: map[DetectorKey][][]int64{
+				CreateDetectorKey(testDetectorV5{}): {{7, 20}},
+			},
+		},
+		{
+			name: "keyword at the end of the credential; MaxSecretSizeProvider, StartOffsetProvider",
+			detectors: []detectors.Detector{
+				testDetectorV5{},
+			},
+			sampleData: "This data ends with a password",
+			expectedResult: map[DetectorKey][][]int64{
+				CreateDetectorKey(testDetectorV5{}): {{19, 30}},
+			},
+		},
+		{
+			name: "keyword near the start of the data; MaxSecretSizeProvider, StartOffsetProvider",
+			detectors: []detectors.Detector{
+				testDetectorV5{},
+			},
+			sampleData: "a password at the start",
+			expectedResult: map[DetectorKey][][]int64{
+				CreateDetectorKey(testDetectorV5{}): {{0, 12}},
+			},
+		},
+		{
+			name: "keyword in the middle of the credential; StartOffsetProvider",
+			detectors: []detectors.Detector{
+				testDetectorV6{},
+			},
+			sampleData: "This is a password in the middle of some data",
+			expectedResult: map[DetectorKey][][]int64{
+				CreateDetectorKey(testDetectorV6{}): {{9, 45}},
+			},
+		},
+		{
+			name: "keyword at the end of the credential; StartOffsetProvider",
+			detectors: []detectors.Detector{
+				testDetectorV6{},
+			},
+			sampleData: "This data ends with a password",
+			expectedResult: map[DetectorKey][][]int64{
+				CreateDetectorKey(testDetectorV6{}): {{21, 30}},
+			},
+		},
+		{
+			name: "keyword near the start of the data; StartOffsetProvider",
+			detectors: []detectors.Detector{
+				testDetectorV6{},
+			},
+			sampleData: "a password at the start",
+			expectedResult: map[DetectorKey][][]int64{
+				CreateDetectorKey(testDetectorV6{}): {{1, 23}},
+			},
+		},
+		{
+			name: "multiple keyword in the middle of the credential; StartOffsetProvider",
+			detectors: []detectors.Detector{
+				testDetectorV6{},
+			},
+			sampleData: "This is a password in the middle of some data, and another password at the end!",
+			expectedResult: map[DetectorKey][][]int64{
+				CreateDetectorKey(testDetectorV6{}): {{9, 79}},
 			},
 		},
 		{


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR introduces a new `StartOffsetProvider` interface to enhance the span calculation strategy for detectors where keywords are not prefixes in the credentials. The `adjustableSpanCalculator` has been updated to utilize this interface, allowing for more precise control over the start index in match spans. Specific detectors can optionally implement this interface to adjust the start index accordingly.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

