### PR TITLE
Fix test compilation errors

### DIFF
--- a/pkg/detectors/gcpapplicationdefaultcredentials/gcpapplicationdefaultcredentials_test.go
+++ b/pkg/detectors/gcpapplicationdefaultcredentials/gcpapplicationdefaultcredentials_test.go
@@ -44,9 +44,8 @@ func TestGcpapplicationdefaultcredentials_Pattern(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			chunkSpecificDetectors := make(map[ahocorasick.DetectorKey]detectors.Detector, 2)
-			ahoCorasickCore.FindDetectorMatches(test.input, chunkSpecificDetectors)
-			if len(chunkSpecificDetectors) == 0 {
+			detectorMatches := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(detectorMatches) == 0 {
 				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
 				return
 			}

--- a/pkg/detectors/groq/groq_test.go
+++ b/pkg/detectors/groq/groq_test.go
@@ -35,9 +35,8 @@ func TestGroq_Pattern(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			chunkSpecificDetectors := make(map[ahocorasick.DetectorKey]detectors.Detector, 2)
-			ahoCorasickCore.PopulateMatchingDetectors(test.input, chunkSpecificDetectors)
-			if len(chunkSpecificDetectors) == 0 {
+			detectorMatches := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(detectorMatches) == 0 {
 				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
 				return
 			}

--- a/pkg/detectors/intra42/intra42_test.go
+++ b/pkg/detectors/intra42/intra42_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
@@ -39,9 +40,8 @@ intra_client_secret = 's-s4t2ud-d91c558a2ba6b47f60f690efc20a33d28c252d5bed840034
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			chunkSpecificDetectors := make(map[ahocorasick.DetectorKey]detectors.Detector, 2)
-			ahoCorasickCore.PopulateMatchingDetectors(test.input, chunkSpecificDetectors)
-			if len(chunkSpecificDetectors) == 0 {
+			detectorMatches := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(detectorMatches) == 0 {
 				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
 				return
 			}

--- a/pkg/detectors/openai/openai_test.go
+++ b/pkg/detectors/openai/openai_test.go
@@ -45,9 +45,8 @@ func TestOpenAI_Pattern(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			chunkSpecificDetectors := make(map[ahocorasick.DetectorKey]detectors.Detector, 2)
-			ahoCorasickCore.PopulateMatchingDetectors(test.input, chunkSpecificDetectors)
-			if len(chunkSpecificDetectors) == 0 {
+			detectorMatches := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(detectorMatches) == 0 {
 				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
 				return
 			}

--- a/pkg/detectors/snykkey/snykkey_test.go
+++ b/pkg/detectors/snykkey/snykkey_test.go
@@ -48,9 +48,8 @@ set PATH=%PATH%;C:\Program Files\nodejs\;C:\Program Files\Git\cmd`,
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			chunkSpecificDetectors := make(map[ahocorasick.DetectorKey]detectors.Detector, 2)
-			ahoCorasickCore.FindDetectorMatches(test.input, chunkSpecificDetectors)
-			if len(chunkSpecificDetectors) == 0 {
+			matches := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(matches) == 0 {
 				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
 				return
 			}

--- a/pkg/sources/github/github_integration_test.go
+++ b/pkg/sources/github/github_integration_test.go
@@ -59,7 +59,7 @@ func TestSource_Token(t *testing.T) {
 		memberCache:   map[string]struct{}{},
 		repoInfoCache: newRepoInfoCache(),
 	}
-	s.filteredRepoCache = s.newFilteredRepoCache(memory.New(), nil, nil)
+	s.filteredRepoCache = s.newFilteredRepoCache(memory.New[string](), nil, nil)
 
 	installationClient, err := s.enumerateWithApp(ctx, "https://api.github.com", conn.GetGithubApp())
 	assert.NoError(t, err)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
PRs #2812 and #2930 inadvertently broke a few tests. 

This wasn't noticed because Go doesn't seem to have a way to compile all tests/tags. The closest you can get is manually specifying all the tags and running a pattern that won't be matched.🤷‍♂️ 
```sh
$ go test -run=XXX_SHOULD_NEVER_MATCH_XXX -tags="detectors,integration,localInfra" ./...
```

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

