### PR TITLE
Double archive `maxDepth` until bug is fixed

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -20,7 +20,9 @@ const (
 )
 
 var (
-	maxDepth   = 5
+	// NOTE: This is a temporary workaround for |openArchive| incrementing depth twice per archive.
+	// See: https://github.com/trufflesecurity/trufflehog/issues/2942
+	maxDepth   = 5 * 2
 	maxSize    = 2 << 30 // 2 GB
 	maxTimeout = time.Duration(30) * time.Second
 )


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This is a temporary workaround to #2942.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

