### PR TITLE
Fix integration tests

### DIFF
--- a/pkg/detectors/multi_part_credential_provider_test.go
+++ b/pkg/detectors/multi_part_credential_provider_test.go
@@ -25,6 +25,7 @@ func TestMultiPartCredentialProviders(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/engine/filesystem_integration_test.go
+++ b/pkg/engine/filesystem_integration_test.go
@@ -61,11 +61,13 @@ func TestFilesystem(t *testing.T) {
 
 	// Run the scan.
 	ctx := context.Background()
-	e, err := Start(ctx,
-		WithDetectors(DefaultDetectors()...),
-		WithVerify(false),
-	)
+	e, err := NewEngine(ctx, &Config{
+		Detectors:     DefaultDetectors(),
+		SourceManager: sources.NewManager(),
+		Verify:        false,
+	})
 	assert.NoError(t, err)
+	e.Start(ctx)
 	err = e.ScanFileSystem(ctx, sources.FilesystemConfig{
 		Paths:            []string{rootDir},
 		ExcludePathsFile: filepath.Join(configDir, "exclude"),

--- a/pkg/engine/gitlab_integration_test.go
+++ b/pkg/engine/gitlab_integration_test.go
@@ -16,11 +16,13 @@ import (
 func TestGitLab(t *testing.T) {
 	// Run the scan.
 	ctx := context.Background()
-	e, err := Start(ctx,
-		WithDetectors(DefaultDetectors()...),
-		WithVerify(false),
-	)
+	e, err := NewEngine(ctx, &Config{
+		Detectors:     DefaultDetectors(),
+		SourceManager: sources.NewManager(),
+		Verify:        false,
+	})
 	assert.NoError(t, err)
+	e.Start(ctx)
 
 	secret, err := common.GetTestSecret(ctx)
 	if err != nil {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The recent engine changes (#2887) broke some integration tests. This PR fixes them. I also fixed an unrelated linter issue.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

