### PR TITLE
fix: Github CI example fails with single quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,9 +471,12 @@ If you're incorporating TruffleHog into a standalone workflow and aren't running
 ```
 ...
       - shell: bash
+        env:
+          JSON_STRING: ${{ toJson(github.event.commits) }}
         run: |
           if [ "${{ github.event_name }}" == "push" ]; then
-            echo "depth=$(($(jq length <<< '${{ toJson(github.event.commits) }}') + 2))" >> $GITHUB_ENV
+            printf '%s\n' "$JSON_STRING" > commit_info.json
+            echo "depth=$(($(jq length < commit_info.json) + 2))" >> $GITHUB_ENV
             echo "branch=${{ github.ref_name }}" >> $GITHUB_ENV
           fi
           if [ "${{ github.event_name }}" == "pull_request" ]; then


### PR DESCRIPTION
### Description:

I am proposing a fix for the CI example in the README.

When someone commits a message containing a `'`, the CI will error given the raw JSON is simply enclosed with single quotes:
```yaml
jq length <<< '${{ toJson(github.event.commits) }}'
```

cf https://github.com/huggingface/huggingface.js/pull/754 for more context

### Checklist:
* ~[ ] Tests passing (`make test-community`)?~
* ~[ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?~

