### PR TITLE
Fix giturl handling of paths containing `%`

### DIFF
--- a/pkg/giturl/giturl.go
+++ b/pkg/giturl/giturl.go
@@ -174,6 +174,7 @@ var linePattern = regexp.MustCompile(`L\d+`)
 // UpdateLinkLineNumber updates the line number in a repository link.
 // Used post-link generation to refine reported issue locations within large scanned blocks.
 func UpdateLinkLineNumber(ctx context.Context, link string, newLine int64) string {
+	link = strings.Replace(link, "%", "%25", -1)
 	parsedURL, err := url.Parse(link)
 	if err != nil {
 		ctx.Logger().Error(err, "unable to parse link to update line number", "link", link)

--- a/pkg/giturl/giturl_test.go
+++ b/pkg/giturl/giturl_test.go
@@ -290,6 +290,14 @@ func TestUpdateLinkLineNumber(t *testing.T) {
 			want: "https://github.com/coinbase/cbpay-js/issues/181",
 		},
 		{
+			name: "Encode percent",
+			args: args{
+				link:    "https://github.com/coinbase/cbpay-js/blob/abcdefg/folder/%/name",
+				newLine: int64(0),
+			},
+			want: "https://github.com/coinbase/cbpay-js/blob/abcdefg/folder/%25/name",
+		},
+		{
 			name: "Invalid link",
 			args: args{
 				link:    "definitely not a link",


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This fixes an issue where paths that contain `%` cause `UpdateLinkLineNumber` to fail.

```
parse \"https://github.com/coinbase/cbpay-js/blob/abcdefg/folder/%/name\": invalid URL escape \"%/n\"
```

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

