### PR TITLE
Disambiguate step names in `detector-tests` workflow

### DIFF
--- a/.github/workflows/detector-tests.yml
+++ b/.github/workflows/detector-tests.yml
@@ -25,13 +25,13 @@ jobs:
         with:
           workload_identity_provider: "projects/811013774421/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "github-ci-external@trufflehog-testing.iam.gserviceaccount.com"
-      - name: Test
+      - name: Test integration
         run: make test-integration
       - name: Set up gotestsum
         run: |
           go install gotest.tools/gotestsum@latest
           mkdir -p tmp/test-results
-      - name: Test
+      - name: Test detectors
         run: |
           CGO_ENABLED=1 gotestsum --junitfile tmp/test-results/test.xml --raw-command -- go test -json -tags=detectors -timeout=15m $(go list ./... | grep pkg/detectors)
       - name: Upload test results to BuildPulse for flaky test detection


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Right now, it isn't immediately clear which step failed.
![image](https://github.com/trufflesecurity/trufflehog/assets/32133502/07efc0bc-203c-4e21-be62-ee7abbe899c6)

Incidentally, is it desirable to skip detector tests when integration tests fail for any reason? Perhaps the integration test step ought to have [`continue-on-error`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error)?

Tangentially related to https://github.com/trufflesecurity/trufflehog/pull/2746#issuecomment-2088767271.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

