### PR TITLE
Ensure that `detector-tests` workflow runs detector tests

### DIFF
--- a/.github/workflows/detector-tests.yml
+++ b/.github/workflows/detector-tests.yml
@@ -26,6 +26,7 @@ jobs:
           workload_identity_provider: "projects/811013774421/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "github-ci-external@trufflehog-testing.iam.gserviceaccount.com"
       - name: Test integration
+        continue-on-error: true
         run: make test-integration
       - name: Set up gotestsum
         run: |


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This is a follow-up to #2989.

Right now, no detector tests run if there happens to be an issue with the preceding set of steps. e.g., none of the recent structural engine changes have been tested because an assertion is failing in the `gcs` integration test (https://github.com/trufflesecurity/trufflehog/actions/runs/9593821520/job/26455075295).



### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

