### PR TITLE
Return targeted scan errors

### DIFF
--- a/pkg/sources/errors.go
+++ b/pkg/sources/errors.go
@@ -70,3 +70,7 @@ var _ error = (*TargetedScanError)(nil)
 func (t TargetedScanError) Error() string {
 	return t.Err.Error()
 }
+
+func (t TargetedScanError) Unwrap() error {
+	return t.Err
+}

--- a/pkg/sources/errors.go
+++ b/pkg/sources/errors.go
@@ -58,16 +58,15 @@ func (s *ScanErrors) Errors() error {
 	return errors.Join(s.errors...)
 }
 
-// TargetedScanErrorGroup maps secret IDs to errors. It can be used by targeted scans to return error information for
-// multiple targets together.
-type TargetedScanErrorGroup map[int64]error
+// TargetedScanError is an error with a secret ID attached. Collections of them can be returned by targeted scans that
+// scan multiple targets in order to associate individual errors with individual scan targets.
+type TargetedScanError struct {
+	Err      error
+	SecretID int64
+}
 
-var _ error = (*TargetedScanErrorGroup)(nil)
+var _ error = (*TargetedScanError)(nil)
 
-func (t TargetedScanErrorGroup) Error() string {
-	var errs []error
-	for _, e := range t {
-		errs = append(errs, e)
-	}
-	return errors.Join(errs...).Error()
+func (t TargetedScanError) Error() string {
+	return t.Err.Error()
 }

--- a/pkg/sources/errors.go
+++ b/pkg/sources/errors.go
@@ -57,3 +57,17 @@ func (s *ScanErrors) Errors() error {
 	defer s.mu.RUnlock()
 	return errors.Join(s.errors...)
 }
+
+// TargetedScanErrorGroup maps secret IDs to errors. It can be used by targeted scans to return error information for
+// multiple targets together.
+type TargetedScanErrorGroup map[int64]error
+
+var _ error = (*TargetedScanErrorGroup)(nil)
+
+func (t TargetedScanErrorGroup) Error() string {
+	var errs []error
+	for _, e := range t {
+		errs = append(errs, e)
+	}
+	return errors.Join(errs...).Error()
+}

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -1514,11 +1514,17 @@ func (s *Source) chunkPullRequestComments(ctx context.Context, repoInfo repoInfo
 	return nil
 }
 
-func (s *Source) scanTargets(ctx context.Context, targets []sources.ChunkingTarget, chunksChan chan *sources.Chunk) error {
+func (s *Source) scanTargets(ctx context.Context, targets []sources.ChunkingTarget, chunksChan chan *sources.Chunk) *sources.TargetedScanErrorGroup {
+	errs := make(map[int64]error)
 	for _, tgt := range targets {
 		if err := s.scanTarget(ctx, tgt, chunksChan); err != nil {
 			ctx.Logger().Error(err, "error scanning target")
+			errs[tgt.SecretID] = err
 		}
+	}
+
+	if len(errs) > 0 {
+		return (*sources.TargetedScanErrorGroup)(&errs)
 	}
 
 	return nil

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -361,11 +361,7 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, tar
 	// Otherwise, we're scanning all data.
 	// This allows us to only scan the commit where a vulnerability was found.
 	if len(targets) > 0 {
-		targetedErrs := s.scanTargets(ctx, targets, chunksChan)
-		errs := make([]error, 0, len(targetedErrs))
-		for _, e := range targetedErrs {
-			errs = append(errs, e)
-		}
+		errs := s.scanTargets(ctx, targets, chunksChan)
 		return errors.Join(errs...)
 	}
 
@@ -1519,8 +1515,8 @@ func (s *Source) chunkPullRequestComments(ctx context.Context, repoInfo repoInfo
 	return nil
 }
 
-func (s *Source) scanTargets(ctx context.Context, targets []sources.ChunkingTarget, chunksChan chan *sources.Chunk) []*sources.TargetedScanError {
-	var errs []*sources.TargetedScanError
+func (s *Source) scanTargets(ctx context.Context, targets []sources.ChunkingTarget, chunksChan chan *sources.Chunk) []error {
+	var errs []error
 	for _, tgt := range targets {
 		if err := s.scanTarget(ctx, tgt, chunksChan); err != nil {
 			ctx.Logger().Error(err, "error scanning target")

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -18,6 +19,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-github/v62/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/anypb"
 	"gopkg.in/h2non/gock.v1"
@@ -842,5 +844,31 @@ func TestGetGistID(t *testing.T) {
 	for _, tt := range tests {
 		got := extractGistID(tt.trimmedURL)
 		assert.Equal(t, tt.expected, got)
+	}
+}
+
+// This isn't really a GitHub test, but GitHub is the only source that supports scan targeting right now, so this is
+// where I've put this targeted scan test.
+func Test_ScanMultipleTargets_MultipleErrors(t *testing.T) {
+	s := &Source{conn: &sourcespb.GitHub{}} // This test doesn't require initialization
+	ctx := context.Background()
+	chunksChan := make(chan *sources.Chunk)
+
+	targets := []sources.ChunkingTarget{
+		{SecretID: 1},
+		{SecretID: 2},
+	}
+
+	// The specific error text doesn't matter for the test, but it has to match what the source generates
+	want := []*sources.TargetedScanError{
+		{SecretID: 1, Err: errors.New("unable to cast metadata type for targeted scan")},
+		{SecretID: 2, Err: errors.New("unable to cast metadata type for targeted scan")},
+	}
+
+	err := s.Chunks(ctx, chunksChan, targets...)
+	unwrappable, ok := err.(interface{ Unwrap() []error })
+	if assert.True(t, ok, "returned error was not unwrappable") {
+		got := unwrappable.Unwrap()
+		assert.ElementsMatch(t, got, want)
 	}
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Targeted scans should return their errors so that consumers can process them. By creating a type that combines an error with a targeted secret ID, we can return these errors without having to modify the `Source` interface.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

