### PR TITLE
Clarify "no decoder found for chunk" log message

### DIFF
--- a/pkg/decoders/base64.go
+++ b/pkg/decoders/base64.go
@@ -27,6 +27,10 @@ func init() {
 	}
 }
 
+func (d *Base64) Type() detectorspb.DecoderType {
+	return detectorspb.DecoderType_BASE64
+}
+
 func (d *Base64) FromChunk(chunk *sources.Chunk) *DecodableChunk {
 	decodableChunk := &DecodableChunk{Chunk: chunk, DecoderType: d.Type()}
 	encodedSubstrings := getSubstringsOfCharacterSet(chunk.Data, 20, b64CharsetMapping, b64EndChars)

--- a/pkg/decoders/base64.go
+++ b/pkg/decoders/base64.go
@@ -71,10 +71,6 @@ func (d *Base64) FromChunk(chunk *sources.Chunk) *DecodableChunk {
 	return nil
 }
 
-func (d *Base64) Type() detectorspb.DecoderType {
-	return detectorspb.DecoderType_BASE64
-}
-
 func isASCII(b []byte) bool {
 	for i := 0; i < len(b); i++ {
 		if b[i] > unicode.MaxASCII {

--- a/pkg/decoders/escaped_unicode.go
+++ b/pkg/decoders/escaped_unicode.go
@@ -24,6 +24,10 @@ var (
 	escapePat = regexp.MustCompile(`(?i:\\{1,2}u)([a-fA-F0-9]{4})`)
 )
 
+func (d *EscapedUnicode) Type() detectorspb.DecoderType {
+	return detectorspb.DecoderType_ESCAPED_UNICODE
+}
+
 func (d *EscapedUnicode) FromChunk(chunk *sources.Chunk) *DecodableChunk {
 	if chunk == nil || len(chunk.Data) == 0 {
 		return nil

--- a/pkg/decoders/escaped_unicode.go
+++ b/pkg/decoders/escaped_unicode.go
@@ -98,10 +98,6 @@ func decodeCodePoint(input []byte) []byte {
 	return input
 }
 
-func (d *EscapedUnicode) Type() detectorspb.DecoderType {
-	return detectorspb.DecoderType_ESCAPED_UNICODE
-}
-
 func decodeEscaped(input []byte) []byte {
 	// Find all Unicode escape sequences in the input byte slice
 	indices := escapePat.FindAllSubmatchIndex(input, -1)

--- a/pkg/decoders/utf16.go
+++ b/pkg/decoders/utf16.go
@@ -11,6 +11,10 @@ import (
 
 type UTF16 struct{}
 
+func (d *UTF16) Type() detectorspb.DecoderType {
+	return detectorspb.DecoderType_UTF16
+}
+
 func (d *UTF16) FromChunk(chunk *sources.Chunk) *DecodableChunk {
 	if chunk == nil || len(chunk.Data) == 0 {
 		return nil

--- a/pkg/decoders/utf16.go
+++ b/pkg/decoders/utf16.go
@@ -32,10 +32,6 @@ func (d *UTF16) FromChunk(chunk *sources.Chunk) *DecodableChunk {
 	return nil
 }
 
-func (d *UTF16) Type() detectorspb.DecoderType {
-	return detectorspb.DecoderType_UTF16
-}
-
 // utf16ToUTF8 converts a byte slice containing UTF-16 encoded data to a UTF-8 encoded byte slice.
 func utf16ToUTF8(b []byte) ([]byte, error) {
 	var bufBE, bufLE bytes.Buffer

--- a/pkg/decoders/utf8.go
+++ b/pkg/decoders/utf8.go
@@ -10,6 +10,10 @@ import (
 
 type UTF8 struct{}
 
+func (d *UTF8) Type() detectorspb.DecoderType {
+	return detectorspb.DecoderType_PLAIN
+}
+
 func (d *UTF8) FromChunk(chunk *sources.Chunk) *DecodableChunk {
 	if chunk == nil || len(chunk.Data) == 0 {
 		return nil

--- a/pkg/decoders/utf8.go
+++ b/pkg/decoders/utf8.go
@@ -29,10 +29,6 @@ func (d *UTF8) FromChunk(chunk *sources.Chunk) *DecodableChunk {
 	return decodableChunk
 }
 
-func (d *UTF8) Type() detectorspb.DecoderType {
-	return detectorspb.DecoderType_PLAIN
-}
-
 // extractSubstrings performs similarly to the strings binutil,
 // extacting contigous portions of printable characters that we care
 // about from some bytes

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -771,7 +771,7 @@ func (e *Engine) scannerWorker(ctx context.Context) {
 			decodeLatency.WithLabelValues(decoder.Type().String(), chunk.SourceName).Observe(float64(decodeTime))
 
 			if decoded == nil {
-				ctx.Logger().V(4).Info("no decoder found for chunk", "chunk", chunk)
+				ctx.Logger().V(4).Info("decoder not applicable for chunk", "decoder", decoder.Type().String(), "chunk", chunk)
 				continue
 			}
 
@@ -797,7 +797,6 @@ func (e *Engine) scannerWorker(ctx context.Context) {
 					wgDoneFn: wgDetect.Done,
 				}
 			}
-			continue
 		}
 
 		dataSize := float64(len(chunk.Data))


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
When looking at trace logs you will see countless lines with the message: "no decoder found for chunk".

```
2024-05-01T15:10:28Z    info-4  trufflehog      finished scanning chunks        {"secret_worker_id": "MMpLT"}
2024-05-01T15:10:28Z    info-4  trufflehog      no decoder found for chunk      {"secret_worker_id": "w1TPA", "chunk": ...}
2024-05-01T15:10:28Z    info-4  trufflehog      no decoder found for chunk      {"secret_worker_id": "w1TPA", "chunk": {...}
2024-05-01T15:10:28Z    info-4  trufflehog      no decoder found for chunk      {"secret_worker_id": "w1TPA", "chunk": ...}
```

This message is unhelpful and somewhat confusing. It makes it seem like there's an issue, when in reality it's that a specific detector didn't find any content in a given chunk.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

