### PR TITLE
Fix race in `caflou` and `ldap` detectors

### DIFF
--- a/pkg/detectors/ldap/ldap.go
+++ b/pkg/detectors/ldap/ldap.go
@@ -16,12 +16,16 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
-type Scanner struct{
+type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
 }
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+
+func init() {
+	ldap.DefaultTimeout = 5 * time.Second
+}
 
 var (
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
@@ -126,8 +130,6 @@ func isErrDeterminate(err error) bool {
 
 func verifyLDAP(username, password string, ldapURL *url.URL) error {
 	// Tests with non-TLS, TLS, and STARTTLS
-
-	ldap.DefaultTimeout = 5 * time.Second
 
 	uri := ldapURL.String()
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This fixes one of the races mentioned in #3027.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

