### PR TITLE
Update Azure secretPatFmt

### DIFF
--- a/pkg/detectors/azure/azure.go
+++ b/pkg/detectors/azure/azure.go
@@ -33,7 +33,7 @@ var (
 	tenantIDPat = mustFmtPat("tenant_id", idPatFmt)
 
 	// TODO: support old patterns
-	secretPatFmt    = `(?i)(%s).{0,20}([a-z0-9_\.\-~]{34})`
+	secretPatFmt    = `(?i)(%s)[:=]?\s*([\w\-~]{24}|[\w]{32}|[\w]{40}|[\w\-~]{44}|[\w\-~]{56}|[\w\-~]{88})`
 	clientSecretPat = mustFmtPat("client_secret", secretPatFmt)
 )
 


### PR DESCRIPTION
We had a secret leak through and looks like the existing detector doesn't match Azure docs:

https://learn.microsoft.com/en-us/purview/sit-defn-client-secret-api-key

This changed regex should match what is found in the above docs:

A combination of 24 characters consisting of letters, digits, and special characters.

or

A combination of 32 characters consisting of letters and digits.

or

A combination of 40 characters consisting of letters and digits.

or

A combination of 44 characters consisting of letters, digits, and special characters.

or

A combination of 56 characters consisting of letters, digits, and special characters

or

A combination of 88 characters consisting of letters, digits, and special characters.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

### Checklist:
* [X] Tests passing (`make test-community`)?
* [X] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

