### PR TITLE
Order GitLab repos consistently

### DIFF
--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -450,8 +450,8 @@ func (s *Source) getAllProjectRepos(
 	}
 
 	const (
-		orderBy         = "last_activity_at"
-		paginationLimit = 100 // Default is 20, max is 100.
+		orderBy         = "id" // TODO: Use keyset pagination (https://docs.gitlab.com/ee/api/rest/index.html#keyset-based-pagination)
+		paginationLimit = 100  // Default is 20, max is 100.
 	)
 	listOpts := gitlab.ListOptions{PerPage: paginationLimit}
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
GitLab repo enumeration is paginated, but the requested order could change during the pagination, leading to inconsistent and incomplete lists of repos. This PR changes the ordering to based on an immutable repo property, avoiding this problem.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

