### PR TITLE
[refactor] - Free Chunk Data

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -144,7 +144,7 @@ func TestFragmentLineOffset(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			lineOffset, isIgnored := FragmentLineOffset(tt.chunk, tt.result)
+			lineOffset, isIgnored := FragmentLineOffset(tt.chunk.Data, tt.result)
 			if lineOffset != tt.expectedLine {
 				t.Errorf("Expected line offset to be %d, got %d", tt.expectedLine, lineOffset)
 			}
@@ -174,21 +174,21 @@ func setupFragmentLineOffsetBench(totalLines, needleLine int) (*sources.Chunk, *
 func BenchmarkFragmentLineOffsetStart(b *testing.B) {
 	chunk, result := setupFragmentLineOffsetBench(512, 2)
 	for i := 0; i < b.N; i++ {
-		_, _ = FragmentLineOffset(chunk, result)
+		_, _ = FragmentLineOffset(chunk.Data, result)
 	}
 }
 
 func BenchmarkFragmentLineOffsetMiddle(b *testing.B) {
 	chunk, result := setupFragmentLineOffsetBench(512, 256)
 	for i := 0; i < b.N; i++ {
-		_, _ = FragmentLineOffset(chunk, result)
+		_, _ = FragmentLineOffset(chunk.Data, result)
 	}
 }
 
 func BenchmarkFragmentLineOffsetEnd(b *testing.B) {
 	chunk, result := setupFragmentLineOffsetBench(512, 510)
 	for i := 0; i < b.N; i++ {
-		_, _ = FragmentLineOffset(chunk, result)
+		_, _ = FragmentLineOffset(chunk.Data, result)
 	}
 }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR introduces optimizations to reduce memory usage and improve efficiency in the scanner worker process.

#### Changes

1. **Memory Optimization**: 
   - Setting `chunk.Data` to `nil` to allow the GC to reclaim the memory sooner, thereby reducing overall memory usage during scans.

2. **Efficiency Improvement**:
   - Updating the `FragmentLineOffset` function to process only a subset of the chunk data, rather than the entire chunk, improving both memory overhead and processing time.


NOTE: Easier to review without whitespace.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

