### PR TITLE
chore: fix goreleaser config and command line options for goreleaser v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 builds:
   - binary: trufflehog
     ldflags:
@@ -87,7 +88,7 @@ docker_manifests:
     - ghcr.io/trufflesecurity/{{ .ProjectName }}:{{ .Version }}-amd64
     - ghcr.io/trufflesecurity/{{ .ProjectName }}:{{ .Version }}-arm64v8
 brews:
-  - tap:
+  - repository:
       owner: trufflesecurity
       name: homebrew-trufflehog
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"

--- a/Makefile
+++ b/Makefile
@@ -65,4 +65,4 @@ snifftest:
 	./hack/snifftest/snifftest.sh
 
 test-release:
-	goreleaser release --rm-dist --skip-publish --snapshot
+	goreleaser release --clean --skip-publish --snapshot


### PR DESCRIPTION
Close #3074

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

Fix the release failure.

https://github.com/trufflesecurity/trufflehog/actions/runs/9981511254/job/27585298933

```
Run goreleaser/goreleaser-action@v6
Warning: You are using 'latest' as default version. Will lock to '~> v2'.
Downloading https://github.com/goreleaser/goreleaser/releases/download/v2.1.0/goreleaser_Linux_x86_64.tar.gz
Extracting GoReleaser
/usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/5e95eb9b-dff8-48e0-9ddc-fff20f3cd786 -f /home/runner/work/_temp/3865545d-7096-44[15](https://github.com/trufflesecurity/trufflehog/actions/runs/9981511254/job/27585298933#step:8:16)-bf10-c5ad8ea8e27a
GoReleaser latest installed successfully
/opt/hostedtoolcache/goreleaser-action/2.1.0/x64/goreleaser release --rm-dist
  ⨯ command failed                                   error=unknown flag: --rm-dist
Error: The process '/opt/hostedtoolcache/goreleaser-action/2.1.0/x64/goreleaser' failed with exit code 1
```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

