### PR TITLE
fixed cloudflare global api key detector

### DIFF
--- a/pkg/detectors/cloudflareglobalapikey/cloudflareglobalapikey.go
+++ b/pkg/detectors/cloudflareglobalapikey/cloudflareglobalapikey.go
@@ -51,9 +51,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		apiKeyRes := strings.TrimSpace(apiKeyMatch[1])
 
 		for _, emailMatch := range emailMatches {
-			if len(emailMatch) != 2 {
-				continue
-			}
 			emailRes := strings.TrimSpace(emailMatch[1])
 
 			s1 := detectors.Result{


### PR DESCRIPTION
### Description:
This detector is failing due to the check on email match. when i initially submitted a PR #2101 , i fixed it there but this was not committed into the main then. Not sure why. it should have.

Also, not sure why the detector fails with the email check in place. ideally, it should work but it doesn't.

@zricethezav

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

