### PR TITLE
[perf] - Optimize FindDetectorMatch

### DIFF
--- a/pkg/engine/ahocorasick/ahocorasickcore.go
+++ b/pkg/engine/ahocorasick/ahocorasickcore.go
@@ -167,9 +167,7 @@ type matchSpan struct {
 }
 
 // addMatchSpan adds a match span to the DetectorMatch instance.
-func (d *DetectorMatch) addMatchSpan(spans ...matchSpan) {
-	d.matchSpans = append(d.matchSpans, spans...)
-}
+func (d *DetectorMatch) addMatchSpan(span matchSpan) { d.matchSpans = append(d.matchSpans, span) }
 
 // mergeMatches merges overlapping or adjacent matchSpans into a single matchSpan.
 // It updates the matchSpans field with the merged spans.

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -840,7 +840,7 @@ func TestLikelyDuplicate(t *testing.T) {
 	}
 }
 
-func BenchmarkPopulateMatchingDetectors(b *testing.B) {
+func BenchmarkFindDetectorMatches(b *testing.B) {
 	allDetectors := DefaultDetectors()
 	ac := ahocorasick.NewAhoCorasickCore(allDetectors)
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR updates the `ahoC` modules to avoid `[]byte` to `string` conversions for keywords. It leverages compiler optimization by using `runtime.mapaccess2_faststr` for `[]byte` to `string` conversion during map lookups, which does not allocate memory. Additionally, we now use the `[]byte` variant of the keywords directly with the `ahoC` library, further avoiding unnecessary `[]byte` to `string` conversions.

**Note:** The `[]byte` to `string` conversion must occur during the map lookup for the compiler to optimize it. If done elsewhere, `runtime.slicebytetostring` will allocate memory.


#### Benchmarks:



Refs:
[github issue](https://github.com/golang/go/issues/3512)
[test example](https://godbolt.org/z/9GdcWT7K4)

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

