### PR TITLE
[refactor] - Optimize memory usage for small chunks in readInChunks function

### DIFF
--- a/pkg/sources/chunker.go
+++ b/pkg/sources/chunker.go
@@ -17,9 +17,14 @@ const (
 	TotalChunkSize = ChunkSize + PeekSize
 
 	// smallChunkThresholdRatio represents the ratio of the chunk size
-	// below which a chunk is considered "small" and will be optimized.
+	// below which a chunk is considered "small" and will be optimized
+	// by creating a smaller byte slice to only accommodate the data.
+	// This prevents a mostly empty buffer, saving memory, reducing the
+	// application's memory footprint, and allowing the garbage collector
+	// to reclaim the extra space. It could also improve cache efficiency,
+	// though most operations use the slice length rather than capacity.
 	// It's expressed as a value between 0 and 1.
-	smallChunkThresholdRatio = 0.5
+	smallChunkThresholdRatio = 0.3
 )
 
 type chunkReaderConfig struct {
@@ -27,12 +32,9 @@ type chunkReaderConfig struct {
 	totalSize int
 	peekSize  int
 
-	// smallChunkThresholdRatio represents the ratio of the chunk size
-	// below which a chunk is considered "small" and will be optimized
-	// by creating a smaller byte slice to only accommodate the data.
-	// This prevents a mostly empty buffer, saving memory and reducing
-	// computations downstream from operating on a larger-than-needed chunk.
-	// It's expressed as a value between 0 and 1.
+	// smallChunkThreshold is the size below which a chunk is considered "small"
+	// and will be optimized by creating a new, smaller slice.
+	// Chunks larger than this threshold will use the original, larger slice.
 	smallChunkThreshold int
 }
 

--- a/pkg/sources/chunker.go
+++ b/pkg/sources/chunker.go
@@ -15,12 +15,25 @@ const (
 	PeekSize = 3 * 1024
 	// TotalChunkSize is the total size of a chunk with peek data.
 	TotalChunkSize = ChunkSize + PeekSize
+
+	// smallChunkThresholdRatio represents the ratio of the chunk size
+	// below which a chunk is considered "small" and will be optimized.
+	// It's expressed as a value between 0 and 1.
+	smallChunkThresholdRatio = 0.5
 )
 
 type chunkReaderConfig struct {
 	chunkSize int
 	totalSize int
 	peekSize  int
+
+	// smallChunkThresholdRatio represents the ratio of the chunk size
+	// below which a chunk is considered "small" and will be optimized
+	// by creating a smaller byte slice to only accommodate the data.
+	// This prevents a mostly empty buffer, saving memory and reducing
+	// computations downstream from operating on a larger-than-needed chunk.
+	// It's expressed as a value between 0 and 1.
+	smallChunkThreshold int
 }
 
 // ConfigOption is a function that configures a chunker.
@@ -28,16 +41,12 @@ type ConfigOption func(*chunkReaderConfig)
 
 // WithChunkSize sets the chunk size.
 func WithChunkSize(size int) ConfigOption {
-	return func(c *chunkReaderConfig) {
-		c.chunkSize = size
-	}
+	return func(c *chunkReaderConfig) { c.chunkSize = size }
 }
 
 // WithPeekSize sets the peek size.
 func WithPeekSize(size int) ConfigOption {
-	return func(c *chunkReaderConfig) {
-		c.peekSize = size
-	}
+	return func(c *chunkReaderConfig) { c.peekSize = size }
 }
 
 // ChunkResult is the output unit of a ChunkReader,
@@ -72,8 +81,9 @@ func NewChunkReader(opts ...ConfigOption) ChunkReader {
 func applyOptions(opts []ConfigOption) *chunkReaderConfig {
 	// Set defaults.
 	config := &chunkReaderConfig{
-		chunkSize: ChunkSize, // default
-		peekSize:  PeekSize,  // default
+		chunkSize:           ChunkSize, // default
+		peekSize:            PeekSize,  // default
+		smallChunkThreshold: int(float64(ChunkSize+PeekSize) * smallChunkThresholdRatio),
 	}
 
 	for _, opt := range opts {
@@ -106,8 +116,15 @@ func readInChunks(ctx context.Context, reader io.Reader, config *chunkReaderConf
 			n, err := io.ReadFull(chunkReader, chunkBytes)
 			if n > 0 {
 				peekData, _ := chunkReader.Peek(config.totalSize - n)
-				chunkBytes = append(chunkBytes[:n], peekData...)
-				chunkRes.data = chunkBytes
+				if n+len(peekData) < config.smallChunkThreshold {
+					optimizedChunk := make([]byte, n+len(peekData))
+					copy(optimizedChunk, chunkBytes[:n])
+					copy(optimizedChunk[n:], peekData)
+					chunkRes.data = optimizedChunk
+				} else {
+					chunkBytes = append(chunkBytes[:n], peekData...)
+					chunkRes.data = chunkBytes
+				}
 			}
 
 			// If there is an error other than EOF, or if we have read some bytes, send the chunk.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR introduces an optimization to reduce memory usage when processing 
small chunks of data in the readInChunks function. Key changes include:

1. Added a smallChunkThresholdRatio constant (set to 0.3) to define when 
   a chunk is considered "small".
2. Modified chunkReaderConfig to include a pre-calculated smallChunkThreshold.
3. Updated readInChunks to create a new, optimized slice only for chunks 
   smaller than the threshold.

This optimization aims to improve memory efficiency for smaller chunks 
while maintaining performance for larger ones. It should reduce unnecessary 
memory allocation and potentially improve the speed of downstream operations 
like FindDetectorMatches for smaller data chunks.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

