### PR TITLE
[chore] - Reduce `VerificationOverlapWorker`s

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -620,9 +620,8 @@ func (e *Engine) startScannerWorkers(ctx context.Context) {
 	}
 }
 
-const detectorWorkerMultiplier = 50
-
 func (e *Engine) startDetectorWorkers(ctx context.Context) {
+	const detectorWorkerMultiplier = 4
 	ctx.Logger().V(2).Info("starting detector workers", "count", e.concurrency*detectorWorkerMultiplier)
 	for worker := uint64(0); worker < uint64(e.concurrency*detectorWorkerMultiplier); worker++ {
 		e.wgDetectorWorkers.Add(1)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -636,9 +636,8 @@ func (e *Engine) startDetectorWorkers(ctx context.Context) {
 }
 
 func (e *Engine) startVerificationOverlapWorkers(ctx context.Context) {
-	const verificationOverlapWorkerMultiplier = detectorWorkerMultiplier
 	ctx.Logger().V(2).Info("starting verificationOverlap workers", "count", e.concurrency)
-	for worker := uint64(0); worker < uint64(e.concurrency*verificationOverlapWorkerMultiplier); worker++ {
+	for worker := uint64(0); worker < uint64(e.concurrency); worker++ {
 		e.verificationOverlapWg.Add(1)
 		go func() {
 			ctx := context.WithValue(ctx, "verification_overlap_worker_id", common.RandomID(5))


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR reduces the number of `verificationOverlapWorkers` to runtime.NumCPU(). Since all the work within the worker is CPU-bound, having additional workers is detrimental and causes unnecessary contention.

#### Examples:

**BEFORE**:
![Screenshot 2024-07-19 at 10 30 19 AM](https://github.com/user-attachments/assets/50fe416c-a1ea-44d4-993d-7c499bb2384f)
![Screenshot 2024-07-19 at 10 43 51 AM](https://github.com/user-attachments/assets/3bfea2f9-d89d-4806-a499-3636d90a102a)
![Screenshot 2024-07-19 at 10 52 41 AM](https://github.com/user-attachments/assets/5684528c-f054-4ed5-96d5-66ceed5ce166)



**AFTER**:
![Screenshot 2024-07-19 at 10 30 28 AM](https://github.com/user-attachments/assets/167c0f4c-eec5-49d4-9a20-931200adaa08)
![Screenshot 2024-07-19 at 10 44 02 AM](https://github.com/user-attachments/assets/722295dd-9028-4c72-a91c-9233702772a7)
![Screenshot 2024-07-19 at 10 50 28 AM](https://github.com/user-attachments/assets/fa1c4a0b-4d0d-4ac0-8881-e3ec328b523a)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

