### PR TITLE
[bug]-  Invalid Seek for Non-Seekable Readers

### DIFF
--- a/pkg/handlers/ar_test.go
+++ b/pkg/handlers/ar_test.go
@@ -20,6 +20,7 @@ func TestHandleARFile(t *testing.T) {
 
 	rdr, err := newFileReader(file)
 	assert.NoError(t, err)
+	defer rdr.Close()
 
 	handler := newARHandler()
 	archiveChan, err := handler.HandleFile(context.AddLogger(ctx), rdr)

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -24,7 +24,7 @@ var (
 	// See: https://github.com/trufflesecurity/trufflehog/issues/2942
 	maxDepth   = 5 * 2
 	maxSize    = 2 << 30 // 2 GB
-	maxTimeout = time.Duration(3000) * time.Second
+	maxTimeout = time.Duration(30) * time.Second
 )
 
 // SetArchiveMaxSize sets the maximum size of the archive.

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -24,7 +24,7 @@ var (
 	// See: https://github.com/trufflesecurity/trufflehog/issues/2942
 	maxDepth   = 5 * 2
 	maxSize    = 2 << 30 // 2 GB
-	maxTimeout = time.Duration(30) * time.Second
+	maxTimeout = time.Duration(3000) * time.Second
 )
 
 // SetArchiveMaxSize sets the maximum size of the archive.
@@ -111,6 +111,7 @@ func (h *archiveHandler) openArchive(ctx logContext.Context, depth int, reader f
 			}
 			return fmt.Errorf("error creating custom reader: %w", err)
 		}
+		defer rdr.Close()
 
 		return h.openArchive(ctx, depth+1, rdr, archiveChan)
 	case archiver.Extractor:
@@ -194,6 +195,7 @@ func (h *archiveHandler) extractorHandler(archiveChan chan []byte) func(context.
 			}
 			return fmt.Errorf("error creating custom reader: %w", err)
 		}
+		defer rdr.Close()
 
 		h.metrics.incFilesProcessed()
 		h.metrics.observeFileSize(fileSize)

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -89,6 +89,8 @@ func TestArchiveHandler(t *testing.T) {
 			if err != nil {
 				t.Errorf("error creating reusable reader: %s", err)
 			}
+			defer newReader.Close()
+
 			archiveChan, err := handler.HandleFile(logContext.Background(), newReader)
 			if testCase.expectErr {
 				assert.NoError(t, err)
@@ -119,6 +121,7 @@ func TestOpenInvalidArchive(t *testing.T) {
 
 	rdr, err := newFileReader(io.NopCloser(reader))
 	assert.NoError(t, err)
+	defer rdr.Close()
 
 	archiveChan := make(chan []byte)
 

--- a/pkg/handlers/default_test.go
+++ b/pkg/handlers/default_test.go
@@ -20,6 +20,7 @@ func TestHandleNonArchiveFile(t *testing.T) {
 
 	rdr, err := newFileReader(file)
 	assert.NoError(t, err)
+	defer rdr.Close()
 
 	handler := newDefaultHandler(defaultHandlerType)
 	archiveChan, err := handler.HandleFile(context.AddLogger(ctx), rdr)

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -59,7 +59,7 @@ func newMimeTypeReaderFromFileReader(r fileReader) mimeTypeReader {
 
 // newMimeTypeReader creates a new mimeTypeReader from an io.Reader.
 // It uses a bufio.Reader to perform MIME type detection on the input reader
-// without consuming it, by peeking into the first 512 bytes of the input.
+// without consuming it, by peeking into the first 3072 bytes of the input.
 // This encapsulates both the original reader and the detected MIME type information.
 // This function is particularly useful for specialized archive handlers
 // that need to pass extracted content to the default handler without modifying the original reader.
@@ -83,9 +83,6 @@ func newFileReader(r io.Reader) (fileReader, error) {
 	var fReader fileReader
 
 	fReader.BufferedReadSeeker = iobuf.NewBufferedReaderSeeker(r)
-
-	// Disable buffering after initial reads.
-	// This optimization ensures we don't continue writing to the buffer after the initial reads.
 
 	mime, err := mimetype.DetectReader(fReader)
 	if err != nil {
@@ -280,6 +277,7 @@ func HandleFile(
 		}
 		return fmt.Errorf("error creating custom reader: %w", err)
 	}
+	defer rdr.Close()
 
 	mimeT := mimeType(rdr.mime.String())
 	config := newFileHandlingConfig(options...)

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -86,7 +86,6 @@ func newFileReader(r io.Reader) (fileReader, error) {
 
 	// Disable buffering after initial reads.
 	// This optimization ensures we don't continue writing to the buffer after the initial reads.
-	defer fReader.DisableBuffering()
 
 	mime, err := mimetype.DetectReader(fReader)
 	if err != nil {

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -31,8 +31,7 @@ func TestHandleFile(t *testing.T) {
 
 	// Only one chunk is sent on the channel.
 	// TODO: Embed a zip without making an HTTP request.
-	// resp, err := http.Get("https://raw.githubusercontent.com/bill-rich/bad-secrets/master/aws-canary-creds.zip")
-	resp, err := http.Get("https://raw.githubusercontent.com/ahrav/nothing-to-see-here/main/sm_random_data.json")
+	resp, err := http.Get("https://raw.githubusercontent.com/bill-rich/bad-secrets/master/aws-canary-creds.zip")
 	assert.NoError(t, err)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -27,11 +27,12 @@ func TestHandleFileCancelledContext(t *testing.T) {
 }
 
 func TestHandleFile(t *testing.T) {
-	reporter := sources.ChanReporter{Ch: make(chan *sources.Chunk, 2)}
+	reporter := sources.ChanReporter{Ch: make(chan *sources.Chunk, 513)}
 
 	// Only one chunk is sent on the channel.
 	// TODO: Embed a zip without making an HTTP request.
-	resp, err := http.Get("https://raw.githubusercontent.com/bill-rich/bad-secrets/master/aws-canary-creds.zip")
+	// resp, err := http.Get("https://raw.githubusercontent.com/bill-rich/bad-secrets/master/aws-canary-creds.zip")
+	resp, err := http.Get("https://raw.githubusercontent.com/ahrav/nothing-to-see-here/main/sm_random_data.json")
 	assert.NoError(t, err)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
@@ -39,7 +40,51 @@ func TestHandleFile(t *testing.T) {
 
 	assert.Equal(t, 0, len(reporter.Ch))
 	assert.NoError(t, HandleFile(context.Background(), resp.Body, &sources.Chunk{}, reporter))
-	assert.Equal(t, 1, len(reporter.Ch))
+	assert.Equal(t, 513, len(reporter.Ch))
+}
+
+func TestHandleHTTPJson(t *testing.T) {
+	resp, err := http.Get("https://raw.githubusercontent.com/ahrav/nothing-to-see-here/main/sm_random_data.json")
+	assert.NoError(t, err)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	chunkCh := make(chan *sources.Chunk, 1)
+	go func() {
+		defer close(chunkCh)
+		err := HandleFile(logContext.Background(), resp.Body, &sources.Chunk{}, sources.ChanReporter{Ch: chunkCh})
+		assert.NoError(t, err)
+	}()
+
+	wantCount := 513
+	count := 0
+	for range chunkCh {
+		count++
+	}
+	assert.Equal(t, wantCount, count)
+}
+
+func TestHandleHTTPJsonZip(t *testing.T) {
+	resp, err := http.Get("https://raw.githubusercontent.com/ahrav/nothing-to-see-here/main/sm.zip")
+	assert.NoError(t, err)
+	if resp != nil && resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	chunkCh := make(chan *sources.Chunk, 1)
+	go func() {
+		defer close(chunkCh)
+		err := HandleFile(logContext.Background(), resp.Body, &sources.Chunk{}, sources.ChanReporter{Ch: chunkCh})
+		assert.NoError(t, err)
+	}()
+
+	wantCount := 513
+	count := 0
+	for range chunkCh {
+		count++
+	}
+	assert.Equal(t, wantCount, count)
 }
 
 func BenchmarkHandleFile(b *testing.B) {

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -33,9 +33,11 @@ func TestHandleFile(t *testing.T) {
 	// TODO: Embed a zip without making an HTTP request.
 	resp, err := http.Get("https://raw.githubusercontent.com/bill-rich/bad-secrets/master/aws-canary-creds.zip")
 	assert.NoError(t, err)
-	if resp != nil && resp.Body != nil {
-		defer resp.Body.Close()
-	}
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+	}()
 
 	assert.Equal(t, 0, len(reporter.Ch))
 	assert.NoError(t, HandleFile(context.Background(), resp.Body, &sources.Chunk{}, reporter))
@@ -45,9 +47,11 @@ func TestHandleFile(t *testing.T) {
 func TestHandleHTTPJson(t *testing.T) {
 	resp, err := http.Get("https://raw.githubusercontent.com/ahrav/nothing-to-see-here/main/sm_random_data.json")
 	assert.NoError(t, err)
-	if resp != nil && resp.Body != nil {
-		defer resp.Body.Close()
-	}
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+	}()
 
 	chunkCh := make(chan *sources.Chunk, 1)
 	go func() {
@@ -67,9 +71,11 @@ func TestHandleHTTPJson(t *testing.T) {
 func TestHandleHTTPJsonZip(t *testing.T) {
 	resp, err := http.Get("https://raw.githubusercontent.com/ahrav/nothing-to-see-here/main/sm.zip")
 	assert.NoError(t, err)
-	if resp != nil && resp.Body != nil {
-		defer resp.Body.Close()
-	}
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+	}()
 
 	chunkCh := make(chan *sources.Chunk, 1)
 	go func() {

--- a/pkg/handlers/rpm_test.go
+++ b/pkg/handlers/rpm_test.go
@@ -20,6 +20,7 @@ func TestHandleRPMFile(t *testing.T) {
 
 	rdr, err := newFileReader(file)
 	assert.NoError(t, err)
+	defer rdr.Close()
 
 	handler := newRPMHandler()
 	archiveChan, err := handler.HandleFile(context.AddLogger(ctx), rdr)

--- a/pkg/iobuf/bufferedreaderseeker.go
+++ b/pkg/iobuf/bufferedreaderseeker.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/cleantemp"
 )
 
 // BufferedReadSeeker provides a buffered reading interface with seeking capabilities.
@@ -19,105 +22,133 @@ type BufferedReadSeeker struct {
 	bytesRead int64 // Total number of bytes read from the underlying reader
 	index     int64 // Current position in the virtual stream
 
-	// Flag to control buffering. This flag is used to indicate whether buffering is active.
-	// Buffering is enabled during initial reads (e.g., for MIME type detection and format identification).
-	// Once these operations are done, buffering should be disabled to prevent further writes to the buffer
-	// and to optimize subsequent reads directly from the underlying reader. This helps avoid excessive
-	// memory usage while still providing the necessary functionality for initial detection operations.
-	activeBuffering bool
+	threshold      int64    // Threshold for switching to file buffering
+	tempFile       *os.File // Temporary file for disk-based buffering
+	tempFileName   string   // Name of the temporary file
+	diskBufferSize int64    // Size of data written to disk
 }
 
 // NewBufferedReaderSeeker creates and initializes a BufferedReadSeeker.
 // It takes an io.Reader and checks if it supports seeking.
 // If the reader supports seeking, it is stored in the seeker field.
 func NewBufferedReaderSeeker(r io.Reader) *BufferedReadSeeker {
-	var (
-		seeker          io.Seeker
-		buffer          *bytes.Buffer
-		activeBuffering = true
+	const (
+		defaultThreshold   = 1 << 24 // 16MB threshold for switching to file buffering
+		mimeTypeBufferSize = 3072    // Approx buffer size for MIME type detection
 	)
-	if s, ok := r.(io.Seeker); ok {
-		seeker = s
-		activeBuffering = false
-	}
+	seeker, _ := r.(io.Seeker)
 
-	const mimeTypeBufferSize = 3072 // Approx buffer size for MIME type detection
+	var buffer *bytes.Buffer
 
 	if seeker == nil {
 		buffer = bytes.NewBuffer(make([]byte, 0, mimeTypeBufferSize))
 	}
 
 	return &BufferedReadSeeker{
-		reader:          r,
-		seeker:          seeker,
-		buffer:          buffer,
-		bytesRead:       0,
-		index:           0,
-		activeBuffering: activeBuffering,
+		reader:    r,
+		seeker:    seeker,
+		buffer:    buffer,
+		bytesRead: 0,
+		index:     0,
+		// activeBuffering: activeBuffering,
+		threshold: defaultThreshold,
 	}
 }
 
 // Read reads len(out) bytes from the reader starting at the current index.
 // It handles both seekable and non-seekable underlying readers efficiently.
 func (br *BufferedReadSeeker) Read(out []byte) (int, error) {
-	// For seekable readers, read directly from the underlying reader.
 	if br.seeker != nil {
+		// For seekable readers, read directly from the underlying reader
 		n, err := br.reader.Read(out)
 		br.index += int64(n)
 		br.bytesRead = max(br.bytesRead, br.index)
 		return n, err
 	}
 
-	// For non-seekable readers, use buffered reading.
-	outLen := int64(len(out))
-	if outLen == 0 {
-		return 0, nil
+	var (
+		n   int
+		err error
+	)
+
+	// If the current read position is within the in-memory buffer.
+	if br.index < int64(br.buffer.Len()) {
+		n = copy(out, br.buffer.Bytes()[br.index:])
+		br.index += int64(n)
+		if n == len(out) {
+			return n, nil
+		}
+		out = out[n:]
 	}
 
-	// If the current read position (br.index) is within the buffer's valid data range,
-	// read from the buffer. This ensures previously read data (e.g., for mime type detection)
-	// is included in subsequent reads, providing a consistent view of the reader's content.
-	if br.index < int64(br.buffer.Len()) {
-		n := copy(out, br.buffer.Bytes()[br.index:])
-		br.index += int64(n)
+	// If we've exceeded the in-memory threshold and have a temp file.
+	if br.tempFile != nil && br.index < br.diskBufferSize {
+		if _, err := br.tempFile.Seek(br.index-int64(br.buffer.Len()), io.SeekStart); err != nil {
+			return n, err
+		}
+		m, err := br.tempFile.Read(out)
+		n += m
+		br.index += int64(m)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return n, err
+		}
+		if n == len(out) {
+			return n, nil
+		}
+		out = out[n:]
+	}
+
+	if len(out) == 0 {
 		return n, nil
 	}
 
-	if !br.activeBuffering {
-		// If buffering is not active, read directly from the underlying reader.
-		n, err := br.reader.Read(out)
-		br.index += int64(n)
-		br.bytesRead = max(br.bytesRead, br.index)
+	// If we still need to read more data.
+	var m int
+	m, err = br.reader.Read(out)
+	n += m
+	br.index += int64(m)
+	br.bytesRead = max(br.bytesRead, br.index)
+
+	// Always write new data to the buffer.
+	br.buffer.Write(out[:m])
+
+	// Check if we've reached or exceeded the threshold.
+	if br.buffer.Len() < int(br.threshold) {
 		return n, err
 	}
 
-	// Ensure there are enough bytes in the buffer to read from.
-	if outLen+br.index > int64(br.buffer.Len()) {
-		bytesToRead := int(outLen + br.index - int64(br.buffer.Len()))
-		readerBytes := make([]byte, bytesToRead)
-		n, err := br.reader.Read(readerBytes)
-		br.buffer.Write(readerBytes[:n])
-		br.bytesRead += int64(n)
-
-		if err != nil {
+	if br.tempFile == nil {
+		if err = br.createTempFile(); err != nil {
 			return n, err
 		}
 	}
 
-	// Ensure the read does not exceed the buffer length.
-	endIndex := br.index + outLen
-	bufLen := int64(br.buffer.Len())
-	if endIndex > bufLen {
-		endIndex = bufLen
+	// Flush the buffer to disk.
+	if err = br.flushBufferToDisk(); err != nil {
+		return n, err
 	}
 
-	if br.index >= bufLen {
-		return 0, io.EOF
-	}
+	return n, err
+}
 
-	n := copy(out, br.buffer.Bytes()[br.index:endIndex])
-	br.index += int64(n)
-	return n, nil
+func (br *BufferedReadSeeker) createTempFile() error {
+	tempFile, err := os.CreateTemp(os.TempDir(), cleantemp.MkFilename())
+	if err != nil {
+		return err
+	}
+	br.tempFile = tempFile
+	br.tempFileName = tempFile.Name()
+
+	return nil
+}
+
+func (br *BufferedReadSeeker) flushBufferToDisk() error {
+	if _, err := br.buffer.WriteTo(br.tempFile); err != nil {
+		return err
+	}
+	br.diskBufferSize = int64(br.buffer.Len())
+
+	return nil
 }
 
 // Seek sets the offset for the next Read or Write to offset.
@@ -138,32 +169,19 @@ func (br *BufferedReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	// Manual seeking for non-seekable readers.
 	newIndex := br.index
 
-	const bufferSize = 64 * 1024 // 64KB chunk size for reading
-
 	switch whence {
 	case io.SeekStart:
 		newIndex = offset
 	case io.SeekCurrent:
 		newIndex += offset
 	case io.SeekEnd:
-		// Read the entire reader to determine its length
-		buffer := make([]byte, bufferSize)
-		for {
-			n, err := br.reader.Read(buffer)
-			if n > 0 {
-				if br.activeBuffering {
-					br.buffer.Write(buffer[:n])
-				}
-				br.bytesRead += int64(n)
-			}
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			if err != nil {
+		// If we haven't read to the end yet, we need to do so
+		if br.bytesRead < br.diskBufferSize || br.tempFile == nil {
+			if err := br.readToEnd(); err != nil {
 				return 0, err
 			}
 		}
-		newIndex = min(br.bytesRead+offset, br.bytesRead)
+		newIndex = br.bytesRead + offset
 	default:
 		return 0, errors.New("invalid whence value")
 	}
@@ -172,27 +190,111 @@ func (br *BufferedReadSeeker) Seek(offset int64, whence int) (int64, error) {
 		return 0, errors.New("can not seek to before start of reader")
 	}
 
-	br.index = newIndex
+	// For non-seekable readers, we need to ensure we've read up to the new index
+	if br.seeker == nil && newIndex > br.bytesRead {
+		if err := br.readUntil(newIndex); err != nil {
+			return 0, err
+		}
+	}
 
+	br.index = newIndex
 	return newIndex, nil
+}
+
+const bufferSize = 64 * 1024 // 64KB chunk size for reading
+func (br *BufferedReadSeeker) readToEnd() error {
+	buffer := make([]byte, bufferSize)
+	for {
+		n, err := br.reader.Read(buffer)
+		if n > 0 {
+			if br.tempFile != nil {
+				if _, err := br.tempFile.Write(buffer[:n]); err != nil {
+					return err
+				}
+				br.diskBufferSize += int64(n)
+			} else {
+				br.buffer.Write(buffer[:n])
+			}
+			br.bytesRead += int64(n)
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+	}
+	// br.totalSize = br.bytesRead
+	// br.sizeKnown = true
+
+	return nil
+}
+
+func (br *BufferedReadSeeker) readUntil(index int64) error {
+	for br.bytesRead < index {
+		remaining := index - br.bytesRead
+		bufSize := int64(bufferSize)
+		if remaining < bufSize {
+			bufSize = remaining
+		}
+
+		buf := make([]byte, bufSize)
+		n, err := br.Read(buf)
+		if err != nil && err != io.EOF {
+			return err
+		}
+
+		if n == 0 {
+			break // We've reached the end of the reader
+		}
+	}
+
+	return nil
 }
 
 // ReadAt reads len(out) bytes into out starting at offset off in the underlying input source.
 // It uses Seek and Read to implement random access reading.
 func (br *BufferedReadSeeker) ReadAt(out []byte, offset int64) (int, error) {
-	startIndex, err := br.Seek(offset, io.SeekStart)
-	if err != nil {
+	if br.seeker != nil {
+		// Use the underlying Seeker if available.
+		_, err := br.Seek(offset, io.SeekStart)
+		if err != nil {
+			return 0, err
+		}
+		return br.Read(out)
+	}
+
+	// For non-seekable readers, use our buffering logic
+	// Save the current index
+	currentIndex := br.index
+
+	// Seek to the desired offset
+	if _, err := br.Seek(offset, io.SeekStart); err != nil {
 		return 0, err
 	}
 
-	if startIndex != offset {
-		return 0, io.EOF
+	n, err := br.Read(out)
+	if err != nil {
+		return n, err
 	}
 
-	return br.Read(out)
+	// Seek back to the original position.
+	if _, err = br.Seek(currentIndex, io.SeekStart); err != nil {
+		return n, err
+	}
+
+	return n, err
+}
+
+func (br *BufferedReadSeeker) Close() error {
+	if br.tempFile != nil {
+		br.tempFile.Close()
+		os.Remove(br.tempFileName)
+	}
+	return nil
 }
 
 // DisableBuffering stops the buffering process.
 // This is useful after initial reads (e.g., for MIME type detection and format identification)
 // to prevent further writes to the buffer, optimizing subsequent reads.
-func (br *BufferedReadSeeker) DisableBuffering() { br.activeBuffering = false }
+// func (br *BufferedReadSeeker) DisableBuffering() { br.activeBuffering = false }

--- a/pkg/iobuf/bufferedreaderseeker.go
+++ b/pkg/iobuf/bufferedreaderseeker.go
@@ -161,13 +161,13 @@ func (br *BufferedReadSeeker) Seek(offset int64, whence int) (int64, error) {
 	case io.SeekCurrent:
 		newIndex += offset
 	case io.SeekEnd:
-		// If we haven't read to the end yet, we need to do so.
-		if br.bytesRead < br.diskBufferSize || br.tempFile == nil {
+		// If we already know the total size, we can use it directly.
+		if !br.sizeKnown {
 			if err := br.readToEnd(); err != nil {
 				return 0, err
 			}
 		}
-		newIndex = br.bytesRead + offset
+		newIndex = br.totalSize + offset
 	default:
 		return 0, errors.New("invalid whence value")
 	}

--- a/pkg/iobuf/bufferedreaderseeker_test.go
+++ b/pkg/iobuf/bufferedreaderseeker_test.go
@@ -13,7 +13,6 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 	tests := []struct {
 		name              string
 		reader            io.Reader
-		activeBuffering   bool
 		reads             []int
 		expectedReads     []int
 		expectedBytes     [][]byte
@@ -25,7 +24,6 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 		{
 			name:              "read from seekable reader",
 			reader:            strings.NewReader("test data"),
-			activeBuffering:   true,
 			reads:             []int{4},
 			expectedReads:     []int{4},
 			expectedBytes:     [][]byte{[]byte("test")},
@@ -35,7 +33,6 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 		{
 			name:              "read from non-seekable reader with buffering",
 			reader:            bytes.NewBufferString("test data"),
-			activeBuffering:   true,
 			reads:             []int{4},
 			expectedReads:     []int{4},
 			expectedBytes:     [][]byte{[]byte("test")},
@@ -46,7 +43,6 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 		{
 			name:              "read from non-seekable reader without buffering",
 			reader:            bytes.NewBufferString("test data"),
-			activeBuffering:   false,
 			reads:             []int{4},
 			expectedReads:     []int{4},
 			expectedBytes:     [][]byte{[]byte("test")},
@@ -56,7 +52,6 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 		{
 			name:              "read beyond buffer",
 			reader:            strings.NewReader("test data"),
-			activeBuffering:   true,
 			reads:             []int{10},
 			expectedReads:     []int{9},
 			expectedBytes:     [][]byte{[]byte("test data")},
@@ -66,7 +61,6 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 		{
 			name:              "read with empty reader",
 			reader:            strings.NewReader(""),
-			activeBuffering:   true,
 			reads:             []int{4},
 			expectedReads:     []int{0},
 			expectedBytes:     [][]byte{[]byte("")},
@@ -77,7 +71,6 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 		{
 			name:              "read exact buffer size",
 			reader:            strings.NewReader("test"),
-			activeBuffering:   true,
 			reads:             []int{4},
 			expectedReads:     []int{4},
 			expectedBytes:     [][]byte{[]byte("test")},
@@ -87,7 +80,6 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 		{
 			name:              "read less than buffer size",
 			reader:            strings.NewReader("te"),
-			activeBuffering:   true,
 			reads:             []int{4},
 			expectedReads:     []int{2},
 			expectedBytes:     [][]byte{[]byte("te")},
@@ -97,7 +89,6 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 		{
 			name:              "read more than buffer size without buffering",
 			reader:            bytes.NewBufferString("test data"),
-			activeBuffering:   false,
 			reads:             []int{4},
 			expectedReads:     []int{4},
 			expectedBytes:     [][]byte{[]byte("test")},
@@ -107,7 +98,6 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 		{
 			name:              "multiple reads with buffering",
 			reader:            bytes.NewBufferString("test data"),
-			activeBuffering:   true,
 			reads:             []int{4, 5},
 			expectedReads:     []int{4, 5},
 			expectedBytes:     [][]byte{[]byte("test"), []byte(" data")},
@@ -118,7 +108,6 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 		{
 			name:              "multiple reads without buffering",
 			reader:            bytes.NewBufferString("test data"),
-			activeBuffering:   false,
 			reads:             []int{4, 5},
 			expectedReads:     []int{4, 5},
 			expectedBytes:     [][]byte{[]byte("test"), []byte(" data")},
@@ -132,7 +121,6 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 			t.Parallel()
 
 			brs := NewBufferedReaderSeeker(tt.reader)
-			brs.activeBuffering = tt.activeBuffering
 
 			for i, readSize := range tt.reads {
 				buf := make([]byte, readSize)
@@ -240,7 +228,7 @@ func TestBufferedReaderSeekerSeek(t *testing.T) {
 			reader:       bytes.NewBufferString("test data"),
 			offset:       20,
 			whence:       io.SeekEnd,
-			expectedPos:  9,
+			expectedPos:  29,
 			expectedErr:  false,
 			expectedRead: []byte{},
 		},

--- a/pkg/iobuf/bufferedreaderseeker_test.go
+++ b/pkg/iobuf/bufferedreaderseeker_test.go
@@ -139,10 +139,12 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 			}
 
 			assert.Equal(t, tt.expectedBytesRead, brs.bytesRead)
-			assert.Equal(t, tt.expectedIndex, brs.index)
+			if brs.seeker == nil {
+				assert.Equal(t, tt.expectedIndex, brs.index)
+			}
 
-			if brs.buffer != nil && len(tt.expectedBuffer) > 0 {
-				assert.Equal(t, tt.expectedBuffer, brs.buffer.Bytes())
+			if brs.buf != nil && len(tt.expectedBuffer) > 0 {
+				assert.Equal(t, tt.expectedBuffer, brs.buf.Bytes())
 			} else {
 				assert.Nil(t, tt.expectedBuffer)
 			}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR fixes the bug encountered when scanning non-seekable reader archives. While extracting contents from .zip, .7z, or .rar files, the reader needs to seek to the end to determine its size. However, this can cause memory issues with very large readers. To address this, if the reader is larger than 16MB, we buffer it using disk storage. Otherwise, we keep it in memory.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

