### PR TITLE
nitro detector was removed and needs to be deprecated

### DIFF
--- a/proto/detectors.proto
+++ b/proto/detectors.proto
@@ -377,7 +377,7 @@ enum DetectorType {
   Nutritionix = 364;
   Swell = 365;
   ClickupPersonalToken = 366;
-  Nitro = 367;
+  Nitro = 367 [deprecated = true];
   Rev = 368;
   RunRunIt = 369;
   Typeform = 370;


### PR DESCRIPTION
https://github.com/trufflesecurity/trufflehog/pull/2631

### Description:
Explain the purpose of the PR.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

