### PR TITLE
[chore] Use string instead of time.Time for expiration metadata

### DIFF
--- a/pkg/analyzer/analyzers/github/github.go
+++ b/pkg/analyzer/analyzers/github/github.go
@@ -50,7 +50,7 @@ func secretInfoToAnalyzerResult(info *SecretInfo) *analyzers.AnalyzerResult {
 		Metadata: map[string]any{
 			"type":         info.Metadata.Type,
 			"fine_grained": info.Metadata.FineGrained,
-			"expiration":   info.Metadata.Expiration,
+			"expiration":   info.Metadata.Expiration.String(),
 		},
 	}
 	result.Bindings = append(result.Bindings, secretInfoToUserBindings(info)...)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
`time.Time` should not be used due to unsupported types in protobufs.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

