### PR TITLE
Include default detectors when using a config that contains detectors

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -308,9 +308,7 @@ func (e *Engine) setDefaults(ctx context.Context) {
 		e.decoders = decoders.DefaultDecoders()
 	}
 
-	if len(e.detectors) == 0 {
-		e.detectors = DefaultDetectors()
-	}
+	e.detectors = append(e.detectors, DefaultDetectors()...)
 
 	if e.dispatcher == nil {
 		e.dispatcher = NewPrinterDispatcher(new(output.PlainPrinter))

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -417,12 +417,13 @@ func TestVerificationOverlapChunk(t *testing.T) {
 	sourceManager := sources.NewManager(opts...)
 
 	c := Config{
-		Concurrency:   1,
-		Decoders:      decoders.DefaultDecoders(),
-		Detectors:     conf.Detectors,
-		Verify:        false,
-		SourceManager: sourceManager,
-		Dispatcher:    NewPrinterDispatcher(new(discardPrinter)),
+		Concurrency:      1,
+		Decoders:         decoders.DefaultDecoders(),
+		Detectors:        conf.Detectors,
+		IncludeDetectors: "904", // isolate this test to only the custom detectors provided
+		Verify:           false,
+		SourceManager:    sourceManager,
+		Dispatcher:       NewPrinterDispatcher(new(discardPrinter)),
 	}
 
 	e, err := NewEngine(ctx, &c)


### PR DESCRIPTION
### Description:
After #2887, Trufflehog no longer included the default detectors when using a config file to pass custom detectors to the engine. This PR ensures that default detectors are still included even when using a config file with custom detectors in it. 

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

