### PR TITLE
Separate out printing statements with anlayzer logic for twilio

### DIFF
--- a/pkg/analyzer/cli.go
+++ b/pkg/analyzer/cli.go
@@ -206,7 +206,7 @@ func Run(cmd string) {
 		slack.AnalyzePermissions(cfg, *slackKey)
 	case twilioScan.FullCommand():
 		cfg.LogFile = analyzers.CreateLogFileName("twilio")
-		twilio.AnalyzePermissions(cfg, *twilioKey)
+		twilio.AnalyzeAndPrintPermissions(cfg, *twilioKey)
 	case airbrakeScan.FullCommand():
 		cfg.LogFile = analyzers.CreateLogFileName("airbrake")
 		airbrake.AnalyzeAndPrintPermissions(cfg, *airbrakeKey)


### PR DESCRIPTION
### Description:
Separate out printing logic from `AnalyzePermission` func For Twilio Analyzer

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

