### PR TITLE
Separate out printing statements with anlayzer logic for SourceGraph

### DIFF
--- a/pkg/analyzer/analyzers/sourcegraph/sourcegraph.go
+++ b/pkg/analyzer/analyzers/sourcegraph/sourcegraph.go
@@ -137,12 +137,6 @@ func AnalyzePermissions(cfg *config.Config, key string) (*SecretInfo, error) {
 		return nil, err
 	}
 
-	// second call
-	userInfo, err = getUserInfo(cfg, key)
-	if err != nil {
-		return nil, err
-	}
-
 	if userInfo.Data.CurrentUser.Username == "" {
 		return nil, fmt.Errorf("invalid Sourcegraph Access Token")
 	}

--- a/pkg/analyzer/analyzers/sourcegraph/sourcegraph.go
+++ b/pkg/analyzer/analyzers/sourcegraph/sourcegraph.go
@@ -4,6 +4,7 @@ package sourcegraph
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -31,6 +32,11 @@ type UserInfoJSON struct {
 			CreatedAt string `json:"createdAt"`
 		} `json:"currentUser"`
 	} `json:"data"`
+}
+
+type SecretInfo struct {
+	User        UserInfoJSON
+	IsSiteAdmin bool
 }
 
 func getUserInfo(cfg *config.Config, key string) (UserInfoJSON, error) {
@@ -98,42 +104,56 @@ func checkSiteAdmin(cfg *config.Config, key string) (bool, error) {
 	return true, nil
 }
 
-func AnalyzePermissions(cfg *config.Config, key string) {
+func AnalyzeAndPrintPermissions(cfg *config.Config, key string) {
+	// ToDo: Add in logging
+	if cfg.LoggingEnabled {
+		color.Red("[x] Logging is not supported for this analyzer.")
+		return
+	}
 
-	userInfo, err := getUserInfo(cfg, key)
+	info, err := AnalyzePermissions(cfg, key)
 	if err != nil {
-		color.Red("Error: %s", err)
+		color.Red("[x] Error: %s", err.Error())
 		return
 	}
 
-	// second call
-	userInfo, err = getUserInfo(cfg, key)
-	if err != nil {
-		color.Red("Error: %s", err)
-		return
-	}
-
-	if userInfo.Data.CurrentUser.Username == "" {
-		color.Red("[x] Invalid Sourcegraph Access Token")
-		return
-	}
 	color.Green("[!] Valid Sourcegraph Access Token\n\n")
 	color.Yellow("[i] Sourcegraph User Information\n")
-	color.Green("Username: %s\n", userInfo.Data.CurrentUser.Username)
-	color.Green("Email: %s\n", userInfo.Data.CurrentUser.Email)
-	color.Green("Created At: %s\n\n", userInfo.Data.CurrentUser.CreatedAt)
+	color.Green("Username: %s\n", info.User.Data.CurrentUser.Username)
+	color.Green("Email: %s\n", info.User.Data.CurrentUser.Email)
+	color.Green("Created At: %s\n\n", info.User.Data.CurrentUser.CreatedAt)
 
-	isSiteAdmin, err := checkSiteAdmin(cfg, key)
-	if err != nil {
-		color.Red("Error: %s", err)
-		return
-	}
-
-	if isSiteAdmin {
+	if info.IsSiteAdmin {
 		color.Green("[!] Token Permissions: Site Admin")
 	} else {
 		// This is the default for all access tokens as of 6/11/24
 		color.Yellow("[i] Token Permissions: user:full (default)")
 	}
+}
 
+func AnalyzePermissions(cfg *config.Config, key string) (*SecretInfo, error) {
+	userInfo, err := getUserInfo(cfg, key)
+	if err != nil {
+		return nil, err
+	}
+
+	// second call
+	userInfo, err = getUserInfo(cfg, key)
+	if err != nil {
+		return nil, err
+	}
+
+	if userInfo.Data.CurrentUser.Username == "" {
+		return nil, fmt.Errorf("invalid Sourcegraph Access Token")
+	}
+
+	isSiteAdmin, err := checkSiteAdmin(cfg, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SecretInfo{
+		User:        userInfo,
+		IsSiteAdmin: isSiteAdmin,
+	}, nil
 }

--- a/pkg/analyzer/cli.go
+++ b/pkg/analyzer/cli.go
@@ -239,7 +239,7 @@ func Run(cmd string) {
 		square.AnalyzePermissions(cfg, *squareKey)
 	case sourcegraphScan.FullCommand():
 		cfg.LogFile = analyzers.CreateLogFileName("sourcegraph")
-		sourcegraph.AnalyzePermissions(cfg, *sourcegraphKey)
+		sourcegraph.AnalyzeAndPrintPermissions(cfg, *sourcegraphKey)
 	case shopifyScan.FullCommand():
 		cfg.LogFile = analyzers.CreateLogFileName("shopify")
 		shopify.AnalyzePermissions(cfg, *shopifyKey, *shopifyStoreURL)


### PR DESCRIPTION
### Description:
Separate out printing logic from `AnalyzePermission` func For SourceGraph Analyzer

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

