### PR TITLE
[analyze] Combine access level into permission value

### DIFF
--- a/pkg/analyzer/analyzers/stripe/stripe.go
+++ b/pkg/analyzer/analyzers/stripe/stripe.go
@@ -72,8 +72,7 @@ func secretInfoToAnalyzerResult(info *SecretInfo) *analyzers.AnalyzerResult {
 				result.Bindings = append(result.Bindings, analyzers.Binding{
 					Resource: *parentResource,
 					Permission: analyzers.Permission{
-						Value:       permission.Name,
-						AccessLevel: *permission.Value,
+						Value: fmt.Sprintf("%s:%s", permission.Name, *permission.Value),
 					},
 				})
 			}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
`AccessLevel` was removed in a previous PR, so this fixes compilation.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

