### PR TITLE
[fix] Always configure the engine with the default detectors

### DIFF
--- a/main.go
+++ b/main.go
@@ -465,8 +465,12 @@ func run(state overseer.State) {
 	}
 
 	engConf := engine.Config{
-		Concurrency:           *concurrency,
-		Detectors:             conf.Detectors,
+		Concurrency: *concurrency,
+		// The engine must always be configured with the list of
+		// default detectors, which can be further filtered by the
+		// user. The filters are applied by the engine and are only
+		// subtractive.
+		Detectors:             append(engine.DefaultDetectors(), conf.Detectors...),
 		Verify:                !*noVerification,
 		IncludeDetectors:      *includeDetectors,
 		ExcludeDetectors:      *excludeDetectors,


### PR DESCRIPTION
If detectors are not wanted by a user, they can be filtered out via the `--include-detectors` or `--exclude-detectors` flag.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
I accidentally reverted a fix which introduced another issue. This fix shouldn't cause the same problem.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

