### PR TITLE
[bug] - add context timeout to ssh verification

### DIFF
--- a/pkg/detectors/privatekey/privatekey.go
+++ b/pkg/detectors/privatekey/privatekey.go
@@ -109,7 +109,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				user, err := verifyGitHubUser(parsedKey)
+				user, err := verifyGitHubUser(ctx, parsedKey)
 				if err != nil && !errors.Is(err, errPermissionDenied) {
 					verificationErrors.Add(err)
 				}
@@ -122,7 +122,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				user, err := verifyGitLabUser(parsedKey)
+				user, err := verifyGitLabUser(ctx, parsedKey)
 				if err != nil && !errors.Is(err, errPermissionDenied) {
 					verificationErrors.Add(err)
 				}

--- a/pkg/detectors/privatekey/ssh_test.go
+++ b/pkg/detectors/privatekey/ssh_test.go
@@ -5,8 +5,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 )
 
 func TestFirstResponseFromSSH(t *testing.T) {
@@ -23,7 +24,7 @@ func TestFirstResponseFromSSH(t *testing.T) {
 		t.Fatalf("could not parse test secret: %s", err)
 	}
 
-	output, err := firstResponseFromSSH(parsedKey, "git", "github.com:22")
+	output, err := firstResponseFromSSH(ctx, parsedKey, "git", "github.com:22")
 	if err != nil {
 		t.Fail()
 	}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR adds a timeout to the SSH verification process to prevent connections from staying open indefinitely.
### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

