### PR TITLE
[bug] - Create a new context with timeout per request

### DIFF
--- a/pkg/detectors/privatekey/ssh.go
+++ b/pkg/detectors/privatekey/ssh.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"time"
 
 	"golang.org/x/crypto/ssh"
 )
@@ -35,8 +34,7 @@ func firstResponseFromSSH(ctx context.Context, parsedKey any, username, hostport
 
 	// Verify the server fingerprint to ensure that there is no MITM replay attack
 	config := &ssh.ClientConfig{
-		Timeout: 5 * time.Second,
-		User:    username,
+		User: username,
 		Auth: []ssh.AuthMethod{
 			ssh.PublicKeys(signer),
 		},

--- a/pkg/detectors/privatekey/ssh.go
+++ b/pkg/detectors/privatekey/ssh.go
@@ -87,7 +87,7 @@ func firstResponseFromSSH(ctx context.Context, parsedKey any, username, hostport
 }
 
 func sshDialWithContext(ctx context.Context, network, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
-	d := net.Dialer{Timeout: config.Timeout}
+	d := net.Dialer{}
 	conn, err := d.DialContext(ctx, network, addr)
 	if err != nil {
 		return nil, fmt.Errorf("error dialing %s: %w", addr, err)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -882,7 +882,7 @@ func (e *Engine) verificationOverlapWorker(ctx context.Context) {
 			// DO NOT VERIFY at this stage of the pipeline.
 			matchedBytes := detector.Matches()
 			for _, match := range matchedBytes {
-				ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+				ctx, cancel := context.WithTimeout(ctx, time.Second*2)
 				results, err := detector.FromData(ctx, false, match)
 				cancel()
 				if err != nil {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -882,11 +882,15 @@ func (e *Engine) verificationOverlapWorker(ctx context.Context) {
 			// DO NOT VERIFY at this stage of the pipeline.
 			matchedBytes := detector.Matches()
 			for _, match := range matchedBytes {
+				ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 				results, err := detector.FromData(ctx, false, match)
-				ctx.Logger().Error(
-					err, "error finding results in chunk during verification overlap",
-					"detector", detector.Key.Type().String(),
-				)
+				cancel()
+				if err != nil {
+					ctx.Logger().Error(
+						err, "error finding results in chunk during verification overlap",
+						"detector", detector.Key.Type().String(),
+					)
+				}
 
 				if len(results) == 0 {
 					continue
@@ -980,9 +984,7 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 	if e.printAvgDetectorTime {
 		start = time.Now()
 	}
-	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer common.Recover(ctx)
-	defer cancel()
 
 	isFalsePositive := detectors.GetFalsePositiveCheck(data.detector)
 
@@ -996,7 +998,10 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 	for _, matchBytes := range matches {
 		matchCount++
 		detectBytesPerMatch.Observe(float64(len(matchBytes)))
+
+		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 		results, err := data.detector.Detector.FromData(ctx, data.chunk.Verify, matchBytes)
+		cancel()
 		if err != nil {
 			ctx.Logger().Error(
 				err, "error finding results in chunk",


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR creates a new context with a timeout for each call to FromData. This ensures a cancelled context only affects the request in flight.
### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

