### PR TITLE
Add Auth to Github Experimental Init

### DIFF
--- a/pkg/sources/github_experimental/github_experimental_test.go
+++ b/pkg/sources/github_experimental/github_experimental_test.go
@@ -1,0 +1,33 @@
+package github_experimental
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func createTestSource(src *sourcespb.GitHubExperimental) (*Source, *anypb.Any) {
+	s := &Source{}
+	conn, err := anypb.New(src)
+	if err != nil {
+		panic(err)
+	}
+	return s, conn
+}
+
+func TestInit(t *testing.T) {
+	source, conn := createTestSource(&sourcespb.GitHubExperimental{
+		Repository: "https://github.com/dustin-decker/secretsandstuff.git",
+		Credential: &sourcespb.GitHubExperimental_Token{
+			Token: "super secret token",
+		},
+		ObjectDiscovery: true,
+	})
+
+	err := source.Init(context.Background(), "test - github_experimental", 0, 1337, false, conn, 1)
+	assert.Nil(t, err)
+	assert.Equal(t, "super secret token", source.conn.GetToken())
+}


### PR DESCRIPTION
### Description:
Adds the token submitted via the CLI to the httpClient/apiClient upon Initialization of Github Experimental. The Alpha implementation currently only functions for public repositories because the token is not passed into the connection.

```object_discovery.go
// scanHiddenData scans hidden data (and non-hidden data) for secrets in a GitHub repository
func (s *Source) EnumerateAndScanAllObjects(ctx context.Context, chunksChan chan *sources.Chunk) error {
	// assign github token to global variable
	ghToken = s.conn.GetToken()
```

#3145 

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

