### PR TITLE
Change log verbosity for detection errors

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -886,7 +886,7 @@ func (e *Engine) verificationOverlapWorker(ctx context.Context) {
 				results, err := detector.FromData(ctx, false, match)
 				cancel()
 				if err != nil {
-					ctx.Logger().Error(
+					ctx.Logger().V(2).Error(
 						err, "error finding results in chunk during verification overlap",
 						"detector", detector.Key.Type().String(),
 					)


### PR DESCRIPTION
### Description:
This line can be noisy sometimes right now.


### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

