### PR TITLE
[analyze] Separate SID from token in twilio analyzer

### DIFF
--- a/pkg/analyzer/analyzers/twilio/twilio_test.go
+++ b/pkg/analyzer/analyzers/twilio/twilio_test.go
@@ -20,13 +20,15 @@ func TestAnalyzer_Analyze(t *testing.T) {
 
 	tests := []struct {
 		name    string
+		sid     string
 		key     string
 		want    string // JSON string
 		wantErr bool
 	}{
 		{
 			name: "valid Twilio key",
-			key:  testSecrets.MustGetField("TWILLIO_ID") + ":" + testSecrets.MustGetField("TWILLIO_API"),
+			sid:  testSecrets.MustGetField("TWILLIO_ID"),
+			key:  testSecrets.MustGetField("TWILLIO_API"),
 			want: `            {
              "AnalyzerType": 20,
              "Bindings": [
@@ -249,7 +251,7 @@ func TestAnalyzer_Analyze(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			a := Analyzer{}
-			got, err := a.Analyze(ctx, map[string]string{"key": tt.key})
+			got, err := a.Analyze(ctx, map[string]string{"key": tt.key, "sid": tt.sid})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Analyzer.Analyze() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/analyzer/cli.go
+++ b/pkg/analyzer/cli.go
@@ -70,7 +70,7 @@ func Run(cmd string) {
 	case "slack":
 		slack.AnalyzeAndPrintPermissions(secretInfo.Cfg, secretInfo.Parts["key"])
 	case "twilio":
-		twilio.AnalyzeAndPrintPermissions(secretInfo.Cfg, secretInfo.Parts["key"])
+		twilio.AnalyzeAndPrintPermissions(secretInfo.Cfg, secretInfo.Parts["sid"], secretInfo.Parts["key"])
 	case "airbrake":
 		airbrake.AnalyzeAndPrintPermissions(secretInfo.Cfg, secretInfo.Parts["key"])
 	case "huggingface":

--- a/pkg/analyzer/tui/form.go
+++ b/pkg/analyzer/tui/form.go
@@ -20,19 +20,40 @@ type FormPage struct {
 }
 
 func NewFormPage(c *common.Common, keyType string) FormPage {
-	inputs := []textinputs.InputConfig{{
-		Label:       "Secret",
-		Key:         "key",
-		Required:    true,
-		RedactInput: true,
-	}}
-	if keyType == "shopify" {
-		inputs = append(inputs, textinputs.InputConfig{
+	var inputs []textinputs.InputConfig
+	switch keyType {
+	case "twilio":
+		inputs = []textinputs.InputConfig{{
+			Label:    "SID",
+			Key:      "sid",
+			Required: true,
+		}, {
+			Label:       "Token",
+			Key:         "key",
+			Required:    true,
+			RedactInput: true,
+		}}
+	case "shopify":
+		inputs = []textinputs.InputConfig{{
+			Label:       "Secret",
+			Key:         "key",
+			Required:    true,
+			RedactInput: true,
+		}, {
 			Label:    "Shopify URL",
 			Key:      "url",
 			Required: true,
-		})
+		}}
+	default:
+		inputs = []textinputs.InputConfig{{
+			Label:       "Secret",
+			Key:         "key",
+			Required:    true,
+			RedactInput: true,
+		}}
 	}
+
+	// Always append a log file option.
 	inputs = append(inputs, textinputs.InputConfig{
 		Label: "Log file",
 		Help:  "Log HTTP requests that analysis performs to this file",

--- a/pkg/detectors/twilio/twilio.go
+++ b/pkg/detectors/twilio/twilio.go
@@ -90,7 +90,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
-						s1.AnalysisInfo = map[string]string{"key": sid + ":" + key}
+						s1.AnalysisInfo = map[string]string{"key": key, "sid": sid}
 						var serviceResponse serviceResponse
 						if err := json.NewDecoder(res.Body).Decode(&serviceResponse); err == nil && len(serviceResponse.Services) > 0 { // no error in parsing and have at least one service
 							service := serviceResponse.Services[0]


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Instead of submitting a single key of `sid:token` it now has two inputs.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

