### PR TITLE
Add metrics for command invocation

### DIFF
--- a/main.go
+++ b/main.go
@@ -300,7 +300,8 @@ func main() {
 	}
 
 	if !*noUpdate {
-		updateCfg.Fetcher = updater.Fetcher(usingTUI)
+		topLevelCmd, _, _ := strings.Cut(cmd, " ")
+		updateCfg.Fetcher = updater.Fetcher(topLevelCmd, usingTUI)
 	}
 	if version.BuildVersion == "dev" {
 		updateCfg.Fetcher = nil

--- a/pkg/updater/updater.go
+++ b/pkg/updater/updater.go
@@ -19,12 +19,13 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/version"
 )
 
-func Fetcher(tui bool) fetcher.Interface {
-	return &OSS{TUI: tui}
+func Fetcher(cmd string, tui bool) fetcher.Interface {
+	return &OSS{Cmd: cmd, TUI: tui}
 }
 
 type OSS struct {
 	Interval time.Duration
+	Cmd      string
 	TUI      bool
 	Updated  bool
 }
@@ -41,6 +42,7 @@ type FormData struct {
 	OS             string
 	Arch           string
 	CurrentVersion string
+	Cmd            string
 	TUI            bool
 	Timezone       string
 	Binary         string
@@ -58,6 +60,7 @@ func (g *OSS) Fetch() (io.Reader, error) {
 		OS:             runtime.GOOS,
 		Arch:           runtime.GOARCH,
 		CurrentVersion: version.BuildVersion,
+		Cmd:            g.Cmd,
 		TUI:            g.TUI,
 		Timezone:       zone,
 		Binary:         "trufflehog",


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Add metrics to track what top level command trufflehog was invoked with.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

