### PR TITLE
[analyze] Add analyze option to main TUI and unhide subcommand

### DIFF
--- a/pkg/analyzer/cli.go
+++ b/pkg/analyzer/cli.go
@@ -36,7 +36,7 @@ var (
 )
 
 func Command(app *kingpin.Application) *kingpin.CmdClause {
-	cli := app.Command("analyze", "Analyze API keys for fine-grained permissions information.").Hidden()
+	cli := app.Command("analyze", "Analyze API keys for fine-grained permissions information.")
 
 	keyTypeHelp := fmt.Sprintf(
 		"Type of key to analyze. Omit to interactively choose. Available key types: %s",

--- a/pkg/tui/pages/wizard_intro/wizard_intro.go
+++ b/pkg/tui/pages/wizard_intro/wizard_intro.go
@@ -14,6 +14,7 @@ import (
 const (
 	ScanSourceWithWizard Item = iota
 	// ScanSourceWithConfig
+	AnalyzeSecret
 	ViewHelpDocs
 	ViewOSSProject
 	EnterpriseInquire
@@ -24,6 +25,8 @@ func (w Item) String() string {
 	switch w {
 	case ScanSourceWithWizard:
 		return "Scan a source using wizard"
+	case AnalyzeSecret:
+		return "Analyze a secret's permissions"
 	//case ScanSourceWithConfig:
 	//	return "Scan a source with a config file"
 	case ViewHelpDocs:
@@ -47,6 +50,7 @@ func New(cmn common.Common) *WizardIntro {
 	sel := selector.New(cmn,
 		[]selector.IdentifiableItem{
 			ScanSourceWithWizard,
+			AnalyzeSecret,
 			// ScanSourceWithConfig,
 			ViewHelpDocs,
 			ViewOSSProject,

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -128,11 +128,14 @@ func (ui *TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case wizard_intro.ViewHelpDocs:
 				ui.args = []string{"--help"}
 
-				return ui, tea.Batch(nil, tea.Quit)
+				return ui, tea.Quit
 			case wizard_intro.EnterpriseInquire:
 				ui.activePage = contactEnterprisePage
 			case wizard_intro.ScanSourceWithWizard:
 				ui.activePage = sourceSelectPage
+			case wizard_intro.AnalyzeSecret:
+				ui.args = []string{"analyze"}
+				return ui, tea.Quit
 			}
 		case source_select.SourceItem:
 			ui.activePage = sourceConfigurePage


### PR DESCRIPTION
This is currently a one-way operation. Once you select "analyze" you cannot get back to the main menu.


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

