### PR TITLE
[analyze] Bandaid solution for occasional slow startups

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/felixge/fgprof"
@@ -338,9 +337,6 @@ func run(state overseer.State) {
 		} else {
 			logger.Info("cleaned temporary artifacts")
 		}
-
-		time.Sleep(time.Second * 10)
-		logger.Info("10 seconds elapsed. Forcing shutdown.")
 		os.Exit(0)
 	}()
 

--- a/pkg/analyzer/tui/keytype.go
+++ b/pkg/analyzer/tui/keytype.go
@@ -86,3 +86,10 @@ func (i KeyTypeItem) ID() string          { return string(i) }
 func (i KeyTypeItem) Title() string       { return string(i) }
 func (i KeyTypeItem) Description() string { return "" }
 func (i KeyTypeItem) FilterValue() string { return string(i) }
+
+func init() {
+	// Preload HasDarkBackground call. For some reason, if we don't do
+	// this, the TUI can take a noticeably long time to start. We should
+	// investigate further, but this is a good-enough bandaid for now.
+	_ = lipgloss.HasDarkBackground()
+}

--- a/pkg/analyzer/tui/keytype.go
+++ b/pkg/analyzer/tui/keytype.go
@@ -91,5 +91,6 @@ func init() {
 	// Preload HasDarkBackground call. For some reason, if we don't do
 	// this, the TUI can take a noticeably long time to start. We should
 	// investigate further, but this is a good-enough bandaid for now.
+	// See: https://github.com/charmbracelet/lipgloss/issues/73
 	_ = lipgloss.HasDarkBackground()
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
I traced the slow startups to the `lipgloss.HasDarkBackground()` call during rendering, which is performed in a `sync.Once`. Preloading it seems to help.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

