### PR TITLE
[analyze] Add environment variable support to text inputs

### DIFF
--- a/pkg/analyzer/tui/form.go
+++ b/pkg/analyzer/tui/form.go
@@ -25,14 +25,18 @@ func NewFormPage(c *common.Common, keyType string) FormPage {
 	switch strings.ToLower(keyType) {
 	case "twilio":
 		inputs = []textinputs.InputConfig{{
-			Label:    "SID",
-			Key:      "sid",
-			Required: true,
+			Label:       "SID",
+			Key:         "sid",
+			Required:    true,
+			AllowEnv:    true,
+			Placeholder: "$TWILIO_SID",
 		}, {
 			Label:       "Token",
 			Key:         "key",
 			Required:    true,
 			RedactInput: true,
+			AllowEnv:    true,
+			Placeholder: "$TWILIO_TOKEN",
 		}}
 	case "shopify":
 		inputs = []textinputs.InputConfig{{
@@ -40,25 +44,33 @@ func NewFormPage(c *common.Common, keyType string) FormPage {
 			Key:         "key",
 			Required:    true,
 			RedactInput: true,
+			AllowEnv:    true,
+			Placeholder: "$SHOPIFY_TOKEN",
 		}, {
-			Label:    "Shopify URL",
-			Key:      "url",
-			Required: true,
+			Label:       "Shopify URL",
+			Key:         "url",
+			Required:    true,
+			AllowEnv:    true,
+			Placeholder: "$SHOPIFY_URL",
 		}}
 	default:
+		kt := strings.ToUpper(keyType)
 		inputs = []textinputs.InputConfig{{
 			Label:       "Secret",
 			Key:         "key",
 			Required:    true,
 			RedactInput: true,
+			AllowEnv:    true,
+			Placeholder: fmt.Sprintf("$%s_TOKEN", kt),
 		}}
 	}
 
 	// Always append a log file option.
 	inputs = append(inputs, textinputs.InputConfig{
-		Label: "Log file",
-		Help:  "Log HTTP requests that analysis performs to this file",
-		Key:   "log_file",
+		Label:    "Log file",
+		Help:     "Log HTTP requests that analysis performs to this file",
+		Key:      "log_file",
+		AllowEnv: true,
 	})
 
 	form := textinputs.New(inputs).


### PR DESCRIPTION
### Description:
The values will only be replaced if the input begins with a dollar sign, and allows for multiple expansions like "${A} and ${B}". The requirement for the first character to be a dollar sign prevents any issues with a dollar sign embedded in a key itself.


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

