### PR TITLE
Log when a detector ignores the timeout

### DIFF
--- a/pkg/engine/ahocorasick/ahocorasickcore.go
+++ b/pkg/engine/ahocorasick/ahocorasickcore.go
@@ -24,6 +24,17 @@ type DetectorKey struct {
 	customDetectorName string
 }
 
+func (k DetectorKey) Loggable() map[string]any {
+	res := map[string]any{"type": k.detectorType.String()}
+	if k.version > 0 {
+		res["version"] = k.version
+	}
+	if k.customDetectorName != "" {
+		res["name"] = k.customDetectorName
+	}
+	return res
+}
+
 // Type returns the detector type of the key.
 func (k DetectorKey) Type() detectorspb.DetectorType { return k.detectorType }
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -29,6 +29,8 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
+const detectionTimeout = 10 * time.Second
+
 var errOverlap = errors.New(
 	"More than one detector has found this result. For your safety, verification has been disabled." +
 		"You can override this behavior by using the --allow-verification-overlap flag.",
@@ -1001,8 +1003,8 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 		matchCount++
 		detectBytesPerMatch.Observe(float64(len(matchBytes)))
 
-		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
-		t := time.AfterFunc(time.Second*11, func() {
+		ctx, cancel := context.WithTimeout(ctx, detectionTimeout)
+		t := time.AfterFunc(detectionTimeout+1*time.Second, func() {
 			ctx.Logger().Error(nil, "a detector ignored the context timeout")
 		})
 		results, err := data.detector.Detector.FromData(ctx, data.chunk.Verify, matchBytes)

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1006,6 +1006,7 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 			ctx.Logger().Error(nil, "a detector ignored the context timeout")
 		})
 		results, err := data.detector.Detector.FromData(ctx, data.chunk.Verify, matchBytes)
+		t.Stop()
 		cancel()
 		if err != nil {
 			ctx.Logger().Error(err, "error finding results in chunk")


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
If a detector ignores the configured timeout it is _probably_ because of I/O blocking, which degrades the efficiency of the detector worker pool when it happens a lot. In the worst case, a detector that fully hangs will zombify its worker, causing really bad performance problems. When this happens, we don't really have a good way to notice other than seeing scan throughput drop suspiciously. This PR adds explicit logging when detection takes longer than it should so we have a better chance of catching this.

(This problem theoretically can spring up anywhere, in any worker, but the detector fleet is vast, uses network I/O, and is implemented by a much larger group of people, so this sort of problem is much more likely to slip into detector implementations than anywhere else in the codebase. We _could_ generalize this mechanism, but I don't want to make that investment before seeing if this smaller change captures the information we need.)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

