### PR TITLE
[bug] - Correctly Handle Large Files in BufferedReadSeeker

### DIFF
--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -390,3 +390,27 @@ func BenchmarkHandleTar(b *testing.B) {
 		assert.NoError(b, err)
 	}
 }
+
+func TestHandleLargeHTTPJson(t *testing.T) {
+	resp, err := http.Get("https://raw.githubusercontent.com/ahrav/nothing-to-see-here/main/md_random_data.json.zip")
+	assert.NoError(t, err)
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	chunkCh := make(chan *sources.Chunk, 1)
+	go func() {
+		defer close(chunkCh)
+		err := HandleFile(logContext.Background(), resp.Body, &sources.Chunk{}, sources.ChanReporter{Ch: chunkCh})
+		assert.NoError(t, err)
+	}()
+
+	wantCount := 5121
+	count := 0
+	for range chunkCh {
+		count++
+	}
+	assert.Equal(t, wantCount, count)
+}

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -393,7 +393,10 @@ func BenchmarkHandleTar(b *testing.B) {
 
 func TestHandleLargeHTTPJson(t *testing.T) {
 	resp, err := http.Get("https://raw.githubusercontent.com/ahrav/nothing-to-see-here/main/md_random_data.json.zip")
-	assert.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
+
 	defer func() {
 		if resp != nil && resp.Body != nil {
 			resp.Body.Close()

--- a/pkg/iobuf/bufferedreaderseeker.go
+++ b/pkg/iobuf/bufferedreaderseeker.go
@@ -87,6 +87,19 @@ func (br *BufferedReadSeeker) Read(out []byte) (int, error) {
 		return n, err
 	}
 
+	// If we have a temp file and the total size is known, we can read directly from it.
+	if br.sizeKnown && br.tempFile != nil {
+		if br.index >= br.totalSize {
+			return 0, io.EOF
+		}
+		if _, err := br.tempFile.Seek(br.index, io.SeekStart); err != nil {
+			return 0, err
+		}
+		n, err := br.tempFile.Read(out)
+		br.index += int64(n)
+		return n, err
+	}
+
 	var (
 		totalBytesRead int
 		err            error
@@ -211,6 +224,17 @@ func (br *BufferedReadSeeker) readToEnd() error {
 			return err
 		}
 	}
+
+	// If a temporary file exists and the buffer contains data,
+	// flush the buffer to the file. This allows future operations
+	// to utilize the temporary file exclusively, simplifying
+	// management by avoiding separate handling of the buffer and file.
+	if br.tempFile != nil && br.buf.Len() > 0 {
+		if err := br.flushBufferToDisk(); err != nil {
+			return err
+		}
+	}
+
 	br.totalSize = br.bytesRead
 	br.sizeKnown = true
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR addresses a bug in the BufferedReadSeeker implementation where large files were not handled correctly. The fix ensures that the transition from in-memory buffering to disk-based buffering is seamless and efficient, allowing for proper management of large files.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

