### PR TITLE
[th-563] new metrics for scan job reports

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+)
+
+var (
+	reportGenerationTotal = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: common.MetricsNamespace,
+		Subsystem: common.MetricsSubsystem,
+		Name:      "report_generation_total",
+		Help:      "Total number of report generation attempts",
+	})
+
+	reportGenerationErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: common.MetricsNamespace,
+		Subsystem: common.MetricsSubsystem,
+		Name:      "report_generation_errors",
+		Help:      "Total number of errors encountered during report generation, by error type",
+	},
+		[]string{"error_type"},
+	)
+
+	unitMetricsTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: common.MetricsNamespace,
+		Subsystem: common.MetricsSubsystem,
+		Name:      "unit_metrics_total",
+		Help:      "Total number of UnitMetrics generated, by unit type",
+	},
+		[]string{"unit_type"},
+	)
+
+	unitMetricsWithErrors = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: common.MetricsNamespace,
+		Subsystem: common.MetricsSubsystem,
+		Name:      "unit_metrics_with_errors_total",
+		Help:      "Total number of UnitMetrics containing errors, by unit type",
+	},
+		[]string{"unit_type"},
+	)
+
+	reportFileSize = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: common.MetricsNamespace,
+		Subsystem: common.MetricsSubsystem,
+		Name:      "report_file_size_bytes",
+		Help:      "Size of the generated report file in bytes",
+	})
+
+	reportGenerationDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Namespace: common.MetricsNamespace,
+		Subsystem: common.MetricsSubsystem,
+		Name:      "report_generation_duration_seconds",
+		Help:      "Time taken to generate a report",
+		Buckets:   prometheus.ExponentialBuckets(0.1, 2, 10),
+	})
+)

--- a/pkg/sources/job_progress_hook.go
+++ b/pkg/sources/job_progress_hook.go
@@ -39,6 +39,7 @@ func NewUnitHook(ctx context.Context, opts ...UnitHookOpt) (*UnitHook, <-chan Un
 		logBackPressure: func() {
 			once.Do(func() {
 				ctx.Logger().Info("back pressure detected in unit hook")
+				backPressureOccurrences.Inc()
 			})
 		},
 	}

--- a/pkg/sources/metrics.go
+++ b/pkg/sources/metrics.go
@@ -21,4 +21,11 @@ var (
 		Name:      "hooks_channel_size",
 		Help:      "Total number of metrics waiting in the finished channel.",
 	}, nil)
+
+	backPressureOccurrences = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: common.MetricsNamespace,
+		Subsystem: common.MetricsSubsystem,
+		Name:      "back_pressure_occurrences_total",
+		Help:      "Total number of times back pressure was detected",
+	})
 )


### PR DESCRIPTION
### Description:

Seven new metrics for monitoring Scan Job Reports:

`backPressureOccurrences`: 
- frequency of back pressure occurrences (when the finishedMetrics channel is full)
- will tell us if metric generation is outpacing consumption

`reportGenerationTotal`, `reportGenerationErrors`:
- number of successful report generations vs. total attempts
- will tell us if reports are being generated as expected

`unitMetricsTotal`:
- number of UnitMetrics generated per job
- will tell us if all expected units are being processed

`unitMetricsWithErrors`:
- proportion of UnitMetrics containing errors
- will help us identify problematic scan units

`reportFileSize`:
- size of generated report files
- will help us detect unexpectedly large or small reports

`reportGenerationDuration`:
- time taken to generate each report
- will help us monitor performance and detect slowdowns


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

