### PR TITLE
Support for kebab case and dot notation in permission generation tool

### DIFF
--- a/pkg/analyzer/README.md
+++ b/pkg/analyzer/README.md
@@ -2,7 +2,10 @@
 
 ## Defining the Permissions
 
-Permissions are defined in lower snake case as `permission_name:access_level`.
+Permissions can be defined in:
+- lower snake case as `permission_name:access_level`
+- kebab case as `permission-name:read`
+- dot notation as `permission.name:read`
 
 The Permissions are initially defined as a [yaml file](analyzers/twilio/permissions.yaml).
 

--- a/pkg/analyzer/generate_permissions/generate_permissions.go
+++ b/pkg/analyzer/generate_permissions/generate_permissions.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
 	"strings"
 	"text/template"
 
@@ -95,7 +96,7 @@ func ToCamelCase(s string) string {
 	parts := strings.Split(s, ":")
 	caser := cases.Title(language.English)
 	for i := range parts {
-		subParts := strings.Split(parts[i], "_")
+		subParts := regexp.MustCompile(`[\_\.\-]+`).Split(parts[i], -1)
 		for j := range subParts {
 			subParts[j] = caser.String(subParts[j])
 		}


### PR DESCRIPTION
### Description:
Right now, only lower snake case was allowed in permission generations tool. This PR also handles kebab case and dot notation permissions which are being used in slack and gitlab analyzer.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

