### PR TITLE
fixing slack regex to accomodate a missing pattern

### DIFF
--- a/pkg/detectors/slack/slack.go
+++ b/pkg/detectors/slack/slack.go
@@ -12,7 +12,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
-)
+	)
 
 type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
@@ -25,10 +25,10 @@ var _ detectors.Detector = Scanner{}
 var (
 	defaultClient = common.SaneHttpClient()
 	tokenPats     = map[string]*regexp.Regexp{
-		"Slack Bot Token":               regexp.MustCompile(`xoxb\-[0-9]{10,13}\-[0-9]{10,13}[a-zA-Z0-9\-]*`),
-		"Slack User Token":              regexp.MustCompile(`xoxp\-[0-9]{10,13}\-[0-9]{10,13}[a-zA-Z0-9\-]*`),
-		"Slack Workspace Access Token":  regexp.MustCompile(`xoxa\-[0-9]{10,13}\-[0-9]{10,13}[a-zA-Z0-9\-]*`),
-		"Slack Workspace Refresh Token": regexp.MustCompile(`xoxr\-[0-9]{10,13}\-[0-9]{10,13}[a-zA-Z0-9\-]*`),
+		"Slack Bot Token":               regexp.MustCompile(`xoxb\-[0-9]{10,13}[a-zA-Z0-9\-]*`),
+		"Slack User Token":              regexp.MustCompile(`xoxp\-[0-9]{10,13}[a-zA-Z0-9\-]*`),
+		"Slack Workspace Access Token":  regexp.MustCompile(`xoxa\-[0-9]{10,13}[a-zA-Z0-9\-]*`),
+		"Slack Workspace Refresh Token": regexp.MustCompile(`xoxr\-[0-9]{10,13}[a-zA-Z0-9\-]*`),
 	}
 	verifyURL = "https://slack.com/api/auth.test"
 )


### PR DESCRIPTION
### Description:
This PR fixes a flaw in the slack regex. There are valid tokens out there in the format of `xoxb-358710623633-aUGO32mVW`. Current regex doesn't detect this. I fixed the regex to accommodate one subset of digits. Current regex requires 2 subset of [0-9] digits. 

![slack](https://github.com/user-attachments/assets/bcd66e4f-b3e0-4aba-a052-af6ae30d4834)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

