### PR TITLE
Added Onfido API Token detector

### DIFF
--- a/pkg/detectors/onfido/onfido.go
+++ b/pkg/detectors/onfido/onfido.go
@@ -1,0 +1,92 @@
+package onfido
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+type Scanner struct {
+	client *http.Client
+}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	defaultClient = common.SaneHttpClientTimeOut(time.Second * 10)
+
+	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
+	keyPat = regexp.MustCompile(`\b(?:api_live(?:_[a-zA-Z]{2})?\.[a-zA-Z0-9-_]{11}\.[-_a-zA-Z0-9]{32})\b`)
+)
+
+// Keywords are used for efficiently pre-filtering chunks.
+// Use identifiers in the secret preferably, or the provider name.
+func (s Scanner) Keywords() []string {
+	return []string{"api_live.", "api_live_ca.", "api_live_us."}
+}
+
+// FromData will find and optionally verify Onfido secrets in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
+
+	for _, match := range matches {
+		// There are no capturing group in the regex, so match[0] is the only one we need.
+		resMatch := strings.TrimSpace(match[0])
+
+		s1 := detectors.Result{
+			DetectorType: detectorspb.DetectorType_Onfido,
+			Raw:          []byte(resMatch),
+		}
+
+		if verify {
+			client := s.client
+			if client == nil {
+				client = defaultClient
+			}
+
+			// Determine the region code based on the prefix of resMatch
+			region := "eu" // Default region
+			if strings.HasPrefix(resMatch, "api_live_ca.") {
+				region = "ca"
+			} else if strings.HasPrefix(resMatch, "api_live_us.") {
+				region = "us"
+			}
+
+			// Construct the URL using the region variable
+			url := fmt.Sprintf("https://api.%s.onfido.com/v3/validate_api_token", region)
+			req, err := http.NewRequestWithContext(ctx, "POST", url, nil)
+
+			// req, err := http.NewRequestWithContext(ctx, "POST", "https://api.eu.onfido.com/v3/validate_api_token", nil)
+			if err != nil {
+				continue
+			}
+			req.Header.Add("Authorization", fmt.Sprintf("Token token=%s", resMatch))
+			res, err := client.Do(req)
+			if err == nil {
+				defer res.Body.Close()
+				if res.StatusCode == 200 {
+					s1.Verified = true
+				} else {
+					s1.Verified = false
+				}
+			}
+		}
+
+		results = append(results, s1)
+	}
+
+	return results, nil
+}
+
+func (s Scanner) Type() detectorspb.DetectorType {
+	return detectorspb.DetectorType_Onfido
+}

--- a/pkg/detectors/onfido/onfido_test.go
+++ b/pkg/detectors/onfido/onfido_test.go
@@ -1,0 +1,120 @@
+//go:build detectors
+// +build detectors
+
+package onfido
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/kylelemons/godebug/pretty"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+func TestOnfido_FromChunk(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors2")
+	if err != nil {
+		t.Fatalf("could not get test secrets from GCP: %s", err)
+	}
+	secret := testSecrets.MustGetField("ONFIDO_API_TOKEN")
+	inactiveSecret := testSecrets.MustGetField("ONFIDO_INACTIVE")
+
+	type args struct {
+		ctx    context.Context
+		data   []byte
+		verify bool
+	}
+	tests := []struct {
+		name    string
+		s       Scanner
+		args    args
+		want    []detectors.Result
+		wantErr bool
+	}{
+		{
+			name: "found, verified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find an onfido secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Onfido,
+					Verified:     true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "found, unverified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find an onfido secret %s within but not valid", inactiveSecret)), // the secret would satisfy the regex but not pass validation
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Onfido,
+					Verified:     false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "not found",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte("You cannot find the secret within"),
+				verify: true,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Scanner{}
+			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Onfido.FromData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if len(got[i].Raw) == 0 {
+					t.Fatalf("no raw secret present: \n %+v", got[i])
+				}
+				got[i].Raw = nil
+			}
+			if diff := pretty.Compare(got, tt.want); diff != "" {
+				t.Errorf("Onfido.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			}
+		})
+	}
+}
+
+func BenchmarkFromData(benchmark *testing.B) {
+	ctx := context.Background()
+	s := Scanner{}
+	for name, data := range detectors.MustGetBenchmarkData() {
+		benchmark.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				_, err := s.FromData(ctx, false, data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/engine/defaults.go
+++ b/pkg/engine/defaults.go
@@ -480,6 +480,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/onelogin"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/onepagecrm"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/onesignal"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/onfido"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/onfleet"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/oopspam"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/openai"
@@ -1628,6 +1629,7 @@ func DefaultDetectors() []detectors.Detector {
 		atlassianv2.Scanner{},
 		netsuite.Scanner{},
 		robinhoodcrypto.Scanner{},
+		onfido.Scanner{},
 	}
 }
 

--- a/pkg/pb/detectorspb/detectors.pb.go
+++ b/pkg/pb/detectorspb/detectors.pb.go
@@ -1098,6 +1098,7 @@ const (
 	DetectorType_ElevenLabs                              DetectorType = 994
 	DetectorType_Netsuite                                DetectorType = 995
 	DetectorType_RobinhoodCrypto                         DetectorType = 996
+	DetectorType_Onfido                                  DetectorType = 997
 )
 
 // Enum value maps for DetectorType.
@@ -2096,6 +2097,7 @@ var (
 		994: "ElevenLabs",
 		995: "Netsuite",
 		996: "RobinhoodCrypto",
+		997: "Onfido",
 	}
 	DetectorType_value = map[string]int32{
 		"Alibaba":                               0,
@@ -3091,6 +3093,7 @@ var (
 		"ElevenLabs":                       994,
 		"Netsuite":                         995,
 		"RobinhoodCrypto":                  996,
+		"Onfido":                           997,
 	}
 )
 

--- a/proto/detectors.proto
+++ b/proto/detectors.proto
@@ -1006,6 +1006,7 @@ enum DetectorType {
   ElevenLabs = 994;
   Netsuite = 995;
   RobinhoodCrypto = 996;
+  Onfido = 997;
 }
 
 message Result {


### PR DESCRIPTION
### Description:
Add [Onfido](https://onfido.com/) API Token detector to recognize this type of secrets. Documentation on API token can be found here: https://documentation.onfido.com/api/latest/#api-tokens.

Note that Onfido is a GitHub [secret scanning partner](https://docs.github.com/en/code-security/secret-scanning/introduction/supported-secret-scanning-patterns) and those tokens are detected by the built-in GitHub scanner.

### Test
Tested in local, it worked fine for both non verified and verified detection. To test the former, it's possible to use [this](https://github.com/dry-runs-test/test-new-repo-2/) repo which is an official GitHub secret scanning test repository, to test the latter please reach out to me as i can generate valid API tokens to validate.

Cli command:
`./trufflehog git https://github.com/dry-runs-test/test-new-repo-2/ --include-detectors=onfido`

