### PR TITLE
Azure Detector Regex fix

### DIFF
--- a/pkg/detectors/azure/azure.go
+++ b/pkg/detectors/azure/azure.go
@@ -33,7 +33,7 @@ var (
 	tenantIDPat = mustFmtPat("tenant_id", idPatFmt)
 
 	// TODO: support old patterns
-	secretPatFmt    = `(?i)(%s).{0,20}([a-z0-9_\.\-~]{34})`
+	secretPatFmt    = `(?i)(%s).{0,20}?([A-Za-z0-9_\.\-~]{40}|[A-Za-z0-9_\.\-~]{34})`
 	clientSecretPat = mustFmtPat("client_secret", secretPatFmt)
 )
 


### PR DESCRIPTION
### Description:

Azure now uses a 40 char string as a secret for the service principal instead of 34 chars. Also, even both 34 and 40 char versions used [A-Z] which was missing from the current regex. I don't think there was a need for a v2 detector unless the format for the secret key was changed. This new regex will detect both 40 char and 34 char versions.

See this video for the 34 char version - https://www.youtube.com/watch?v=Kf1Tai_BkWU. At 3:19, it shows that the 34 char version also had [A-Z] in it.


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

