### PR TITLE
update aha keyword

### DIFF
--- a/pkg/detectors/aha/aha.go
+++ b/pkg/detectors/aha/aha.go
@@ -31,7 +31,7 @@ var (
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"aha"}
+	return []string{"aha.io"}
 }
 
 func (s Scanner) getClient() *http.Client {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Since the regex requires `aha.io` we should update the keyword to be `aha.io` instead of `aha`

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

