### PR TITLE
Refactor GitHub source to allow asynchronous enumeration

### DIFF
--- a/pkg/sources/github/filter_set.go
+++ b/pkg/sources/github/filter_set.go
@@ -1,0 +1,77 @@
+package github
+
+import (
+	"github.com/gobwas/glob"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+)
+
+type filterSet struct {
+	include []glob.Glob
+	exclude []glob.Glob
+	set     map[string]struct{}
+}
+
+func newFilterSet(ctx context.Context, include, exclude []string) filterSet {
+	includeGlobs := make([]glob.Glob, 0, len(include))
+	excludeGlobs := make([]glob.Glob, 0, len(exclude))
+	for _, ig := range include {
+		g, err := glob.Compile(ig)
+		if err != nil {
+			ctx.Logger().V(1).Info("invalid include glob", "include_value", ig, "err", err)
+			continue
+		}
+		includeGlobs = append(includeGlobs, g)
+	}
+	for _, eg := range exclude {
+		g, err := glob.Compile(eg)
+		if err != nil {
+			ctx.Logger().V(1).Info("invalid exclude glob", "exclude_value", eg, "err", err)
+			continue
+		}
+		excludeGlobs = append(excludeGlobs, g)
+	}
+	return filterSet{include: includeGlobs, exclude: excludeGlobs, set: make(map[string]struct{})}
+}
+
+// Add adds the value to the set. True is returned if the value was not
+// previously in the set, and false otherwise. It is safe for concurrent use.
+func (f *filterSet) Add(v string) bool {
+	if f.ignoreValue(v) {
+		return false
+	}
+	if !f.includeValue(v) {
+		return false
+	}
+
+	if _, ok := f.set[v]; ok {
+		return false
+	}
+	f.set[v] = struct{}{}
+	return true
+}
+
+// ignoreValue checks the exclude globs for a match. It is safe for concurrent
+// use because the slice is written only once on initialization.
+func (f *filterSet) ignoreValue(v string) bool {
+	for _, g := range f.exclude {
+		if g.Match(v) {
+			return true
+		}
+	}
+	return false
+}
+
+// includeValue checks the include globs for a match. It is safe for concurrent
+// use because the slice is written only once on initialization.
+func (f *filterSet) includeValue(v string) bool {
+	if len(f.include) == 0 {
+		return true
+	}
+
+	for _, g := range f.include {
+		if g.Match(v) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -391,91 +391,18 @@ func (s *Source) enumerateAll(ctx context.Context, reporter sources.UnitReporter
 	// this felt like a compromise that allowed me to isolate connection logic without rewriting the entire source.
 	switch c := s.connector.(type) {
 	case *appConnector:
-		// getReposByApp
-		//	totalRepoSize
-		//	filteredRepoCache
-		//	repoInfoCache
-		// addMembersByApp
-		//	addMembersByOrg
-		//		memberCache
-		// addUserGistsToCache
-		//	filteredRepoCache
-		//	repoInfoCache
-		// getReposByUser
-		//	totalRepoSize
-		//	filteredRepoCache
-		//	repoInfoCache
 		if err := s.enumerateWithApp(ctx, c.InstallationClient(), reporter); err != nil {
 			_ = reporter.UnitErr(ctx, err)
 		}
 	case *basicAuthConnector:
-		// getReposByOrgOrUser
-		//	getReposByOrg
-		//		totalRepoSize
-		//		filteredRepoCache
-		//		repoInfoCache
-		//	getReposByUser
-		//		totalRepoSize
-		//		filteredRepoCache
-		//		repoInfoCache
-		//	addUserGistsToCache
-		//		filteredRepoCache
-		//		repoInfoCache
-		// addMembersByOrg
-		//	memberCache
 		if err := s.enumerateBasicAuth(ctx, reporter); err != nil {
 			_ = reporter.UnitErr(ctx, err)
 		}
 	case *tokenConnector:
-		// getReposByUser
-		//	totalRepoSize
-		//	filteredRepoCache
-		//	repoInfoCache
-		// addUserGistsToCache
-		//	filteredRepoCache
-		//	repoInfoCache
-		// addAllVisibleOrgs
-		//	orgsCache
-		// addOrgsByUser
-		//	orgsCache
-		// getReposByOrgOrUser
-		//	getReposByOrg
-		//		totalRepoSize
-		//		filteredRepoCache
-		//		repoInfoCache
-		//	getReposByUser
-		//		totalRepoSize
-		//		filteredRepoCache
-		//		repoInfoCache
-		//	addUserGistsToCache
-		//		filteredRepoCache
-		//		repoInfoCache
-		// addMembersByOrg
-		//	memberCache
-		// addReposForMembers
-		//	addUserGistsToCache
-		//		filteredRepoCache
-		//		repoInfoCache
-		//	getReposByUser
-		//		totalRepoSize
-		//		filteredRepoCache
-		//		repoInfoCache
 		if err := s.enumerateWithToken(ctx, c.IsGithubEnterprise(), reporter); err != nil {
 			_ = reporter.UnitErr(ctx, err)
 		}
 	case *unauthenticatedConnector:
-		// getReposByOrgOrUser
-		//	getReposByOrg
-		//		totalRepoSize
-		//		filteredRepoCache
-		//		repoInfoCache
-		//	getReposByUser
-		//		totalRepoSize
-		//		filteredRepoCache
-		//		repoInfoCache
-		//	addUserGistsToCache
-		//		filteredRepoCache
-		//		repoInfoCache
 		s.enumerateUnauthenticated(ctx, reporter)
 	}
 }

--- a/pkg/sources/github/github_integration_test.go
+++ b/pkg/sources/github/github_integration_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -58,14 +57,13 @@ func TestSource_Token(t *testing.T) {
 
 	s := Source{
 		conn:          src,
-		log:           logr.Discard(),
 		memberCache:   map[string]struct{}{},
 		repoInfoCache: newRepoInfoCache(),
 	}
 	s.Init(ctx, "github integration test source", 0, 0, false, conn, 1)
-	s.filteredRepoCache = s.newFilteredRepoCache(memory.New[string](), nil, nil)
+	s.filteredRepoCache = s.newFilteredRepoCache(ctx, memory.New[string](), nil, nil)
 
-	err = s.enumerateWithApp(ctx, s.connector.(*appConnector).InstallationClient())
+	err = s.enumerateWithApp(ctx, s.connector.(*appConnector).InstallationClient(), noopReporter())
 	assert.NoError(t, err)
 
 	_, _, err = s.cloneRepo(ctx, "https://github.com/truffle-test-integration-org/another-test-repo.git")
@@ -633,7 +631,7 @@ func TestSource_paginateGists(t *testing.T) {
 			}
 			chunksCh := make(chan *sources.Chunk, 5)
 			go func() {
-				assert.NoError(t, s.addUserGistsToCache(ctx, tt.user))
+				assert.NoError(t, s.addUserGistsToCache(ctx, tt.user, noopReporter()))
 				chunksCh <- &sources.Chunk{}
 			}()
 			var wantedRepo string

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -99,7 +99,7 @@ func TestAddReposByOrg(t *testing.T) {
 		Repositories: nil,
 		IgnoreRepos:  []string{"secret/super-*-repo2"},
 	})
-	err := s.getReposByOrg(context.Background(), "super-secret-org")
+	err := s.getReposByOrg(context.Background(), "super-secret-org", noopReporter())
 	assert.Nil(t, err)
 	assert.Equal(t, 1, s.filteredRepoCache.Count())
 	ok := s.filteredRepoCache.Exists("super-secret-repo")
@@ -127,7 +127,7 @@ func TestAddReposByOrg_IncludeRepos(t *testing.T) {
 		IncludeRepos:  []string{"super-secret-org/super*"},
 		Organizations: []string{"super-secret-org"},
 	})
-	err := s.getReposByOrg(context.Background(), "super-secret-org")
+	err := s.getReposByOrg(context.Background(), "super-secret-org", noopReporter())
 	assert.Nil(t, err)
 	assert.Equal(t, 2, s.filteredRepoCache.Count())
 	ok := s.filteredRepoCache.Exists("super-secret-org/super-secret-repo")
@@ -155,7 +155,7 @@ func TestAddReposByUser(t *testing.T) {
 		},
 		IgnoreRepos: []string{"super-secret-user/super-secret-repo2"},
 	})
-	err := s.getReposByUser(context.Background(), "super-secret-user")
+	err := s.getReposByUser(context.Background(), "super-secret-user", noopReporter())
 	assert.Nil(t, err)
 	assert.Equal(t, 1, s.filteredRepoCache.Count())
 	ok := s.filteredRepoCache.Exists("super-secret-user/super-secret-repo")
@@ -173,7 +173,7 @@ func TestAddGistsByUser(t *testing.T) {
 		JSON([]map[string]string{{"id": "aa5a315d61ae9438b18d", "git_pull_url": "https://gist.github.com/aa5a315d61ae9438b18d.git"}})
 
 	s := initTestSource(&sourcespb.GitHub{Credential: &sourcespb.GitHub_Unauthenticated{}})
-	err := s.addUserGistsToCache(context.Background(), "super-secret-user")
+	err := s.addUserGistsToCache(context.Background(), "super-secret-user", noopReporter())
 	assert.Nil(t, err)
 	assert.Equal(t, 1, s.filteredRepoCache.Count())
 	ok := s.filteredRepoCache.Exists("aa5a315d61ae9438b18d")
@@ -265,7 +265,7 @@ func TestAddReposByApp(t *testing.T) {
 		})
 
 	s := initTestSource(&sourcespb.GitHub{Credential: &sourcespb.GitHub_Unauthenticated{}})
-	err := s.getReposByApp(context.Background())
+	err := s.getReposByApp(context.Background(), noopReporter())
 	assert.Nil(t, err)
 	assert.Equal(t, 2, s.filteredRepoCache.Count())
 	ok := s.filteredRepoCache.Exists("ssr1")
@@ -419,7 +419,7 @@ func TestEnumerateUnauthenticated(t *testing.T) {
 	s.orgsCache = memory.New[string]()
 	s.orgsCache.Set("super-secret-org", "super-secret-org")
 	//s.enumerateUnauthenticated(context.Background(), apiEndpoint)
-	s.enumerateUnauthenticated(context.Background())
+	s.enumerateUnauthenticated(context.Background(), noopReporter())
 	assert.Equal(t, 1, s.filteredRepoCache.Count())
 	ok := s.filteredRepoCache.Exists("super-secret-org/super-secret-repo")
 	assert.True(t, ok)
@@ -458,7 +458,7 @@ func TestEnumerateWithToken(t *testing.T) {
 			Token: "token",
 		},
 	})
-	err := s.enumerateWithToken(context.Background(), false)
+	err := s.enumerateWithToken(context.Background(), false, noopReporter())
 	assert.Nil(t, err)
 	assert.Equal(t, 2, s.filteredRepoCache.Count())
 	ok := s.filteredRepoCache.Exists("super-secret-user/super-secret-repo")
@@ -502,7 +502,7 @@ func BenchmarkEnumerateWithToken(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = s.enumerateWithToken(context.Background(), false)
+		_ = s.enumerateWithToken(context.Background(), false, noopReporter())
 	}
 }
 
@@ -660,7 +660,7 @@ func TestEnumerateWithToken_IncludeRepos(t *testing.T) {
 	})
 	s.repos = []string{"some-special-repo"}
 
-	err := s.enumerateWithToken(context.Background(), false)
+	err := s.enumerateWithToken(context.Background(), false, noopReporter())
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(s.repos))
 	assert.Equal(t, []string{"some-special-repo"}, s.repos)
@@ -693,7 +693,7 @@ func TestEnumerateWithApp(t *testing.T) {
 			},
 		},
 	})
-	err := s.enumerateWithApp(context.Background(), s.connector.(*appConnector).InstallationClient())
+	err := s.enumerateWithApp(context.Background(), s.connector.(*appConnector).InstallationClient(), noopReporter())
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(s.repos))
 	assert.False(t, gock.HasUnmatchedRequest())
@@ -906,5 +906,13 @@ func Test_ScanMultipleTargets_MultipleErrors(t *testing.T) {
 	if assert.True(t, ok, "returned error was not unwrappable") {
 		got := unwrappable.Unwrap()
 		assert.ElementsMatch(t, got, want)
+	}
+}
+
+func noopReporter() sources.UnitReporter {
+	return sources.VisitorReporter{
+		VisitUnit: func(context.Context, sources.SourceUnit) error {
+			return nil
+		},
 	}
 }

--- a/pkg/sources/github/repo.go
+++ b/pkg/sources/github/repo.go
@@ -14,6 +14,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/giturl"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
 type repoInfoCache struct {
@@ -76,8 +77,8 @@ func (s *Source) appListReposWrapper(ctx context.Context, _ string, opts repoLis
 	return nil, res, err
 }
 
-func (s *Source) getReposByApp(ctx context.Context) error {
-	return s.processRepos(ctx, "", s.appListReposWrapper, &appListOptions{
+func (s *Source) getReposByApp(ctx context.Context, reporter sources.UnitReporter) error {
+	return s.processRepos(ctx, "", reporter, s.appListReposWrapper, &appListOptions{
 		ListOptions: github.ListOptions{
 			PerPage: defaultPagination,
 		},
@@ -96,8 +97,8 @@ func (s *Source) userListReposWrapper(ctx context.Context, user string, opts rep
 	return s.connector.APIClient().Repositories.ListByUser(ctx, user, &opts.(*userListOptions).RepositoryListByUserOptions)
 }
 
-func (s *Source) getReposByUser(ctx context.Context, user string) error {
-	return s.processRepos(ctx, user, s.userListReposWrapper, &userListOptions{
+func (s *Source) getReposByUser(ctx context.Context, user string, reporter sources.UnitReporter) error {
+	return s.processRepos(ctx, user, reporter, s.userListReposWrapper, &userListOptions{
 		RepositoryListByUserOptions: github.RepositoryListByUserOptions{
 			ListOptions: github.ListOptions{
 				PerPage: defaultPagination,
@@ -119,8 +120,8 @@ func (s *Source) orgListReposWrapper(ctx context.Context, org string, opts repoL
 	return s.connector.APIClient().Repositories.ListByOrg(ctx, org, &opts.(*orgListOptions).RepositoryListByOrgOptions)
 }
 
-func (s *Source) getReposByOrg(ctx context.Context, org string) error {
-	return s.processRepos(ctx, org, s.orgListReposWrapper, &orgListOptions{
+func (s *Source) getReposByOrg(ctx context.Context, org string, reporter sources.UnitReporter) error {
+	return s.processRepos(ctx, org, reporter, s.orgListReposWrapper, &orgListOptions{
 		RepositoryListByOrgOptions: github.RepositoryListByOrgOptions{
 			ListOptions: github.ListOptions{
 				PerPage: defaultPagination,
@@ -145,11 +146,11 @@ const (
 	organization
 )
 
-func (s *Source) getReposByOrgOrUser(ctx context.Context, name string) (userType, error) {
+func (s *Source) getReposByOrgOrUser(ctx context.Context, name string, reporter sources.UnitReporter) (userType, error) {
 	var err error
 
 	// List repositories for the organization |name|.
-	err = s.getReposByOrg(ctx, name)
+	err = s.getReposByOrg(ctx, name, reporter)
 	if err == nil {
 		return organization, nil
 	} else if !isGitHub404Error(err) {
@@ -157,9 +158,9 @@ func (s *Source) getReposByOrgOrUser(ctx context.Context, name string) (userType
 	}
 
 	// List repositories for the user |name|.
-	err = s.getReposByUser(ctx, name)
+	err = s.getReposByUser(ctx, name, reporter)
 	if err == nil {
-		if err := s.addUserGistsToCache(ctx, name); err != nil {
+		if err := s.addUserGistsToCache(ctx, name, reporter); err != nil {
 			ctx.Logger().Error(err, "Unable to add user to cache")
 		}
 		return user, nil
@@ -180,7 +181,7 @@ func isGitHub404Error(err error) bool {
 	return ghErr.Response.StatusCode == http.StatusNotFound
 }
 
-func (s *Source) processRepos(ctx context.Context, target string, listRepos repoLister, listOpts repoListOptions) error {
+func (s *Source) processRepos(ctx context.Context, target string, reporter sources.UnitReporter, listRepos repoLister, listOpts repoListOptions) error {
 	logger := ctx.Logger().WithValues("target", target)
 	opts := listOpts.getListOptions()
 
@@ -215,8 +216,10 @@ func (s *Source) processRepos(ctx context.Context, target string, listRepos repo
 			repoName, repoURL := r.GetFullName(), r.GetCloneURL()
 			s.totalRepoSize += r.GetSize()
 			s.filteredRepoCache.Set(repoName, repoURL)
-
 			s.cacheRepoInfo(r)
+			if err := reporter.UnitOk(ctx, RepoUnit{name: repoName, url: repoURL}); err != nil {
+				return err
+			}
 			logger.V(3).Info("repo attributes", "name", repoName, "kb_size", r.GetSize(), "repo_url", repoURL)
 		}
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
There's quite a bit of spaghetti that I tried to leave untouched. This works by adding a `UnitReporter`, passing those values into a channel, and draining all the values out of the channel for the synchronous case.

This reorganizes the code but does not change the existing behavior of enumerating then scanning.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

