### PR TITLE
Implement SourceUnitEnumChunker for GitHub

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -642,6 +642,10 @@ func (s *Source) scan(ctx context.Context, reporter sources.ChunkReporter) error
 	return nil
 }
 
+// scanRepo attempts to scan the provided URL and any associated wiki and
+// comments if configured. An error is returned if we could not find necessary
+// repository metadata or clone the repo, otherwise all errors are reported to
+// the ChunkReporter.
 func (s *Source) scanRepo(ctx context.Context, repoURL string, reporter sources.ChunkReporter) error {
 	if !strings.HasSuffix(repoURL, ".git") {
 		return fmt.Errorf("repo does not end in .git")

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -84,20 +84,20 @@ var _ sources.SourceUnit = (*RepoUnit)(nil)
 var _ sources.SourceUnit = (*GistUnit)(nil)
 
 type RepoUnit struct {
-	name string
-	url  string
+	Name string `json:"name"`
+	URL  string `json:"url"`
 }
 
-func (r RepoUnit) SourceUnitID() (string, sources.SourceUnitKind) { return r.url, "repo" }
-func (r RepoUnit) Display() string                                { return r.name }
+func (r RepoUnit) SourceUnitID() (string, sources.SourceUnitKind) { return r.URL, "repo" }
+func (r RepoUnit) Display() string                                { return r.Name }
 
 type GistUnit struct {
-	name string
-	url  string
+	Name string `json:"name"`
+	URL  string `json:"url"`
 }
 
-func (g GistUnit) SourceUnitID() (string, sources.SourceUnitKind) { return g.url, "gist" }
-func (g GistUnit) Display() string                                { return g.name }
+func (g GistUnit) SourceUnitID() (string, sources.SourceUnitKind) { return g.URL, "gist" }
+func (g GistUnit) Display() string                                { return g.Name }
 
 // --------------------------------------------------------------------------------
 
@@ -373,7 +373,7 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 	// Report any values that were already configured.
 	for _, name := range s.filteredRepoCache.Keys() {
 		url, _ := s.filteredRepoCache.Get(name)
-		_ = dedupeReporter.UnitOk(ctx, RepoUnit{name: name, url: url})
+		_ = dedupeReporter.UnitOk(ctx, RepoUnit{Name: name, URL: url})
 	}
 
 	// I'm not wild about switching on the connector type here (as opposed to dispatching to the connector itself) but
@@ -820,7 +820,7 @@ func (s *Source) addUserGistsToCache(ctx context.Context, user string, reporter 
 		for _, gist := range gists {
 			s.filteredRepoCache.Set(gist.GetID(), gist.GetGitPullURL())
 			s.cacheGistInfo(gist)
-			if err := reporter.UnitOk(ctx, GistUnit{name: gist.GetID(), url: gist.GetGitPullURL()}); err != nil {
+			if err := reporter.UnitOk(ctx, GistUnit{Name: gist.GetID(), URL: gist.GetGitPullURL()}); err != nil {
 				return err
 			}
 		}

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -213,6 +213,11 @@ func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, so
 	s.jobPool = &errgroup.Group{}
 	s.jobPool.SetLimit(concurrency)
 
+	// Setup scan options if it wasn't provided.
+	if s.scanOptions == nil {
+		s.scanOptions = &git.ScanOptions{}
+	}
+
 	var conn sourcespb.GitHub
 	err = anypb.UnmarshalTo(connection, &conn, proto.UnmarshalOptions{})
 	if err != nil {
@@ -621,11 +626,6 @@ func (s *Source) scan(ctx context.Context, reporter sources.ChunkReporter) error
 	// If there is resume information available, limit this scan to only the repos that still need scanning.
 	reposToScan, progressIndexOffset := sources.FilterReposToResume(s.repos, s.GetProgress().EncodedResumeInfo)
 	s.repos = reposToScan
-
-	// Setup scan options if it wasn't provided.
-	if s.scanOptions == nil {
-		s.scanOptions = &git.ScanOptions{}
-	}
 
 	for i, repoURL := range s.repos {
 		i, repoURL := i, repoURL

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -1509,5 +1509,11 @@ func (s *Source) scanTarget(ctx context.Context, target sources.ChunkingTarget, 
 func (s *Source) ChunkUnit(ctx context.Context, unit sources.SourceUnit, reporter sources.ChunkReporter) error {
 	repoURL, _ := unit.SourceUnitID()
 	ctx = context.WithValue(ctx, "repo", repoURL)
+	// ChunkUnit is not guaranteed to be called from Enumerate, so we must
+	// check and fetch the repoInfoCache for this repo.
+	repoURL, err := s.ensureRepoInfoCache(ctx, repoURL)
+	if err != nil {
+		return err
+	}
 	return s.scanRepo(ctx, repoURL, reporter)
 }

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -577,7 +577,7 @@ func TestEnumerate(t *testing.T) {
 	}
 
 	// Act
-	err := s.enumerate(context.Background(), reporter)
+	err := s.Enumerate(context.Background(), reporter)
 	slices.Sort(reportedRepos)
 
 	// Assert
@@ -653,7 +653,7 @@ func BenchmarkEnumerate(b *testing.B) {
 		setupMocks(b)
 
 		b.StartTimer()
-		_ = s.enumerate(context.Background(), noopReporter())
+		_ = s.Enumerate(context.Background(), noopReporter())
 	}
 }
 

--- a/pkg/sources/github/repo.go
+++ b/pkg/sources/github/repo.go
@@ -217,7 +217,7 @@ func (s *Source) processRepos(ctx context.Context, target string, reporter sourc
 			s.totalRepoSize += r.GetSize()
 			s.filteredRepoCache.Set(repoName, repoURL)
 			s.cacheRepoInfo(r)
-			if err := reporter.UnitOk(ctx, RepoUnit{name: repoName, url: repoURL}); err != nil {
+			if err := reporter.UnitOk(ctx, RepoUnit{Name: repoName, URL: repoURL}); err != nil {
 				return err
 			}
 			logger.V(3).Info("repo attributes", "name", repoName, "kb_size", r.GetSize(), "repo_url", repoURL)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Implements `SourceUnitEnumChunker` for GitHub source. When merged, `github` scans will use the `Enumerate` and `ChunkUnit` methods instead of `Chunks` to scan.

Builds off of #3296 and #3292

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

