### PR TITLE
[Detector] Cut out unneccessary false positive session tokens of AWSSession Key

### DIFF
--- a/pkg/detectors/awssessionkeys/awssessionkey.go
+++ b/pkg/detectors/awssessionkeys/awssessionkey.go
@@ -86,8 +86,10 @@ func GetHMAC(key []byte, data []byte) []byte {
 	return hasher.Sum(nil)
 }
 
+// Reference: https://nitter.poast.org/TalBeerySec/status/1816449053841838223#m
 func checkSessionToken(sessionToken string, secret string) bool {
-	if !strings.Contains(sessionToken, "YXdz") || strings.Contains(sessionToken, secret) {
+	if !(strings.Contains(sessionToken, "YXdz") || strings.Contains(sessionToken, "Jb3JpZ2luX2Vj")) ||
+		strings.Contains(sessionToken, secret) {
 		// Handle error if the sessionToken is not a valid base64 string
 		return false
 	}


### PR DESCRIPTION
### Description:
Based on the [article](https://twitter.com/TalBeerySec/status/1816449041347080382), Session Key can be of 5 variants and can be easily identified based on sub-strings (`YXdz` & `Jb3JpZ2luX2Vj`). Current implementation was only looking for `YXdz`. This PR includes check for another string `Jb3JpZ2luX2Vj`.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

