### PR TITLE
Update timeout to 60s

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -250,7 +250,7 @@ func selectHandler(mimeT mimeType, isGenericArchive bool) FileHandler {
 	}
 }
 
-var maxTimeout = time.Duration(30) * time.Second
+var maxTimeout = time.Duration(60) * time.Second
 
 // SetArchiveMaxTimeout sets the maximum timeout for the archive handler.
 func SetArchiveMaxTimeout(timeout time.Duration) { maxTimeout = timeout }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR increases the default archive handling timeout to 60 seconds. In the future, we should make this configurable, but for now, I'm just updating the default.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

