### PR TITLE
[fix] Correctly initialize detectors with cloud endpoint customization

### DIFF
--- a/pkg/detectors/gitlab/v2/gitlab_v2.go
+++ b/pkg/detectors/gitlab/v2/gitlab_v2.go
@@ -23,8 +23,8 @@ var _ detectors.Detector = (*Scanner)(nil)
 var _ detectors.EndpointCustomizer = (*Scanner)(nil)
 var _ detectors.Versioner = (*Scanner)(nil)
 
-func (Scanner) Version() int            { return 2 }
-func (Scanner) DefaultEndpoint() string { return "https://gitlab.com" }
+func (Scanner) Version() int          { return 2 }
+func (Scanner) CloudEndpoint() string { return "https://gitlab.com" }
 
 var (
 	defaultClient = common.SaneHttpClient()
@@ -77,7 +77,7 @@ func (s Scanner) verifyGitlab(ctx context.Context, resMatch string) (bool, error
 	if client == nil {
 		client = defaultClient
 	}
-	for _, baseURL := range s.Endpoints(s.DefaultEndpoint()) {
+	for _, baseURL := range s.Endpoints() {
 		// test `read_user` scope
 		req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/api/v4/user", nil)
 		if err != nil {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -268,6 +268,20 @@ func NewEngine(ctx context.Context, cfg *Config) (*Engine, error) {
 		return nil, err
 	}
 
+	// Abuse filters to initialize endpoint customizer detectors.
+	filters = append(filters, func(d detectors.Detector) bool {
+		customizer, ok := d.(detectors.EndpointCustomizer)
+		if !ok {
+			return true
+		}
+		customizer.UseFoundEndpoints(true)
+		customizer.UseCloudEndpoint(true)
+		if cloudProvider, ok := d.(detectors.CloudProvider); ok {
+			customizer.SetCloudEndpoint(cloudProvider.CloudEndpoint())
+		}
+		return true
+	})
+
 	if len(detectorsWithCustomVerifierEndpoints) > 0 {
 		filters = append(filters, func(d detectors.Detector) bool {
 			urls, ok := getWithDetectorID(d, detectorsWithCustomVerifierEndpoints)

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1043,3 +1043,26 @@ func TestEngine_ShouldVerifyChunk(t *testing.T) {
 		}
 	}
 }
+
+func TestEngineInitializesCloudProviderDetectors(t *testing.T) {
+	ctx := context.Background()
+	conf := Config{
+		Concurrency:   1,
+		Detectors:     DefaultDetectors(),
+		Verify:        false,
+		SourceManager: sources.NewManager(),
+		Dispatcher:    NewPrinterDispatcher(new(discardPrinter)),
+	}
+
+	e, err := NewEngine(ctx, &conf)
+	assert.NoError(t, err)
+
+	for _, det := range e.detectors {
+		if endpoints, ok := det.(interface{ Endpoints(...string) []string }); ok {
+			id := config.GetDetectorID(det)
+			if len(endpoints.Endpoints()) == 0 {
+				t.Fatalf("detector %q Endpoints() is empty", id.String())
+			}
+		}
+	}
+}


### PR DESCRIPTION


<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We were only initializing if the detector was configured with a custom endpoint, but not in the default case.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

