### PR TITLE
[chore] Ensure testing Endpoints() doesn't silently pass on change

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1057,12 +1057,18 @@ func TestEngineInitializesCloudProviderDetectors(t *testing.T) {
 	e, err := NewEngine(ctx, &conf)
 	assert.NoError(t, err)
 
+	var count int
 	for _, det := range e.detectors {
 		if endpoints, ok := det.(interface{ Endpoints(...string) []string }); ok {
 			id := config.GetDetectorID(det)
 			if len(endpoints.Endpoints()) == 0 {
 				t.Fatalf("detector %q Endpoints() is empty", id.String())
 			}
+			count++
 		}
+	}
+
+	if count == 0 {
+		t.Fatal("no detectors found implementing Endpoints(), did EndpointSetter change?")
 	}
 }


### PR DESCRIPTION


<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Since Endpoints() isn't a defined interface, we are testing an implementation detail of EndpointSetter. If that function changes in anyway, the test will now fail instead of skipping every detector and passing.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

