### PR TITLE
Improve process cleanup

### DIFF
--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -314,12 +314,14 @@ func (c *Parser) executeCommand(ctx context.Context, cmd *exec.Cmd, isStaged boo
 	}()
 
 	go func() {
+		defer func() {
+			if err := cmd.Wait(); err != nil {
+				ctx.Logger().V(2).Info("Error waiting for git command to complete.", "error", err)
+			}
+		}()
 		c.FromReader(ctx, stdOut, diffChan, isStaged)
 		if err := stdOut.Close(); err != nil {
 			ctx.Logger().V(2).Info("Error closing git stdout pipe.", "error", err)
-		}
-		if err := cmd.Wait(); err != nil {
-			ctx.Logger().V(2).Info("Error waiting for git command to complete.", "error", err)
 		}
 	}()
 

--- a/pkg/process/zombies.go
+++ b/pkg/process/zombies.go
@@ -1,0 +1,48 @@
+package process
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+func GetGitProcessList() []string {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "darwin" {
+		cmd = exec.Command("ps", "-eo", "pid,state,command")
+	} else {
+		cmd = exec.Command("ps", "-eo", "pid,stat,cmd")
+	}
+
+	output, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+
+	lines := strings.Split(string(output), "\n")
+	var gitProcesses []string
+	for _, line := range lines {
+		if strings.Contains(line, "git") {
+			gitProcesses = append(gitProcesses, line)
+		}
+	}
+	return gitProcesses
+}
+
+func DetectGitZombies(before, after []string) []string {
+	beforeMap := make(map[string]bool)
+	for _, process := range before {
+		beforeMap[process] = true
+	}
+
+	var zombies []string
+	for _, process := range after {
+		if !beforeMap[process] {
+			fields := strings.Fields(process)
+			if len(fields) >= 2 && (fields[1] == "Z" || strings.HasPrefix(fields[1], "Z")) {
+				zombies = append(zombies, process)
+			}
+		}
+	}
+	return zombies
+}

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -1241,10 +1241,12 @@ func (s *Git) handleBinary(ctx context.Context, gitDir string, reporter sources.
 	}
 
 	cmd := exec.Command("git", "-C", gitDir, "cat-file", "blob", commitHash.String()+":"+path)
-	stdout, err := s.executeCatFileCmd(cmd)
+	stdout, catCmd, err := s.executeCatFileCmd(cmd)
 	if err != nil {
 		return err
 	}
+	// Wait must be called after closing the pipe (defer is a stack, so first defer is executed last)
+	defer catCmd.Wait()
 	defer stdout.Close()
 
 	err = handlers.HandleFile(ctx, stdout, chunkSkel, reporter, handlers.WithSkipArchives(s.skipArchives))
@@ -1261,20 +1263,20 @@ func (s *Git) handleBinary(ctx context.Context, gitDir string, reporter sources.
 	return waitErr
 }
 
-func (s *Git) executeCatFileCmd(cmd *exec.Cmd) (io.ReadCloser, error) {
+func (s *Git) executeCatFileCmd(cmd *exec.Cmd) (io.ReadCloser, *exec.Cmd, error) {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return nil, fmt.Errorf("error running git cat-file: %w\n%s", err, stderr.Bytes())
+		return nil, nil, fmt.Errorf("error running git cat-file: %w\n%s", err, stderr.Bytes())
 	}
 
 	if err := cmd.Start(); err != nil {
-		return nil, fmt.Errorf("error starting git cat-file: %w\n%s", err, stderr.Bytes())
+		return nil, nil, fmt.Errorf("error starting git cat-file: %w\n%s", err, stderr.Bytes())
 	}
 
-	return stdout, nil
+	return stdout, cmd, nil
 }
 
 func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) error {

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -1245,12 +1245,20 @@ func (s *Git) handleBinary(ctx context.Context, gitDir string, reporter sources.
 	if err != nil {
 		return err
 	}
+	defer stdout.Close()
 
-	if err = handlers.HandleFile(ctx, stdout, chunkSkel, reporter, handlers.WithSkipArchives(s.skipArchives)); err != nil {
+	err = handlers.HandleFile(ctx, stdout, chunkSkel, reporter, handlers.WithSkipArchives(s.skipArchives))
+
+	// Always call Wait() to ensure the process is properly cleaned up
+	waitErr := cmd.Wait()
+
+	// If there was an error in HandleFile, return that error
+	if err != nil {
 		return err
 	}
 
-	return cmd.Wait()
+	// If Wait() resulted in an error, return that error
+	return waitErr
 }
 
 func (s *Git) executeCatFileCmd(cmd *exec.Cmd) (io.ReadCloser, error) {

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -1246,7 +1246,9 @@ func (s *Git) handleBinary(ctx context.Context, gitDir string, reporter sources.
 		return err
 	}
 	// Wait must be called after closing the pipe (defer is a stack, so first defer is executed last)
-	defer catCmd.Wait()
+	defer func() {
+		_ = catCmd.Wait()
+	}()
 	defer stdout.Close()
 
 	err = handlers.HandleFile(ctx, stdout, chunkSkel, reporter, handlers.WithSkipArchives(s.skipArchives))

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/credentialspb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/process"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sourcestest"
 )
@@ -235,6 +236,8 @@ func TestSource_Chunks_Integration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Source{}
 
+			beforeProcesses := process.GetGitProcessList()
+
 			conn, err := anypb.New(tt.init.connection)
 			if err != nil {
 				t.Fatal(err)
@@ -279,6 +282,12 @@ func TestSource_Chunks_Integration(t *testing.T) {
 					t.Errorf("Expected data with key %q not found", key)
 				}
 
+			}
+
+			afterProcesses := process.GetGitProcessList()
+			zombies := process.DetectGitZombies(beforeProcesses, afterProcesses)
+			if len(zombies) > 0 {
+				t.Errorf("Git zombies detected: %v", zombies)
 			}
 		})
 	}


### PR DESCRIPTION
### Description:
Makes process cleanup more robust for gitparse, and adds missing process cleanup to the git package.
The git package was leaving zombie processes and the gitparse one could under some failure scenarios.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

