### PR TITLE
[fix] - Use Parent Context in Azure Detector

### DIFF
--- a/pkg/detectors/azure/azure.go
+++ b/pkg/detectors/azure/azure.go
@@ -3,8 +3,9 @@ package azure
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 
@@ -69,7 +70,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					if err != nil {
 						continue
 					}
-					err = token.Refresh()
+					err = token.RefreshWithContext(ctx)
 					if err == nil {
 						res.Verified = true
 					}

--- a/pkg/detectors/azure/azure.go
+++ b/pkg/detectors/azure/azure.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	regexp "github.com/wasilibs/go-re2"
-
 	"github.com/Azure/go-autorest/autorest/azure/auth"
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR ensures the Azure detector uses the provided context to respect the context's Timeout.
### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

