### PR TITLE
[bug] - Recover From Panic During Archive Handling

### DIFF
--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -56,9 +56,9 @@ func (h *archiveHandler) HandleFile(ctx logContext.Context, input fileReader) (c
 		var err error
 		defer close(dataChan)
 
-		// Sometimes the undelrying 7zip library panics when trying to open an archive.
-		// It is caused by an IOOR error when reading the header of the archive.
-		// https://github.com/bodgit/sevenzip/blob/74bff0da9b233317e4ea7dd8c184a315db71af2a/types.go#L846
+		// The underlying 7zip library may panic when attempting to open an archive.
+		// This is due to an Index Out Of Range (IOOR) error when reading the archive header.
+		// See: https://github.com/bodgit/sevenzip/blob/74bff0da9b233317e4ea7dd8c184a315db71af2a/types.go#L846
 		defer func() {
 			if r := recover(); r != nil {
 				// Return the panic as an error.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR adds deferred recovery when handling archives to address an index out-of-range (IOOR) panic in the 7zip library. I haven't traced the full call stack yet, but once I do, I'll open an issue and submit a PR with a fix to the upstream repo if I can find a solution.

![Screenshot 2024-09-29 at 1 20 56 PM](https://github.com/user-attachments/assets/d751b393-4b8a-4ea8-a46d-0c4cd32187b4)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

