### PR TITLE
[chore] - Rename memory cache package to 'simple' for clarity

### DIFF
--- a/pkg/cache/simple/simple.go
+++ b/pkg/cache/simple/simple.go
@@ -1,4 +1,4 @@
-package memory
+package simple
 
 import (
 	"strings"

--- a/pkg/cache/simple/simple.go
+++ b/pkg/cache/simple/simple.go
@@ -35,11 +35,11 @@ func WithPurgeInterval[T any](interval time.Duration) CacheOption[T] {
 	return func(c *Cache[T]) { c.purgeInterval = interval }
 }
 
-// New constructs a new in-memory cache instance with optional configurations.
+// NewCache constructs a new in-memory cache instance with optional configurations.
 // By default, it sets the expiration and purge intervals to 12 and 13 hours, respectively.
 // These defaults can be overridden using the functional options: WithExpirationInterval and WithPurgeInterval.
-func New[T any](opts ...CacheOption[T]) *Cache[T] {
-	return NewWithData[T](nil, opts...)
+func NewCache[T any](opts ...CacheOption[T]) *Cache[T] {
+	return NewCacheWithData[T](nil, opts...)
 }
 
 // CacheEntry represents a single entry in the cache, consisting of a key and its corresponding value.
@@ -50,9 +50,9 @@ type CacheEntry[T any] struct {
 	Value T
 }
 
-// NewWithData constructs a new in-memory cache with existing data.
+// NewCacheWithData constructs a new in-memory cache with existing data.
 // It also accepts CacheOption parameters to override default configuration values.
-func NewWithData[T any](data []CacheEntry[T], opts ...CacheOption[T]) *Cache[T] {
+func NewCacheWithData[T any](data []CacheEntry[T], opts ...CacheOption[T]) *Cache[T] {
 	instance := &Cache[T]{expiration: defaultExpirationInterval, purgeInterval: defaultPurgeInterval}
 	for _, opt := range opts {
 		opt(instance)

--- a/pkg/cache/simple/simple_test.go
+++ b/pkg/cache/simple/simple_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestCache(t *testing.T) {
-	c := New[string]()
+	c := NewCache[string]()
 
 	// Test set and get.
 	c.Set("key1", "key1")
@@ -82,7 +82,7 @@ func TestCache(t *testing.T) {
 
 func TestCache_NewWithData(t *testing.T) {
 	data := []CacheEntry[string]{{"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}}
-	c := NewWithData(data)
+	c := NewCacheWithData(data)
 
 	// Test the count.
 	if c.Count() != 3 {
@@ -107,7 +107,7 @@ func TestCache_NewWithData(t *testing.T) {
 func setupBenchmarks(b *testing.B) *Cache[string] {
 	b.Helper()
 
-	c := New[string]()
+	c := NewCache[string]()
 
 	for i := 0; i < 500_000; i++ {
 		key := fmt.Sprintf("key%d", i)
@@ -118,7 +118,7 @@ func setupBenchmarks(b *testing.B) *Cache[string] {
 }
 
 func BenchmarkSet(b *testing.B) {
-	c := New[string]()
+	c := NewCache[string]()
 
 	for i := 0; i < b.N; i++ {
 		key := fmt.Sprintf("key%d", i)

--- a/pkg/cache/simple/simple_test.go
+++ b/pkg/cache/simple/simple_test.go
@@ -1,4 +1,4 @@
-package memory
+package simple
 
 import (
 	"fmt"

--- a/pkg/sources/gcs/gcs.go
+++ b/pkg/sources/gcs/gcs.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/cache"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/cache/memory"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/cache/simple"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/handlers"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/credentialspb"
@@ -296,15 +296,15 @@ func (s *Source) setupCache(ctx context.Context) *persistableCache {
 	var c cache.Cache[string]
 	if s.Progress.EncodedResumeInfo != "" {
 		keys := strings.Split(s.Progress.EncodedResumeInfo, ",")
-		entries := make([]memory.CacheEntry[string], len(keys))
+		entries := make([]simple.CacheEntry[string], len(keys))
 		for i, val := range keys {
-			entries[i] = memory.CacheEntry[string]{Key: val, Value: val}
+			entries[i] = simple.CacheEntry[string]{Key: val, Value: val}
 		}
 
-		c = memory.NewWithData[string](entries)
+		c = simple.NewWithData[string](entries)
 		ctx.Logger().V(3).Info("Loaded cache", "num_entries", len(entries))
 	} else {
-		c = memory.New[string]()
+		c = simple.New[string]()
 	}
 
 	// TODO (ahrav): Make this configurable via conn.

--- a/pkg/sources/gcs/gcs.go
+++ b/pkg/sources/gcs/gcs.go
@@ -301,10 +301,10 @@ func (s *Source) setupCache(ctx context.Context) *persistableCache {
 			entries[i] = simple.CacheEntry[string]{Key: val, Value: val}
 		}
 
-		c = simple.NewWithData[string](entries)
+		c = simple.NewCacheWithData[string](entries)
 		ctx.Logger().V(3).Info("Loaded cache", "num_entries", len(entries))
 	} else {
-		c = simple.New[string]()
+		c = simple.NewCache[string]()
 	}
 
 	// TODO (ahrav): Make this configurable via conn.

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -21,13 +21,12 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/handlers"
-
 	"github.com/trufflesecurity/trufflehog/v3/pkg/cache"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/cache/simple"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/giturl"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/handlers"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sanitizer"

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -16,14 +16,15 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/gobwas/glob"
 	"github.com/google/go-github/v63/github"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/handlers"
 	"golang.org/x/exp/rand"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/handlers"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/cache"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/cache/memory"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/cache/simple"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/giturl"
@@ -231,14 +232,14 @@ func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, so
 	}
 	s.connector = connector
 
-	s.orgsCache = memory.New[string]()
+	s.orgsCache = simple.New[string]()
 	for _, org := range s.conn.Organizations {
 		s.orgsCache.Set(org, org)
 	}
 	s.memberCache = make(map[string]struct{})
 
 	s.filteredRepoCache = s.newFilteredRepoCache(aCtx,
-		memory.New[string](),
+		simple.New[string](),
 		append(s.conn.GetRepositories(), s.conn.GetIncludeRepos()...),
 		s.conn.GetIgnoreRepos(),
 	)

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -232,14 +232,14 @@ func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, so
 	}
 	s.connector = connector
 
-	s.orgsCache = simple.New[string]()
+	s.orgsCache = simple.NewCache[string]()
 	for _, org := range s.conn.Organizations {
 		s.orgsCache.Set(org, org)
 	}
 	s.memberCache = make(map[string]struct{})
 
 	s.filteredRepoCache = s.newFilteredRepoCache(aCtx,
-		simple.New[string](),
+		simple.NewCache[string](),
 		append(s.conn.GetRepositories(), s.conn.GetIncludeRepos()...),
 		s.conn.GetIgnoreRepos(),
 	)

--- a/pkg/sources/github/github_integration_test.go
+++ b/pkg/sources/github/github_integration_test.go
@@ -61,7 +61,7 @@ func TestSource_Token(t *testing.T) {
 		repoInfoCache: newRepoInfoCache(),
 	}
 	s.Init(ctx, "github integration test source", 0, 0, false, conn, 1)
-	s.filteredRepoCache = s.newFilteredRepoCache(ctx, simple.New[string](), nil, nil)
+	s.filteredRepoCache = s.newFilteredRepoCache(ctx, simple.NewCache[string](), nil, nil)
 
 	err = s.enumerateWithApp(ctx, s.connector.(*appConnector).InstallationClient(), noopReporter())
 	assert.NoError(t, err)

--- a/pkg/sources/github/github_integration_test.go
+++ b/pkg/sources/github/github_integration_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/cache/memory"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/cache/simple"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/credentialspb"
@@ -61,7 +61,7 @@ func TestSource_Token(t *testing.T) {
 		repoInfoCache: newRepoInfoCache(),
 	}
 	s.Init(ctx, "github integration test source", 0, 0, false, conn, 1)
-	s.filteredRepoCache = s.newFilteredRepoCache(ctx, memory.New[string](), nil, nil)
+	s.filteredRepoCache = s.newFilteredRepoCache(ctx, simple.New[string](), nil, nil)
 
 	err = s.enumerateWithApp(ctx, s.connector.(*appConnector).InstallationClient(), noopReporter())
 	assert.NoError(t, err)

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -23,7 +23,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"gopkg.in/h2non/gock.v1"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/cache/memory"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/cache/simple"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/credentialspb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
@@ -417,9 +417,9 @@ func TestEnumerateUnauthenticated(t *testing.T) {
 		Endpoint:   apiEndpoint,
 		Credential: &sourcespb.GitHub_Unauthenticated{},
 	})
-	s.orgsCache = memory.New[string]()
+	s.orgsCache = simple.New[string]()
 	s.orgsCache.Set("super-secret-org", "super-secret-org")
-	//s.enumerateUnauthenticated(context.Background(), apiEndpoint)
+	// s.enumerateUnauthenticated(context.Background(), apiEndpoint)
 	s.enumerateUnauthenticated(context.Background(), noopReporter())
 	assert.Equal(t, 1, s.filteredRepoCache.Count())
 	ok := s.filteredRepoCache.Exists("super-secret-org/super-secret-repo")

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -417,7 +417,7 @@ func TestEnumerateUnauthenticated(t *testing.T) {
 		Endpoint:   apiEndpoint,
 		Credential: &sourcespb.GitHub_Unauthenticated{},
 	})
-	s.orgsCache = simple.New[string]()
+	s.orgsCache = simple.NewCache[string]()
 	s.orgsCache.Set("super-secret-org", "super-secret-org")
 	// s.enumerateUnauthenticated(context.Background(), apiEndpoint)
 	s.enumerateUnauthenticated(context.Background(), noopReporter())

--- a/pkg/sources/huggingface/huggingface.go
+++ b/pkg/sources/huggingface/huggingface.go
@@ -191,12 +191,12 @@ func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, so
 	}
 	s.conn = &conn
 
-	s.orgsCache = simple.New[string]()
+	s.orgsCache = simple.NewCache[string]()
 	for _, org := range s.conn.Organizations {
 		s.orgsCache.Set(org, org)
 	}
 
-	s.usersCache = simple.New[string]()
+	s.usersCache = simple.NewCache[string]()
 	for _, user := range s.conn.Users {
 		s.usersCache.Set(user, user)
 	}
@@ -208,17 +208,17 @@ func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, so
 		return err
 	}
 
-	s.filteredModelsCache = s.newFilteredRepoCache(simple.New[string](),
+	s.filteredModelsCache = s.newFilteredRepoCache(simple.NewCache[string](),
 		append(s.conn.GetModels(), s.conn.GetIncludeModels()...),
 		s.conn.GetIgnoreModels(),
 	)
 
-	s.filteredSpacesCache = s.newFilteredRepoCache(simple.New[string](),
+	s.filteredSpacesCache = s.newFilteredRepoCache(simple.NewCache[string](),
 		append(s.conn.GetSpaces(), s.conn.GetIncludeSpaces()...),
 		s.conn.GetIgnoreSpaces(),
 	)
 
-	s.filteredDatasetsCache = s.newFilteredRepoCache(simple.New[string](),
+	s.filteredDatasetsCache = s.newFilteredRepoCache(simple.NewCache[string](),
 		append(s.conn.GetDatasets(), s.conn.GetIncludeDatasets()...),
 		s.conn.GetIgnoreDatasets(),
 	)

--- a/pkg/sources/huggingface/huggingface.go
+++ b/pkg/sources/huggingface/huggingface.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/cache"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/cache/memory"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/cache/simple"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/giturl"
@@ -191,34 +191,34 @@ func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, so
 	}
 	s.conn = &conn
 
-	s.orgsCache = memory.New[string]()
+	s.orgsCache = simple.New[string]()
 	for _, org := range s.conn.Organizations {
 		s.orgsCache.Set(org, org)
 	}
 
-	s.usersCache = memory.New[string]()
+	s.usersCache = simple.New[string]()
 	for _, user := range s.conn.Users {
 		s.usersCache.Set(user, user)
 	}
 
-	//Verify ignore and include models, spaces, and datasets are valid
+	// Verify ignore and include models, spaces, and datasets are valid
 	// this ensures that calling --org <org> --ignore-model <org/model> contains the proper
 	// repo format of org/model. Otherwise, we would scan the entire org.
 	if err := s.validateIgnoreIncludeRepos(); err != nil {
 		return err
 	}
 
-	s.filteredModelsCache = s.newFilteredRepoCache(memory.New[string](),
+	s.filteredModelsCache = s.newFilteredRepoCache(simple.New[string](),
 		append(s.conn.GetModels(), s.conn.GetIncludeModels()...),
 		s.conn.GetIgnoreModels(),
 	)
 
-	s.filteredSpacesCache = s.newFilteredRepoCache(memory.New[string](),
+	s.filteredSpacesCache = s.newFilteredRepoCache(simple.New[string](),
 		append(s.conn.GetSpaces(), s.conn.GetIncludeSpaces()...),
 		s.conn.GetIgnoreSpaces(),
 	)
 
-	s.filteredDatasetsCache = s.newFilteredRepoCache(memory.New[string](),
+	s.filteredDatasetsCache = s.newFilteredRepoCache(simple.New[string](),
 		append(s.conn.GetDatasets(), s.conn.GetIncludeDatasets()...),
 		s.conn.GetIgnoreDatasets(),
 	)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR renames the memory cache pkg to simple.
### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

