### PR TITLE
[Fix] Update Azure Client, Tenant Ids and Client Secret Detection Regexs.

### DIFF
--- a/pkg/detectors/azure/azure.go
+++ b/pkg/detectors/azure/azure.go
@@ -21,61 +21,75 @@ type Scanner struct {
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 
-func mustFmtPat(id, pat string) *regexp.Regexp {
-	combinedID := strings.ReplaceAll(id, "_", "") + "|" + id
-	return regexp.MustCompile(fmt.Sprintf(pat, combinedID))
-}
-
 var (
 	// TODO: Azure storage access keys and investigate other types of creds.
 
 	// Azure App Oauth
-	idPatFmt         = `(?i)(%s).{0,20}([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})`
-	clientIDPat      = mustFmtPat("client_id", idPatFmt)
-	tenantIDPat      = mustFmtPat("tenant_id", idPatFmt)
-	tenantIDInUrlPat = regexp.MustCompile(`https:\/\/login\.microsoftonline\.com\/([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\/oauth2\/v2\.0\/token`)
+	udidPatFmt  = `([a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})`
+	clientIDPat = regexp.MustCompile(detectors.PrefixRegex([]string{"client_id", "clientid"}) + udidPatFmt)
+	tenantIDPat = regexp.MustCompile(detectors.PrefixRegex([]string{"microsoftonline", "tenant_id", "tenantid"}) + udidPatFmt)
 
-	secretPatFmt    = `(?i)(%s).{0,20}?([a-z0-9_\.\-~]{1,40})`
-	clientSecretPat = mustFmtPat("client_secret", secretPatFmt)
+	// According the Microsoft documentation, the client secret can be 24, 32, 40, 44, 56, or 88 characters long.
+	// https://learn.microsoft.com/en-us/purview/sit-defn-client-secret-api-key
+	clientSecretSubPatFmt = `(\b[a-zA-Z0-9_\.\-~]{%d}\b)`
+
+	clientSecretPat = regexp.MustCompile(detectors.PrefixRegex([]string{"client_secret", "clientsecret"}) + "(" +
+		fmt.Sprintf(clientSecretSubPatFmt, 24) + "|" +
+		fmt.Sprintf(clientSecretSubPatFmt, 32) + "|" +
+		fmt.Sprintf(clientSecretSubPatFmt, 40) + "|" +
+		fmt.Sprintf(clientSecretSubPatFmt, 44) + "|" +
+		fmt.Sprintf(clientSecretSubPatFmt, 56) + "|" +
+		fmt.Sprintf(clientSecretSubPatFmt, 88) + ")")
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"azure"}
+	return []string{"azure", "microsoftonline", "microsoft"}
+}
+
+func trimUniqueMatches(matches [][]string) (result map[string]struct{}) {
+	result = make(map[string]struct{})
+	for _, match := range matches {
+		if len(match) > 1 {
+			trimmedString := strings.TrimSpace(match[1])
+			result[trimmedString] = struct{}{}
+		}
+	}
+	return result
 }
 
 // FromData will find and optionally verify Azure secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
 	dataStr := string(data)
 
-	clientSecretMatches := clientSecretPat.FindAllStringSubmatch(dataStr, -1)
-	for _, clientSecret := range clientSecretMatches {
-		tenantIDMatches := tenantIDPat.FindAllStringSubmatch(dataStr, -1)
-		tenantIDInUrlMatches := tenantIDInUrlPat.FindAllStringSubmatch(dataStr, -1)
-		tenantIDMatches = append(tenantIDMatches, tenantIDInUrlMatches...)
-		for _, tenantIDMatch := range tenantIDMatches {
-			var tenantID string
-			if len(tenantIDMatch) == 3 {
-				tenantID = tenantIDMatch[2]
-			} else {
-				tenantID = tenantIDMatch[1]
-			}
-			fmt.Println(tenantID)
-			clientIDMatches := clientIDPat.FindAllStringSubmatch(dataStr, -1)
-			for _, clientID := range clientIDMatches {
-				res := detectors.Result{
+	uniqueClientSecretMatches := trimUniqueMatches(clientSecretPat.FindAllStringSubmatch(dataStr, -1))
+	uniqueClientIDMatches := trimUniqueMatches(clientIDPat.FindAllStringSubmatch(dataStr, -1))
+	uniqueTenantIDMatches := trimUniqueMatches(tenantIDPat.FindAllStringSubmatch(dataStr, -1))
+
+	for clientSecret := range uniqueClientSecretMatches {
+		for clientID := range uniqueClientIDMatches {
+			for tenantID := range uniqueTenantIDMatches {
+				// to reduce false positives, we can check if they are the same
+				if (tenantID == clientID) ||
+					(tenantID == clientSecret) ||
+					(clientID == clientSecret) {
+					continue
+				}
+
+				s := detectors.Result{
 					DetectorType: detectorspb.DetectorType_Azure,
-					Raw:          []byte(clientSecret[2]),
-					RawV2:        []byte(clientID[2] + clientSecret[2] + tenantID),
-					Redacted:     clientID[2],
-					ExtraData: map[string]string{
-						"rotation_guide": "https://howtorotate.com/docs/tutorials/azure/",
-					},
+					Raw:          []byte(clientSecret),
+					RawV2:        []byte(clientID + clientSecret + tenantID),
+					Redacted:     clientID,
+				}
+				// Set the RotationGuideURL in the ExtraData
+				s.ExtraData = map[string]string{
+					"rotation_guide": "https://howtorotate.com/docs/tutorials/azure/",
 				}
 
 				if verify {
-					cred := auth.NewClientCredentialsConfig(clientID[2], clientSecret[2], tenantID)
+					cred := auth.NewClientCredentialsConfig(clientID, clientSecret, tenantID)
 					token, err := cred.ServicePrincipalToken()
 					if err != nil {
 						continue
@@ -86,7 +100,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					}
 				}
 
-				results = append(results, res)
+				results = append(results, s)
 			}
 		}
 	}

--- a/pkg/detectors/azure/azure.go
+++ b/pkg/detectors/azure/azure.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	regexp "github.com/wasilibs/go-re2"
-
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	regexp "github.com/wasilibs/go-re2"
 
@@ -29,7 +27,7 @@ var (
 	clientIDPat = regexp.MustCompile(detectors.PrefixRegex([]string{"client_id", "clientid"}) + udidPatFmt)
 	tenantIDPat = regexp.MustCompile(detectors.PrefixRegex([]string{"microsoftonline", "tenant_id", "tenantid"}) + udidPatFmt)
 
-	// According the Microsoft documentation, the client secret can be 24, 32, 40, 44, 56, or 88 characters long.
+	// According to the Microsoft documentation, the client secret can be 24, 32, 40, 44, 56, or 88 characters long.
 	// https://learn.microsoft.com/en-us/purview/sit-defn-client-secret-api-key
 	clientSecretSubPatFmt = `(\b[a-zA-Z0-9_\.\-~]{%d}\b)`
 
@@ -45,7 +43,7 @@ var (
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"azure", "microsoftonline", "microsoft"}
+	return []string{"azure", "microsoftonline"}
 }
 
 func trimUniqueMatches(matches [][]string) (result map[string]struct{}) {
@@ -96,7 +94,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					}
 					err = token.RefreshWithContext(ctx)
 					if err == nil {
-						res.Verified = true
+						s.Verified = true
 					}
 				}
 


### PR DESCRIPTION
### Description:
This PR includes the correction of few things in Azure Detector. Here are the details:
- Support for multiple formats of Client Secret based on [microsoft Documentation](https://learn.microsoft.com/en-us/purview/sit-defn-client-secret-api-key).
- Tenant Id can be part of oauth token URL and the autogenerated url has microsoftonline.com as domain. Which can be used as keyword for detector (apart from 'azure').
- Simplified the way to pass keywords in client id, tenant id & client secret expressions. For the consistency and readability, I have used `PrefixRegex` for this purpose.

Thanks to @justanothernate & @rgmz, for having a fruitful discussion over [PR](https://github.com/trufflesecurity/trufflehog/pull/3039), Helped me to fixed these issue in azure detectors.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

