### PR TITLE
Updated Cosign Install URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Checksums are applied to all artifacts, and the resulting checksum file is signe
 
 You need the following tool to verify signature:
 
-- [Cosign](https://docs.sigstore.dev/cosign/installation/)
+- [Cosign](https://docs.sigstore.dev/cosign/system_config/installation/)
 
 Verification steps are as follow:
 


### PR DESCRIPTION
### Description:
The Cosign installation link is in readme is 404'd; it was moved. 

### Checklist:
N/A, Documentation Only