### PR TITLE
Log skipped files on debug level

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -773,7 +773,7 @@ func (e *Engine) scannerWorker(ctx context.Context) {
 			decodeLatency.WithLabelValues(decoder.Type().String(), chunk.SourceName).Observe(float64(decodeTime))
 
 			if decoded == nil {
-				ctx.Logger().V(4).Info("decoder not applicable for chunk", "decoder", decoder.Type().String(), "chunk", chunk)
+				ctx.Logger().V(5).Info("decoder not applicable for chunk", "decoder", decoder.Type().String(), "chunk", chunk)
 				continue
 			}
 

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -154,10 +154,10 @@ func (h *archiveHandler) extractorHandler(archiveChan chan []byte) func(context.
 			"filename", file.Name(),
 			"size", file.Size(),
 		)
-		lCtx.Logger().V(5).Info("Handling extracted file.")
+		lCtx.Logger().V(3).Info("Handling extracted file.")
 
 		if file.IsDir() || file.LinkTarget != "" {
-			lCtx.Logger().V(5).Info("skipping directory or symlink")
+			lCtx.Logger().V(3).Info("skipping directory or symlink")
 			return nil
 		}
 
@@ -172,13 +172,13 @@ func (h *archiveHandler) extractorHandler(archiveChan chan []byte) func(context.
 
 		fileSize := file.Size()
 		if int(fileSize) > maxSize {
-			lCtx.Logger().V(3).Info("skipping file due to size", "size", fileSize)
+			lCtx.Logger().V(2).Info("skipping file: size exceeds max allowed", "size", fileSize, "limit", maxSize)
 			h.metrics.incFilesSkipped()
 			return nil
 		}
 
 		if common.SkipFile(file.Name()) || common.IsBinary(file.Name()) {
-			lCtx.Logger().V(5).Info("skipping file")
+			lCtx.Logger().V(2).Info("skipping file: extension is ignored")
 			h.metrics.incFilesSkipped()
 			return nil
 		}

--- a/pkg/handlers/default.go
+++ b/pkg/handlers/default.go
@@ -76,7 +76,7 @@ func (h *defaultHandler) handleNonArchiveContent(ctx logContext.Context, reader 
 	mimeExt := reader.mimeExt
 
 	if common.SkipFile(mimeExt) || common.IsBinary(mimeExt) {
-		ctx.Logger().V(5).Info("skipping file", "ext", mimeExt)
+		ctx.Logger().V(2).Info("skipping file: extension is ignored", "ext", mimeExt)
 		h.metrics.incFilesSkipped()
 		// Make sure we consume the reader to avoid potentially blocking indefinitely.
 		_, _ = io.Copy(io.Discard, reader)

--- a/pkg/sources/docker/docker.go
+++ b/pkg/sources/docker/docker.go
@@ -345,7 +345,7 @@ type chunkProcessingInfo struct {
 func (s *Source) processChunk(ctx context.Context, info chunkProcessingInfo, chunksChan chan *sources.Chunk) error {
 	const filesizeLimitBytes int64 = 50 * 1024 * 1024 // 50MB
 	if info.size > filesizeLimitBytes {
-		ctx.Logger().V(4).Info("skipping large file", "file", info.name, "size", info.size)
+		ctx.Logger().V(2).Info("skipping file: size exceeds max allowed", "file", info.name, "size", info.size, "limit", filesizeLimitBytes)
 		return nil
 	}
 

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -13,7 +13,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/gobwas/glob"
 	"github.com/google/go-github/v63/github"
 	"golang.org/x/exp/rand"
@@ -725,15 +724,6 @@ func (s *Source) cloneAndScanRepo(ctx context.Context, repoURL string, repoInfo 
 
 	// TODO: Can this be set once or does it need to be set on every iteration? Is |s.scanOptions| set every clone?
 	s.setScanOptions(s.conn.Base, s.conn.Head)
-
-	// Repo size is not collected for wikis.
-	var logger logr.Logger
-	if !strings.HasSuffix(repoURL, ".wiki.git") && repoInfo.size > 0 {
-		logger = ctx.Logger().WithValues("repo_size_kb", repoInfo.size)
-	} else {
-		logger = ctx.Logger()
-	}
-	logger.V(2).Info("scanning repo")
 
 	start := time.Now()
 	if err = s.git.ScanRepo(ctx, repo, path, s.scanOptions, reporter); err != nil {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This was inspired by my comment [here](https://github.com/trufflesecurity/trufflehog/pull/3375#issuecomment-2396885980). Trace is extremely noisy[^1], such information should be logged on the debug level IMO.

```sh
$ ./trufflehog github ... --debug
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

2024-10-07T19:50:42-04:00	info-2	trufflehog	starting scanner workers	{"count": 4}
2024-10-07T19:50:42-04:00	info-2	trufflehog	starting detector workers	{"count": 32}
2024-10-07T19:50:42-04:00	info-2	trufflehog	starting verificationOverlap workers	{"count": 4}
2024-10-07T19:50:42-04:00	info-2	trufflehog	starting notifier workers	{"count": 4}
2024-10-07T19:50:42-04:00	info-0	trufflehog	running source	{"source_manager_worker_id": "skxXF", "with_units": true}
2024-10-07T19:50:42-04:00	info-2	trufflehog	enumerating source	{"source_manager_worker_id": "skxXF"}
2024-10-07T19:50:42-04:00	info-2	trufflehog	Caching repository info	{"source_manager_worker_id": "skxXF"}
2024-10-07T19:50:42-04:00	info-1	trufflehog	Enumerating with token	{"source_manager_worker_id": "skxXF"}
2024-10-07T19:50:42-04:00	info-2	trufflehog	attempting to clone repo	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git"}
2024-10-07T19:50:42-04:00	info-0	trufflehog	Completed enumeration	{"source_manager_worker_id": "skxXF", "num_repos": 1, "num_orgs": 0, "num_members": 0}
2024-10-07T19:50:46-04:00	info-1	trufflehog	successfully cloned repo	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git", "subcommand": "git clone", "repo": "https://github.com/cohere-ai/tokenizer.git", "path": "/tmp/trufflehog-41733-1261391252", "args": []}
2024-10-07T19:50:46-04:00	info-0	trufflehog	scanning repo	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git"}
2024-10-07T19:50:46-04:00	info-2	trufflehog	skipping file: extension is ignored	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git", "mime": "application/x-sharedlib", "timeout": 60, "ext": ".so"}
2024-10-07T19:50:46-04:00	info-2	trufflehog	skipping file: extension is ignored	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git", "mime": "application/x-sharedlib", "timeout": 60, "ext": ".so"}
2024-10-07T19:50:46-04:00	info-2	trufflehog	skipping file: extension is ignored	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git", "mime": "application/x-sharedlib", "timeout": 60, "ext": ".so"}
2024-10-07T19:50:46-04:00	info-2	trufflehog	skipping file: extension is ignored	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git", "mime": "application/x-sharedlib", "timeout": 60, "ext": ".so"}
2024-10-07T19:50:46-04:00	info-2	trufflehog	skipping file: extension is ignored	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git", "mime": "application/x-sharedlib", "timeout": 60, "ext": ".so"}
2024-10-07T19:50:46-04:00	info-2	trufflehog	skipping file: extension is ignored	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git", "mime": "application/x-sharedlib", "timeout": 60, "ext": ".so"}
2024-10-07T19:50:46-04:00	info-2	trufflehog	skipping file: extension is ignored	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git", "mime": "application/x-sharedlib", "timeout": 60, "ext": ".so"}
2024-10-07T19:50:47-04:00	info-2	trufflehog	finished parsing git log.	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git", "total_log_size": 1593783}
2024-10-07T19:50:47-04:00	info-1	trufflehog	scanning staged changes	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git", "path": "/tmp/trufflehog-41733-1261391252"}
2024-10-07T19:50:47-04:00	info-2	trufflehog	finished parsing git log.	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git", "total_log_size": 0}
2024-10-07T19:50:47-04:00	info-1	trufflehog	scanning git repo complete	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git", "path": "/tmp/trufflehog-41733-1261391252", "time_seconds": 1, "commits_scanned": 93}
2024-10-07T19:50:47-04:00	info-2	trufflehog	finished scanning repo	{"source_manager_worker_id": "skxXF", "unit": "https://github.com/cohere-ai/tokenizer.git", "unit_kind": "repo", "repo": "https://github.com/cohere-ai/tokenizer.git", "duration_seconds": 0.892665195}
2024-10-07T19:50:47-04:00	info-0	trufflehog	finished scanning	{"chunks": 2381, "bytes": 11359546, "verified_secrets": 0, "unverified_secrets": 0, "scan_duration": "4.981928411s", "trufflehog_version": "dev"}
```

[^1]: Why is `debug` 2 and `trace` 5? What is the meaningful difference between 3, 4, and 5? https://github.com/trufflesecurity/trufflehog/blob/dcf8363eaa78aab4242849351c7a53f93662420e/main.go#L267-L271

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?

