### PR TITLE
fix: pr template link to golangci-lint

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,4 @@ Explain the purpose of the PR.
 
 ### Checklist:
 * [ ] Tests passing (`make test-community`)?
-* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/usage/install/#local-installation))?
-
+* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?


### PR DESCRIPTION
This fixes a link in the PR template