### PR TITLE
Propagate file info in log context

### DIFF
--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -153,7 +153,7 @@ func (s *Source) scanDir(ctx context.Context, path string, chunksChan chan *sour
 var skipSymlinkErr = errors.New("skipping symlink")
 
 func (s *Source) scanFile(ctx context.Context, path string, chunksChan chan *sources.Chunk) error {
-	logger := ctx.Logger().WithValues("path", path)
+	fileCtx := context.WithValues(ctx, "path", path)
 	fileStat, err := os.Lstat(path)
 	if err != nil {
 		return fmt.Errorf("unable to stat file: %w", err)
@@ -168,7 +168,7 @@ func (s *Source) scanFile(ctx context.Context, path string, chunksChan chan *sou
 	}
 	defer inputFile.Close()
 
-	logger.V(3).Info("scanning file")
+	fileCtx.Logger().V(3).Info("scanning file")
 
 	chunkSkel := &sources.Chunk{
 		SourceType: s.Type(),
@@ -185,7 +185,7 @@ func (s *Source) scanFile(ctx context.Context, path string, chunksChan chan *sou
 		Verify: s.verify,
 	}
 
-	return handlers.HandleFile(ctx, inputFile, chunkSkel, sources.ChanReporter{Ch: chunksChan})
+	return handlers.HandleFile(fileCtx, inputFile, chunkSkel, sources.ChanReporter{Ch: chunksChan})
 }
 
 // Enumerate implements SourceUnitEnumerator interface. This implementation simply

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -1492,8 +1492,10 @@ func (s *Source) scanTarget(ctx context.Context, target sources.ChunkingTarget, 
 		SourceMetadata: &source_metadatapb.MetaData{
 			Data: &source_metadatapb.MetaData_Github{Github: meta},
 		},
-		Verify: s.verify}
-	return handlers.HandleFile(ctx, readCloser, &chunkSkel, reporter)
+		Verify: s.verify,
+	}
+	fileCtx := context.WithValues(ctx, "path", meta.GetFile())
+	return handlers.HandleFile(fileCtx, readCloser, &chunkSkel, reporter)
 }
 
 func (s *Source) ChunkUnit(ctx context.Context, unit sources.SourceUnit, reporter sources.ChunkReporter) error {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
I noticed that file-related errors no longer (?) include information about the file in the log context. This makes troubleshooting errors incredibly difficult. Also, in some cases the information *is* included but is duplicated.

**Before**
```
2024-10-14T13:00:47-04:00	error	trufflehog	error unarchiving chunk.	{"source_manager_worker_id": "qCLmT", "unit": "/tmp/desktop", "unit_kind": "dir", "mime": "application/x-rar-compressed", "timeout": 60, "error": "error extracting archive with format: .rar: rardecode: incorrect password"}
2024-10-14T12:33:22-04:00	error	trufflehog	error handling binary file	{"source_manager_worker_id": "zo8YL", "unit": "https://github.com/operasoftware/desktop.git", "unit_kind": "repo", "repo": "https://github.com/operasoftware/desktop.git", "filename": "lgpl/sources/chromium/src/chrome/installer/mac/third_party/xz/xz/tests/files/unsupported-check.xz", "commit": "87acf535ec96827fa48c134de50b6225ad0fc432", "file": "lgpl/sources/chromium/src/chrome/installer/mac/third_party/xz/xz/tests/files/unsupported-check.xz", "error": "error creating custom reader: error identifying archive: matching zip: xz: integrity check type not supported"}
```

**After**
```
2024-10-14T13:00:47-04:00	error	trufflehog	error unarchiving chunk.	{"source_manager_worker_id": "qCLmT", "unit": "/tmp/desktop", "unit_kind": "dir", "commit": "9e22ccb", "path": "lgpl/sources/chromium/src/chrome/test/data/safe_browsing/rar/passwd1234_two_files.rar", "mime": "application/x-rar-compressed", "timeout": 60, "error": "error extracting archive with format: .rar: rardecode: incorrect password"}
2024-10-14T12:53:25-04:00	error	trufflehog	error handling binary file	{"source_manager_worker_id": "bnjof", "unit": "/tmp/desktop", "unit_kind": "dir", "repo": "https://github.com/operasoftware/desktop.git", "commit": "95264d4038ea7e1ddb9a8942e09b2329f8e68093", "path": "lgpl/sources/chromium/src/third_party/zstd/src/tests/gzip/hufts-segv.gz", "error": "error creating custom reader: error identifying archive: matching zip: flate: corrupt input before offset 5"}
```

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
