### PR TITLE
Re-order log context fields

### DIFF
--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -364,7 +364,7 @@ func (s *SourceManager) runWithUnits(ctx context.Context, source SourceUnitEnumC
 			// TODO: Catch panics and add to report.
 			defer close(chunkReporter.chunkCh)
 			id, kind := unit.SourceUnitID()
-			ctx := context.WithValues(ctx, "unit", id, "unit_kind", kind)
+			ctx := context.WithValues(ctx, "unit_kind", kind, "unit", id)
 			ctx.Logger().V(3).Info("chunking unit")
 			if err := source.ChunkUnit(ctx, unit, chunkReporter); err != nil {
 				report.ReportError(Fatal{ChunkError{Unit: unit, Err: err}})


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This bugs me.

> 2024-10-15T22:41:33-04:00	info-0	trufflehog	scanning repo	
{
"source_manager_worker_id": "9STWR", "unit": "https://github.com/Azure/Azure-MachineLearning-ClientLibrary-R.git", "unit_kind": "repo", "repo": "https://github.com/Azure/Azure-MachineLearning-ClientLibrary-R.git"
}

More seriously, the log context ideally wouldn't be duplicating the repo URL for every log message... I don't know what the best way to handle this is.
> 2024-10-15T22:39:57-04:00	info-0	trufflehog	scanning repo	{"source_manager_worker_id": "9STWR", "unit": "https://github.com/Azure/go-ansiterm.git", "unit_kind": "repo", "repo": "https://github.com/Azure/go-ansiterm.git"}
> 2024-10-15T22:41:45-04:00	info-0	trufflehog	scanning repo	{"source_manager_worker_id": "9STWR", "unit": "https://github.com/Azure/azure-storage-python.git", "unit_kind": "repo", "repo": "https://github.com/Azure/azure-storage-python.git"}


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
