### PR TITLE
fix: added correct api endpoint for verification & logic for Aeroworkflow

### DIFF
--- a/pkg/detectors/aeroworkflow/aeroworkflow.go
+++ b/pkg/detectors/aeroworkflow/aeroworkflow.go
@@ -85,7 +85,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 }
 
 func verifyAeroworkflow(ctx context.Context, client *http.Client, resMatch, resIdMatch string) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, aeroworkflowURL+"/api/"+resIdMatch+"/v1/AeroAppointments", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, aeroworkflowURL+"/api/"+resIdMatch+"/me", nil)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/detectors/aeroworkflow/aeroworkflow.go
+++ b/pkg/detectors/aeroworkflow/aeroworkflow.go
@@ -27,7 +27,7 @@ var (
 	defaultClient = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"aeroworkflow"}) + `([a-zA-Z0-9^!?#:*;]{20})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"aeroworkflow"}) + `\b([a-zA-Z0-9^!?#:*;]{20})`)
 	idPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"aeroworkflow"}) + `\b([0-9]{1,})\b`)
 )
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Fixes #3434 .

API Endpoint Correction:
   - Current: The detector uses `/api/{accountid}/v1/AeroAppointments` for verification.
   - Issue: This endpoint is not appropriate as it might involve COGs.
   - Fix: Update to use `/api/{accountid}/me`, which aligns with other detector patterns.
   - Reference: https://api.aeroworkflow.com/swagger/index.html

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
