### PR TITLE
Compress release with UPX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
           go-version: "1.23"
       - name: Cosign install
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+      - name: Install UPX
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y upx
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,9 @@ builds:
     goarch:
     - amd64
     - arm64
+    hooks:
+      post:
+        - bash -c 'if [ "{{ .Env.GGOOS  }}" != "darwin" ]; then upx -q "{{ .Path }}"; fi'
 dockers:
   - image_templates: ["trufflesecurity/{{ .ProjectName }}:{{ .Version }}-amd64"]
     dockerfile: Dockerfile.goreleaser


### PR DESCRIPTION
### Description:
Compresses the release binary with UPX. On my machine, I had a 48% compression ratio!
I've omitted Darwin because we've seen issues with OSX signing on our Enterprise build when using UPX.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
