### PR TITLE
Revert "Compress release with UPX"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,6 @@ jobs:
           go-version: "1.23"
       - name: Cosign install
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
-      - name: Install UPX
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y upx
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,9 +11,6 @@ builds:
     goarch:
     - amd64
     - arm64
-    hooks:
-      post:
-        - bash -c 'if [ "{{ .Env.GGOOS  }}" != "darwin" ]; then upx -q "{{ .Path }}"; fi'
 dockers:
   - image_templates: ["trufflesecurity/{{ .ProjectName }}:{{ .Version }}-amd64"]
     dockerfile: Dockerfile.goreleaser


### PR DESCRIPTION
Build failed, reverting so we can re-release

Reverts trufflesecurity/trufflehog#3445