### PR TITLE
Compress release with UPX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,10 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          distribution: goreleaser
+          distribution: goreleaser-pro
           version: latest
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,10 @@ jobs:
           go-version: "1.23"
       - name: Cosign install
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+      - name: Install UPX
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y upx
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
     - arm64
     hooks:
       post:
-        - bash -c 'if [ "{{ .Env.GGOOS  }}" != "darwin" ]; then upx -q "{{ .Path }}"; fi'
+        - bash -c 'if [ "{{ .Env.GGOOS  }}" != "darwin" ]; then upx -q "{{ .Path }}" || true; fi'
 dockers:
   - image_templates: ["trufflesecurity/{{ .ProjectName }}:{{ .Version }}-amd64"]
     dockerfile: Dockerfile.goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,19 +1,29 @@
 version: 2
 builds:
-  - binary: trufflehog
+  - id: trufflehog-upx
+    binary: trufflehog
     ldflags:
       - -X 'github.com/trufflesecurity/trufflehog/v3/pkg/version.BuildVersion={{ .Version }}'
     env: [CGO_ENABLED=0]
     goos:
     - linux
-    - windows
-    - darwin
     goarch:
     - amd64
     - arm64
     hooks:
       post:
-        - bash -c 'if [ "{{ .Env.GGOOS  }}" != "darwin" ]; then upx -q "{{ .Path }}" || true; fi'
+        - upx -q "{{ .Path }}"
+  - id: trufflehog
+    binary: trufflehog
+    ldflags:
+      - -X 'github.com/trufflesecurity/trufflehog/v3/pkg/version.BuildVersion={{ .Version }}'
+    env: [CGO_ENABLED=0]
+    goos:
+    - darwin
+    - windows
+    goarch:
+    - amd64
+    - arm64
 dockers:
   - image_templates: ["trufflesecurity/{{ .ProjectName }}:{{ .Version }}-amd64"]
     dockerfile: Dockerfile.goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,9 @@ builds:
     goarch:
     - amd64
     - arm64
+    hooks:
+      post:
+        - bash -c 'if [ "{{ .Env.GGOOS  }}" != "darwin" ]; then upx -q "{{ .Path }}"; fi'
 dockers:
   - image_templates: ["trufflesecurity/{{ .ProjectName }}:{{ .Version }}-amd64"]
     dockerfile: Dockerfile.goreleaser


### PR DESCRIPTION
### Description:
Compresses the release binary with UPX. On my machine, I had a 48% compression ratio!
I've omitted Darwin because we've seen issues with OSX signing on our Enterprise build when using UPX.

In this PR i've updated the UPX command to allow failure.
I've also changed CI to use the gorelease-pro distribution. That will allow us to parallelize builds later on as well.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
