### PR TITLE
Extend `algoliaadminkey` prefixes

### DIFF
--- a/pkg/detectors/algoliaadminkey/algoliaadminkey.go
+++ b/pkg/detectors/algoliaadminkey/algoliaadminkey.go
@@ -22,14 +22,14 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"algolia"}) + `\b([a-zA-Z0-9]{32})\b`)
-	idPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"algolia"}) + `\b([A-Z0-9]{10})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"algolia", "docsearch", "appId"}) + `\b([a-zA-Z0-9]{32})\b`)
+	idPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"algolia", "docsearch", "apiKey"}) + `\b([A-Z0-9]{10})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"algolia"}
+	return []string{"algolia", "docsearch"}
 }
 
 // FromData will find and optionally verify AlgoliaAdminKey secrets in a given set of bytes.


### PR DESCRIPTION
### Description

This pull requests enhances the detection of Algolia keys by looking also for Algolia DocSearch keywords and option names on the official libraries ([example](https://github.com/algolia/docsearch/blob/90f3c6aabbc324fe49e9a1dfe0906fcd4d90f27b/README.md?plain=1#L68-L73)).

### Checklist
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
