### PR TITLE
[Fix] - buffer leak

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -83,7 +83,7 @@ func newMimeTypeReader(r io.Reader) (mimeTypeReader, error) {
 func newFileReader(r io.Reader) (fileReader, error) {
 	var fReader fileReader
 
-	fReader.BufferedReadSeeker = iobuf.NewBufferedReaderSeeker(r)
+	fReader.BufferedReadSeeker = iobuf.NewBufferedReadSeeker(r)
 
 	mime, err := mimetype.DetectReader(fReader)
 	if err != nil {

--- a/pkg/iobuf/bufferedreaderseeker.go
+++ b/pkg/iobuf/bufferedreaderseeker.go
@@ -70,10 +70,10 @@ func asSeeker(r io.Reader) io.Seeker {
 	return seeker
 }
 
-// NewBufferedReaderSeeker creates and initializes a BufferedReadSeeker.
+// NewBufferedReadSeeker creates and initializes a BufferedReadSeeker.
 // It takes an io.Reader and checks if it supports seeking.
 // If the reader supports seeking, it is stored in the seeker field.
-func NewBufferedReaderSeeker(r io.Reader) *BufferedReadSeeker {
+func NewBufferedReadSeeker(r io.Reader) *BufferedReadSeeker {
 	const defaultThreshold = 1 << 24 // 16MB threshold for switching to file buffering
 
 	var (
@@ -82,10 +82,6 @@ func NewBufferedReaderSeeker(r io.Reader) *BufferedReadSeeker {
 	)
 
 	seeker = asSeeker(r)
-	if seeker == nil {
-		buf = defaultBufferPool.Get()
-	}
-
 	return &BufferedReadSeeker{
 		reader:    r,
 		seeker:    seeker,
@@ -266,6 +262,10 @@ func (br *BufferedReadSeeker) readToEnd() error {
 }
 
 func (br *BufferedReadSeeker) writeData(data []byte) error {
+	if br.buf == nil {
+		br.buf = br.bufPool.Get()
+	}
+
 	_, err := br.buf.Write(data)
 	if err != nil {
 		return err

--- a/pkg/iobuf/bufferedreaderseeker_test.go
+++ b/pkg/iobuf/bufferedreaderseeker_test.go
@@ -121,7 +121,7 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			brs := NewBufferedReaderSeeker(tt.reader)
+			brs := NewBufferedReadSeeker(tt.reader)
 
 			for i, readSize := range tt.reads {
 				buf := make([]byte, readSize)
@@ -241,7 +241,7 @@ func TestBufferedReaderSeekerSeek(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			brs := NewBufferedReaderSeeker(tt.reader)
+			brs := NewBufferedReadSeeker(tt.reader)
 			pos, err := brs.Seek(tt.offset, tt.whence)
 			if tt.expectedErr {
 				assert.Error(t, err)
@@ -336,7 +336,7 @@ func TestBufferedReaderSeekerReadAt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			brs := NewBufferedReaderSeeker(tt.reader)
+			brs := NewBufferedReadSeeker(tt.reader)
 
 			out := make([]byte, tt.length)
 			n, err := brs.ReadAt(out, tt.offset)
@@ -436,7 +436,7 @@ func TestBufferedReadSeekerSize(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			brs := NewBufferedReaderSeeker(tt.reader)
+			brs := NewBufferedReadSeeker(tt.reader)
 
 			if tt.setup != nil {
 				tt.setup(brs)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The original `NewBufferedReadSeeker` constructor checked out a buffer from the pool, which could result in an orphaned buffer if MIME type detection failed during `newFileReader`. This PR addresses the issue by lazily initializing the buffer for `BufferedReadSeeker` only when needed.

![Screenshot 2024-10-18 at 12 15 49 PM](https://github.com/user-attachments/assets/a8a763e0-a6b3-44be-9633-a92f2a7fda04)

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
