### PR TITLE
Extract FP logic correctly at other call site

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1035,7 +1035,7 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 
 	ctx = context.WithValue(ctx, "detector", data.detector.Key.Loggable())
 
-	isFalsePositive := detectors.GetFalsePositiveCheck(data.detector)
+	isFalsePositive := detectors.GetFalsePositiveCheck(data.detector.Detector)
 
 	var matchCount int
 	// To reduce the overhead of regex calls in the detector,


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Custom false positive logic is implemented by smuggling `CustomFalsePositiveChecker` through `detector.Detector`. This doesn't work when `detector.Detector` is embedded inside `DetectorMatch` - which we caught at [the _other_ call site where this is relevant](https://github.com/trufflesecurity/trufflehog/blob/88b8c862a6ee7cb884257038a06e5f8aaa9d2db8/pkg/engine/engine.go#L919). But we have two! And this one didn't get fixed.

(I want to make some time to try to figure out why the false positive logic is draped over the codebase like a dying octopus, but fixing the bug first seems prudent.)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
