### PR TITLE
Move DecoderType into ResultWithMetadata

### DIFF
--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -89,9 +89,7 @@ type Result struct {
 	DetectorType detectorspb.DetectorType
 	// DetectorName is the name of the Detector. Used for custom detectors.
 	DetectorName string
-	// DecoderType is the type of Decoder.
-	DecoderType detectorspb.DecoderType
-	Verified    bool
+	Verified     bool
 	// Raw contains the raw secret identifier data. Prefer IDs over secrets since it is used for deduping after hashing.
 	Raw []byte
 	// RawV2 contains the raw secret identifier that is a combination of both the ID and the secret.
@@ -168,6 +166,8 @@ type ResultWithMetadata struct {
 	Result
 	// Data from the sources.Chunk which this result was emitted for
 	Data []byte
+	// DecoderType is the decoder type used for this result's source data
+	DecoderType detectorspb.DecoderType
 }
 
 // CopyMetadata returns a detector result with included metadata from the source chunk.

--- a/pkg/output/github_actions.go
+++ b/pkg/output/github_actions.go
@@ -19,7 +19,7 @@ type GitHubActionsPrinter struct{ mu sync.Mutex }
 func (p *GitHubActionsPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) error {
 	out := gitHubActionsOutputFormat{
 		DetectorType: r.Result.DetectorType.String(),
-		DecoderType:  r.Result.DecoderType.String(),
+		DecoderType:  r.DecoderType.String(),
 		Verified:     r.Result.Verified,
 	}
 
@@ -60,7 +60,7 @@ func (p *GitHubActionsPrinter) Print(_ context.Context, r *detectors.ResultWithM
 	dedupeCache[key] = struct{}{}
 
 	message := fmt.Sprintf("Found %s %s result 🐷🔑\n", verifiedStatus, out.DetectorType)
-	if r.Result.DecoderType != detectorspb.DecoderType_PLAIN {
+	if r.DecoderType != detectorspb.DecoderType_PLAIN {
 		message = fmt.Sprintf("Found %s %s result with %s encoding 🐷🔑\n", verifiedStatus, out.DetectorType, out.DecoderType)
 	}
 

--- a/pkg/output/plain.go
+++ b/pkg/output/plain.go
@@ -30,7 +30,7 @@ type PlainPrinter struct{ mu sync.Mutex }
 func (p *PlainPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) error {
 	out := outputFormat{
 		DetectorType:      r.Result.DetectorType.String(),
-		DecoderType:       r.Result.DecoderType.String(),
+		DecoderType:       r.DecoderType.String(),
 		Verified:          r.Result.Verified,
 		VerificationError: r.Result.VerificationError(),
 		MetaData:          r.SourceMetadata,


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
`detectors.Result.DecoderType` is only ever used as part of an embedding into `ResultWithMetadata`, so we might as well move the field there to simplify the relationship between the structures. (I had the idea for this because it makes the sketch in #3457 simpler.)

(Draft until we double-check that enterprise consumption won't be affected.)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
