### PR TITLE
Redact more source credentials

### DIFF
--- a/pkg/sources/circleci/circleci.go
+++ b/pkg/sources/circleci/circleci.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 
 	"github.com/go-errors/errors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -73,6 +74,7 @@ func (s *Source) Init(_ context.Context, name string, jobId sources.JobID, sourc
 	switch conn.Credential.(type) {
 	case *sourcespb.CircleCI_Token:
 		s.token = conn.GetToken()
+		log.RedactGlobally(s.token)
 	}
 
 	return nil

--- a/pkg/sources/elasticsearch/elasticsearch.go
+++ b/pkg/sources/elasticsearch/elasticsearch.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sanitizer"
@@ -71,6 +72,7 @@ func (s *Source) Init(
 
 	if conn.Password != "" {
 		esConfig.Password = conn.Password
+		log.RedactGlobally(conn.Password)
 	}
 
 	if conn.CloudId != "" {
@@ -79,10 +81,12 @@ func (s *Source) Init(
 
 	if conn.ApiKey != "" {
 		esConfig.APIKey = conn.ApiKey
+		log.RedactGlobally(conn.ApiKey)
 	}
 
 	if conn.ServiceToken != "" {
 		esConfig.ServiceToken = conn.ServiceToken
+		log.RedactGlobally(conn.ServiceToken)
 	}
 
 	s.esConfig = esConfig

--- a/pkg/sources/gcs/gcs.go
+++ b/pkg/sources/gcs/gcs.go
@@ -12,6 +12,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/go-errors/errors"
 	"github.com/go-logr/logr"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/endpoints"
 	"google.golang.org/protobuf/proto"
@@ -149,6 +150,7 @@ func configureGCSManager(aCtx context.Context, conn *sourcespb.GCS, concurrency 
 	switch conn.Credential.(type) {
 	case *sourcespb.GCS_ApiKey:
 		gcsManagerAuthOption = withAPIKey(aCtx, conn.GetApiKey())
+		log.RedactGlobally(conn.GetApiKey())
 	case *sourcespb.GCS_ServiceAccountFile:
 		b, err := os.ReadFile(conn.GetServiceAccountFile())
 		if err != nil {

--- a/pkg/sources/github/connector.go
+++ b/pkg/sources/github/connector.go
@@ -5,6 +5,7 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/google/go-github/v66/github"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
@@ -27,10 +28,13 @@ func newConnector(source *Source) (connector, error) {
 
 	switch cred := source.conn.GetCredential().(type) {
 	case *sourcespb.GitHub_GithubApp:
+		log.RedactGlobally(cred.GithubApp.GetPrivateKey())
 		return newAppConnector(apiEndpoint, cred.GithubApp)
 	case *sourcespb.GitHub_BasicAuth:
+		log.RedactGlobally(cred.BasicAuth.GetPassword())
 		return newBasicAuthConnector(apiEndpoint, cred.BasicAuth)
 	case *sourcespb.GitHub_Token:
+		log.RedactGlobally(cred.Token)
 		return newTokenConnector(apiEndpoint, cred.Token, source.handleRateLimit)
 	case *sourcespb.GitHub_Unauthenticated:
 		return newUnauthenticatedConnector(apiEndpoint)

--- a/pkg/sources/jenkins/jenkins.go
+++ b/pkg/sources/jenkins/jenkins.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-errors/errors"
 	"github.com/go-logr/logr"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
@@ -111,12 +112,14 @@ func (s *Source) Init(aCtx context.Context, name string, jobId sources.JobID, so
 		if len(s.token) == 0 {
 			return errors.Errorf("Jenkins source basic auth credential requires 'password' to be specified")
 		}
+		log.RedactGlobally(s.token)
 	case *sourcespb.Jenkins_Header:
 		unparsedURL = conn.Endpoint
 		s.header = &header{
 			key:   cred.Header.Key,
 			value: cred.Header.Value,
 		}
+		log.RedactGlobally(cred.Header.GetValue())
 	case *sourcespb.Jenkins_Unauthenticated:
 		unparsedURL = conn.Endpoint
 	default:

--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
@@ -117,6 +118,7 @@ func (s *Source) Init(ctx context.Context, name string, jobId sources.JobID, sou
 		}
 		s.client = NewClient(conn.GetToken())
 		s.client.HTTPClient = common.RetryableHTTPClientTimeout(3)
+		log.RedactGlobally(conn.GetToken())
 	case *sourcespb.Postman_Unauthenticated:
 		s.client = nil
 		// No client needed if reading from local

--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/go-errors/errors"
 	"github.com/go-logr/logr"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -136,8 +137,11 @@ func (s *Source) newClient(region, roleArn string) (*s3.S3, error) {
 	switch cred := s.conn.GetCredential().(type) {
 	case *sourcespb.S3_SessionToken:
 		cfg.Credentials = credentials.NewStaticCredentials(cred.SessionToken.Key, cred.SessionToken.Secret, cred.SessionToken.SessionToken)
+		log.RedactGlobally(cred.SessionToken.GetSecret())
+		log.RedactGlobally(cred.SessionToken.GetSessionToken())
 	case *sourcespb.S3_AccessKey:
 		cfg.Credentials = credentials.NewStaticCredentials(cred.AccessKey.Key, cred.AccessKey.Secret, "")
+		log.RedactGlobally(cred.AccessKey.GetSecret())
 	case *sourcespb.S3_Unauthenticated:
 		cfg.Credentials = credentials.AnonymousCredentials
 	default:

--- a/pkg/sources/travisci/travisci.go
+++ b/pkg/sources/travisci/travisci.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-errors/errors"
 	"github.com/shuheiktgw/go-travis"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -76,6 +77,7 @@ func (s *Source) Init(ctx context.Context, name string, jobId sources.JobID, sou
 		}
 		s.client = travis.NewClient(baseURL, conn.GetToken())
 		s.client.HTTPClient = common.RetryableHTTPClientTimeout(3)
+		log.RedactGlobally(conn.GetToken())
 
 		user, _, err := s.client.User.Current(ctx, nil)
 		if err != nil {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR implements global log redaction for the credentials of most other source types. It doesn't redact for sources that don't load their credentials with `Init` as a way to keep the PR simple - we can do those separately.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
