### PR TITLE
Add Scanning team to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,17 @@
 # catch-all
 * @trufflesecurity/product-eng
 
-# teams
-pkg/sources/ @trufflesecurity/backend
-pkg/detectors/ @trufflesecurity/detection
+# Scanning
+pkg/decoders/ @trufflesecurity/Scanning
+pkg/engine/ @trufflesecurity/Scanning
+pkg/gitparse/ @trufflesecurity/Scanning
+pkg/giturl/ @trufflesecurity/Scanning
+pkg/handlers/ @trufflesecurity/Scanning
+pkg/iobuf/ @trufflesecurity/Scanning
+pkg/sanitizer/ @trufflesecurity/Scanning
+pkg/sources/ @trufflesecurity/Scanning
+pkg/writers/ @trufflesecurity/Scanning
+proto/ @trufflesecurity/Scanning
 
 # critical detectors
 pkg/detectors/aws/ @trufflesecurity/backend


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
I added @trufflesecurity/scanning to CODEOWNERS and removed some older obsolete groups.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
