### PR TITLE
strip symbol table and DWARF generation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,7 @@ version: 2
 builds:
   - binary: trufflehog
     ldflags:
-      - -X 'github.com/trufflesecurity/trufflehog/v3/pkg/version.BuildVersion={{ .Version }}'
+      - -s -w -X 'github.com/trufflesecurity/trufflehog/v3/pkg/version.BuildVersion={{ .Version }}'
     env: [CGO_ENABLED=0]
     goos:
     - linux


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR strips the symbol `-s` table and DWARF `-w` generation which are mainly used for hopping into a debugger. Using these ldflags seems like a pretty common convention when shipping release builds. This takes the existing TH binary down from 174MB to 121MB.

- https://github.com/search?q=path%3A**%2F.goreleaser.yml&type=code&ref=advsearch
- https://www.reddit.com/r/golang/comments/zvqell/what_are_the_possible_problems_when_using_go/



### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
