### PR TITLE
fixed gitlab extradata overwriting

### DIFF
--- a/pkg/detectors/gitlab/v1/gitlab.go
+++ b/pkg/detectors/gitlab/v1/gitlab.go
@@ -72,7 +72,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		if verify {
 			isVerified, extraData, verificationErr := s.verifyGitlab(ctx, resMatch)
 			s1.Verified = isVerified
-			s1.ExtraData = extraData
+			for key, value := range extraData {
+				s1.ExtraData[key] = value
+			}
 
 			s1.SetVerificationError(verificationErr, resMatch)
 			s1.AnalysisInfo = map[string]string{

--- a/pkg/detectors/gitlab/v2/gitlab_v2.go
+++ b/pkg/detectors/gitlab/v2/gitlab_v2.go
@@ -61,7 +61,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		if verify {
 			isVerified, extraData, verificationErr := s.verifyGitlab(ctx, resMatch)
 			s1.Verified = isVerified
-			s1.ExtraData = extraData
+			for key, value := range extraData {
+				s1.ExtraData[key] = value
+			}
 
 			s1.SetVerificationError(verificationErr, resMatch)
 			s1.AnalysisInfo = map[string]string{


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The extra data is already being assigned at the top result level, directly assigning extraData map which is being returned from verification func is overwriting it.
### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
