### PR TITLE
Stop logging all GitLab projects

### DIFF
--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -602,7 +602,6 @@ func (s *Source) getAllProjectRepos(
 	}
 
 	ctx.Logger().Info("Enumerated GitLab projects", "count", len(projectsWithNamespace))
-	ctx.Logger().V(2).Info("Enumerated GitLab projects", "projects", projectsWithNamespace)
 
 	return nil
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
#3532 stopped logging one huge GItLab slice, but there's a second one! We should stop logging it for the same reason.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
