### PR TITLE
set verification error if failed to decode body

### DIFF
--- a/pkg/detectors/opsgenie/opsgenie.go
+++ b/pkg/detectors/opsgenie/opsgenie.go
@@ -81,6 +81,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				err := json.NewDecoder(res.Body).Decode(&data)
 				if err != nil {
 					s1.Verified = false
+					// set verification error in result if failed to decode the body of response
+					s1.SetVerificationError(err, resMatch)
 					continue
 				}
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Add verification error in result if failed to decode response body in case of 200OK response.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
