### PR TITLE
chore: fix typos in comments and tests; enable misspell

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          args: --enable bodyclose --enable copyloopvar --timeout 10m
+          args: --enable bodyclose --enable copyloopvar --enable misspell --timeout 10m
 
           # Optional: if set to true then the action don't cache or restore ~/go/pkg.
           # skip-pkg-cache: true

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ check:
 	go vet $(shell go list ./... | grep -v /vendor/)
 
 lint:
-	golangci-lint run --enable bodyclose --enable copyloopvar --out-format=colored-line-number --timeout 10m
+	golangci-lint run --enable bodyclose --enable copyloopvar --enable misspell --out-format=colored-line-number --timeout 10m
 
 test-failing:
 	CGO_ENABLED=0 go test -timeout=5m $(shell go list ./... | grep -v /vendor/) | grep FAIL

--- a/pkg/analyzer/analyzers/mysql/mysql.go
+++ b/pkg/analyzer/analyzers/mysql/mysql.go
@@ -52,11 +52,11 @@ func secretInfoToAnalyzerResult(info *SecretInfo) *analyzers.AnalyzerResult {
 		Bindings:     []analyzers.Binding{},
 	}
 
-	// add user priviliges to bindings
+	// add user privileges to bindings
 	userBindings, userResource := bakeUserBindings(info)
 	result.Bindings = append(result.Bindings, userBindings...)
 
-	// add user's database priviliges to bindings
+	// add user's database privileges to bindings
 	databaseBindings := bakeDatabaseBindings(userResource, info)
 	result.Bindings = append(result.Bindings, databaseBindings...)
 
@@ -67,7 +67,7 @@ func bakeUserBindings(info *SecretInfo) ([]analyzers.Binding, *analyzers.Resourc
 
 	var userBindings []analyzers.Binding
 
-	// add user and their priviliges to bindings
+	// add user and their privileges to bindings
 	userResource := analyzers.Resource{
 		Name:               info.User,
 		FullyQualifiedName: info.Host + "/" + info.User,

--- a/pkg/analyzer/analyzers/postgres/postgres.go
+++ b/pkg/analyzer/analyzers/postgres/postgres.go
@@ -54,11 +54,11 @@ func secretInfoToAnalyzerResult(info *SecretInfo) *analyzers.AnalyzerResult {
 	userResource, userBindings := bakeUserBindings(info)
 	result.Bindings = append(result.Bindings, userBindings...)
 
-	// add user's database priviliges to bindings
+	// add user's database privileges to bindings
 	dbNameToResourceMap, dbBindings := bakeDatabaseBindings(userResource, info)
 	result.Bindings = append(result.Bindings, dbBindings...)
 
-	// add user's table priviliges to bindings
+	// add user's table privileges to bindings
 	tableBindings := bakeTableBindings(dbNameToResourceMap, info)
 	result.Bindings = append(result.Bindings, tableBindings...)
 

--- a/pkg/analyzer/analyzers/sourcegraph/sourcegraph.go
+++ b/pkg/analyzer/analyzers/sourcegraph/sourcegraph.go
@@ -1,7 +1,7 @@
 //go:generate generate_permissions permissions.yaml permissions.go sourcegraph
 package sourcegraph
 
-// ToDo: Add suport for custom domain
+// ToDo: Add support for custom domain
 
 import (
 	"encoding/json"

--- a/pkg/common/patterns_test.go
+++ b/pkg/common/patterns_test.go
@@ -25,7 +25,7 @@ func TestEmailRegexCheck(t *testing.T) {
 		hyphen domain      = info@my-site.net
 		service email      = contact@web-service.io
 		underscore email   = example_user@domain.info
-		departement email  = first.last@department.company.edu
+		department email   = first.last@department.company.edu
 		alphanumeric email = user1234@domain.co
 		local server email = admin@local-server.local
 		dot email          = test.email@my-email-service.xyz

--- a/pkg/detectors/agora/agora_test.go
+++ b/pkg/detectors/agora/agora_test.go
@@ -15,7 +15,7 @@ var (
 	validKeyPattern    = "asdf0987mnbv1234qsxojb6ygb2wsx0o"
 	validSecretPattern = "beqr7215fr4g6bfjkmnvxrtygb2wsxap"
 	complexPattern     = `agora credentials
-							these are some example credentails for login.
+							these are some example credentials for login.
 							use these to login.
 							key: asdf0987mnbv1234qsxojb6ygb2wsx0o
 							secret: beqr7215fr4g6bfjkmnvxrtygb2wsxap

--- a/pkg/detectors/alchemy/alchemy_test.go
+++ b/pkg/detectors/alchemy/alchemy_test.go
@@ -28,7 +28,7 @@ alchemy_token2 = '3aDcDFE56789012245678a0_1a2b3c2d'`,
 			want: []string{"3aBcDFE5678901234567890_1a2b3c4d", "3aDcDFE56789012245678a0_1a2b3c2d"},
 		},
 		{
-			name:  "invald pattern",
+			name:  "invalid pattern",
 			input: "alchemy_token = '1a2b3c4d'",
 			want:  []string{},
 		},

--- a/pkg/detectors/apimatic/apimatic.go
+++ b/pkg/detectors/apimatic/apimatic.go
@@ -66,7 +66,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					s1.Verified = true
 				}
 			} else {
-				// if any error happens during api request capture that as verificaiton error
+				// if any error happens during api request capture that as verification error
 				s1.SetVerificationError(err, apiKey)
 			}
 		}

--- a/pkg/detectors/appfollow/appfollow_test.go
+++ b/pkg/detectors/appfollow/appfollow_test.go
@@ -27,12 +27,12 @@ func TestAppFollow_Pattern(t *testing.T) {
 	}{
 		{
 			name:  "valid pattern",
-			input: fmt.Sprintf("appfollow credentail: %s", validPattern),
+			input: fmt.Sprintf("appfollow credential: %s", validPattern),
 			want:  []string{"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.333HbjEo1oxVUFcASR0sQ8cMuIJRLcMd5H9iJWDbovCw6ESjNtuoEMQQGPN9aSoxponxrTPvn1.btADhgNetsaUBuwoyHo5ip0Jab6N6MEBnSaT6CHiO6z"},
 		},
 		{
 			name:  "invalid pattern",
-			input: fmt.Sprintf("appfollow credentail: %s", invalidPattern),
+			input: fmt.Sprintf("appfollow credential: %s", invalidPattern),
 			want:  nil,
 		},
 	}

--- a/pkg/detectors/appointedd/appointedd_test.go
+++ b/pkg/detectors/appointedd/appointedd_test.go
@@ -27,12 +27,12 @@ func TestAppFollow_Pattern(t *testing.T) {
 	}{
 		{
 			name:  "valid pattern",
-			input: fmt.Sprintf("appointedd credentail: %s", validPattern),
+			input: fmt.Sprintf("appointedd credential: %s", validPattern),
 			want:  []string{"Ci0a2bSpRyFcZyEXBEr9RHzf3xXllqO=XVoh+t0L0s8T2s3MFntfWhBlovqLaqEadtuJ9=Jy6yCOXmhbpEZPfY7Y"},
 		},
 		{
 			name:  "invalid pattern",
-			input: fmt.Sprintf("appointedd credentail: %s", invalidPattern),
+			input: fmt.Sprintf("appointedd credential: %s", invalidPattern),
 			want:  nil,
 		},
 	}

--- a/pkg/detectors/appoptics/appoptics_test.go
+++ b/pkg/detectors/appoptics/appoptics_test.go
@@ -27,12 +27,12 @@ func TestAppOptics_Pattern(t *testing.T) {
 	}{
 		{
 			name:  "valid pattern",
-			input: fmt.Sprintf("appoptics credentail: %s", validPattern),
+			input: fmt.Sprintf("appoptics credential: %s", validPattern),
 			want:  []string{"IABJPR08RmvsGrebJhr1TUdo27-KtTn0mLCKkJJqj5lyba-otXPklygO9DK62o3QSPoIJ4E"},
 		},
 		{
 			name:  "invalid pattern",
-			input: fmt.Sprintf("appoptics credentail: %s", invalidPattern),
+			input: fmt.Sprintf("appoptics credential: %s", invalidPattern),
 			want:  nil,
 		},
 	}

--- a/pkg/detectors/appsynergy/appsynergy_test.go
+++ b/pkg/detectors/appsynergy/appsynergy_test.go
@@ -27,12 +27,12 @@ func TestAppSynergy_Pattern(t *testing.T) {
 	}{
 		{
 			name:  "valid pattern",
-			input: fmt.Sprintf("appsynergy credentail: %s", validPattern),
+			input: fmt.Sprintf("appsynergy credential: %s", validPattern),
 			want:  []string{"mg1pgwlndtq7rbk8i3kum344aso8ggp02ximdhsp8nsqasd3btxf84lz9ekfdpwo"},
 		},
 		{
 			name:  "invalid pattern",
-			input: fmt.Sprintf("appsynergy credentail: %s", invalidPattern),
+			input: fmt.Sprintf("appsynergy credential: %s", invalidPattern),
 			want:  nil,
 		},
 	}

--- a/pkg/detectors/auth0managementapitoken/auth0managementapitoken_test.go
+++ b/pkg/detectors/auth0managementapitoken/auth0managementapitoken_test.go
@@ -19,7 +19,7 @@ var (
 	validPattern   = generateRandomString() // this has the exact token string only which can be used in want too
 	validDomain    = "QHHPu7VPj.sI.auth0.com"
 	invalidPattern = `
-		auth0_credentails:
+		auth0_credentials:
 			apiToken: eywT2nGMZwOcbsUVBwfiRPEl8P_wnmo6XfdUoGVwxDfOSjNyqhYqFdi.KojZZOM8Ox
 			domain: QHHPu7VPj.sI.auth0.com
 	`

--- a/pkg/detectors/boxoauth/boxoauth.go
+++ b/pkg/detectors/boxoauth/boxoauth.go
@@ -80,7 +80,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			results = append(results, s1)
 
-			// box client supportes only one client id and secret pair
+			// box client supports only one client id and secret pair
 			if s1.Verified {
 				break
 			}

--- a/pkg/detectors/sentrytoken/sentrytoken_test.go
+++ b/pkg/detectors/sentrytoken/sentrytoken_test.go
@@ -125,7 +125,7 @@ func TestSentryToken_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found, account deactivated",
-			s:    Scanner{client: common.ConstantResponseHttpClient(200, reponseAccountDeactivated)},
+			s:    Scanner{client: common.ConstantResponseHttpClient(200, responseAccountDeactivated)},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a sentry super secret %s within", secret)),
@@ -142,7 +142,7 @@ func TestSentryToken_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found, account deactivated",
-			s:    Scanner{client: common.ConstantResponseHttpClient(200, responseEnmpty)},
+			s:    Scanner{client: common.ConstantResponseHttpClient(200, responseEmpty)},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a sentry super secret %s within", secret)),
@@ -209,8 +209,8 @@ const (
   }
 ]
 `
-	reponseAccountDeactivated = `{"detail": "Authentication credentials were not provided"}`
-	responseEnmpty            = `[]`
+	responseAccountDeactivated = `{"detail": "Authentication credentials were not provided"}`
+	responseEmpty              = `[]`
 )
 
 func BenchmarkFromData(benchmark *testing.B) {

--- a/pkg/detectors/sumologickey/sumologickey_test.go
+++ b/pkg/detectors/sumologickey/sumologickey_test.go
@@ -44,7 +44,7 @@ sumoKey2 = 'Khk3i2ugMxMgkb8bIA2auj4I8juZ3HiimDNssjzYdGqfizPZcxHK21a0LckgRSCL'`,
 			want: []string{"CzrMhR8zzy1eH1F0XlY1tu5ywqa2yaSFoWGg2cqE43XkfnUVCytnPQfv1enUYrzv", "Khk3i2ugMxMgkb8bIA2auj4I8juZ3HiimDNssjzYdGqfizPZcxHK21a0LckgRSCL"},
 		},
 		{
-			name:  "invald pattern",
+			name:  "invalid pattern",
 			input: "sumoId = 'doDkVYKjXZAwsz'",
 			want:  []string{},
 		},

--- a/pkg/detectors/weightsandbiases/weightsandbiases_test.go
+++ b/pkg/detectors/weightsandbiases/weightsandbiases_test.go
@@ -30,7 +30,7 @@ WANDB_API_KEY= 'eedf1c984f6b995ec40ecc6658356044847ffb32'`,
 			want: []string{"eedf1c984f6b995ec40ecc6658356044847ffb31", "eedf1c984f6b995ec40ecc6658356044847ffb32"},
 		},
 		{
-			name:  "invald pattern",
+			name:  "invalid pattern",
 			input: "WANDB_API_KEY = 'e84f6b995ec40ecc6658356044847ffb31'",
 			want:  []string{},
 		},

--- a/pkg/sanitizer/utf8_test.go
+++ b/pkg/sanitizer/utf8_test.go
@@ -19,14 +19,14 @@ func TestUTF8(t *testing.T) {
 			want: "hello123",
 		},
 		{
-			name: "santized",
+			name: "sanitized",
 			args: args{
 				in: "Gr\351gory Smith",
 			},
 			want: "Gr❗gory Smith",
 		},
 		{
-			name: "santized",
+			name: "sanitized",
 			args: args{
 				in: "no \x00 nulls because postgres does not support it in text fields",
 			},

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -201,7 +201,7 @@ func TestSource_Chunks_Integration(t *testing.T) {
 				"27fbead3bf883cdb7de9d7825ed401f28f9398f1-slack": {B: []byte("\n\n\nyup, just did that\n\ngithub_lol: \"ffc7e0f9400fb6300167009e42d2f842cd7956e2\"\n\noh, goodness. there's another one!\n")},
 				"8afb0ecd4998b1179e428db5ebbcdc8221214432-":      {B: []byte("Dustin <dustindecker@protonmail.com>\nDustin <dustindecker@protonmail.com>\nadd slack token\n")},
 				"8afb0ecd4998b1179e428db5ebbcdc8221214432-slack": {B: []byte("oops might drop a slack token here\n\ngithub_secret=\"369963c1434c377428ca8531fbc46c0c43d037a0\"\n\nyup, just did that\n"), Multi: true},
-				"8fe6f04ef1839e3fc54b5147e3d0e0b7ab971bd5-":      {B: []byte("Dustin <dustindecker@protonmail.com>\nDustin <dustindecker@protonmail.com>\noops, accidently commited AWS token...\n")},
+				"8fe6f04ef1839e3fc54b5147e3d0e0b7ab971bd5-":      {B: []byte("Dustin <dustindecker@protonmail.com>\nDustin <dustindecker@protonmail.com>\noops, accidently commited AWS token...\n")}, //nolint:misspell
 				"8fe6f04ef1839e3fc54b5147e3d0e0b7ab971bd5-aws":   {B: []byte("blah blaj\n\nthis is the secret: AKIA2E0A8F3B244C9986\n\nokay thank you bye\n"), Multi: true},
 				"84e9c75e388ae3e866e121087ea2dd45a71068f2-":      {B: []byte("Dylan Ayrey <dxa4481@rit.edu>\nGitHub <noreply@github.com>\nUpdate aws\n")},
 				"84e9c75e388ae3e866e121087ea2dd45a71068f2-aws":   {B: []byte("\n\nthis is the secret: [Default]\nAccess key Id: AKIAILE3JG6KMS3HZGCA\nSecret Access Key: 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\n\nokay thank you bye\n"), Multi: false},

--- a/pkg/sources/github_experimental/object_discovery.go
+++ b/pkg/sources/github_experimental/object_discovery.go
@@ -39,7 +39,7 @@ const startingCharLen = 4
 // Max character length (6 is the default maximum)
 // 6 chars == 16M possibilities --> which will take 18k-55k queries.
 // that's really the max that's tolerable since it will take a long time to run.
-// If you increase this to accomdate a MASSIVE repository, it will take a long time to run.
+// If you increase this to accommodate a MASSIVE repository, it will take a long time to run.
 const maxCharLen = 6
 
 // Starting GraphQL query chunk size.


### PR DESCRIPTION
### Description:

The PR corrects grammar mistakes in comments and test files. And enables `misspell` linter that reports typos.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
