### PR TITLE
Log false positive result as string

### DIFF
--- a/pkg/detectors/falsepositives.go
+++ b/pkg/detectors/falsepositives.go
@@ -191,7 +191,7 @@ func FilterKnownFalsePositives(ctx context.Context, detector Detector, results [
 		}
 
 		if isFp, reason := isFalsePositive(result); isFp {
-			ctx.Logger().V(4).Info("Skipping result: false positive", "result", result.Raw, "reason", reason)
+			ctx.Logger().V(4).Info("Skipping result: false positive", "result", string(result.Raw), "reason", reason)
 			continue
 		}
 		filteredResults = append(filteredResults, result)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This is a follow-up to #3579. The result needs to be `string` and not `[]byte`, otherwise it gets logged as base64.

```
"result": "bXlQYXNzd29yZA=="
```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
