### PR TITLE
fix base on initial commits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,7 @@ runs:
           fi
           HEAD=${{ github.event.after }}
           if [ ${{ github.event.before }} == "0000000000000000000000000000000000000000" ]; then
-            BASE=$(git rev-parse $HEAD~$COMMIT_LENGTH)
+            BASE=""
           else
             BASE=${{ github.event.before }}
           fi


### PR DESCRIPTION
### Description:

* On initial commits of a GitHub repository all commits (part of the initial commit) should be checked
* Trufflehog should work when the Trufflehog workflow is part of an initial commit
* Trufflehog should work when it is part of a GitHub repository template (again part of an initial commit)

Fix #3557

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
