### PR TITLE
[fix] - remove unused embedded struct

### DIFF
--- a/pkg/detectors/github_oauth2/github_oauth2.go
+++ b/pkg/detectors/github_oauth2/github_oauth2.go
@@ -14,7 +14,6 @@ import (
 )
 
 type Scanner struct {
-	detectors.EndpointSetter
 	detectors.DefaultMultiPartCredentialProvider
 }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR removes the embedded detectors.EndpointSetter from the github_oauth2 detector since it's unused.
### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
