### PR TITLE
[bug] - correctly capture db type for postgres detector

### DIFF
--- a/pkg/detectors/postgres/postgres.go
+++ b/pkg/detectors/postgres/postgres.go
@@ -21,18 +21,19 @@ import (
 const (
 	defaultPort = "5432"
 
-	pg_connect_timeout = "connect_timeout"
-	pg_dbname          = "dbname"
-	pg_host            = "host"
-	pg_password        = "password"
-	pg_port            = "port"
-	pg_requiressl      = "requiressl"
-	pg_sslmode         = "sslmode"
-	pg_sslmode_allow   = "allow"
-	pg_sslmode_disable = "disable"
-	pg_sslmode_prefer  = "prefer"
-	pg_sslmode_require = "require"
-	pg_user            = "user"
+	pgConnectTimeout = "connect_timeout"
+	pgDbname         = "dbname"
+	pgHost           = "host"
+	pgPassword       = "password"
+	pgPort           = "port"
+	pgRequiressl     = "requiressl"
+	pgSslmode        = "sslmode"
+	pgSslmodeAllow   = "allow"
+	pgSslmodeDisable = "disable"
+	pgSslmodePrefer  = "prefer"
+	pgSslmodeRequire = "require"
+	pgUser           = "user"
+	pgDbType         = "db_type"
 )
 
 // This detector currently only finds Postgres connection string URIs
@@ -71,17 +72,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 		if common.IsDone(ctx) {
 			break
 		}
-		user, ok := params[pg_user]
+		user, ok := params[pgUser]
 		if !ok {
 			continue
 		}
 
-		password, ok := params[pg_password]
+		password, ok := params[pgPassword]
 		if !ok {
 			continue
 		}
 
-		host, ok := params[pg_host]
+		host, ok := params[pgHost]
 		if !ok {
 			continue
 		}
@@ -94,14 +95,14 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 			}
 		}
 
-		port, ok := params[pg_port]
+		port, ok := params[pgPort]
 		if !ok {
 			port = defaultPort
-			params[pg_port] = port
+			params[pgPort] = port
 		}
 
 		const defaultDBType = "postgresql"
-		dbType, ok := params["db_type"]
+		dbType, ok := params[pgDbType]
 		if !ok {
 			dbType = defaultDBType
 		}
@@ -117,17 +118,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 		// do it for us - but we will do it anyway here so that when we later capture sslmode into ExtraData we will
 		// capture it post-normalization. (The detector's behavior is undefined for candidate secrets that have both
 		// requiressl and sslmode set.)
-		if requiressl := params[pg_requiressl]; requiressl == "0" {
-			params[pg_sslmode] = pg_sslmode_prefer
+		if requiressl := params[pgRequiressl]; requiressl == "0" {
+			params[pgSslmode] = pgSslmodePrefer
 		} else if requiressl == "1" {
-			params[pg_sslmode] = pg_sslmode_require
+			params[pgSslmode] = pgSslmodeRequire
 		}
 
 		if verify {
 			// pq appears to ignore the context deadline, so we copy any timeout that's been set into the connection
 			// parameters themselves.
 			if timeout, ok := getDeadlineInSeconds(ctx); ok && timeout > 0 {
-				params[pg_connect_timeout] = strconv.Itoa(timeout)
+				params[pgConnectTimeout] = strconv.Itoa(timeout)
 			} else if timeout <= 0 {
 				// Deadline in the context has already exceeded.
 				break
@@ -142,12 +143,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 		}
 
 		// We gather SSL information into ExtraData in case it's useful for later reporting.
-		sslmode := params[pg_sslmode]
+		sslmode := params[pgSslmode]
 		if sslmode == "" {
 			sslmode = "<unset>"
 		}
 		result.ExtraData = map[string]string{
-			pg_sslmode: sslmode,
+			pgSslmode: sslmode,
 		}
 
 		results = append(results, result)
@@ -181,7 +182,7 @@ func findUriMatches(data []byte) []map[string]string {
 			params[part[1]] = part[2]
 		}
 
-		params["db_type"] = dbType
+		params[pgDbType] = dbType
 		matches = append(matches, params)
 	}
 	return matches
@@ -211,14 +212,14 @@ func isErrorDatabaseNotFound(err error, dbName string) bool {
 }
 
 func verifyPostgres(params map[string]string) (bool, error) {
-	if sslmode := params[pg_sslmode]; sslmode == pg_sslmode_allow || sslmode == pg_sslmode_prefer {
+	if sslmode := params[pgSslmode]; sslmode == pgSslmodeAllow || sslmode == pgSslmodePrefer {
 		// pq doesn't support 'allow' or 'prefer'. If we find either of them, we'll just ignore it. This will trigger
 		// the same logic that is run if no sslmode is set at all (which mimics 'prefer', which is the default).
-		delete(params, pg_sslmode)
+		delete(params, pgSslmode)
 
 		// We still want to save the original sslmode in ExtraData, so we'll re-add it before returning.
 		defer func() {
-			params[pg_sslmode] = sslmode
+			params[pgSslmode] = sslmode
 		}()
 	}
 
@@ -239,14 +240,14 @@ func verifyPostgres(params map[string]string) (bool, error) {
 		return true, nil
 	case strings.Contains(err.Error(), "password authentication failed"):
 		return false, nil
-	case errors.Is(err, pq.ErrSSLNotSupported) && params[pg_sslmode] == "":
+	case errors.Is(err, pq.ErrSSLNotSupported) && params[pgSslmode] == "":
 		// If the sslmode is unset, then either it was unset in the candidate secret, or we've intentionally unset it
 		// because it was specified as 'allow' or 'prefer', neither of which pq supports. In all of these cases, non-SSL
 		// connections are acceptable, so now we try a connection without SSL.
-		params[pg_sslmode] = pg_sslmode_disable
-		defer delete(params, pg_sslmode) // We want to return with the original params map intact (for ExtraData)
+		params[pgSslmode] = pgSslmodeDisable
+		defer delete(params, pgSslmode) // We want to return with the original params map intact (for ExtraData)
 		return verifyPostgres(params)
-	case isErrorDatabaseNotFound(err, params[pg_dbname]):
+	case isErrorDatabaseNotFound(err, params[pgDbname]):
 		return true, nil // If we know this, we were able to authenticate
 	default:
 		return false, err


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR ensures the Postgres detector correctly captures the database type name instead of always defaulting to postgresql in the `Raw` field of the `Result`.

This fixes: https://github.com/trufflesecurity/trufflehog/issues/3602
### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
