### PR TITLE
fixed github classic token analyzer expiry time

### DIFF
--- a/pkg/analyzer/analyzers/github/common/github.go
+++ b/pkg/analyzer/analyzers/github/common/github.go
@@ -81,8 +81,6 @@ func GetTokenMetadata(token string, client *gh.Client) (*TokenMetadata, error) {
 		return nil, err
 	}
 
-	expiration, _ := time.Parse("2006-01-02 15:04:05 -0700", resp.Header.Get("github-authentication-token-expiration"))
-
 	var oauthScopes []analyzers.Permission
 	for _, scope := range resp.Header.Values("X-OAuth-Scopes") {
 		for _, scope := range strings.Split(scope, ", ") {
@@ -90,6 +88,15 @@ func GetTokenMetadata(token string, client *gh.Client) (*TokenMetadata, error) {
 		}
 	}
 	tokenType, fineGrained := checkFineGrained(token, oauthScopes)
+
+	var expiration time.Time
+	if tokenType == TokenTypeClassicPAT {
+		// for classic tokens, github return token expiration time in header in UTC format.
+		expiration, _ = time.Parse("2006-01-02 15:04:05 UTC", resp.Header.Get("github-authentication-token-expiration"))
+	} else {
+		expiration, _ = time.Parse("2006-01-02 15:04:05 -0700", resp.Header.Get("github-authentication-token-expiration"))
+	}
+
 	return &TokenMetadata{
 		Type:        tokenType,
 		FineGrained: fineGrained,


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Fix the expiry time for github analyzer for classic tokens

### Output:
**Previous:**
![Screenshot from 2024-11-19 12-33-51](https://github.com/user-attachments/assets/1fca1608-7d92-4869-8249-703b4137aeed)
**After Fix:**
![Screenshot from 2024-11-19 12-32-51](https://github.com/user-attachments/assets/e919e85a-c737-4394-9ac5-14f9e3ae6192)

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
