### PR TITLE
Remove unused findLevel function

### DIFF
--- a/pkg/log/level.go
+++ b/pkg/log/level.go
@@ -1,9 +1,6 @@
 package log
 
 import (
-	"sort"
-
-	"github.com/go-logr/logr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -31,13 +28,4 @@ func SetLevelForControl(control levelSetter, level int8) {
 	// by zapr here: https://github.com/go-logr/zapr#increasing-verbosity
 	// For example setting the level to -2 below, means log.V(2) will be enabled.
 	control.SetLevel(zapcore.Level(-level))
-}
-
-// findLevel probes a logr.Logger to figure out what level it is at via binary
-// search. We only search [0, 128), so worst case is ~7 checks.
-func findLevel(logger logr.Logger) int8 {
-	sink := logger.GetSink()
-	return int8(sort.Search(128, func(i int) bool {
-		return !sink.Enabled(i)
-	}) - 1)
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -224,17 +224,6 @@ func splitLines(s string) []string {
 	return logLines
 }
 
-func TestFindLevel(t *testing.T) {
-	lvl := zap.NewAtomicLevel()
-	logger, _ := New("parent", WithConsoleSink(io.Discard, WithLeveler(lvl)))
-
-	for i := 0; i < 128; i++ {
-		i8 := int8(i)
-		SetLevelForControl(lvl, i8)
-		assert.Equal(t, i8, findLevel(logger))
-	}
-}
-
 func TestGlobalRedaction_Console(t *testing.T) {
 	oldState := globalRedactor
 	globalRedactor = &dynamicRedactor{


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Was previously referenced in other unused functionality that got removed.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
