### PR TITLE
[Fix] Handling of forbidden status in Slack Webhook

### DIFF
--- a/pkg/detectors/slackwebhook/slackwebhook.go
+++ b/pkg/detectors/slackwebhook/slackwebhook.go
@@ -90,7 +90,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						s1.Verified = true
 					case res.StatusCode == http.StatusBadRequest && bytes.Equal(bodyBytes, []byte("invalid_payload")):
 						s1.Verified = true
-					case res.StatusCode == http.StatusNotFound:
+					case res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusForbidden:
 						// Not a real webhook or the owning app's OAuth token has been revoked or the app has been deleted
 						// You might want to handle this case or log it.
 					default:


### PR DESCRIPTION
### Description:
One of the customer reported that they have rotated slack webhook url but detector was throwing error `403` due to not handling of Forbidden status. This PR fix this issue and mark webhook url as unverified if forbidden is being returned.

### Checklist:
* [] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
