### PR TITLE
Fix nil pointer in Azure Storage detector

### DIFF
--- a/pkg/detectors/azure_storage/storage.go
+++ b/pkg/detectors/azure_storage/storage.go
@@ -20,7 +20,7 @@ import (
 
 type Scanner struct {
 	client *http.Client
-	detectors.MultiPartCredentialProvider
+	detectors.DefaultMultiPartCredentialProvider
 }
 
 var _ detectors.Detector = (*Scanner)(nil)
@@ -29,13 +29,13 @@ var (
 	defaultClient = detectors.DetectorHttpClientWithNoLocalAddresses
 
 	namePat = regexp.MustCompile(`(?i:Account[_.-]?Name|Storage[_.-]?(?:Account|Name))(?:.|\s){0,20}?\b([a-z0-9]{3,24})\b|([a-z0-9]{3,24})(?i:\.blob\.core\.windows\.net)`) // Names can only be lowercase alphanumeric.
+	keyPat  = regexp.MustCompile(`(?i:(?:Access|Account|Storage)[_.-]?Key)(?:.|\s){0,25}?([a-zA-Z0-9+\/-]{86,88}={0,2})`)
+
 	// https://learn.microsoft.com/en-us/azure/storage/common/storage-use-emulator
 	testNames = map[string]struct{}{
 		"devstoreaccount1": {},
 		"storagesample":    {},
 	}
-
-	keyPat   = regexp.MustCompile(`(?i:(?:Access|Account|Storage)[_.-]?Key)(?:.|\s){0,25}?([a-zA-Z0-9+\/-]{86,88}={0,2})`)
 	testKeys = map[string]struct{}{
 		"Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==": {},
 	}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This fixes [a nil pointer caused by using `detectors.MultiPartCredentialProvider`](https://github.com/trufflesecurity/trufflehog/pull/3634/checks).


Side-note: I find all `MultiPartCredentialProvider`, `StartOffsetProvider`, `MaxSecretSizeProvider`, `DefaultMultiPartCredentialProvider`, and `CustomMultiPartCredentialProvider` incredibly confusing. I feel like I'm guessing most of the time.

https://github.com/trufflesecurity/trufflehog/blob/9d99de8e5984f2f6afa79d54fca39ffac6620606/pkg/detectors/aws/session_keys/sessionkey.go#L36

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
