### PR TITLE
[feat] - Add x509 cert info to privatekey detector ExtraData

### DIFF
--- a/pkg/detectors/privatekey/privatekey.go
+++ b/pkg/detectors/privatekey/privatekey.go
@@ -87,8 +87,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		if verify {
 			var (
 				wg                 sync.WaitGroup
-				verificationErrors = newVerificationErrors()
 				extraData          = newExtraData()
+				verificationErrors = newVerificationErrors()
 			)
 
 			// Look up certificate information.

--- a/pkg/detectors/privatekey/privatekey_test.go
+++ b/pkg/detectors/privatekey/privatekey_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/kylelemons/godebug/pretty"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
@@ -78,7 +79,11 @@ func TestPrivatekey_FromChunk(t *testing.T) {
 					Verified:     true,
 					Redacted:     "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgw",
 					ExtraData: map[string]string{
-						"certificate_urls": "https://crt.sh/?q=1e20c40deb44a8539dd3ac3e8c53b72750cb19f9, https://crt.sh/?q=0e9de31fb2ee16465a4d5d93b227d54f870326d1",
+						"cert_0_expiration":  "2018-06-05T10:00:32Z",
+						"cert_0_fingerprint": "0e9de31fb2ee16465a4d5d93b227d54f870326d1",
+						"cert_1_expiration":  "2017-06-13T07:08:51Z",
+						"cert_1_fingerprint": "1e20c40deb44a8539dd3ac3e8c53b72750cb19f9",
+						"certificate_urls":   "https://crt.sh/?q=0e9de31fb2ee16465a4d5d93b227d54f870326d1, https://crt.sh/?q=1e20c40deb44a8539dd3ac3e8c53b72750cb19f9",
 					},
 				},
 			},


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR adds additional certificate metadata to the `ExtraData` field of the private key detector's results.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
