### PR TITLE
Fix multiple package error in tests

### DIFF
--- a/pkg/detectors/hubspot_apikey/v1/apikey_integration_test.go
+++ b/pkg/detectors/hubspot_apikey/v1/apikey_integration_test.go
@@ -1,7 +1,7 @@
 //go:build detectors
 // +build detectors
 
-package hubspotapikey
+package v1
 
 import (
 	"context"


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
```
=== Errors
found packages v1 (apikey.go) and hubspotapikey (apikey_integration_test.go) in /home/runner/work/trufflehog/trufflehog/pkg/detectors/hubspot_apikey/v1
```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
