### PR TITLE
[refactor] - `detectorKeywordMatcher` initialization

### DIFF
--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -1,12 +1,6 @@
 package defaults
 
 import (
-	"bytes"
-	"strings"
-	"sync"
-
-	ahocorasick "github.com/BobuSumisu/aho-corasick"
-
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/abbysale"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/abuseipdb"
@@ -1696,61 +1690,4 @@ func DefaultDetectorTypesImplementing[T any]() map[detectorspb.DetectorType]stru
 		}
 	}
 	return out
-}
-
-func defaultDetectorKeywords() []string {
-	allDetectors := buildDetectorList()
-
-	// Remove keywords that cause lots of false positives.
-	var exclusions = []string{
-		"AKIA", "SG.", "pat", "token", "gh", "github", "sql", "database", "http", "key", "api-", "sdk-", "float", "-us", "gh", "pat", "token", "sid", "http", "private", "key", "segment", "close", "protocols", "verifier", "box", "privacy", "dm", "sl.", "vf", "flat",
-	}
-
-	var keywords []string
-	exclusionSet := make(map[string]struct{})
-	for _, excl := range exclusions {
-		exclusionSet[strings.ToLower(excl)] = struct{}{}
-	}
-
-	// Aggregate all keywords from detectors.
-	for _, detector := range allDetectors {
-		for _, kw := range detector.Keywords() {
-			kwLower := strings.ToLower(kw)
-			if _, excluded := exclusionSet[kwLower]; !excluded {
-				keywords = append(keywords, kwLower)
-			}
-		}
-	}
-	return keywords
-}
-
-// DefaultDetectorKeywordMatcher encapsulates the Aho-Corasick trie for keyword matching.
-type DefaultDetectorKeywordMatcher struct {
-	mu   sync.RWMutex
-	trie *ahocorasick.Trie
-}
-
-// NewDefaultDetectorKeywordMatcher creates a new DefaultDetectorKeywordMatcher.
-func NewDefaultDetectorKeywordMatcher() *DefaultDetectorKeywordMatcher {
-	keywords := defaultDetectorKeywords()
-	return &DefaultDetectorKeywordMatcher{trie: ahocorasick.NewTrieBuilder().AddStrings(keywords).Build()}
-}
-
-// FindKeywords scans the input text and returns a slice of matched keywords.
-func (km *DefaultDetectorKeywordMatcher) FindKeywords(text []byte) []string {
-	km.mu.RLock()
-	defer km.mu.RUnlock()
-
-	matches := km.trie.Match(bytes.ToLower(text))
-	found := make([]string, 0, len(matches))
-	seen := make(map[string]struct{}) // To avoid duplicate entries
-
-	for _, match := range matches {
-		keyword := match.MatchString()
-		if _, exists := seen[keyword]; !exists {
-			found = append(found, keyword)
-			seen[keyword] = struct{}{}
-		}
-	}
-	return found
 }

--- a/pkg/handlers/apk.go
+++ b/pkg/handlers/apk.go
@@ -68,9 +68,7 @@ func defaultDetectorKeywords() []string {
 // out irrelevant data and focus on content that is more likely to contain credentials.
 // The Aho-Corasick algorithm provides fast, simultaneous matching of multiple patterns in
 // a single pass through the text, which is crucial for performance when scanning large APK files.
-type detectorKeywordMatcher struct {
-	trie *ahocorasick.Trie
-}
+type detectorKeywordMatcher struct{ trie *ahocorasick.Trie }
 
 // getDefaultDetectorKeywordMatcher creates or returns the singleton detectorKeywordMatcher.
 // This is implemented as a singleton for several important reasons:

--- a/pkg/handlers/apk.go
+++ b/pkg/handlers/apk.go
@@ -69,7 +69,6 @@ func defaultDetectorKeywords() []string {
 // The Aho-Corasick algorithm provides fast, simultaneous matching of multiple patterns in
 // a single pass through the text, which is crucial for performance when scanning large APK files.
 type detectorKeywordMatcher struct {
-	mu   sync.RWMutex
 	trie *ahocorasick.Trie
 }
 
@@ -94,9 +93,6 @@ func getDefaultDetectorKeywordMatcher() *detectorKeywordMatcher {
 // It returns unique matches only, eliminating duplicates that may occur when
 // the same keyword appears multiple times in the input text.
 func (km *detectorKeywordMatcher) FindKeywords(text []byte) []string {
-	km.mu.RLock()
-	defer km.mu.RUnlock()
-
 	matches := km.trie.Match(bytes.ToLower(text))
 	found := make([]string, 0, len(matches))
 	seen := make(map[string]struct{}) // To avoid duplicate entries


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR relocates the initialization of the `detectorKeywordMatcher` to the `apk` handler file. This change offers several benefits:  

1. **Efficiency**: Constructing the matcher is relatively resource-intensive and requires a decent amount of memory (~45MB). By initializing it as a singleton in the `apk` handler, we incur this cost only once, enabling reuse across all `apk` handlers throughout the program's lifecycle.  
2. **Relevance**: The matcher’s functionality is closely tied to the `apk` handler rather than the detectors, so keeping it within the `apk` codebase improves logical cohesion (imo).



Sorry @joeleonjr I totally missed the location of this logic in your earlier PR. 😭 
### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
