### PR TITLE
Updated/fixed the function names of pattern tests for detectors n through o

### DIFF
--- a/pkg/detectors/nasdaqdatalink/nasdaqdatalink_test.go
+++ b/pkg/detectors/nasdaqdatalink/nasdaqdatalink_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "nasdaqdatalink"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNasdaqDataLink_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/nethunt/nethunt_test.go
+++ b/pkg/detectors/nethunt/nethunt_test.go
@@ -19,7 +19,7 @@ var (
 	keyword    = "nethunt"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNethunt_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/netlify/netlify_test.go
+++ b/pkg/detectors/netlify/netlify_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "netlify"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNetlify_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/netsuite/netsuite_test.go
+++ b/pkg/detectors/netsuite/netsuite_test.go
@@ -30,7 +30,7 @@ token - '%s' token - '%s'`
 	outputPair2 = validConsumerSecret + validConsumerKey
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNetsuite_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/neutrinoapi/neutrinoapi_test.go
+++ b/pkg/detectors/neutrinoapi/neutrinoapi_test.go
@@ -19,7 +19,7 @@ var (
     keyword    = "neutrinoapi"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNeutrinoApi_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/newrelicpersonalapikey/newrelicpersonalapikey_test.go
+++ b/pkg/detectors/newrelicpersonalapikey/newrelicpersonalapikey_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "newrelicpersonalapikey"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNewRelicPersonalApiKey_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/newsapi/newsapi_test.go
+++ b/pkg/detectors/newsapi/newsapi_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "newsapi"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNewsapi_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/newscatcher/newscatcher_test.go
+++ b/pkg/detectors/newscatcher/newscatcher_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "newscatcher"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNewscatcher_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/nexmoapikey/nexmoapikey_test.go
+++ b/pkg/detectors/nexmoapikey/nexmoapikey_test.go
@@ -19,7 +19,7 @@ var (
 	keyword       = "nexmoapikey"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNexmoApiKey_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/nftport/nftport_test.go
+++ b/pkg/detectors/nftport/nftport_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "nftport"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNftport_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/ngc/ngc_test.go
+++ b/pkg/detectors/ngc/ngc_test.go
@@ -19,7 +19,7 @@ var (
 	keyword        = "ngc"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNGC_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/ngrok/ngrok_test.go
+++ b/pkg/detectors/ngrok/ngrok_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "ngrok"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNgrok_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/nicereply/nicereply_test.go
+++ b/pkg/detectors/nicereply/nicereply_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "nicereply"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNicereply_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/nightfall/nightfall_test.go
+++ b/pkg/detectors/nightfall/nightfall_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "nightfall"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNightfall_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/nimble/nimble_test.go
+++ b/pkg/detectors/nimble/nimble_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "nimble"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNimble_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/noticeable/noticeable_test.go
+++ b/pkg/detectors/noticeable/noticeable_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "noticeable"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNoticeable_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/notion/notion_test.go
+++ b/pkg/detectors/notion/notion_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "notion"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNotion_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/nozbeteams/nozbeteams_test.go
+++ b/pkg/detectors/nozbeteams/nozbeteams_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "nozbeteams"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNozbeTeams_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/npmtoken/npmtoken_test.go
+++ b/pkg/detectors/npmtoken/npmtoken_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "npmtoken"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNpmToken_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/npmtokenv2/npmtokenv2_test.go
+++ b/pkg/detectors/npmtokenv2/npmtokenv2_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "npmtokenv2"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNpmToken_New_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/nugetapikey/nugetapikey_test.go
+++ b/pkg/detectors/nugetapikey/nugetapikey_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "nugetapikey"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNugetapikey_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/numverify/numverify_test.go
+++ b/pkg/detectors/numverify/numverify_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "numverify"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNumverify_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/nutritionix/nutritionix_test.go
+++ b/pkg/detectors/nutritionix/nutritionix_test.go
@@ -19,7 +19,7 @@ var (
     keyword    = "nutritionix"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNutritionix_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/nylas/nylas_test.go
+++ b/pkg/detectors/nylas/nylas_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "nylas"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestNylas_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/oanda/oanda_test.go
+++ b/pkg/detectors/oanda/oanda_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "oanda"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOanda_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/okta/okta_test.go
+++ b/pkg/detectors/okta/okta_test.go
@@ -19,7 +19,7 @@ var (
 	keyword       = "okta"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOkta_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/omnisend/omnisend_test.go
+++ b/pkg/detectors/omnisend/omnisend_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "omnisend"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOmnisend_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/onelogin/onelogin_test.go
+++ b/pkg/detectors/onelogin/onelogin_test.go
@@ -19,7 +19,7 @@ var (
 	keyword                  = "onelogin"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOnelogin_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/onepagecrm/onepagecrm_test.go
+++ b/pkg/detectors/onepagecrm/onepagecrm_test.go
@@ -19,7 +19,7 @@ var (
     keyword    = "onepagecrm"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOnepageCRM_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/oopspam/oopspam_test.go
+++ b/pkg/detectors/oopspam/oopspam_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "oopspam"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOOPSpam_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/opencagedata/opencagedata_test.go
+++ b/pkg/detectors/opencagedata/opencagedata_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "opencagedata"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOpenCageData_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/openuv/openuv_test.go
+++ b/pkg/detectors/openuv/openuv_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "openuv"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOpenuv_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/openvpn/openvpn_test.go
+++ b/pkg/detectors/openvpn/openvpn_test.go
@@ -22,7 +22,7 @@ var (
 	keyword             = "openvpn"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOpenvpn_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/openweather/openweather_test.go
+++ b/pkg/detectors/openweather/openweather_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "openweather"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOpenWeather_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/opsgenie/opsgenie_test.go
+++ b/pkg/detectors/opsgenie/opsgenie_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "opsgenie"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOpsgenie_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/optimizely/optimizely_test.go
+++ b/pkg/detectors/optimizely/optimizely_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "optimizely"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOptimizely_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/overloop/overloop_test.go
+++ b/pkg/detectors/overloop/overloop_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "overloop"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOverloop_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/owlbot/owlbot_test.go
+++ b/pkg/detectors/owlbot/owlbot_test.go
@@ -17,7 +17,7 @@ var (
 	keyword        = "owlbot"
 )
 
-func TestZohocrm_Pattern(t *testing.T) {
+func TestOwlbot_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {


### PR DESCRIPTION
This PR fixes the function names in new pattern tests added [in this pull-request](https://github.com/trufflesecurity/trufflehog/pull/3685).

Test function names should now be consistent and include the correct name of the corresponding detector.

### Test Output:
![image](https://github.com/user-attachments/assets/7059884e-6e13-4526-90f3-133dad2cc366)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
