### PR TITLE
Replace `--debug` and `--trace` with a fine-grained `--log-level` flag

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -16,7 +16,7 @@ Please review the [Community Note](https://github.com/trufflesecurity/trufflehog
 <!---
 Please provide a link to a GitHub Gist containing the complete debug output. Please do NOT paste the debug output in the issue; just paste a link to the Gist.
 
-To obtain the trace output, run trufflehog with the --trace flag.
+To obtain the trace output, run trufflehog with the --log-level=5 flag.
 --->
 
 ### Expected Behavior

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PROTOS_IMAGE ?= trufflesecurity/protos:1.22
 .PHONY: dogfood
 
 dogfood:
-	CGO_ENABLED=0 go run . git file://. --json --debug
+	CGO_ENABLED=0 go run . git file://. --json --log-level=2
 
 install:
 	CGO_ENABLED=0 go install .
@@ -49,7 +49,7 @@ run:
 	CGO_ENABLED=0 go run . git file://. --json
 
 run-debug:
-	CGO_ENABLED=0 go run . git file://. --json --debug
+	CGO_ENABLED=0 go run . git file://. --json --log-level=2
 
 protos:
 	docker run --rm -u "$(shell id -u)" -v "$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))":/pwd "${PROTOS_IMAGE}" bash -c "cd /pwd; /pwd/scripts/gen_proto.sh"

--- a/README.md
+++ b/README.md
@@ -410,8 +410,7 @@ Find credentials in git repositories.
 
 Flags:
   -h, --help                Show context-sensitive help (also try --help-long and --help-man).
-      --debug               Run in debug mode.
-      --trace               Run in trace mode.
+      --log-level=0         Logging verbosity on a scale of 0 (info) to 5 (trace). Can be disabled with "-1".
       --profile             Enables profiling and sets a pprof and fgprof server on :18066.
   -j, --json                Output in JSON format.
       --json-legacy         Use the pre-v3.0 JSON format. Only works with git, gitlab, and github sources.
@@ -567,7 +566,7 @@ TruffleHog statically detects [https://canarytokens.org/](https://canarytokens.o
     # Scan commits until here (usually dev branch).
     head: # optional
     # Extra args to be passed to the trufflehog cli.
-    extra_args: --debug --only-verified
+    extra_args: --log-level=2 --only-verified
 ```
 
 If you'd like to specify specific `base` and `head` refs, you can use the `base` argument (`--since-commit` flag in TruffleHog CLI) and the `head` argument (`--branch` flag in the TruffleHog CLI). We only recommend using these arguments for very specific use cases, where the default behavior does not work.


### PR DESCRIPTION
### Description:
This was motivated by the discussion in https://github.com/trufflesecurity/trufflehog/pull/3589.

It fixes #3668.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
