### PR TITLE
[Fix] detector's integration tests starting with alphabet 'A'

### DIFF
--- a/pkg/detectors/agora/agora_integration_test.go
+++ b/pkg/detectors/agora/agora_integration_test.go
@@ -51,15 +51,7 @@ func TestAgora_FromChunk(t *testing.T) {
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_Agora,
-					Verified:     false,
-				},
-				{
-					DetectorType: detectorspb.DetectorType_Agora,
 					Verified:     true,
-				},
-				{
-					DetectorType: detectorspb.DetectorType_Agora,
-					Verified:     false,
 				},
 				{
 					DetectorType: detectorspb.DetectorType_Agora,
@@ -82,7 +74,7 @@ func TestAgora_FromChunk(t *testing.T) {
 					Verified:     false,
 				}
 				r.SetVerificationError(context.DeadlineExceeded)
-				return []detectors.Result{r, r, r, r}
+				return []detectors.Result{r, r}
 			}(),
 			wantErr: false,
 		},
@@ -100,7 +92,7 @@ func TestAgora_FromChunk(t *testing.T) {
 					Verified:     false,
 				}
 				r.SetVerificationError(fmt.Errorf("unexpected HTTP response status 500"))
-				return []detectors.Result{r, r, r, r}
+				return []detectors.Result{r, r}
 			}(),
 			wantErr: false,
 		},
@@ -113,14 +105,6 @@ func TestAgora_FromChunk(t *testing.T) {
 				verify: true,
 			},
 			want: []detectors.Result{
-				{
-					DetectorType: detectorspb.DetectorType_Agora,
-					Verified:     false,
-				},
-				{
-					DetectorType: detectorspb.DetectorType_Agora,
-					Verified:     false,
-				},
 				{
 					DetectorType: detectorspb.DetectorType_Agora,
 					Verified:     false,

--- a/pkg/detectors/amplitudeapikey/amplitudeapikey_integration_test.go
+++ b/pkg/detectors/amplitudeapikey/amplitudeapikey_integration_test.go
@@ -54,6 +54,10 @@ func TestAmplitudeApiKey_FromChunk(t *testing.T) {
 					DetectorType: detectorspb.DetectorType_AmplitudeApiKey,
 					Verified:     true,
 				},
+				{
+					DetectorType: detectorspb.DetectorType_AmplitudeApiKey,
+					Verified:     false,
+				},
 			},
 			wantErr: false,
 		},
@@ -67,6 +71,10 @@ func TestAmplitudeApiKey_FromChunk(t *testing.T) {
 				verify: true,
 			},
 			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_AmplitudeApiKey,
+					Verified:     false,
+				},
 				{
 					DetectorType: detectorspb.DetectorType_AmplitudeApiKey,
 					Verified:     false,
@@ -99,6 +107,10 @@ func TestAmplitudeApiKey_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				if len(got[i].RawV2) == 0 {
+					t.Fatalf("no rawv2 secret present: \n %+v", got[i])
+				}
+				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("AmplitudeApiKey.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/apideck/apideck_integration_test.go
+++ b/pkg/detectors/apideck/apideck_integration_test.go
@@ -96,6 +96,10 @@ func TestApiDeck_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				if len(got[i].RawV2) == 0 {
+					t.Fatalf("no rawv2 secret present: \n %+v", got[i])
+				}
+				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("ApiDeck.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/apiflash/apiflash_integration_test.go
+++ b/pkg/detectors/apiflash/apiflash_integration_test.go
@@ -96,6 +96,10 @@ func TestApiflash_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				if len(got[i].RawV2) == 0 {
+					t.Fatalf("no rawv2 secret present: \n %+v", got[i])
+				}
+				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Apiflash.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/apiflash/apiflash_integration_test.go
+++ b/pkg/detectors/apiflash/apiflash_integration_test.go
@@ -96,10 +96,6 @@ func TestApiflash_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
-				if len(got[i].RawV2) == 0 {
-					t.Fatalf("no rawv2 secret present: \n %+v", got[i])
-				}
-				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Apiflash.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/appcues/appcues_integration_test.go
+++ b/pkg/detectors/appcues/appcues_integration_test.go
@@ -53,6 +53,10 @@ func TestAppcues_FromChunk(t *testing.T) {
 					DetectorType: detectorspb.DetectorType_Appcues,
 					Verified:     true,
 				},
+				{
+					DetectorType: detectorspb.DetectorType_Appcues,
+					Verified:     false,
+				},
 			},
 			wantErr: false,
 		},
@@ -65,6 +69,10 @@ func TestAppcues_FromChunk(t *testing.T) {
 				verify: true,
 			},
 			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Appcues,
+					Verified:     false,
+				},
 				{
 					DetectorType: detectorspb.DetectorType_Appcues,
 					Verified:     false,
@@ -97,6 +105,10 @@ func TestAppcues_FromChunk(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				got[i].Raw = nil
+				if len(got[i].RawV2) == 0 {
+					t.Fatalf("no rawv2 secret present: \n %+v", got[i])
+				}
+				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Appcues.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/artsy/artsy_integration_test.go
+++ b/pkg/detectors/artsy/artsy_integration_test.go
@@ -96,6 +96,10 @@ func TestArtsy_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				if len(got[i].RawV2) == 0 {
+					t.Fatalf("no rawv2 secret present: \n %+v", got[i])
+				}
+				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Artsy.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/auth0oauth/auth0oauth_integeration_test.go
+++ b/pkg/detectors/auth0oauth/auth0oauth_integeration_test.go
@@ -100,6 +100,10 @@ func TestAuth0oauth_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				if len(got[i].RawV2) == 0 {
+					t.Fatalf("no raw v2 secret present: \n %+v", got[i])
+				}
+				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Auth0oauth.FromData() %s diff: (-got +want)\n%s", tt.name, diff)


### PR DESCRIPTION
### Description:
This PR fixes integration test of detectors starting with 'A'. These test were failing due to changes in detectors like introducing cartesian product of credentials or introducing RawV2 in detector results.

<img width="944" alt="Screenshot 2024-12-09 at 9 25 31 PM" src="https://github.com/user-attachments/assets/2bb3960c-c2b4-42bb-b483-f693ee72513d">

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
