### PR TITLE
[Fix] detector's integration tests starting with alphabet 'b'

### DIFF
--- a/pkg/detectors/bitfinex/bitfinex_integration_test.go
+++ b/pkg/detectors/bitfinex/bitfinex_integration_test.go
@@ -53,6 +53,10 @@ func TestBitfinex_FromChunk(t *testing.T) {
 					DetectorType: detectorspb.DetectorType_Bitfinex,
 					Verified:     true,
 				},
+				{
+					DetectorType: detectorspb.DetectorType_Bitfinex,
+					Verified:     false,
+				},
 			},
 			wantErr: false,
 		},
@@ -65,6 +69,10 @@ func TestBitfinex_FromChunk(t *testing.T) {
 				verify: true,
 			},
 			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Bitfinex,
+					Verified:     false,
+				},
 				{
 					DetectorType: detectorspb.DetectorType_Bitfinex,
 					Verified:     false,

--- a/pkg/detectors/bitmex/bitmex_integration_test.go
+++ b/pkg/detectors/bitmex/bitmex_integration_test.go
@@ -97,6 +97,10 @@ func TestBitmex_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				if len(got[i].RawV2) == 0 {
+					t.Fatalf("no raw v2 secret present: \n %+v", got[i])
+				}
+				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Bitmex.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/browserstack/browserstack_integration_test.go
+++ b/pkg/detectors/browserstack/browserstack_integration_test.go
@@ -116,7 +116,7 @@ func TestBrowserStack_FromChunk(t *testing.T) {
 		},
 		{
 			name: "found, verified but blocked by browserstack",
-			s:    Scanner{client: common.SaneHttpClient()},
+			s:    Scanner{client: common.ConstantResponseHttpClient(403, "blocked")},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a BROWSERSTACK_ACCESS_KEY %s within BROWSERSTACK_USERNAME %s", secret, secretUser)),

--- a/pkg/detectors/buildkite/v1/buildkite_integration_test.go
+++ b/pkg/detectors/buildkite/v1/buildkite_integration_test.go
@@ -95,6 +95,7 @@ func TestBuildkite_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				got[i].ExtraData = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Buildkite.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/buildkite/v2/buildkitev2_integration_test.go
+++ b/pkg/detectors/buildkite/v2/buildkitev2_integration_test.go
@@ -95,6 +95,7 @@ func TestBuildkite_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				got[i].ExtraData = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Buildkite.FromData() %s diff: (-got +want)\n%s", tt.name, diff)


### PR DESCRIPTION
 ### Description:
This PR fixes integration test of detectors starting with 'b'. These test were failing due to changes in detectors like introducing cartesian product of credentials or introducing RawV2 in detector results.

Execution results for changed integration test:
<img width="937" alt="Screenshot 2024-12-09 at 9 34 20 PM" src="https://github.com/user-attachments/assets/e9851038-07cf-4b64-9f1f-baaf6e95f630">


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
