### PR TITLE
[Fix] detector's integration tests starting with alphabet 'd'

### DIFF
--- a/pkg/detectors/datadogtoken/datadogtoken_integration_test.go
+++ b/pkg/detectors/datadogtoken/datadogtoken_integration_test.go
@@ -111,6 +111,11 @@ func TestDatadogToken_FromChunk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Scanner{}
+
+			// use default cloud endpoint
+			s.UseCloudEndpoint(true)
+			s.SetCloudEndpoint(s.CloudEndpoint())
+
 			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("DatadogToken.FromData() error = %v, wantErr %v", err, tt.wantErr)
@@ -122,6 +127,7 @@ func TestDatadogToken_FromChunk(t *testing.T) {
 				}
 				got[i].Raw = nil
 				got[i].RawV2 = nil
+				delete(got[i].ExtraData, "user_emails")
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("DatadogToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/discordbottoken/discordbottoken_integration_test.go
+++ b/pkg/detectors/discordbottoken/discordbottoken_integration_test.go
@@ -98,6 +98,10 @@ func TestDiscordBotToken_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				if len(got[i].RawV2) == 0 {
+					t.Fatalf("no raw v2 secret present: \n %+v", got[i])
+				}
+				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("DiscordBotToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/dnscheck/dnscheck_integration_test.go
+++ b/pkg/detectors/dnscheck/dnscheck_integration_test.go
@@ -96,6 +96,10 @@ func TestDnscheck_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				if len(got[i].RawV2) == 0 {
+					t.Fatalf("no raw v2 secret present: \n %+v", got[i])
+				}
+				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Dnscheck.FromData() %s diff: (-got +want)\n%s", tt.name, diff)


### PR DESCRIPTION
### Description:
This PR fixes integration test of detectors starting with 'd'. These test were failing due to changes in detectors like introducing Cartesian product of credentials or introducing RawV2 in detector results.

Test results after changes:
<img width="946" alt="Screenshot 2024-12-09 at 10 32 52 PM" src="https://github.com/user-attachments/assets/8c2062b7-de0a-4880-9615-ba11c0a90827">


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
