### PR TITLE
[Fix] detector's integration tests starting with alphabet 'e' & 'f'

### DIFF
--- a/pkg/detectors/edamam/edamam_integration_test.go
+++ b/pkg/detectors/edamam/edamam_integration_test.go
@@ -96,6 +96,10 @@ func TestEdamam_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				if len(got[i].RawV2) == 0 {
+					t.Fatalf("no raw v2 secret present: \n %+v", got[i])
+				}
+				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Edamam.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/ftp/ftp_integration_test.go
+++ b/pkg/detectors/ftp/ftp_integration_test.go
@@ -121,7 +121,15 @@ func TestFTP_FromChunk(t *testing.T) {
 				data:   []byte("ftp://abc:123@ftp.freebsd.org/pub/FreeBSD/doc/tr/articles/explaining-bsd/explaining-bsd_tr.pdf"),
 				verify: true,
 			},
-			wantErr: false,
+			want: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_FTP,
+					Verified:     false,
+					Redacted:     "ftp://abc:********@ftp.freebsd.org",
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
### Description:
This PR fixes integration test of detectors starting with 'e' and 'f'. These test were failing due to changes in detectors like introducing RawV2 in detector results.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
