### PR TITLE
[Fix] detector's integration tests starting with alphabet 'g'

### DIFF
--- a/pkg/detectors/geocodio/geocodio_integration_test.go
+++ b/pkg/detectors/geocodio/geocodio_integration_test.go
@@ -96,6 +96,10 @@ func TestGeocodio_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				if len(got[i].RawV2) == 0 {
+					t.Fatalf("no raw v2 secret present: \n %+v", got[i])
+				}
+				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Geocodio.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/github/v2/github_integration_test.go
+++ b/pkg/detectors/github/v2/github_integration_test.go
@@ -205,6 +205,8 @@ func TestGitHub_FromChunk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Scanner{}
+			s.UseCloudEndpoint(true)
+			s.SetCloudEndpoint(s.CloudEndpoint())
 			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GitHub.FromData() error = %v, wantErr %v", err, tt.wantErr)
@@ -215,6 +217,7 @@ func TestGitHub_FromChunk(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				got[i].Raw = nil
+				got[i].AnalysisInfo = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("GitHub.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/githubapp/githubapp_integration_test.go
+++ b/pkg/detectors/githubapp/githubapp_integration_test.go
@@ -101,6 +101,7 @@ func TestGitHubApp_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				got[i].ExtraData = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("GitHubApp.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/gitlab/v2/gitlab_integration_test.go
+++ b/pkg/detectors/gitlab/v2/gitlab_integration_test.go
@@ -264,6 +264,8 @@ func TestGitlabV2_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt.s.UseCloudEndpoint(true)
+			tt.s.SetCloudEndpoint(tt.s.CloudEndpoint())
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gitlab.FromData() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/detectors/godaddy/v1/godaddy_integration_test.go
+++ b/pkg/detectors/godaddy/v1/godaddy_integration_test.go
@@ -95,6 +95,7 @@ func TestGoDaddy_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				got[i].ExtraData = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("GoDaddy.FromData() %s diff: (-got +want)\n%s", tt.name, diff)


### PR DESCRIPTION
### Description:
This PR fixes integration test of detectors starting with 'g'. These test were failing due to changes in detectors like introducing RawV2 in detector results or analyzer results or ExtraData.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
