### PR TITLE
Make |detectionTimeout| configurable

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ var (
 	fail                 = cli.Flag("fail", "Exit with code 183 if results are found.").Bool()
 	verifiers            = cli.Flag("verifier", "Set custom verification endpoints.").StringMap()
 	customVerifiersOnly  = cli.Flag("custom-verifiers-only", "Only use custom verification endpoints.").Bool()
+	detectorTimeout      = cli.Flag("detector-timeout", "Maximum time to spend scanning chunks per detector (e.g., 30s).").Duration()
 	archiveMaxSize       = cli.Flag("archive-max-size", "Maximum size of archive to scan. (Byte units eg. 512B, 2KB, 4MB)").Bytes()
 	archiveMaxDepth      = cli.Flag("archive-max-depth", "Maximum depth of archive to scan.").Int()
 	archiveTimeout       = cli.Flag("archive-timeout", "Maximum time to spend extracting an archive.").Duration()
@@ -439,6 +440,9 @@ func run(state overseer.State) {
 		}
 	}
 
+	if *detectorTimeout != 0 {
+		engine.SetDetectorTimeout(*detectorTimeout)
+	}
 	if *archiveMaxSize != 0 {
 		handlers.SetArchiveMaxSize(int(*archiveMaxSize))
 	}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -30,7 +30,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
-const detectionTimeout = 10 * time.Second
+var detectionTimeout = 10 * time.Second
 
 var errOverlap = errors.New(
 	"More than one detector has found this result. For your safety, verification has been disabled." +
@@ -315,6 +315,9 @@ func NewEngine(ctx context.Context, cfg *Config) (*Engine, error) {
 
 	return engine, nil
 }
+
+// SetDetectorTimeout sets the maximum timeout for each detector to scan a chunk.
+func SetDetectorTimeout(timeout time.Duration) { detectionTimeout = timeout }
 
 // setDefaults ensures that if specific engine properties aren't provided,
 // they're set to reasonable default values. It makes the engine robust to


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This partially fixes #2991. The default timeout of 10s is wholly inadequate and leads to a high rate of false negatives.

I say "partially" because the MongoDB detector has a separate hard-coded timeout. It was bumped slightly in #3620 but ought to be higher.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
