### PR TITLE
[fix] - PrefixRegex test

### DIFF
--- a/pkg/detectors/detectors_test.go
+++ b/pkg/detectors/detectors_test.go
@@ -16,15 +16,15 @@ func TestPrefixRegex(t *testing.T) {
 	}{
 		{
 			keywords: []string{"securitytrails"},
-			expected: `(?i)(?:securitytrails)(?:.|[\n\r]){0,40}`,
+			expected: `(?i:securitytrails)(?:.|[\n\r]){0,40}?`,
 		},
 		{
 			keywords: []string{"zipbooks"},
-			expected: `(?i)(?:zipbooks)(?:.|[\n\r]){0,40}`,
+			expected: `(?i:zipbooks)(?:.|[\n\r]){0,40}?`,
 		},
 		{
 			keywords: []string{"wrike"},
-			expected: `(?i)(?:wrike)(?:.|[\n\r]){0,40}`,
+			expected: `(?i:wrike)(?:.|[\n\r]){0,40}?`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR fixes the `PrefixRegex` test. It _seems_ the tests weren't running in CI due to the build tags

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
