### PR TITLE
[fix] - use typed const

### DIFF
--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -25,10 +25,10 @@ const (
 	defaultDateFormat = "Mon Jan 2 15:04:05 2006 -0700"
 
 	// defaultMaxDiffSize is the maximum size for a diff. Larger diffs will be cut off.
-	defaultMaxDiffSize = 2 * 1024 * 1024 * 1024 // 2GB
+	defaultMaxDiffSize int64 = 2 * 1024 * 1024 * 1024 // 2GB
 
 	// defaultMaxCommitSize is the maximum size for a commit. Larger commits will be cut off.
-	defaultMaxCommitSize = 2 * 1024 * 1024 * 1024 // 2GB
+	defaultMaxCommitSize int64 = 2 * 1024 * 1024 * 1024 // 2GB
 )
 
 // contentWriter defines a common interface for writing, reading, and managing diff content.
@@ -210,8 +210,8 @@ type Option func(*Parser)
 func NewParser(options ...Option) *Parser {
 	parser := &Parser{
 		dateFormat:    defaultDateFormat,
-		maxDiffSize:   defaultMaxDiffSize,
-		maxCommitSize: defaultMaxCommitSize,
+		maxDiffSize:   int(defaultMaxDiffSize),
+		maxCommitSize: int(defaultMaxCommitSize),
 	}
 	for _, option := range options {
 		option(parser)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR uses typed int64 constants to prevent overflow on 32-bit platforms for `defaultMaxSize` and `defaultCommitSize`. This can happen because integer constants in Go are initially untyped and can hold arbitrarily large values. The overflow issue arises when the compiler tries to assign that constant to a typed entity that cannot represent its value.
### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
