### PR TITLE
Update docs from --only-verified with --results

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ $ git clone git@github.com:trufflesecurity/test_keys.git
 
 Run trufflehog from the parent directory (outside the git repo).
 ```bash
-$ trufflehog git file://test_keys --only-verified
+$ trufflehog git file://test_keys --results=verified,unknown
 ```
 
 ## 10: Scan GCS buckets for verified secrets


### PR DESCRIPTION
### Description:
Seems previous PR miss one example: https://github.com/trufflesecurity/trufflehog/pull/3643

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
