### PR TITLE
[Fix] detector's integration tests starting with alphabet 'm'

### DIFF
--- a/pkg/detectors/mailchimp/mailchimp_integration_test.go
+++ b/pkg/detectors/mailchimp/mailchimp_integration_test.go
@@ -9,8 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/kylelemons/godebug/pretty"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
@@ -95,10 +94,9 @@ func TestMailchimp_FromChunk(t *testing.T) {
 				}
 				got[i].Raw = nil
 				got[i].AnalysisInfo = nil
+				got[i].ExtraData = nil
 			}
-
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "AnalysisInfo", "ExtraData")
-			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
+			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Mailchimp.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
 		})

--- a/pkg/detectors/mailchimp/mailchimp_integration_test.go
+++ b/pkg/detectors/mailchimp/mailchimp_integration_test.go
@@ -9,7 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kylelemons/godebug/pretty"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
@@ -95,7 +96,9 @@ func TestMailchimp_FromChunk(t *testing.T) {
 				got[i].Raw = nil
 				got[i].AnalysisInfo = nil
 			}
-			if diff := pretty.Compare(got, tt.want); diff != "" {
+
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "AnalysisInfo", "ExtraData")
+			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Mailchimp.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
 		})

--- a/pkg/detectors/mailgun/mailgun_integration_test.go
+++ b/pkg/detectors/mailgun/mailgun_integration_test.go
@@ -130,6 +130,7 @@ func TestMailgun_FromChunk(t *testing.T) {
 				}
 				got[i].Raw = nil
 				got[i].AnalysisInfo = nil
+				got[i].ExtraData = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Mailgun.FromData() %s  diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/mattermostpersonaltoken/mattermostpersonaltoken_integration_test.go
+++ b/pkg/detectors/mattermostpersonaltoken/mattermostpersonaltoken_integration_test.go
@@ -51,7 +51,6 @@ func TestMattermostPersonalToken_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_MattermostPersonalToken,
 					Verified:     true,
-					RawV2:        []byte(secret + server),
 				},
 			},
 			wantErr: false,
@@ -68,7 +67,6 @@ func TestMattermostPersonalToken_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_MattermostPersonalToken,
 					Verified:     false,
-					RawV2:        []byte(inactiveSecret + server),
 				},
 			},
 			wantErr: false,
@@ -98,6 +96,11 @@ func TestMattermostPersonalToken_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+
+				if len(got[i].RawV2) == 0 {
+					t.Fatalf("no RawV2 secret present: \n %+v", got[i])
+				}
+				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("MattermostPersonalToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/mattermostpersonaltoken/mattermostpersonaltoken_integration_test.go
+++ b/pkg/detectors/mattermostpersonaltoken/mattermostpersonaltoken_integration_test.go
@@ -51,6 +51,7 @@ func TestMattermostPersonalToken_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_MattermostPersonalToken,
 					Verified:     true,
+					RawV2:        []byte(secret + server),
 				},
 			},
 			wantErr: false,
@@ -60,13 +61,14 @@ func TestMattermostPersonalToken_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a mattermost secret %s within mattermost server %s but not valid", inactiveSecret, "test323561.cloud.mattermost.com")), // the secret would satisfy the regex but not pass validation
+				data:   []byte(fmt.Sprintf("You can find a mattermost secret %s within mattermost server %s but not valid", inactiveSecret, server)), // the secret would satisfy the regex but not pass validation
 				verify: true,
 			},
 			want: []detectors.Result{
 				{
 					DetectorType: detectorspb.DetectorType_MattermostPersonalToken,
 					Verified:     false,
+					RawV2:        []byte(inactiveSecret + server),
 				},
 			},
 			wantErr: false,

--- a/pkg/detectors/mux/mux_integration_test.go
+++ b/pkg/detectors/mux/mux_integration_test.go
@@ -97,6 +97,11 @@ func TestMux_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+
+				if len(got[i].RawV2) == 0 {
+					t.Fatalf("no rawv2 secret present: \n %+v", got[i])
+				}
+				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Mux.FromData() %s diff: (-got +want)\n%s", tt.name, diff)


### PR DESCRIPTION
### Description:
This PR fixes integration test of detectors starting with 'm'. These test were failing due to changes in detectors like introducing RawV2 in detector results or ExtraData.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
