### PR TITLE
Stop using context.TODO in archive handler

### DIFF
--- a/pkg/handlers/apk_test.go
+++ b/pkg/handlers/apk_test.go
@@ -39,7 +39,7 @@ func TestAPKHandler(t *testing.T) {
 
 			handler := newAPKHandler()
 
-			newReader, err := newFileReader(resp.Body)
+			newReader, err := newFileReader(context.Background(), resp.Body)
 			if err != nil {
 				t.Errorf("error creating reusable reader: %s", err)
 			}
@@ -75,7 +75,7 @@ func TestOpenInvalidAPK(t *testing.T) {
 	ctx := logContext.AddLogger(context.Background())
 	handler := apkHandler{}
 
-	rdr, err := newFileReader(io.NopCloser(reader))
+	rdr, err := newFileReader(ctx, io.NopCloser(reader))
 	assert.NoError(t, err)
 	defer rdr.Close()
 
@@ -96,7 +96,7 @@ func TestOpenValidZipInvalidAPK(t *testing.T) {
 
 	handler := newAPKHandler()
 
-	newReader, err := newFileReader(resp.Body)
+	newReader, err := newFileReader(context.Background(), resp.Body)
 	if err != nil {
 		t.Errorf("error creating reusable reader: %s", err)
 	}

--- a/pkg/handlers/ar_test.go
+++ b/pkg/handlers/ar_test.go
@@ -18,7 +18,7 @@ func TestHandleARFile(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	rdr, err := newFileReader(file)
+	rdr, err := newFileReader(ctx, file)
 	assert.NoError(t, err)
 	defer rdr.Close()
 

--- a/pkg/handlers/archive.go
+++ b/pkg/handlers/archive.go
@@ -138,7 +138,7 @@ func (h *archiveHandler) openArchive(
 		}
 		defer compReader.Close()
 
-		rdr, err := newFileReader(compReader)
+		rdr, err := newFileReader(ctx, compReader)
 		if err != nil {
 			if errors.Is(err, ErrEmptyReader) {
 				ctx.Logger().V(5).Info("empty reader, skipping file")
@@ -226,7 +226,7 @@ func (h *archiveHandler) extractorHandler(dataOrErrChan chan DataOrErr) func(con
 			}
 		}()
 
-		rdr, err := newFileReader(f)
+		rdr, err := newFileReader(ctx, f)
 		if err != nil {
 			if errors.Is(err, ErrEmptyReader) {
 				lCtx.Logger().V(5).Info("empty reader, skipping file")

--- a/pkg/handlers/archive_test.go
+++ b/pkg/handlers/archive_test.go
@@ -85,7 +85,7 @@ func TestArchiveHandler(t *testing.T) {
 
 			handler := newArchiveHandler()
 
-			newReader, err := newFileReader(resp.Body)
+			newReader, err := newFileReader(context.Background(), resp.Body)
 			if err != nil {
 				t.Errorf("error creating reusable reader: %s", err)
 			}
@@ -119,7 +119,7 @@ func TestOpenInvalidArchive(t *testing.T) {
 	ctx := logContext.AddLogger(context.Background())
 	handler := archiveHandler{}
 
-	rdr, err := newFileReader(io.NopCloser(reader))
+	rdr, err := newFileReader(ctx, io.NopCloser(reader))
 	assert.NoError(t, err)
 	defer rdr.Close()
 

--- a/pkg/handlers/default_test.go
+++ b/pkg/handlers/default_test.go
@@ -18,7 +18,7 @@ func TestHandleNonArchiveFile(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	rdr, err := newFileReader(file)
+	rdr, err := newFileReader(ctx, file)
 	assert.NoError(t, err)
 	defer rdr.Close()
 

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -103,7 +103,7 @@ func newMimeTypeReader(r io.Reader) (mimeTypeReader, error) {
 
 // newFileReader creates a fileReader from an io.Reader, optionally using BufferedFileWriter for certain formats.
 // The caller is responsible for closing the reader when it is no longer needed.
-func newFileReader(r io.Reader, options ...readerOption) (fReader fileReader, err error) {
+func newFileReader(ctx context.Context, r io.Reader, options ...readerOption) (fReader fileReader, err error) {
 	var cfg readerConfig
 
 	for _, opt := range options {
@@ -154,7 +154,7 @@ func newFileReader(r io.Reader, options ...readerOption) (fReader fileReader, er
 	}
 
 	var format archives.Format
-	format, _, err = archives.Identify(context.TODO(), "", fReader)
+	format, _, err = archives.Identify(ctx, "", fReader)
 	switch {
 	case err == nil:
 		fReader.isGenericArchive = true
@@ -359,7 +359,7 @@ func HandleFile(
 	}
 
 	readerOption := withFileExtension(getFileExtension(chunkSkel))
-	rdr, err := newFileReader(reader, readerOption)
+	rdr, err := newFileReader(ctx, reader, readerOption)
 	if err != nil {
 		if errors.Is(err, ErrEmptyReader) {
 			ctx.Logger().V(5).Info("empty reader, skipping file")

--- a/pkg/handlers/rpm_test.go
+++ b/pkg/handlers/rpm_test.go
@@ -18,7 +18,7 @@ func TestHandleRPMFile(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	rdr, err := newFileReader(file)
+	rdr, err := newFileReader(ctx, file)
 	assert.NoError(t, err)
 	defer rdr.Close()
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR cleans up a `context.TODO` left by #3743.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
