### PR TITLE
fixed github issue 3774 for custom detector secret size

### DIFF
--- a/pkg/custom_detectors/custom_detectors.go
+++ b/pkg/custom_detectors/custom_detectors.go
@@ -32,6 +32,7 @@ type CustomRegexWebhook struct {
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*CustomRegexWebhook)(nil)
 var _ detectors.CustomFalsePositiveChecker = (*CustomRegexWebhook)(nil)
+var _ detectors.MaxSecretSizeProvider = (*CustomRegexWebhook)(nil)
 
 // NewWebhookCustomRegex initializes and validates a CustomRegexWebhook. An
 // unexported type is intentionally returned here to ensure the values have
@@ -113,6 +114,11 @@ func (c *CustomRegexWebhook) FromData(ctx context.Context, verify bool, data []b
 
 func (c *CustomRegexWebhook) IsFalsePositive(_ detectors.Result) (bool, string) {
 	return false, ""
+}
+
+// custom max size for custom detector
+func (c *CustomRegexWebhook) MaxSecretSize() int64 {
+	return 1000
 }
 
 func (c *CustomRegexWebhook) createResults(ctx context.Context, match map[string][]string, verify bool, results chan<- detectors.Result) error {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR adds a custom secret max size to `1000` for custom detector, so it can detector large secrets.
This is related to issue #3774

Issue Example Fix:
![Screenshot from 2024-12-24 15-03-09](https://github.com/user-attachments/assets/a9ed77df-ae82-48f0-95d6-792eae78ad52)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
