### PR TITLE
fixed github issue 3821 for string shannon entropy test

### DIFF
--- a/pkg/detectors/falsepositives_test.go
+++ b/pkg/detectors/falsepositives_test.go
@@ -3,7 +3,6 @@ package detectors
 import (
 	"context"
 	_ "embed"
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -174,9 +173,11 @@ func TestStringShannonEntropy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := roundToTwoDigits(StringShannonEntropy(tt.args.input))
-			if got != tt.want {
-				t.Errorf("StringShannonEntropy() = %v, want %v", got, tt.want)
+			got := StringShannonEntropy(tt.args.input)
+			if len(tt.args.input) > 0 && tt.want != 0 {
+				assert.InEpsilon(t, tt.want, got, 0.1)
+			} else {
+				assert.Equal(t, tt.want, got)
 			}
 		})
 	}
@@ -187,9 +188,4 @@ func BenchmarkDefaultIsKnownFalsePositive(b *testing.B) {
 		// Use a string that won't be found in any dictionary for the worst case check.
 		IsKnownFalsePositive("aoeuaoeuaoeuaoeuaoeuaoeu", DefaultFalsePositives, true)
 	}
-}
-
-func roundToTwoDigits(number float64) float64 {
-	scale := math.Pow(10, float64(2))
-	return math.Round(number*scale) / scale
 }

--- a/pkg/detectors/falsepositives_test.go
+++ b/pkg/detectors/falsepositives_test.go
@@ -3,6 +3,7 @@ package detectors
 import (
 	"context"
 	_ "embed"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -154,14 +155,14 @@ func TestStringShannonEntropy(t *testing.T) {
 			args: args{
 				input: "aaaaaaaaaaaaaaaaaaaaaaaaaaab",
 			},
-			want: 0.22228483068568816,
+			want: 0.22,
 		},
 		{
 			name: "entropy 3",
 			args: args{
 				input: "aaaaaaaaaaaaaaaaaaaaaaaaaaabaaaaaaaaaaaaaaaaaaaaaaaaaaab",
 			},
-			want: 0.22228483068568816,
+			want: 0.22,
 		},
 		{
 			name: "empty",
@@ -173,7 +174,8 @@ func TestStringShannonEntropy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := StringShannonEntropy(tt.args.input); got != tt.want {
+			got := roundToTwoDigits(StringShannonEntropy(tt.args.input))
+			if got != tt.want {
 				t.Errorf("StringShannonEntropy() = %v, want %v", got, tt.want)
 			}
 		})
@@ -185,4 +187,9 @@ func BenchmarkDefaultIsKnownFalsePositive(b *testing.B) {
 		// Use a string that won't be found in any dictionary for the worst case check.
 		IsKnownFalsePositive("aoeuaoeuaoeuaoeuaoeuaoeu", DefaultFalsePositives, true)
 	}
+}
+
+func roundToTwoDigits(number float64) float64 {
+	scale := math.Pow(10, float64(2))
+	return math.Round(number*scale) / scale
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This issue fixes the issue #3821 by rounding the output of shannon entropy output to two digits to avoid unnecessary precision.
 
![Screenshot from 2024-12-30 15-35-43](https://github.com/user-attachments/assets/75b472f3-2f9c-4a51-af6f-0b65094ca1aa)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
