### PR TITLE
Updated Slack detector. Added revoked token check

### DIFF
--- a/pkg/detectors/slack/slack.go
+++ b/pkg/detectors/slack/slack.go
@@ -102,6 +102,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						// https://api.slack.com/methods/auth.test) (Per
 						// https://slack.com/help/articles/360000446446-Manage-deactivated-members-apps-and-integrations,
 						// reactivating a bot regenerates its tokens, so this candidate is determinately unverified.)
+					} else if authResponse.Error == "token_revoked" {
+						// "Authentication token is for a deleted user or workspace, or the app has been removed when using a user token."
+						// This indicates the token is no longer valid and determinately unverified.
+						// https://api.slack.com/methods/auth.test
 					} else {
 						err = fmt.Errorf("unexpected error auth response %+v", authResponse.Error)
 						s1.SetVerificationError(err, token)

--- a/pkg/detectors/slack/slack_integration_test.go
+++ b/pkg/detectors/slack/slack_integration_test.go
@@ -103,6 +103,27 @@ func TestSlack_FromChunk(t *testing.T) {
 			wantVerificationErr: false,
 		},
 		{
+			name: "token_revoked",
+			s:    Scanner{client: common.ConstantResponseHttpClient(200, `{"ok": false, "error": "token_revoked"}`)},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a slack secret %s within", secret)),
+				verify: true,
+			},
+			wantResults: []detectors.Result{
+				{
+					DetectorType: detectorspb.DetectorType_Slack,
+					Verified:     false,
+					ExtraData: map[string]string{
+						"rotation_guide": "https://howtorotate.com/docs/tutorials/slack/",
+						"token_type":     "Slack User Token",
+					},
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
 			name: "found, would be verified if not for timeout",
 			s:    Scanner{client: common.SaneHttpClientTimeOut(1 * time.Microsecond)},
 			args: args{


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Updated the Slack detector by adding a check for a `token_revoked` response from the Slack API.
Added a new test case in the Slack integration test to verify the `token_revoked` error response.
Revoked tokens will be determinately unverified.
https://api.slack.com/methods/auth.test

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
