### PR TITLE
[Fix] Opsgenie Analyzer Http Client

### DIFF
--- a/pkg/analyzer/analyzers/client.go
+++ b/pkg/analyzer/analyzers/client.go
@@ -28,9 +28,26 @@ func CreateLogFileName(baseName string) string {
 	return logFileName
 }
 
+// This returns a client that is restricted and filters out unsafe requests returning a success status code.
 func NewAnalyzeClient(cfg *config.Config) *http.Client {
 	client := &http.Client{
 		Transport: AnalyzerRoundTripper{parent: http.DefaultTransport},
+	}
+	if cfg == nil || !cfg.LoggingEnabled {
+		return client
+	}
+	return &http.Client{
+		Transport: LoggingRoundTripper{
+			parent:  client.Transport,
+			logFile: cfg.LogFile,
+		},
+	}
+}
+
+// This returns a client that is unrestricted and does not filter out unsafe requests returning a success status code.
+func NewAnalyzeClientUnrestricted(cfg *config.Config) *http.Client {
+	client := &http.Client{
+		Transport: http.DefaultTransport,
 	}
 	if cfg == nil || !cfg.LoggingEnabled {
 		return client

--- a/pkg/analyzer/analyzers/opsgenie/opsgenie.go
+++ b/pkg/analyzer/analyzers/opsgenie/opsgenie.go
@@ -132,7 +132,7 @@ func (h *HttpStatusTest) RunTest(cfg *config.Config, headers map[string]string) 
 	}
 
 	// Create new HTTP request
-	client := analyzers.NewAnalyzeClient(cfg)
+	client := analyzers.NewAnalyzeClientUnrestricted(cfg)
 	req, err := http.NewRequest(h.Method, h.Endpoint, data)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
### Description:
`Opsgenie` APIs returns HTTP status code of 202 for non-safe requests. The `HTTP Client` for analyzer restricts response to not be in between 200 and 300. Returning error if that's happen. This PR modifies the HTTP Client for only `OpsGenie Analyzer` so restriction can be bypass.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
