### PR TITLE
Remove global variable scanning implementation for Postman

### DIFF
--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -251,21 +251,6 @@ func (s *Source) scanWorkspace(ctx context.Context, chunksChan chan *sources.Chu
 		Type:          "workspace",
 	}
 
-	// scan global variables
-	ctx.Logger().V(2).Info("starting scanning global variables")
-	globalVars, err := s.client.GetGlobalVariables(workspace.ID)
-	if err != nil {
-		// NOTE: global endpoint is finicky
-		ctx.Logger().V(2).Error(err, "skipping global variables")
-	}
-
-	metadata.Type = GLOBAL_TYPE
-	metadata.Link = LINK_BASE_URL + "workspace/" + workspace.ID + "/" + GLOBAL_TYPE
-	metadata.FullID = workspace.CreatedBy + "-" + globalVars.ID
-
-	s.scanVariableData(ctx, chunksChan, metadata, globalVars)
-	ctx.Logger().V(2).Info("finished scanning global variables")
-
 	// gather and scan environment variables
 	for _, envID := range workspace.Environments {
 		envVars, err := s.client.GetEnvironmentVariables(envID.UUID)
@@ -293,7 +278,7 @@ func (s *Source) scanWorkspace(ctx context.Context, chunksChan chan *sources.Chu
 
 	// scan all the collections in the workspace.
 	// at this point we have all the possible
-	// substitutions from Global and Environment variables
+	// substitutions from Environment variables
 	for _, collectionID := range workspace.Collections {
 		if shouldSkip(collectionID.UUID, s.conn.IncludeCollections, s.conn.ExcludeCollections) {
 			continue

--- a/pkg/sources/postman/postman_client.go
+++ b/pkg/sources/postman/postman_client.go
@@ -9,19 +9,10 @@ import (
 )
 
 const (
-	GLOBAL_VARS_URL = "https://www.postman.com/_api/workspace/%s/globals"
-	//Note: This is an undocumented API endpoint. The office API endpoint keeps returning 502.
-	//We'll shift this once that behavior is resolved and stable.
-	//Official API Endpoint: "https://api.getpostman.com/workspaces/%s/global-variables"
-	//GLOBAL_VARS_URL  = "https://api.getpostman.com/workspaces/%s/global-variables"
-	WORKSPACE_URL    = "https://api.getpostman.com/workspaces/%s"
-	ENVIRONMENTS_URL = "https://api.getpostman.com/environments/%s"
-	COLLECTIONS_URL  = "https://api.getpostman.com/collections/%s"
-
-	userAgent     = "PostmanRuntime/7.26.8"
-	alt_userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-	//Since we're using the undocumented API endpoint for global vars, we need a different user agent.
-	//We'll shift this once that behavior is resolved and stable.
+	WORKSPACE_URL      = "https://api.getpostman.com/workspaces/%s"
+	ENVIRONMENTS_URL   = "https://api.getpostman.com/environments/%s"
+	COLLECTIONS_URL    = "https://api.getpostman.com/collections/%s"
+	userAgent          = "PostmanRuntime/7.26.8"
 	defaultContentType = "*"
 )
 
@@ -70,10 +61,6 @@ type Environment struct {
 	VariableData `json:"environment"`
 }
 
-type GlobalVars struct {
-	VariableData `json:"data"`
-}
-
 type Metadata struct {
 	WorkspaceUUID   string
 	WorkspaceName   string
@@ -88,7 +75,6 @@ type Metadata struct {
 	Link            string //direct link to the folder (could be .json file path)
 	Type            string //folder, request, etc.
 	EnvironmentName string
-	GlobalID        string // might just be FullID, not sure
 	VarType         string
 	FieldName       string
 	FieldType       string
@@ -316,33 +302,6 @@ func (c *Client) GetWorkspace(workspaceUUID string) (Workspace, error) {
 	}
 
 	return obj.Workspace, nil
-}
-
-// GetGlobalVariables returns the global variables for a given workspace
-func (c *Client) GetGlobalVariables(workspace_uuid string) (VariableData, error) {
-	obj := struct {
-		VariableData VariableData `json:"data"`
-	}{}
-
-	url := fmt.Sprintf(GLOBAL_VARS_URL, workspace_uuid)
-	r, err := c.getPostmanReq(url, map[string]string{"User-Agent": alt_userAgent})
-	if err != nil {
-		err = fmt.Errorf("could not get global variables for workspace: %s", workspace_uuid)
-		return VariableData{}, err
-	}
-
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		err = fmt.Errorf("could not read response body for workspace: %s", workspace_uuid)
-		return VariableData{}, err
-	}
-	r.Body.Close()
-
-	if err := json.Unmarshal([]byte(body), &obj); err != nil {
-		err = fmt.Errorf("could not unmarshal global variables JSON for workspace: %s", workspace_uuid)
-		return VariableData{}, err
-	}
-	return obj.VariableData, nil
 }
 
 // GetEnvironmentVariables returns the environment variables for a given environment


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Remove global variable scanning from the Postman source since the Postman API is unreliable when it comes to global variables.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
