### PR TITLE
[Fix] use unrestricted http client only for non-safe requests

### DIFF
--- a/pkg/analyzer/analyzers/client.go
+++ b/pkg/analyzer/analyzers/client.go
@@ -114,7 +114,7 @@ type AnalyzerRoundTripper struct {
 
 func (r AnalyzerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := r.parent.RoundTrip(req)
-	if err != nil || MethodIsSafe(req.Method) {
+	if err != nil || IsMethodSafe(req.Method) {
 		return resp, err
 	}
 	// Check that unsafe methods did NOT return a valid status code.
@@ -126,7 +126,7 @@ func (r AnalyzerRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 
 // methodIsSafe is a helper method to check whether the HTTP method is safe according to MDN Web Docs.
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods#safe_idempotent_and_cacheable_request_methods
-func MethodIsSafe(method string) bool {
+func IsMethodSafe(method string) bool {
 	switch strings.ToUpper(method) {
 	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
 		return true

--- a/pkg/analyzer/analyzers/client.go
+++ b/pkg/analyzer/analyzers/client.go
@@ -114,7 +114,7 @@ type AnalyzerRoundTripper struct {
 
 func (r AnalyzerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := r.parent.RoundTrip(req)
-	if err != nil || methodIsSafe(req.Method) {
+	if err != nil || MethodIsSafe(req.Method) {
 		return resp, err
 	}
 	// Check that unsafe methods did NOT return a valid status code.
@@ -126,7 +126,7 @@ func (r AnalyzerRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 
 // methodIsSafe is a helper method to check whether the HTTP method is safe according to MDN Web Docs.
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods#safe_idempotent_and_cacheable_request_methods
-func methodIsSafe(method string) bool {
+func MethodIsSafe(method string) bool {
 	switch strings.ToUpper(method) {
 	case http.MethodGet, http.MethodHead, http.MethodOptions, http.MethodTrace:
 		return true

--- a/pkg/analyzer/analyzers/opsgenie/opsgenie.go
+++ b/pkg/analyzer/analyzers/opsgenie/opsgenie.go
@@ -132,7 +132,16 @@ func (h *HttpStatusTest) RunTest(cfg *config.Config, headers map[string]string) 
 	}
 
 	// Create new HTTP request
-	client := analyzers.NewAnalyzeClientUnrestricted(cfg)
+	var client *http.Client
+
+	// Non-safe Opsgenie APIs are asynchronous and always return 202 if credential has the permission.
+	// For Safe API Methods, use the restricted client
+	if analyzers.MethodIsSafe(h.Method) {
+		client = analyzers.NewAnalyzeClient(cfg)
+	} else {
+		client = analyzers.NewAnalyzeClientUnrestricted(cfg)
+	}
+
 	req, err := http.NewRequest(h.Method, h.Endpoint, data)
 	if err != nil {
 		return false, err

--- a/pkg/analyzer/analyzers/opsgenie/opsgenie.go
+++ b/pkg/analyzer/analyzers/opsgenie/opsgenie.go
@@ -136,7 +136,7 @@ func (h *HttpStatusTest) RunTest(cfg *config.Config, headers map[string]string) 
 
 	// Non-safe Opsgenie APIs are asynchronous and always return 202 if credential has the permission.
 	// For Safe API Methods, use the restricted client
-	if analyzers.MethodIsSafe(h.Method) {
+	if analyzers.IsMethodSafe(h.Method) {
 		client = analyzers.NewAnalyzeClient(cfg)
 	} else {
 		client = analyzers.NewAnalyzeClientUnrestricted(cfg)


### PR DESCRIPTION
### Description:
PR https://github.com/trufflesecurity/trufflehog/pull/3841 removes all the safety majors on OpsGenie Analyzer. This PR use unrestricted http client only for non-safe operations. Other than that restricted one will be used as usual.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
