### PR TITLE
Fix verifier for algolia admin key

### DIFF
--- a/pkg/detectors/algoliaadminkey/algoliaadminkey.go
+++ b/pkg/detectors/algoliaadminkey/algoliaadminkey.go
@@ -123,7 +123,7 @@ func verifyMatch(ctx context.Context, appId, apiKey string) (bool, map[string]st
 				break
 			}
 		}
-		if !hasSensitivePerms {
+		if hasSensitivePerms {
 			return false, nil, nil
 		}
 

--- a/pkg/detectors/algoliaadminkey/algoliaadminkey_integration_test.go
+++ b/pkg/detectors/algoliaadminkey/algoliaadminkey_integration_test.go
@@ -51,7 +51,10 @@ func TestAlgoliaAdminKey_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_AlgoliaAdminKey,
 					Verified:     true,
-					RawV2:        []byte(fmt.Sprintf("%s%s", secret, id)),
+					RawV2:        []byte(fmt.Sprintf("%s:%s", id, secret)),
+					ExtraData: map[string]string{
+						"acl": "listIndexes,search,settings",
+					},
 				},
 			},
 			wantErr: false,
@@ -68,7 +71,7 @@ func TestAlgoliaAdminKey_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_AlgoliaAdminKey,
 					Verified:     false,
-					RawV2:        []byte(fmt.Sprintf("%s%s", inactiveSecret, id)),
+					RawV2:        []byte(fmt.Sprintf("%s:%s", id, inactiveSecret)),
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
### Description:

Ran the integration tests and they immediately failed. Fixed the tests, then fixed the boolean bug in the checker.

Fixes #3848 

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
