### PR TITLE
use first capture group in custom detector regex if available

### DIFF
--- a/pkg/custom_detectors/custom_detectors.go
+++ b/pkg/custom_detectors/custom_detectors.go
@@ -129,7 +129,11 @@ func (c *CustomRegexWebhook) createResults(ctx context.Context, match map[string
 	var raw string
 	for _, values := range match {
 		// values[0] contains the entire regex match.
-		raw += values[0]
+		secret := values[0]
+		if len(values) > 1 {
+			secret = values[1]
+		}
+		raw += secret
 	}
 	result := detectors.Result{
 		DetectorType: detectorspb.DetectorType_CustomRegex,

--- a/pkg/custom_detectors/custom_detectors_test.go
+++ b/pkg/custom_detectors/custom_detectors_test.go
@@ -199,13 +199,13 @@ func TestDetector(t *testing.T) {
 		// "password" is normally flagged as a false positive, but CustomRegex
 		// should allow the user to decide and report it as a result.
 		Keywords: []string{"password"},
-		Regex:    map[string]string{"regex": "password=.*"},
+		Regex:    map[string]string{"regex": "password=\"(.*)\""},
 	})
 	assert.NoError(t, err)
 	results, err := detector.FromData(context.Background(), false, []byte(`password="123456"`))
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(results))
-	assert.Equal(t, results[0].Raw, []byte(`password="123456"`))
+	assert.Equal(t, results[0].Raw, []byte(`123456`))
 }
 
 func BenchmarkProductIndices(b *testing.B) {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Prior to this change results would use the entire _match_ even if a capture group was present. This lead to results including extra characters that were part of the match but not what we want surfaced. 

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
