### PR TITLE
Enable Auth0

### DIFF
--- a/pkg/detectors/auth0oauth/auth0oauth.go
+++ b/pkg/detectors/auth0oauth/auth0oauth.go
@@ -37,23 +37,21 @@ func (s Scanner) Keywords() []string {
 // FromData will find and optionally verify Auth0oauth secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
 	dataStr := string(data)
-	clientIdMatches := clientIdPat.FindAllStringSubmatch(dataStr, -1)
-	clientSecretMatches := clientSecretPat.FindAllStringSubmatch(dataStr, -1)
-	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 	uniqueDomainMatches := make(map[string]struct{})
-	for _, m := range domainMatches {
-		if len(m) > 1 {
-			uniqueDomainMatches[strings.TrimSpace(m[1])] = struct{}{}
-		}
-
+	uniqueClientIDs := make(map[string]struct{})
+	uniqueSecrets := make(map[string]struct{})
+	for _, m := range domainPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueDomainMatches[strings.TrimSpace(m[1])] = struct{}{}
+	}
+	for _, m := range clientIdPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueClientIDs[strings.TrimSpace(m[1])] = struct{}{}
+	}
+	for _, m := range clientSecretPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueSecrets[strings.TrimSpace(m[1])] = struct{}{}
 	}
 
-	for _, clientIdMatch := range clientIdMatches {
-		clientIdRes := strings.TrimSpace(clientIdMatch[1])
-
-		for _, clientSecretMatch := range clientSecretMatches {
-			clientSecretRes := strings.TrimSpace(clientSecretMatch[1])
-
+	for clientIdRes := range uniqueClientIDs {
+		for clientSecretRes := range uniqueSecrets {
 			for domainRes := range uniqueDomainMatches {
 				s1 := detectors.Result{
 					DetectorType: detectorspb.DetectorType_Auth0oauth,

--- a/pkg/detectors/auth0oauth/auth0oauth.go
+++ b/pkg/detectors/auth0oauth/auth0oauth.go
@@ -42,9 +42,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	domainMatches := domainPat.FindAllStringSubmatch(dataStr, -1)
 	uniqueDomainMatches := make(map[string]struct{})
 	for _, m := range domainMatches {
-		if len(m) > 1 {
-			uniqueDomainMatches[strings.TrimSpace(m[1])] = struct{}{}
-		}
+	uniqueDomainMatches[m[1]] = struct{}{}
 
 	}
 

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -53,6 +53,7 @@ import (
 	atlassianv2 "github.com/trufflesecurity/trufflehog/v3/pkg/detectors/atlassian/v2"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/audd"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/auth0managementapitoken"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/auth0oauth"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/autodesk"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/autoklose"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/autopilot"
@@ -879,7 +880,7 @@ func buildDetectorList() []detectors.Detector {
 		&atlassianv2.Scanner{},
 		&audd.Scanner{},
 		&auth0managementapitoken.Scanner{},
-		// &auth0oauth.Scanner{},
+		&auth0oauth.Scanner{},
 		&autodesk.Scanner{},
 		&autoklose.Scanner{},
 		&autopilot.Scanner{},


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Previously, I think, we disabled auth0 because it was too noisy since the verify loop is buried in a 3 deep nested loop. This means a single domain could be matched multiple times in the same chunk.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
