### PR TITLE
[tempfix] - add bounds check check to avoid panics

### DIFF
--- a/pkg/engine/ahocorasick/ahocorasickcore.go
+++ b/pkg/engine/ahocorasick/ahocorasickcore.go
@@ -103,7 +103,7 @@ func (m *adjustableSpanCalculator) calculateSpan(params spanCalculationParams) m
 	// In rare cases where the calculated start index exceeds the end index (possibly due to
 	// detector-provided offsets), we reset the start index to 0 to maintain a valid span range
 	// and avoid runtime panics. This is a temporary fix until the root cause is identified.
-	if startIdx > endIdx {
+	if startIdx >= endIdx {
 		startIdx = 0
 	}
 

--- a/pkg/engine/ahocorasick/ahocorasickcore.go
+++ b/pkg/engine/ahocorasick/ahocorasickcore.go
@@ -99,6 +99,14 @@ func (m *adjustableSpanCalculator) calculateSpan(params spanCalculationParams) m
 	startIdx := max(startOffset, 0)
 	endIdx := min(maxSize, int64(len(params.chunkData)))
 
+	// Ensure the start index is not greater than the end index to prevent invalid spans.
+	// In rare cases where the calculated start index exceeds the end index (possibly due to
+	// detector-provided offsets), we reset the start index to 0 to maintain a valid span range
+	// and avoid runtime panics. This is a temporary fix until the root cause is identified.
+	if startIdx > endIdx {
+		startIdx = 0
+	}
+
 	return matchSpan{startOffset: startIdx, endOffset: endIdx}
 }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Add a defensive bounds check to prevent invalid span ranges in the Aho-Corasick pattern matching implementation. This change ensures that the start index of a match span never exceeds its end index, preventing potential runtime panics.

Note: This is a temporary fix until the root cause is identified.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
