### PR TITLE
Exported Ahocorasick core in engine

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -181,7 +181,7 @@ type Engine struct {
 	scanEntireChunk bool
 
 	// ahoCorasickHandler manages the Aho-Corasick trie and related keyword lookups.
-	ahoCorasickCore *ahocorasick.Core
+	AhoCorasickCore *ahocorasick.Core
 
 	// Engine synchronization primitives.
 	sourceManager                 *sources.SourceManager
@@ -524,7 +524,7 @@ func (e *Engine) initialize(ctx context.Context) error {
 	}
 
 	ctx.Logger().V(4).Info("setting up aho-corasick core")
-	e.ahoCorasickCore = ahocorasick.NewAhoCorasickCore(e.detectors, ahoCOptions...)
+	e.AhoCorasickCore = ahocorasick.NewAhoCorasickCore(e.detectors, ahoCOptions...)
 	ctx.Logger().V(4).Info("set up aho-corasick core")
 
 	return nil
@@ -789,7 +789,7 @@ func (e *Engine) scannerWorker(ctx context.Context) {
 				continue
 			}
 
-			matchingDetectors := e.ahoCorasickCore.FindDetectorMatches(decoded.Chunk.Data)
+			matchingDetectors := e.AhoCorasickCore.FindDetectorMatches(decoded.Chunk.Data)
 			if len(matchingDetectors) > 1 && !e.verificationOverlap {
 				wgVerificationOverlap.Add(1)
 				e.verificationOverlapChunksChan <- verificationOverlapChunk{

--- a/pkg/engine/postman.go
+++ b/pkg/engine/postman.go
@@ -41,7 +41,7 @@ func (e *Engine) ScanPostman(ctx context.Context, c sources.PostmanConfig) (sour
 
 	// Turn AhoCorasick keywordsToDetectors into a map of keywords
 	keywords := make(map[string]struct{})
-	for key := range e.ahoCorasickCore.KeywordsToDetectors() {
+	for key := range e.AhoCorasickCore.KeywordsToDetectors() {
 		keywords[key] = struct{}{}
 	}
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Exporting the Ahocorasick core in the engine struct in order to make it accessible to Postman dependencies.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
