### PR TITLE
Make log command extensible internally

### DIFF
--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -247,10 +247,10 @@ func (c *Parser) RepoPath(
 	} else {
 		args = append(args, "--all")
 	}
+	args = append(args, additionalArgs...) // These need to come before --
 	for _, glob := range excludedGlobs {
 		args = append(args, "--", ".", ":(exclude)"+glob)
 	}
-	args = append(args, additionalArgs...)
 
 	cmd := exec.Command("git", args...)
 	absPath, err := filepath.Abs(source)

--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -228,6 +228,7 @@ func (c *Parser) RepoPath(
 	abbreviatedLog bool,
 	excludedGlobs []string,
 	isBare bool,
+	additionalArgs ...string,
 ) (chan *Diff, error) {
 	args := []string{
 		"-C", source,
@@ -249,6 +250,7 @@ func (c *Parser) RepoPath(
 	for _, glob := range excludedGlobs {
 		args = append(args, "--", ".", ":(exclude)"+glob)
 	}
+	args = append(args, additionalArgs...)
 
 	cmd := exec.Command("git", args...)
 	absPath, err := filepath.Abs(source)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
I'm experimenting with ways to manipulate the git log that's being used to generate diffs (specifically, limiting its depth in come cases). Tweaking `RepoPath` for this locally isn't a huge deal but making the log command extensible seems like it could generally be useful, so I figured I'd do it.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
