### PR TITLE
Change source reporter interfaces to not return errors

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -429,9 +429,7 @@ func handleChunksWithError(
 			if len(dataOrErr.Data) > 0 {
 				chunk := *chunkSkel
 				chunk.Data = dataOrErr.Data
-				if err := reporter.ChunkOk(ctx, chunk); err != nil {
-					return fmt.Errorf("error reporting chunk: %w", err)
-				}
+				reporter.ChunkOk(ctx, chunk)
 			}
 		case <-ctx.Done():
 			return ctx.Err()

--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -785,12 +785,11 @@ func getGitCommitHash(t *testing.T, gitDir string) string {
 
 type mockReporter struct{ reportedChunks int }
 
-func (m *mockReporter) ChunkOk(context.Context, sources.Chunk) error {
+func (m *mockReporter) ChunkOk(context.Context, sources.Chunk) {
 	m.reportedChunks++
-	return nil
 }
 
-func (m *mockReporter) ChunkErr(context.Context, error) error { return nil }
+func (m *mockReporter) ChunkErr(context.Context, error) {}
 
 func TestHandleChunksWithError(t *testing.T) {
 	tests := []struct {

--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -195,21 +195,18 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 	for _, path := range s.paths {
 		fileInfo, err := os.Lstat(filepath.Clean(path))
 		if err != nil {
-			if err := reporter.UnitErr(ctx, err); err != nil {
-				return err
-			}
+			reporter.UnitErr(ctx, err)
 			continue
 		}
 		if !fileInfo.IsDir() {
 			item := sources.CommonSourceUnit{ID: path}
-			if err := reporter.UnitOk(ctx, item); err != nil {
-				return err
-			}
+			reporter.UnitOk(ctx, item)
 			continue
 		}
 		err = fs.WalkDir(os.DirFS(path), ".", func(relativePath string, d fs.DirEntry, err error) error {
 			if err != nil {
-				return reporter.UnitErr(ctx, err)
+				reporter.UnitErr(ctx, err)
+				return nil
 			}
 			if d.IsDir() {
 				return nil
@@ -219,12 +216,11 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 				return nil
 			}
 			item := sources.CommonSourceUnit{ID: fullPath}
-			return reporter.UnitOk(ctx, item)
+			reporter.UnitOk(ctx, item)
+			return nil
 		})
 		if err != nil {
-			if err := reporter.UnitErr(ctx, err); err != nil {
-				return err
-			}
+			reporter.UnitErr(ctx, err)
 		}
 	}
 	return nil
@@ -238,7 +234,8 @@ func (s *Source) ChunkUnit(ctx context.Context, unit sources.SourceUnit, reporte
 	cleanPath := filepath.Clean(path)
 	fileInfo, err := os.Lstat(cleanPath)
 	if err != nil {
-		return reporter.ChunkErr(ctx, fmt.Errorf("unable to get file info: %w", err))
+		reporter.ChunkErr(ctx, fmt.Errorf("unable to get file info: %w", err))
+		return nil
 	}
 
 	ch := make(chan *sources.Chunk)
@@ -259,16 +256,14 @@ func (s *Source) ChunkUnit(ctx context.Context, unit sources.SourceUnit, reporte
 		if chunk == nil {
 			continue
 		}
-		if err := reporter.ChunkOk(ctx, *chunk); err != nil {
-			return err
-		}
+		reporter.ChunkOk(ctx, *chunk)
 	}
 
 	if scanErr != nil && !errors.Is(scanErr, io.EOF) {
 		if !errors.Is(scanErr, skipSymlinkErr) {
 			logger.Error(scanErr, "error scanning filesystem")
 		}
-		return reporter.ChunkErr(ctx, scanErr)
+		reporter.ChunkErr(ctx, scanErr)
 	}
 	return nil
 }

--- a/pkg/sources/filesystem/filesystem_test.go
+++ b/pkg/sources/filesystem/filesystem_test.go
@@ -252,52 +252,6 @@ func TestEnumerateReporterErr(t *testing.T) {
 	s := Source{}
 	err = s.Init(ctx, "test enumerate", 0, 0, true, conn, 1)
 	assert.NoError(t, err)
-
-	// Enumerate should always return an error if the reporter returns an
-	// error.
-	reporter := sourcestest.ErrReporter{}
-	err = s.Enumerate(ctx, &reporter)
-	assert.Error(t, err)
-}
-
-func TestChunkUnitReporterErr(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-
-	// Setup test file to chunk.
-	tmpfile, err := os.CreateTemp("", "example.txt")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tmpfile.Name())
-
-	fileContents := []byte("TestChunkUnit")
-	_, err = tmpfile.Write(fileContents)
-	assert.NoError(t, err)
-	assert.NoError(t, tmpfile.Close())
-
-	conn, err := anypb.New(&sourcespb.Filesystem{})
-	assert.NoError(t, err)
-
-	// Initialize the source.
-	s := Source{}
-	err = s.Init(ctx, "test chunk unit", 0, 0, true, conn, 1)
-	assert.NoError(t, err)
-
-	// Happy path. ChunkUnit should always return an error if the reporter
-	// returns an error.
-	reporter := sourcestest.ErrReporter{}
-	err = s.ChunkUnit(ctx, sources.CommonSourceUnit{
-		ID: tmpfile.Name(),
-	}, &reporter)
-	assert.Error(t, err)
-
-	// Error path. ChunkUnit should always return an error if the reporter
-	// returns an error.
-	err = s.ChunkUnit(ctx, sources.CommonSourceUnit{
-		ID: "/file/not/found",
-	}, &reporter)
-	assert.Error(t, err)
 }
 
 // createTempFile is a helper function to create a temporary file in the given

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -299,7 +299,7 @@ func (s *Source) scanRepo(ctx context.Context, repoURI string, reporter sources.
 		return s.git.ScanRepo(ctx, repo, path, s.scanOptions, reporter)
 	}()
 	if err != nil {
-		return reporter.ChunkErr(ctx, err)
+		reporter.ChunkErr(ctx, err)
 	}
 	return nil
 }
@@ -330,7 +330,8 @@ func (s *Source) scanDir(ctx context.Context, gitDir string, reporter sources.Ch
 	// try paths instead of url
 	repo, err := RepoFromPath(gitDir, s.scanOptions.Bare)
 	if err != nil {
-		return reporter.ChunkErr(ctx, err)
+		reporter.ChunkErr(ctx, err)
+		return nil
 	}
 
 	err = func() error {
@@ -341,7 +342,7 @@ func (s *Source) scanDir(ctx context.Context, gitDir string, reporter sources.Ch
 		return s.git.ScanRepo(ctx, repo, gitDir, s.scanOptions, reporter)
 	}()
 	if err != nil {
-		return reporter.ChunkErr(ctx, err)
+		reporter.ChunkErr(ctx, err)
 	}
 	return nil
 }
@@ -626,9 +627,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 				Data:           []byte(sb.String()),
 				Verify:         s.verify,
 			}
-			if err := reporter.ChunkOk(ctx, chunk); err != nil {
-				return err
-			}
+			reporter.ChunkOk(ctx, chunk)
 		}
 
 		fileName := diff.PathB
@@ -701,7 +700,8 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 				Data:           data,
 				Verify:         s.verify,
 			}
-			return reporter.ChunkOk(ctx, chunk)
+			reporter.ChunkOk(ctx, chunk)
+			return nil
 		}
 		if err := chunkData(diff); err != nil {
 			return err
@@ -739,10 +739,7 @@ func (s *Git) gitChunk(ctx context.Context, diff *gitparse.Diff, fileName, email
 					Data:           append([]byte{}, newChunkBuffer.Bytes()...),
 					Verify:         s.verify,
 				}
-				if err := reporter.ChunkOk(ctx, chunk); err != nil {
-					// TODO: Return error.
-					return
-				}
+				reporter.ChunkOk(ctx, chunk)
 
 				newChunkBuffer.Reset()
 				lastOffset = offset
@@ -759,10 +756,7 @@ func (s *Git) gitChunk(ctx context.Context, diff *gitparse.Diff, fileName, email
 					Data:           line,
 					Verify:         s.verify,
 				}
-				if err := reporter.ChunkOk(ctx, chunk); err != nil {
-					// TODO: Return error.
-					return
-				}
+				reporter.ChunkOk(ctx, chunk)
 				continue
 			}
 		}
@@ -783,10 +777,7 @@ func (s *Git) gitChunk(ctx context.Context, diff *gitparse.Diff, fileName, email
 			Data:           append([]byte{}, newChunkBuffer.Bytes()...),
 			Verify:         s.verify,
 		}
-		if err := reporter.ChunkOk(ctx, chunk); err != nil {
-			// TODO: Return error.
-			return
-		}
+		reporter.ChunkOk(ctx, chunk)
 	}
 }
 
@@ -903,7 +894,8 @@ func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string,
 				Data:           data,
 				Verify:         s.verify,
 			}
-			return reporter.ChunkOk(ctx, chunk)
+			reporter.ChunkOk(ctx, chunk)
+			return nil
 		}
 		if err := chunkData(diff); err != nil {
 			return err
@@ -1302,18 +1294,14 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 			continue
 		}
 		unit := SourceUnit{ID: repo, Kind: UnitDir}
-		if err := reporter.UnitOk(ctx, unit); err != nil {
-			return err
-		}
+		reporter.UnitOk(ctx, unit)
 	}
 	for _, repo := range s.conn.GetRepositories() {
 		if repo == "" {
 			continue
 		}
 		unit := SourceUnit{ID: repo, Kind: UnitRepo}
-		if err := reporter.UnitOk(ctx, unit); err != nil {
-			return err
-		}
+		reporter.UnitOk(ctx, unit)
 	}
 	return nil
 }

--- a/pkg/sources/github/github_integration_test.go
+++ b/pkg/sources/github/github_integration_test.go
@@ -869,12 +869,10 @@ type countChunkReporter struct {
 	errCount   int
 }
 
-func (m *countChunkReporter) ChunkOk(ctx context.Context, chunk sources.Chunk) error {
+func (m *countChunkReporter) ChunkOk(ctx context.Context, chunk sources.Chunk) {
 	m.chunkCount++
-	return nil
 }
 
-func (m *countChunkReporter) ChunkErr(ctx context.Context, err error) error {
+func (m *countChunkReporter) ChunkErr(ctx context.Context, err error) {
 	m.errCount++
-	return nil
 }

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -606,10 +606,9 @@ func TestEnumerate(t *testing.T) {
 
 	var reportedRepos []string
 	reporter := sources.VisitorReporter{
-		VisitUnit: func(ctx context.Context, su sources.SourceUnit) error {
+		VisitUnit: func(ctx context.Context, su sources.SourceUnit) {
 			url, _ := su.SourceUnitID()
 			reportedRepos = append(reportedRepos, url)
-			return nil
 		},
 	}
 
@@ -961,8 +960,6 @@ func Test_ScanMultipleTargets_MultipleErrors(t *testing.T) {
 
 func noopReporter() sources.UnitReporter {
 	return sources.VisitorReporter{
-		VisitUnit: func(context.Context, sources.SourceUnit) error {
-			return nil
-		},
+		VisitUnit: func(context.Context, sources.SourceUnit) {},
 	}
 }

--- a/pkg/sources/github/repo.go
+++ b/pkg/sources/github/repo.go
@@ -154,9 +154,7 @@ func (s *Source) getReposByOrgOrUser(ctx context.Context, name string, reporter 
 	if err == nil {
 		return organization, nil
 	} else if !isGitHub404Error(err) {
-		if err := reporter.UnitErr(ctx, fmt.Errorf("error getting repos by org: %w", err)); err != nil {
-			return unknown, err
-		}
+		reporter.UnitErr(ctx, fmt.Errorf("error getting repos by org: %w", err))
 		return unknown, err
 	}
 
@@ -221,9 +219,7 @@ func (s *Source) processRepos(ctx context.Context, target string, reporter sourc
 			s.totalRepoSize += r.GetSize()
 			s.filteredRepoCache.Set(repoName, repoURL)
 			s.cacheRepoInfo(r)
-			if err := reporter.UnitOk(ctx, RepoUnit{Name: repoName, URL: repoURL}); err != nil {
-				return err
-			}
+			reporter.UnitOk(ctx, RepoUnit{Name: repoName, URL: repoURL})
 			logger.V(3).Info("repo attributes", "name", repoName, "kb_size", r.GetSize(), "repo_url", repoURL)
 		}
 

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -255,10 +255,9 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, tar
 			ctx.Logger().Error(err, "could not compile include/exclude repo glob", "glob", pattern)
 		})
 		reporter := sources.VisitorReporter{
-			VisitUnit: func(ctx context.Context, unit sources.SourceUnit) error {
+			VisitUnit: func(ctx context.Context, unit sources.SourceUnit) {
 				id, _ := unit.SourceUnitID()
 				repos = append(repos, id)
-				return ctx.Err()
 			},
 		}
 		if err := s.getAllProjectRepos(ctx, apiClient, ignoreRepo, reporter); err != nil {
@@ -382,10 +381,9 @@ func (s *Source) Validate(ctx context.Context) []error {
 	// Query GitLab for the list of configured repos.
 	var repos []string
 	visitor := sources.VisitorReporter{
-		VisitUnit: func(ctx context.Context, unit sources.SourceUnit) error {
+		VisitUnit: func(ctx context.Context, unit sources.SourceUnit) {
 			id, _ := unit.SourceUnitID()
 			repos = append(repos, id)
-			return nil
 		},
 	}
 	if err := s.getAllProjectRepos(ctx, apiClient, ignoreProject, visitor); err != nil {
@@ -496,9 +494,7 @@ func (s *Source) getAllProjectRepos(
 					"parse_error", err)
 
 				err = fmt.Errorf("could not parse url %q given by project: %w", proj.HTTPURLToRepo, err)
-				if err := reporter.UnitErr(ctx, err); err != nil {
-					return err
-				}
+				reporter.UnitErr(ctx, err)
 				continue
 			}
 			// Report the unit.
@@ -506,9 +502,7 @@ func (s *Source) getAllProjectRepos(
 			unit := git.SourceUnit{Kind: git.UnitRepo, ID: proj.HTTPURLToRepo}
 			gitlabReposEnumerated.WithLabelValues(s.name).Inc()
 			projectsWithNamespace = append(projectsWithNamespace, proj.NameWithNamespace)
-			if err := reporter.UnitOk(ctx, unit); err != nil {
-				return err
-			}
+			reporter.UnitOk(ctx, unit)
 		}
 		return nil
 	}
@@ -524,9 +518,7 @@ func (s *Source) getAllProjectRepos(
 		userProjects, res, err := apiClient.Projects.ListUserProjects(user.ID, projectQueryOptions)
 		if err != nil {
 			err = fmt.Errorf("received error on listing user projects: %w", err)
-			if err := reporter.UnitErr(ctx, err); err != nil {
-				return err
-			}
+			reporter.UnitErr(ctx, err)
 			break
 		}
 		ctx.Logger().V(3).Info("listed user projects", "count", len(userProjects))
@@ -560,9 +552,7 @@ func (s *Source) getAllProjectRepos(
 		groupList, res, err := apiClient.Groups.ListGroups(&listGroupsOptions)
 		if err != nil {
 			err = fmt.Errorf("received error on listing groups, you probably don't have permissions to do that: %w", err)
-			if err := reporter.UnitErr(ctx, err); err != nil {
-				return err
-			}
+			reporter.UnitErr(ctx, err)
 			break
 		}
 		ctx.Logger().V(3).Info("listed groups", "count", len(groupList))
@@ -591,9 +581,7 @@ func (s *Source) getAllProjectRepos(
 					"received error on listing group projects for %q, you probably don't have permissions to do that: %w",
 					group.FullPath, err,
 				)
-				if err := reporter.UnitErr(ctx, err); err != nil {
-					return err
-				}
+				reporter.UnitErr(ctx, err)
 				break
 			}
 			ctx.Logger().V(3).Info("listed group projects", "count", len(grpPrjs))
@@ -790,9 +778,7 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 	repos, errs := normalizeRepos(s.repos)
 	for _, repoErr := range errs {
 		ctx.Logger().Info("error normalizing repo", "error", repoErr)
-		if err := reporter.UnitErr(ctx, repoErr); err != nil {
-			return err
-		}
+		reporter.UnitErr(ctx, repoErr)
 	}
 
 	// End early if we had errors getting specified repos but none were validated.
@@ -805,9 +791,7 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 		gitlabReposEnumerated.WithLabelValues(s.name).Set(0)
 		for _, repo := range repos {
 			unit := git.SourceUnit{Kind: git.UnitRepo, ID: repo}
-			if err := reporter.UnitOk(ctx, unit); err != nil {
-				return err
-			}
+			reporter.UnitOk(ctx, unit)
 			gitlabReposEnumerated.WithLabelValues(s.name).Inc()
 		}
 		return nil
@@ -816,8 +800,7 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 	// Otherwise, enumerate all repos.
 	ignoreRepo := buildIgnorer(s.includeRepos, s.ignoreRepos, func(err error, pattern string) {
 		ctx.Logger().Error(err, "could not compile include/exclude repo glob", "glob", pattern)
-		// TODO: Handle error returned from UnitErr.
-		_ = reporter.UnitErr(ctx, fmt.Errorf("could not compile include/exclude repo glob: %w", err))
+		reporter.UnitErr(ctx, fmt.Errorf("could not compile include/exclude repo glob: %w", err))
 	})
 	return s.getAllProjectRepos(ctx, apiClient, ignoreRepo, reporter)
 }

--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -649,16 +649,15 @@ type mgrUnitReporter struct {
 
 // UnitOk implements the UnitReporter interface by recording the unit in the
 // report and sending it on the SourceUnit channel.
-func (s *mgrUnitReporter) UnitOk(ctx context.Context, unit SourceUnit) error {
+func (s *mgrUnitReporter) UnitOk(ctx context.Context, unit SourceUnit) {
 	s.report.ReportUnit(unit)
-	return common.CancellableWrite(ctx, s.unitCh, unit)
+	_ = common.CancellableWrite(ctx, s.unitCh, unit)
 }
 
 // UnitErr implements the UnitReporter interface by recording the error in the
 // report.
-func (s *mgrUnitReporter) UnitErr(ctx context.Context, err error) error {
+func (s *mgrUnitReporter) UnitErr(ctx context.Context, err error) {
 	s.report.ReportError(err)
-	return nil
 }
 
 // mgrChunkReporter implements the ChunkReporter interface.
@@ -672,14 +671,13 @@ type mgrChunkReporter struct {
 
 // ChunkOk implements the ChunkReporter interface by recording the chunk and
 // its associated unit in the report and sending it on the Chunk channel.
-func (s *mgrChunkReporter) ChunkOk(ctx context.Context, chunk Chunk) error {
+func (s *mgrChunkReporter) ChunkOk(ctx context.Context, chunk Chunk) {
 	s.report.ReportChunk(s.unit, &chunk)
-	return common.CancellableWrite(ctx, s.chunkCh, &chunk)
+	_ = common.CancellableWrite(ctx, s.chunkCh, &chunk)
 }
 
 // ChunkErr implements the ChunkReporter interface by recording the error and
 // its associated unit in the report.
-func (s *mgrChunkReporter) ChunkErr(ctx context.Context, err error) error {
+func (s *mgrChunkReporter) ChunkErr(ctx context.Context, err error) {
 	s.report.ReportError(ChunkError{s.unit, err})
-	return nil
 }

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -97,9 +97,9 @@ type SourceUnitEnumerator interface {
 	// reporting them or any errors to the UnitReporter. This method is
 	// synchronous but can be called in a goroutine to support concurrent
 	// enumeration and chunking. An error should only be returned from this
-	// method in the case of context cancellation, fatal source errors, or
-	// errors returned by the reporter. All other errors related to unit
-	// enumeration are tracked by the UnitReporter.
+	// method in the case of context cancellation or fatal source errors
+	// All other errors related to unit enumeration are tracked by the
+	// UnitReporter.
 	Enumerate(ctx context.Context, reporter UnitReporter) error
 }
 
@@ -130,8 +130,8 @@ func (b baseUnitReporter) UnitErr(ctx context.Context, err error) error {
 // unit was found during enumeration. Either method may be called any number of
 // times. Implementors of this interface should allow for concurrent calls.
 type UnitReporter interface {
-	UnitOk(ctx context.Context, unit SourceUnit) error
-	UnitErr(ctx context.Context, err error) error
+	UnitOk(ctx context.Context, unit SourceUnit)
+	UnitErr(ctx context.Context, err error)
 }
 
 // SourceUnitChunker defines an optional interface a Source can implement to
@@ -139,9 +139,9 @@ type UnitReporter interface {
 type SourceUnitChunker interface {
 	// ChunkUnit creates 0 or more chunks from a unit, reporting them or
 	// any errors to the ChunkReporter. An error should only be returned
-	// from this method in the case of context cancellation, fatal source
-	// errors, or errors returned by the reporter. All other errors related
-	// to unit chunking are tracked by the ChunkReporter.
+	// from this method in the case of context cancellation or fatal source
+	// errors. All other errors related to unit chunking are tracked by the
+	// ChunkReporter.
 	ChunkUnit(ctx context.Context, unit SourceUnit, reporter ChunkReporter) error
 }
 
@@ -149,8 +149,8 @@ type SourceUnitChunker interface {
 // chunk was found during unit chunking. Either method may be called any number
 // of times. Implementors of this interface should allow for concurrent calls.
 type ChunkReporter interface {
-	ChunkOk(ctx context.Context, chunk Chunk) error
-	ChunkErr(ctx context.Context, err error) error
+	ChunkOk(ctx context.Context, chunk Chunk)
+	ChunkErr(ctx context.Context, err error)
 }
 
 type SourceUnitKind string

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -110,20 +110,18 @@ type baseUnitReporter struct {
 	progress *JobProgress
 }
 
-func (b baseUnitReporter) UnitOk(ctx context.Context, unit SourceUnit) error {
+func (b baseUnitReporter) UnitOk(ctx context.Context, unit SourceUnit) {
 	b.progress.ReportUnit(unit)
 	if b.child != nil {
-		return b.child.UnitOk(ctx, unit)
+		b.child.UnitOk(ctx, unit)
 	}
-	return nil
 }
 
-func (b baseUnitReporter) UnitErr(ctx context.Context, err error) error {
+func (b baseUnitReporter) UnitErr(ctx context.Context, err error) {
 	b.progress.ReportError(err)
 	if b.child != nil {
-		return b.child.UnitErr(ctx, err)
+		b.child.UnitErr(ctx, err)
 	}
-	return nil
 }
 
 // UnitReporter defines the interface a source will use to report whether a

--- a/pkg/sources/travisci/travisci.go
+++ b/pkg/sources/travisci/travisci.go
@@ -101,10 +101,7 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 			if repoPage == 0 {
 				return fmt.Errorf("error listing repositories: %w", err)
 			}
-			err = reporter.UnitErr(ctx, err)
-			if err != nil {
-				return fmt.Errorf("error reporting error: %w", err)
-			}
+			reporter.UnitErr(ctx, err)
 		}
 
 		if len(repositories) == 0 {
@@ -112,13 +109,10 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 		}
 
 		for _, repo := range repositories {
-			err = reporter.UnitOk(ctx, sources.CommonSourceUnit{
+			reporter.UnitOk(ctx, sources.CommonSourceUnit{
 				ID:   strconv.Itoa(int(*repo.Id)),
 				Kind: "repo",
 			})
-			if err != nil {
-				return fmt.Errorf("error reporting unit: %w", err)
-			}
 			ctx.Logger().V(2).Info("enumerated repository", "id", repo.Id, "name", repo.Name)
 		}
 	}
@@ -145,9 +139,7 @@ func (s *Source) ChunkUnit(ctx context.Context, unit sources.SourceUnit, reporte
 			Offset: buildPage * pageSize,
 		})
 		if err != nil {
-			if err := reporter.ChunkErr(ctx, err); err != nil {
-				return err
-			}
+			reporter.ChunkErr(ctx, err)
 			buildPageErrs++
 			if buildPageErrs >= 5 {
 				return fmt.Errorf("encountered too many errors listing builds, aborting")
@@ -164,9 +156,7 @@ func (s *Source) ChunkUnit(ctx context.Context, unit sources.SourceUnit, reporte
 		for _, build := range builds {
 			jobs, _, err := s.client.Jobs.ListByBuild(ctx, *build.Id)
 			if err != nil {
-				if err := reporter.ChunkErr(ctx, err); err != nil {
-					return err
-				}
+				reporter.ChunkErr(ctx, err)
 				continue
 			}
 
@@ -177,9 +167,7 @@ func (s *Source) ChunkUnit(ctx context.Context, unit sources.SourceUnit, reporte
 			for _, job := range jobs {
 				log, _, err := s.client.Logs.FindByJobId(ctx, *job.Id)
 				if err != nil {
-					if err := reporter.ChunkErr(ctx, err); err != nil {
-						return err
-					}
+					reporter.ChunkErr(ctx, err)
 					continue
 				}
 
@@ -206,9 +194,7 @@ func (s *Source) ChunkUnit(ctx context.Context, unit sources.SourceUnit, reporte
 					Verify: s.verify,
 				}
 
-				if err := reporter.ChunkOk(ctx, chunk); err != nil {
-					return err
-				}
+				reporter.ChunkOk(ctx, chunk)
 
 				if s.returnAfterFirstChunk {
 					return nil

--- a/pkg/sourcestest/sourcestest.go
+++ b/pkg/sourcestest/sourcestest.go
@@ -1,8 +1,6 @@
 package sourcestest
 
 import (
-	"fmt"
-
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
@@ -12,10 +10,7 @@ type reporter interface {
 	sources.ChunkReporter
 }
 
-var (
-	_ reporter = (*TestReporter)(nil)
-	_ reporter = (*ErrReporter)(nil)
-)
+var _ reporter = (*TestReporter)(nil)
 
 // TestReporter is a helper struct that implements both UnitReporter and
 // ChunkReporter by simply recording the values passed in the methods.
@@ -26,36 +21,15 @@ type TestReporter struct {
 	ChunkErrs []error
 }
 
-func (t *TestReporter) UnitOk(_ context.Context, unit sources.SourceUnit) error {
+func (t *TestReporter) UnitOk(_ context.Context, unit sources.SourceUnit) {
 	t.Units = append(t.Units, unit)
-	return nil
 }
-func (t *TestReporter) UnitErr(_ context.Context, err error) error {
+func (t *TestReporter) UnitErr(_ context.Context, err error) {
 	t.UnitErrs = append(t.UnitErrs, err)
-	return nil
 }
-func (t *TestReporter) ChunkOk(_ context.Context, chunk sources.Chunk) error {
+func (t *TestReporter) ChunkOk(_ context.Context, chunk sources.Chunk) {
 	t.Chunks = append(t.Chunks, chunk)
-	return nil
 }
-func (t *TestReporter) ChunkErr(_ context.Context, err error) error {
+func (t *TestReporter) ChunkErr(_ context.Context, err error) {
 	t.ChunkErrs = append(t.ChunkErrs, err)
-	return nil
-}
-
-// ErrReporter implements UnitReporter and ChunkReporter but always returns an
-// error.
-type ErrReporter struct{}
-
-func (ErrReporter) UnitOk(context.Context, sources.SourceUnit) error {
-	return fmt.Errorf("ErrReporter: UnitOk error")
-}
-func (ErrReporter) UnitErr(context.Context, error) error {
-	return fmt.Errorf("ErrReporter: UnitErr error")
-}
-func (ErrReporter) ChunkOk(context.Context, sources.Chunk) error {
-	return fmt.Errorf("ErrReporter: ChunkOk error")
-}
-func (ErrReporter) ChunkErr(context.Context, error) error {
-	return fmt.Errorf("ErrReporter: ChunkErr error")
 }


### PR DESCRIPTION


### Description:

The error was meant to allow the reporter to end scanning, but in practice would only be useful for context cancellations, which sources should be handling anyway. Removing the error simplifies the usage of the interface.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
