### PR TITLE
[fix] False Positive Verification in Auth0oauth Detectors

### DIFF
--- a/pkg/detectors/auth0oauth/auth0oauth.go
+++ b/pkg/detectors/auth0oauth/auth0oauth.go
@@ -2,6 +2,7 @@ package auth0oauth
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -15,13 +16,14 @@ import (
 
 type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
+	client *http.Client
 }
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = detectors.DetectorHttpClientWithLocalAddresses
+	defaultClient = detectors.DetectorHttpClientWithLocalAddresses
 
 	clientIdPat     = regexp.MustCompile(detectors.PrefixRegex([]string{"auth0"}) + `\b([a-zA-Z0-9_-]{32,60})\b`)
 	clientSecretPat = regexp.MustCompile(`\b([a-zA-Z0-9_-]{64,})\b`)
@@ -61,42 +63,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 
 				if verify {
-					/*
-					   curl --request POST \
-					     --url 'https://YOUR_DOMAIN/oauth/token' \
-					     --header 'content-type: application/x-www-form-urlencoded' \
-					     --data 'grant_type=authorization_code&client_id=W44JmL3qD6LxHeEJyKe9lMuhcwvPOaOq&client_secret=YOUR_CLIENT_SECRET&code=AUTHORIZATION_CODE&redirect_uri=undefined'
-					*/
 
-					data := url.Values{}
-					data.Set("grant_type", "authorization_code")
-					data.Set("client_id", clientIdRes)
-					data.Set("client_secret", clientSecretRes)
-					data.Set("code", "AUTHORIZATION_CODE")
-					data.Set("redirect_uri", "undefined")
+					client := s.client
+					if client == nil {
+						client = defaultClient
+					}
 
-					req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://"+domainRes+"/oauth/token", strings.NewReader(data.Encode())) // URL-encoded payload
+					isVerified, err := verifyTuple(ctx, client, domainRes, clientIdRes, clientSecretRes)
 					if err != nil {
-						continue
+						s1.SetVerificationError(err, clientIdRes)
 					}
-					req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-					res, err := client.Do(req)
-					if err == nil {
-						defer res.Body.Close()
-						bodyBytes, err := io.ReadAll(res.Body)
-						if err != nil {
-							continue
-						}
-						body := string(bodyBytes)
-
-						// if client_id and client_secret is valid -> 403 {"error":"invalid_grant","error_description":"Invalid authorization code"}
-						// if invalid -> 401 {"error":"access_denied","error_description":"Unauthorized"}
-						// ingenious!
-
-						if !strings.Contains(body, "access_denied") {
-							s1.Verified = true
-						}
-					}
+					s1.Verified = isVerified
 				}
 
 				results = append(results, s1)
@@ -105,6 +82,65 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	return results, nil
+}
+
+func verifyTuple(ctx context.Context, client *http.Client, domainRes, clientId, clientSecret string) (bool, error) {
+	/*
+	   curl --request POST \
+	     --url 'https://YOUR_DOMAIN/oauth/token' \
+	     --header 'content-type: application/x-www-form-urlencoded' \
+	     --data 'grant_type=authorization_code&client_id=W44JmL3qD6LxHeEJyKe9lMuhcwvPOaOq&client_secret=YOUR_CLIENT_SECRET&code=AUTHORIZATION_CODE&redirect_uri=undefined'
+	*/
+
+	fmt.Println("domainRes: ", domainRes)
+	fmt.Println("clientId: ", clientId)
+	fmt.Println("clientSecret: ", clientSecret)
+
+	data := url.Values{}
+	data.Set("grant_type", "authorization_code")
+	data.Set("client_id", clientId)
+	data.Set("client_secret", clientSecret)
+	data.Set("code", "AUTHORIZATION_CODE")
+	data.Set("redirect_uri", "undefined")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://"+domainRes+"/oauth/token", strings.NewReader(data.Encode())) // URL-encoded payload
+	if err != nil {
+		return false, err
+	}
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// This condition will never meet due to invalid request body
+		return true, nil
+	case http.StatusUnauthorized:
+		return false, nil
+	case http.StatusForbidden:
+		// cross check about 'invalid_grant' in response body
+		bodyBytes, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false, err
+		}
+		bodyStr := string(bodyBytes)
+		if strings.Contains(bodyStr, "invalid_grant") {
+			return true, nil
+		}
+		return false, nil
+	case http.StatusNotFound:
+		// domain is invalid
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected HTTP response status %d", resp.StatusCode)
+	}
 }
 
 func (s Scanner) Type() detectorspb.DetectorType {

--- a/pkg/detectors/auth0oauth/auth0oauth.go
+++ b/pkg/detectors/auth0oauth/auth0oauth.go
@@ -121,13 +121,13 @@ func verifyTuple(ctx context.Context, client *http.Client, domainRes, clientId, 
 	case http.StatusUnauthorized:
 		return false, nil
 	case http.StatusForbidden:
-		// cross check about 'invalid_grant' in response body
+		// cross check about 'invalid_grant' or 'unauthorized_client' in response body
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return false, err
 		}
 		bodyStr := string(bodyBytes)
-		if strings.Contains(bodyStr, "invalid_grant") {
+		if strings.Contains(bodyStr, "invalid_grant") || strings.Contains(bodyStr, "unauthorized_client") {
 			return true, nil
 		}
 		return false, nil

--- a/pkg/detectors/auth0oauth/auth0oauth.go
+++ b/pkg/detectors/auth0oauth/auth0oauth.go
@@ -92,10 +92,6 @@ func verifyTuple(ctx context.Context, client *http.Client, domainRes, clientId, 
 	     --data 'grant_type=authorization_code&client_id=W44JmL3qD6LxHeEJyKe9lMuhcwvPOaOq&client_secret=YOUR_CLIENT_SECRET&code=AUTHORIZATION_CODE&redirect_uri=undefined'
 	*/
 
-	fmt.Println("domainRes: ", domainRes)
-	fmt.Println("clientId: ", clientId)
-	fmt.Println("clientSecret: ", clientSecret)
-
 	data := url.Values{}
 	data.Set("grant_type", "authorization_code")
 	data.Set("client_id", clientId)
@@ -136,7 +132,7 @@ func verifyTuple(ctx context.Context, client *http.Client, domainRes, clientId, 
 		}
 		return false, nil
 	case http.StatusNotFound:
-		// domain is invalid
+		// domain does not exists - 404 not found
 		return false, nil
 	default:
 		return false, fmt.Errorf("unexpected HTTP response status %d", resp.StatusCode)

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -54,6 +54,7 @@ import (
 	atlassianv2 "github.com/trufflesecurity/trufflehog/v3/pkg/detectors/atlassian/v2"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/audd"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/auth0managementapitoken"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/auth0oauth"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/autodesk"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/autoklose"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/autopilot"
@@ -882,7 +883,7 @@ func buildDetectorList() []detectors.Detector {
 		&atlassianv2.Scanner{},
 		&audd.Scanner{},
 		&auth0managementapitoken.Scanner{},
-		// &auth0oauth.Scanner{},
+		&auth0oauth.Scanner{},
 		&autodesk.Scanner{},
 		&autoklose.Scanner{},
 		&autopilot.Scanner{},


### PR DESCRIPTION
### Description:
This PR addresses an issue where a buggy verification process was incorrectly marking false-positive credentials as verified. The following cases are now handled properly:

-  Malformed `authorization_code` Request:
        If an invalid authorization_code request is sent for verification, the API responds with a 403 Forbidden status and an invalid_grant error code.
        Fix: These credentials will now be marked as verified in this case.

- Unauthorized Client:
        If the credentials do not have permission to make an authorization_code request, the API returns a 403 Forbidden status with the unauthorized_client error code.
        Fix: No change in behavior; this case continues to be handled correctly.

- Invalid Domain:
        If the provided domain is not valid, the API returns a 404 Not Found status.
        Fix: These credentials will now be correctly marked as unverified.

- Invalid ID/Secret:
        If the client ID or secret is invalid, the API responds with a 401 Unauthorized status.
        Fix: These credentials will now be correctly marked as unverified.

This PR ensures a more accurate verification process and reduces false positives.

Here is the results of modified test results:
![image](https://github.com/user-attachments/assets/51eb6498-39da-4c6c-aa90-224786fb6518)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
