### PR TITLE
Reinstated Postman body scanning

### DIFF
--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -578,21 +578,18 @@ func (s *Source) scanRequestBody(ctx context.Context, chunksChan chan *sources.C
 		m.LocationType = source_metadatapb.PostmanLocationType_REQUEST_BODY_URL_ENCODED
 		s.scanVariableData(ctx, chunksChan, m, vars)
 		m.LocationType = source_metadatapb.PostmanLocationType_UNKNOWN_POSTMAN
-	case "raw", "graphql":
+	case "raw":
+		m.Type = originalType + " > raw"
 		data := b.Raw
-		if b.Mode == "graphql" {
-			m.Type = originalType + " > graphql"
-			data = b.GraphQL.Query + " " + b.GraphQL.Variables
-			m.LocationType = source_metadatapb.PostmanLocationType_REQUEST_BODY_GRAPHQL
-		}
-		if b.Mode == "raw" {
-			m.Type = originalType + " > raw"
-			m.LocationType = source_metadatapb.PostmanLocationType_REQUEST_BODY_RAW
-		}
+		m.LocationType = source_metadatapb.PostmanLocationType_REQUEST_BODY_RAW
 		s.scanData(ctx, chunksChan, s.formatAndInjectKeywords(s.buildSubstitueSet(m, data)), m)
 		m.LocationType = source_metadatapb.PostmanLocationType_UNKNOWN_POSTMAN
-	default:
-		break
+	case "graphql":
+		m.Type = originalType + " > graphql"
+		data := b.GraphQL.Query + " " + b.GraphQL.Variables
+		m.LocationType = source_metadatapb.PostmanLocationType_REQUEST_BODY_GRAPHQL
+		s.scanData(ctx, chunksChan, s.formatAndInjectKeywords(s.buildSubstitueSet(m, data)), m)
+		m.LocationType = source_metadatapb.PostmanLocationType_UNKNOWN_POSTMAN
 	}
 }
 

--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -550,9 +550,50 @@ func (s *Source) scanHTTPRequest(ctx context.Context, chunksChan chan *sources.C
 		s.scanAuth(ctx, chunksChan, metadata, r.Auth, r.URL)
 	}
 
-	// We would scan the body, but currently the body has different radio buttons that can be scanned but only the selected one is scanned. The unselected radio button options can still
-	// have secrets in them but will not be scanned. The selction of the radio button will also change the secret metadata for that particular scanning pass and can create confusion for
-	// the user as to the status of a secret. We will reimplement at some point.
+	if r.Body.Mode != "" {
+		metadata.Type = originalType + " > body"
+		s.scanBody(ctx, chunksChan, metadata, r.Body)
+	}
+}
+
+func (s *Source) scanBody(ctx context.Context, chunksChan chan *sources.Chunk, m Metadata, b Body) {
+	if !m.fromLocal {
+		m.Link = m.Link + "?tab=body"
+	}
+	originalType := m.Type
+	switch b.Mode {
+	case "formdata":
+		m.Type = originalType + " > form data"
+		vars := VariableData{
+			KeyValues: b.FormData,
+		}
+		m.LocationType = source_metadatapb.PostmanLocationType_REQUEST_BODY_FORM_DATA
+		s.scanVariableData(ctx, chunksChan, m, vars)
+		m.LocationType = source_metadatapb.PostmanLocationType_UNKNOWN_POSTMAN
+	case "urlencoded":
+		m.Type = originalType + " > url encoded"
+		vars := VariableData{
+			KeyValues: b.URLEncoded,
+		}
+		m.LocationType = source_metadatapb.PostmanLocationType_REQUEST_BODY_URL_ENCODED
+		s.scanVariableData(ctx, chunksChan, m, vars)
+		m.LocationType = source_metadatapb.PostmanLocationType_UNKNOWN_POSTMAN
+	case "raw", "graphql":
+		data := b.Raw
+		if b.Mode == "graphql" {
+			m.Type = originalType + " > graphql"
+			data = b.GraphQL.Query + " " + b.GraphQL.Variables
+			m.LocationType = source_metadatapb.PostmanLocationType_REQUEST_BODY_GRAPHQL
+		}
+		if b.Mode == "raw" {
+			m.Type = originalType + " > raw"
+			m.LocationType = source_metadatapb.PostmanLocationType_REQUEST_BODY_RAW
+		}
+		s.scanData(ctx, chunksChan, s.formatAndInjectKeywords(s.buildSubstitueSet(m, data)), m)
+		m.LocationType = source_metadatapb.PostmanLocationType_UNKNOWN_POSTMAN
+	default:
+		break
+	}
 }
 
 func (s *Source) scanHTTPResponse(ctx context.Context, chunksChan chan *sources.Chunk, m Metadata, response Response) {

--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -552,11 +552,11 @@ func (s *Source) scanHTTPRequest(ctx context.Context, chunksChan chan *sources.C
 
 	if r.Body.Mode != "" {
 		metadata.Type = originalType + " > body"
-		s.scanBody(ctx, chunksChan, metadata, r.Body)
+		s.scanRequestBody(ctx, chunksChan, metadata, r.Body)
 	}
 }
 
-func (s *Source) scanBody(ctx context.Context, chunksChan chan *sources.Chunk, m Metadata, b Body) {
+func (s *Source) scanRequestBody(ctx context.Context, chunksChan chan *sources.Chunk, m Metadata, b Body) {
 	if !m.fromLocal {
 		m.Link = m.Link + "?tab=body"
 	}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Gave Postman sources the ability to scan request bodies again. Gave the function a more specific name to differentiate from scanning response bodies.

Reinstating the code removed [here](https://github.com/trufflesecurity/trufflehog/commit/9ecaf075c5e7bb593e23634557b869ade366cf08#diff-b8dfca92646598b2f3db2691242188c6cb06dc17125b0d18fef18d0c5cc051ddL510).
### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
