### PR TITLE
Implemented Postman collection authorization scanning

### DIFF
--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -321,6 +321,9 @@ func (s *Source) scanCollection(ctx context.Context, chunksChan chan *sources.Ch
 	})
 	metadata.LocationType = source_metadatapb.PostmanLocationType_UNKNOWN_POSTMAN
 
+	// collections don't have URLs in the Postman API, but we can scan the Authorization section without it.
+	s.scanAuth(ctx, chunksChan, metadata, collection.Auth, URL{})
+
 	for _, event := range collection.Events {
 		s.scanEvent(ctx, chunksChan, metadata, event)
 	}
@@ -492,7 +495,11 @@ func (s *Source) scanAuth(ctx context.Context, chunksChan chan *sources.Chunk, m
 	}
 
 	if !m.fromLocal {
-		m.Link += "?tab=auth"
+		if strings.Contains(m.Type, REQUEST_TYPE) {
+			m.Link += "?tab=auth"
+		} else {
+			m.Link += "?tab=authorization"
+		}
 		m.Type += " > authorization"
 	}
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Implements scanning of the Postman collection's authorization section for secrets. When generating the link I noticed that authorizations in collections and folders have a different link structure than authorizations in requests.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
