### PR TITLE
Differentiate postman folder from request when at collection root

### DIFF
--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -338,11 +338,6 @@ func (s *Source) scanItem(ctx context.Context, chunksChan chan *sources.Chunk, c
 	s.attemptToAddKeyword(item.Name)
 
 	// override the base collection metadata with item-specific metadata
-	if parentItemId != "" {
-		metadata.FolderID = parentItemId
-	} else {
-		metadata.FolderID = item.UID
-	}
 	metadata.Type = FOLDER_TYPE
 	if metadata.FolderName != "" {
 		// keep track of the folder hierarchy
@@ -354,6 +349,7 @@ func (s *Source) scanItem(ctx context.Context, chunksChan chan *sources.Chunk, c
 	if item.UID != "" {
 		metadata.FullID = item.UID
 		metadata.Link = LINK_BASE_URL + FOLDER_TYPE + "/" + metadata.FullID
+		metadata.FolderID = item.UID
 	}
 	// recurse through the folders
 	for _, subItem := range item.Items {
@@ -363,12 +359,13 @@ func (s *Source) scanItem(ctx context.Context, chunksChan chan *sources.Chunk, c
 	// check if there are any requests in the folder
 	if item.Request.Method != "" {
 		metadata.FolderName = strings.Replace(metadata.FolderName, (" > " + item.Name), "", -1)
-		if metadata.FolderName == item.Name {
+		if parentItemId == "" {
 			metadata.FolderName = ""
 			metadata.FolderID = ""
 		}
 		metadata.RequestID = item.UID
 		metadata.RequestName = item.Name
+		metadata.FolderID = parentItemId
 		metadata.Type = REQUEST_TYPE
 		if item.UID != "" {
 			// Route to API endpoint

--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -338,6 +338,7 @@ func (s *Source) scanItem(ctx context.Context, chunksChan chan *sources.Chunk, c
 	s.attemptToAddKeyword(item.Name)
 
 	// override the base collection metadata with item-specific metadata
+	metadata.FolderID = parentItemId
 	metadata.Type = FOLDER_TYPE
 	if metadata.FolderName != "" {
 		// keep track of the folder hierarchy

--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -338,7 +338,11 @@ func (s *Source) scanItem(ctx context.Context, chunksChan chan *sources.Chunk, c
 	s.attemptToAddKeyword(item.Name)
 
 	// override the base collection metadata with item-specific metadata
-	metadata.FolderID = parentItemId
+	if parentItemId != "" {
+		metadata.FolderID = parentItemId
+	} else {
+		metadata.FolderID = item.UID
+	}
 	metadata.Type = FOLDER_TYPE
 	if metadata.FolderName != "" {
 		// keep track of the folder hierarchy
@@ -353,7 +357,7 @@ func (s *Source) scanItem(ctx context.Context, chunksChan chan *sources.Chunk, c
 	}
 	// recurse through the folders
 	for _, subItem := range item.Items {
-		s.scanItem(ctx, chunksChan, collection, metadata, subItem, item.ID)
+		s.scanItem(ctx, chunksChan, collection, metadata, subItem, item.UID)
 	}
 
 	// check if there are any requests in the folder
@@ -361,8 +365,9 @@ func (s *Source) scanItem(ctx context.Context, chunksChan chan *sources.Chunk, c
 		metadata.FolderName = strings.Replace(metadata.FolderName, (" > " + item.Name), "", -1)
 		if metadata.FolderName == item.Name {
 			metadata.FolderName = ""
+			metadata.FolderID = ""
 		}
-		metadata.RequestID = item.ID
+		metadata.RequestID = item.UID
 		metadata.RequestName = item.Name
 		metadata.Type = REQUEST_TYPE
 		if item.UID != "" {

--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -355,6 +355,10 @@ func (s *Source) scanItem(ctx context.Context, chunksChan chan *sources.Chunk, c
 		s.scanItem(ctx, chunksChan, collection, metadata, subItem, item.UID)
 	}
 
+	// The assignment of the folder ID to be the current item UID is due to wanting to assume that your current item is a folder unless you have request data inside of your item.
+	// If your current item is a folder, you will want the folder ID to match the UID of the current item.
+	// If your current item is a request, you will want the folder ID to match the UID of the parent folder.
+	// If the request is at the root of a collection and has no parent folder, the folder ID will be empty.
 	metadata.FolderID = item.UID
 	// check if there are any requests in the folder
 	if item.Request.Method != "" {

--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -338,7 +338,6 @@ func (s *Source) scanItem(ctx context.Context, chunksChan chan *sources.Chunk, c
 	s.attemptToAddKeyword(item.Name)
 
 	// override the base collection metadata with item-specific metadata
-	metadata.FolderID = parentItemId
 	metadata.Type = FOLDER_TYPE
 	if metadata.FolderName != "" {
 		// keep track of the folder hierarchy
@@ -350,10 +349,10 @@ func (s *Source) scanItem(ctx context.Context, chunksChan chan *sources.Chunk, c
 	if item.UID != "" {
 		metadata.FullID = item.UID
 		metadata.Link = LINK_BASE_URL + FOLDER_TYPE + "/" + metadata.FullID
-		metadata.FolderID = item.UID
 	}
 	// recurse through the folders
 	for _, subItem := range item.Items {
+		metadata.FolderID = item.UID
 		s.scanItem(ctx, chunksChan, collection, metadata, subItem, item.UID)
 	}
 

--- a/pkg/sources/postman/postman_client.go
+++ b/pkg/sources/postman/postman_client.go
@@ -109,7 +109,7 @@ type Item struct {
 	Request     Request    `json:"request,omitempty"`
 	Response    []Response `json:"response,omitempty"`
 	Description string     `json:"description,omitempty"`
-	UID         string     `json:"uid,omitempty"` //Need to use this to get the collection via API
+	UID         string     `json:"uid,omitempty"` //Need to use this to get the collection via API. The UID is a concatenation of the ID and the user ID of whoever created the item.
 }
 
 type Auth struct {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
When Postman items (mainly requests) did not have a parent folder and were at the root of a collection, the folder id/name would be the same as the request id/name. This change helps to keep track of the parent folder through the recursive calls and gives the folder ID of the last folder that the call went through.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
