### PR TITLE
Export git.handleBinary and getSafeRemoteURL

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -661,7 +661,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 				Verify:         s.verify,
 			}
 
-			if err := s.handleBinary(ctx, gitDir, reporter, chunkSkel, commitHash, fileName); err != nil {
+			if err := s.handleBinary(ctx, gitDir, reporter, chunkSkel, commitHash, fileName, s.skipArchives); err != nil {
 				logger.Error(
 					err,
 					"error handling binary file",
@@ -889,7 +889,7 @@ func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string,
 				SourceMetadata: metadata,
 				Verify:         s.verify,
 			}
-			if err := s.handleBinary(ctx, gitDir, reporter, chunkSkel, commitHash, fileName); err != nil {
+			if err := s.handleBinary(ctx, gitDir, reporter, chunkSkel, commitHash, fileName, s.skipArchives); err != nil {
 				logger.Error(err, "error handling binary file")
 			}
 			continue
@@ -1236,6 +1236,7 @@ func (s *Git) handleBinary(
 	chunkSkel *sources.Chunk,
 	commitHash plumbing.Hash,
 	path string,
+	skipArchives bool,
 ) (err error) {
 	fileCtx := context.WithValues(ctx, "commit", commitHash.String()[:7], "path", path)
 	fileCtx.Logger().V(5).Info("handling binary file")
@@ -1304,7 +1305,7 @@ func (s *Git) handleBinary(
 		err = errors.Join(err, copyErr, waitErr)
 	}()
 
-	return handlers.HandleFile(catFileCtx, stdout, chunkSkel, reporter, handlers.WithSkipArchives(s.skipArchives))
+	return handlers.HandleFile(catFileCtx, stdout, chunkSkel, reporter, handlers.WithSkipArchives(skipArchives))
 }
 
 func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) error {

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -543,7 +543,7 @@ func getGitDir(path string, options *ScanOptions) string {
 
 func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string, scanOptions *ScanOptions, reporter sources.ChunkReporter) error {
 	// Get the remote URL for reporting (may be empty)
-	remoteURL := getSafeRemoteURL(repo, "origin")
+	remoteURL := GetSafeRemoteURL(repo, "origin")
 	var repoCtx context.Context
 
 	if ctx.Value("repo") == nil {
@@ -801,7 +801,7 @@ func (s *Git) gitChunk(ctx context.Context, diff *gitparse.Diff, fileName, email
 // ScanStaged chunks staged changes.
 func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string, scanOptions *ScanOptions, reporter sources.ChunkReporter) error {
 	// Get the URL metadata for reporting (may be empty).
-	urlMetadata := getSafeRemoteURL(repo, "origin")
+	urlMetadata := GetSafeRemoteURL(repo, "origin")
 
 	diffChan, err := s.parser.Staged(ctx, path)
 	if err != nil {
@@ -954,7 +954,7 @@ func (s *Git) ScanRepo(ctx context.Context, repo *git.Repository, repoPath strin
 		remotes, _ := repo.Remotes()
 		repoURL := "Could not get remote for repo"
 		if len(remotes) != 0 {
-			repoURL = getSafeRemoteURL(repo, remotes[0].Config().Name)
+			repoURL = GetSafeRemoteURL(repo, remotes[0].Config().Name)
 		}
 		logger = logger.WithValues("repo", repoURL)
 	}
@@ -1206,10 +1206,10 @@ func PrepareRepo(ctx context.Context, uriString string) (string, bool, error) {
 	return path, remote, nil
 }
 
-// getSafeRemoteURL is a helper function that will attempt to get a safe URL first
+// GetSafeRemoteURL is a helper function that will attempt to get a safe URL first
 // from the preferred remote name, falling back to the first remote name
 // available, or an empty string if there are no remotes.
-func getSafeRemoteURL(repo *git.Repository, preferred string) string {
+func GetSafeRemoteURL(repo *git.Repository, preferred string) string {
 	remote, err := repo.Remote(preferred)
 	if err != nil {
 		var remotes []*git.Remote

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -661,7 +661,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 				Verify:         s.verify,
 			}
 
-			if err := s.handleBinary(ctx, gitDir, reporter, chunkSkel, commitHash, fileName, s.skipArchives); err != nil {
+			if err := HandleBinary(ctx, gitDir, reporter, chunkSkel, commitHash, fileName, s.skipArchives); err != nil {
 				logger.Error(
 					err,
 					"error handling binary file",
@@ -889,7 +889,7 @@ func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string,
 				SourceMetadata: metadata,
 				Verify:         s.verify,
 			}
-			if err := s.handleBinary(ctx, gitDir, reporter, chunkSkel, commitHash, fileName, s.skipArchives); err != nil {
+			if err := HandleBinary(ctx, gitDir, reporter, chunkSkel, commitHash, fileName, s.skipArchives); err != nil {
 				logger.Error(err, "error handling binary file")
 			}
 			continue
@@ -1229,7 +1229,7 @@ func getSafeRemoteURL(repo *git.Repository, preferred string) string {
 	return safeURL
 }
 
-func (s *Git) handleBinary(
+func HandleBinary(
 	ctx context.Context,
 	gitDir string,
 	reporter sources.ChunkReporter,


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR exports some functionality from the git source so that it's usable in a (new, under development) git-flavored source that does not need to wrap an entire git source in order to operate.

One is `getSafeRemoteURL`. This is a straightforward change.

The other is `handleBinary`. Right now, all git binary file handling is invoked from `Git.ScanRepo`, which is itself invoked by our various git-flavored sources.

Since the actual binary file handling function `handleBinary` only used two pieces of information from the "git" source, I just removed its receiver. One of the pieces of information was a flag that caused the function to be skipped entirely; I moved this one to the (two) call sites. The other I just forwarded as an argument.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
