### PR TITLE
[chore] - re-activate plaidkey detector

### DIFF
--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -531,6 +531,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/pipedrive"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/pivotaltracker"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/pixabay"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/plaidkey"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/planetscale"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/planetscaledb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/planviewleankit"
@@ -1375,7 +1376,7 @@ func buildDetectorList() []detectors.Detector {
 		&pipedrive.Scanner{},
 		&pivotaltracker.Scanner{},
 		&pixabay.Scanner{},
-		// &plaidkey.Scanner{},
+		&plaidkey.Scanner{},
 		&planetscale.Scanner{},
 		&planetscaledb.Scanner{},
 		&planviewleankit.Scanner{},


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The `plaidkey` detector has been **commented out since the beginning of time**—even though it was first [fixed](https://github.com/trufflesecurity/trufflehog/pull/1917) during our Detector competition **two years ago** and then [updated recently](https://github.com/trufflesecurity/trufflehog/pull/3709) to improve results and add a uniqueness check.  

We just **never remembered to uncomment it**. 😅
### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
