### PR TITLE
Postman enumeration rate limiting

### DIFF
--- a/pkg/sources/postman/postman_client.go
+++ b/pkg/sources/postman/postman_client.go
@@ -202,7 +202,7 @@ func NewClient(postmanToken string) *Client {
 	c := &Client{
 		HTTPClient:  http.DefaultClient,
 		Headers:     bh,
-		RateLimiter: rate.NewLimiter(rate.Every(time.Second), 0), // default to 1 request per second since the current rate limit implementation deals with workspace endpoints only.
+		RateLimiter: rate.NewLimiter(rate.Every(time.Second), 1), // default to 1 request per second since the current rate limit implementation deals with workspace endpoints only.
 	}
 
 	return c

--- a/pkg/sources/postman/postman_client.go
+++ b/pkg/sources/postman/postman_client.go
@@ -202,7 +202,7 @@ func NewClient(postmanToken string) *Client {
 	c := &Client{
 		HTTPClient:  http.DefaultClient,
 		Headers:     bh,
-		RateLimiter: rate.NewLimiter(rate.Every(time.Second), 1), // default to 1 request per second since the current rate limit implementation deals with workspace endpoints only.
+		RateLimiter: rate.NewLimiter(rate.Every(time.Second), 0), // default to 1 request per second since the current rate limit implementation deals with workspace endpoints only.
 	}
 
 	return c

--- a/pkg/sources/postman/postman_test.go
+++ b/pkg/sources/postman/postman_test.go
@@ -238,3 +238,6 @@ func TestSource_ScanVariableData(t *testing.T) {
 		})
 	}
 }
+
+func TestSource_ScanEnumerateRateLimit(t *testing.T) {
+}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
According to the current Postman API [docs](https://www.postman.com/postman/postman-public-workspace/documentation/i2uqzpp/postman-api), the overall rate limit for the Postman API is:
<code> 300 requests per minute. Postman Monitors, as well as the GET /collections, GET /workspaces, and GET /workspaces/{id} endpoints have a rate limit of 10 calls in 10 seconds.
</code>
I added a rate limiter to the TruffleHog Postman client that by default limits the request rate to 1 request/sec to deal with the lower limit of workspace endpoints. The allowed burst limit is set to 1 because the Postman API does not have anything about bursts or throttling, so I am playing it safe with 1 allowed burst size. 
### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
