### PR TITLE
[bug] - Avoid panic in Snowflake detector

### DIFF
--- a/pkg/detectors/snowflake/snowflake.go
+++ b/pkg/detectors/snowflake/snowflake.go
@@ -107,8 +107,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					// Open a connection to Snowflake
 					db, err := sql.Open("snowflake", uri) // Needs the snowflake driver from gosnowflake
 					if err != nil {
-						// sql.Open() only errors if unable to import the snowflake driver, in which case we should panic.
-						panic(err)
+						return nil, err
 					}
 					defer db.Close()
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR replaces the **panic** with an **error return**, as `sql.Open` can fail if the provided arguments are invalid. Also no panic, panic bad.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
