### PR TITLE
Optionally exclude sources from binary

### DIFF
--- a/main.go
+++ b/main.go
@@ -294,7 +294,11 @@ func init() {
 	}
 
 	if isatty.IsTerminal(os.Stdout.Fd()) && (len(os.Args) <= 1 || os.Args[1] == analyzeCmd.FullCommand()) {
-		args := tui.Run(os.Args[1:])
+		args, err := tui.Run(os.Args[1:])
+		if err != nil {
+			fmt.Printf("failed to run TUI: %s", err.Error())
+			os.Exit(1)
+		}
 		if len(args) == 0 {
 			os.Exit(0)
 		}

--- a/pkg/analyzer/analyzers/airbrake/airbrake.go
+++ b/pkg/analyzer/analyzers/airbrake/airbrake.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package airbrake
 
 import (

--- a/pkg/analyzer/analyzers/airbrake/scopes.go
+++ b/pkg/analyzer/analyzers/airbrake/scopes.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package airbrake
 
 var scope_order = []string{

--- a/pkg/analyzer/analyzers/airtable/airtableoauth/airtable.go
+++ b/pkg/analyzer/analyzers/airtable/airtableoauth/airtable.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package airtableoauth
 
 import (

--- a/pkg/analyzer/analyzers/airtable/airtableoauth/airtable_test.go
+++ b/pkg/analyzer/analyzers/airtable/airtableoauth/airtable_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package airtableoauth
 
 import (

--- a/pkg/analyzer/analyzers/airtable/airtablepat/airtable.go
+++ b/pkg/analyzer/analyzers/airtable/airtablepat/airtable.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package airtablepat
 
 import (

--- a/pkg/analyzer/analyzers/airtable/airtablepat/airtable_test.go
+++ b/pkg/analyzer/analyzers/airtable/airtablepat/airtable_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package airtablepat
 
 import (

--- a/pkg/analyzer/analyzers/airtable/airtablepat/requests.go
+++ b/pkg/analyzer/analyzers/airtable/airtablepat/requests.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package airtablepat
 
 import (

--- a/pkg/analyzer/analyzers/airtable/common/endpoints.go
+++ b/pkg/analyzer/analyzers/airtable/common/endpoints.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package common
 
 import "net/http"

--- a/pkg/analyzer/analyzers/airtable/common/models.go
+++ b/pkg/analyzer/analyzers/airtable/common/models.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package common
 
 type AirtableUserInfo struct {

--- a/pkg/analyzer/analyzers/airtable/common/scopes.go
+++ b/pkg/analyzer/analyzers/airtable/common/scopes.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package common
 
 var scopeToPermissions = map[string][]string{

--- a/pkg/analyzer/analyzers/analyzers.go
+++ b/pkg/analyzer/analyzers/analyzers.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package analyzers
 
 import (

--- a/pkg/analyzer/analyzers/anthropic/anthropic_test.go
+++ b/pkg/analyzer/analyzers/anthropic/anthropic_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package anthropic
 
 import (

--- a/pkg/analyzer/analyzers/anthropic/requests.go
+++ b/pkg/analyzer/analyzers/anthropic/requests.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package anthropic
 
 import (

--- a/pkg/analyzer/analyzers/asana/asana_test.go
+++ b/pkg/analyzer/analyzers/asana/asana_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package asana
 
 import (

--- a/pkg/analyzer/analyzers/bitbucket/bitbucket_test.go
+++ b/pkg/analyzer/analyzers/bitbucket/bitbucket_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package bitbucket
 
 import (

--- a/pkg/analyzer/analyzers/bitbucket/scopes.go
+++ b/pkg/analyzer/analyzers/bitbucket/scopes.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package bitbucket
 
 var credential_type_map = map[string]string{

--- a/pkg/analyzer/analyzers/client.go
+++ b/pkg/analyzer/analyzers/client.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package analyzers
 
 import (

--- a/pkg/analyzer/analyzers/client_test.go
+++ b/pkg/analyzer/analyzers/client_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package analyzers
 
 import (

--- a/pkg/analyzer/analyzers/digitalocean/digitalocean_test.go
+++ b/pkg/analyzer/analyzers/digitalocean/digitalocean_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package digitalocean
 
 import (

--- a/pkg/analyzer/analyzers/dockerhub/dockerhub_test.go
+++ b/pkg/analyzer/analyzers/dockerhub/dockerhub_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package dockerhub
 
 import (

--- a/pkg/analyzer/analyzers/dockerhub/helper.go
+++ b/pkg/analyzer/analyzers/dockerhub/helper.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package dockerhub
 
 import (

--- a/pkg/analyzer/analyzers/dockerhub/requests.go
+++ b/pkg/analyzer/analyzers/dockerhub/requests.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package dockerhub
 
 import (

--- a/pkg/analyzer/analyzers/elevenlabs/elevenlabs.go
+++ b/pkg/analyzer/analyzers/elevenlabs/elevenlabs.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package elevenlabs
 
 import (

--- a/pkg/analyzer/analyzers/elevenlabs/elevenlabs_test.go
+++ b/pkg/analyzer/analyzers/elevenlabs/elevenlabs_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package elevenlabs
 
 import (

--- a/pkg/analyzer/analyzers/elevenlabs/requests.go
+++ b/pkg/analyzer/analyzers/elevenlabs/requests.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package elevenlabs
 
 import (

--- a/pkg/analyzer/analyzers/github/common/github.go
+++ b/pkg/analyzer/analyzers/github/common/github.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package common
 
 import (

--- a/pkg/analyzer/analyzers/github/finegrained/finegrained_test.go
+++ b/pkg/analyzer/analyzers/github/finegrained/finegrained_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package finegrained
 
 import (

--- a/pkg/analyzer/analyzers/github/github.go
+++ b/pkg/analyzer/analyzers/github/github.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package github
 
 import (

--- a/pkg/analyzer/analyzers/github/github_test.go
+++ b/pkg/analyzer/analyzers/github/github_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package github
 
 import (

--- a/pkg/analyzer/analyzers/gitlab/gitlab_test.go
+++ b/pkg/analyzer/analyzers/gitlab/gitlab_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package gitlab
 
 import (

--- a/pkg/analyzer/analyzers/gitlab/scopes.go
+++ b/pkg/analyzer/analyzers/gitlab/scopes.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package gitlab
 
 var gitlab_scopes = map[string]string{

--- a/pkg/analyzer/analyzers/groq/groq_test.go
+++ b/pkg/analyzer/analyzers/groq/groq_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package groq
 
 import (

--- a/pkg/analyzer/analyzers/groq/requests.go
+++ b/pkg/analyzer/analyzers/groq/requests.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package groq
 
 import (

--- a/pkg/analyzer/analyzers/huggingface/huggingface_test.go
+++ b/pkg/analyzer/analyzers/huggingface/huggingface_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package huggingface
 
 import (

--- a/pkg/analyzer/analyzers/huggingface/scopes.go
+++ b/pkg/analyzer/analyzers/huggingface/scopes.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package huggingface
 
 //nolint:unused

--- a/pkg/analyzer/analyzers/launchdarkly/launchdarkly_test.go
+++ b/pkg/analyzer/analyzers/launchdarkly/launchdarkly_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package launchdarkly
 
 import (

--- a/pkg/analyzer/analyzers/launchdarkly/models.go
+++ b/pkg/analyzer/analyzers/launchdarkly/models.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package launchdarkly
 
 import "sync"

--- a/pkg/analyzer/analyzers/launchdarkly/requests.go
+++ b/pkg/analyzer/analyzers/launchdarkly/requests.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package launchdarkly
 
 import (

--- a/pkg/analyzer/analyzers/mailchimp/mailchimp_test.go
+++ b/pkg/analyzer/analyzers/mailchimp/mailchimp_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package mailchimp
 
 import (

--- a/pkg/analyzer/analyzers/mailgun/mailgun_test.go
+++ b/pkg/analyzer/analyzers/mailgun/mailgun_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package mailgun
 
 import (

--- a/pkg/analyzer/analyzers/mailgun/requests.go
+++ b/pkg/analyzer/analyzers/mailgun/requests.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package mailgun
 
 import (

--- a/pkg/analyzer/analyzers/mysql/mysql_test.go
+++ b/pkg/analyzer/analyzers/mysql/mysql_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package mysql
 
 import (

--- a/pkg/analyzer/analyzers/mysql/scopes.go
+++ b/pkg/analyzer/analyzers/mysql/scopes.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package mysql
 
 type PrivTypes struct {

--- a/pkg/analyzer/analyzers/notion/notion_test.go
+++ b/pkg/analyzer/analyzers/notion/notion_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package notion
 
 import (

--- a/pkg/analyzer/analyzers/openai/openai_test.go
+++ b/pkg/analyzer/analyzers/openai/openai_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package openai
 
 import (

--- a/pkg/analyzer/analyzers/openai/scopes.go
+++ b/pkg/analyzer/analyzers/openai/scopes.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package openai
 
 import (

--- a/pkg/analyzer/analyzers/opsgenie/opsgenie_test.go
+++ b/pkg/analyzer/analyzers/opsgenie/opsgenie_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package opsgenie
 
 import (

--- a/pkg/analyzer/analyzers/planetscale/planetscale_test.go
+++ b/pkg/analyzer/analyzers/planetscale/planetscale_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package planetscale
 
 import (

--- a/pkg/analyzer/analyzers/postgres/postgres_test.go
+++ b/pkg/analyzer/analyzers/postgres/postgres_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package postgres
 
 import (

--- a/pkg/analyzer/analyzers/postman/postman_test.go
+++ b/pkg/analyzer/analyzers/postman/postman_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package postman
 
 import (

--- a/pkg/analyzer/analyzers/postman/scopes.go
+++ b/pkg/analyzer/analyzers/postman/scopes.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package postman
 
 var roleDescriptions = map[string]string{

--- a/pkg/analyzer/analyzers/privatekey/privatekey_test.go
+++ b/pkg/analyzer/analyzers/privatekey/privatekey_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package privatekey
 
 import (

--- a/pkg/analyzer/analyzers/sendgrid/scopes.go
+++ b/pkg/analyzer/analyzers/sendgrid/scopes.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package sendgrid
 
 import (

--- a/pkg/analyzer/analyzers/sendgrid/sendgrid_test.go
+++ b/pkg/analyzer/analyzers/sendgrid/sendgrid_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package sendgrid
 
 import (

--- a/pkg/analyzer/analyzers/shopify/shopify_test.go
+++ b/pkg/analyzer/analyzers/shopify/shopify_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package shopify
 
 import (

--- a/pkg/analyzer/analyzers/slack/scopes.go
+++ b/pkg/analyzer/analyzers/slack/scopes.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package slack
 
 // SCOPES := []string{string} {

--- a/pkg/analyzer/analyzers/slack/slack_test.go
+++ b/pkg/analyzer/analyzers/slack/slack_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package slack
 
 import (

--- a/pkg/analyzer/analyzers/sourcegraph/sourcegraph_test.go
+++ b/pkg/analyzer/analyzers/sourcegraph/sourcegraph_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package sourcegraph
 
 import (

--- a/pkg/analyzer/analyzers/square/scopes.go
+++ b/pkg/analyzer/analyzers/square/scopes.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package square
 
 var permissions_slice = []map[string]map[string][]string{

--- a/pkg/analyzer/analyzers/square/square_test.go
+++ b/pkg/analyzer/analyzers/square/square_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package square
 
 import (

--- a/pkg/analyzer/analyzers/stripe/stripe_test.go
+++ b/pkg/analyzer/analyzers/stripe/stripe_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package stripe
 
 import (

--- a/pkg/analyzer/analyzers/twilio/twilio_test.go
+++ b/pkg/analyzer/analyzers/twilio/twilio_test.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package twilio
 
 import (

--- a/pkg/analyzer/cli.go
+++ b/pkg/analyzer/cli.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package analyzer
 
 import (

--- a/pkg/analyzer/cli_disabled.go
+++ b/pkg/analyzer/cli_disabled.go
@@ -1,0 +1,11 @@
+//go:build no_tui
+
+package analyzer
+
+import (
+	"github.com/alecthomas/kingpin/v2"
+)
+
+func Command(app *kingpin.Application) *kingpin.CmdClause {
+	return nil
+}

--- a/pkg/analyzer/config/config.go
+++ b/pkg/analyzer/config/config.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package config
 
 // TODO: separate CLI configuration from analysis configuration.

--- a/pkg/analyzer/generate_permissions/generate_permissions.go
+++ b/pkg/analyzer/generate_permissions/generate_permissions.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package main
 
 import (

--- a/pkg/engine/circleci/circleci.go
+++ b/pkg/engine/circleci/circleci.go
@@ -1,4 +1,6 @@
-package engine
+//go:build !no_circleci
+
+package circleci
 
 import (
 	"runtime"
@@ -7,13 +9,14 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/circleci"
 )
 
-// ScanCircleCI scans CircleCI logs.
-func (e *Engine) ScanCircleCI(ctx context.Context, token string) (sources.JobProgressRef, error) {
+// Scan scans CircleCI logs.
+func Scan(ctx context.Context, token string, e *engine.Engine) (sources.JobProgressRef, error) {
 	connection := &sourcespb.CircleCI{
 		Credential: &sourcespb.CircleCI_Token{
 			Token: token,
@@ -28,11 +31,11 @@ func (e *Engine) ScanCircleCI(ctx context.Context, token string) (sources.JobPro
 	}
 
 	sourceName := "trufflehog - Circle CI"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, circleci.SourceType)
+	sourceID, jobID, _ := e.SourceManager().GetIDs(ctx, sourceName, circleci.SourceType)
 
 	circleSource := &circleci.Source{}
 	if err := circleSource.Init(ctx, "trufflehog - Circle CI", jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return sources.JobProgressRef{}, err
 	}
-	return e.sourceManager.EnumerateAndScan(ctx, sourceName, circleSource)
+	return e.SourceManager().EnumerateAndScan(ctx, sourceName, circleSource)
 }

--- a/pkg/engine/circleci/circleci_disabled.go
+++ b/pkg/engine/circleci/circleci_disabled.go
@@ -1,0 +1,13 @@
+//go:build no_circleci
+
+package circleci
+
+import (
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ string, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/engine/docker/docker.go
+++ b/pkg/engine/docker/docker.go
@@ -1,4 +1,6 @@
-package engine
+//go:build !no_docker
+
+package docker
 
 import (
 	"runtime"
@@ -7,13 +9,14 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/docker"
 )
 
-// ScanDocker scans a given docker connection.
-func (e *Engine) ScanDocker(ctx context.Context, c sources.DockerConfig) (sources.JobProgressRef, error) {
+// Scan scans a given docker connection.
+func Scan(ctx context.Context, c sources.DockerConfig, e *engine.Engine) (sources.JobProgressRef, error) {
 	connection := &sourcespb.Docker{Images: c.Images}
 
 	switch {
@@ -33,11 +36,11 @@ func (e *Engine) ScanDocker(ctx context.Context, c sources.DockerConfig) (source
 	}
 
 	sourceName := "trufflehog - docker"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, docker.SourceType)
+	sourceID, jobID, _ := e.SourceManager().GetIDs(ctx, sourceName, docker.SourceType)
 
 	dockerSource := &docker.Source{}
 	if err := dockerSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return sources.JobProgressRef{}, err
 	}
-	return e.sourceManager.EnumerateAndScan(ctx, sourceName, dockerSource)
+	return e.SourceManager().EnumerateAndScan(ctx, sourceName, dockerSource)
 }

--- a/pkg/engine/docker/docker_disabled.go
+++ b/pkg/engine/docker/docker_disabled.go
@@ -1,0 +1,13 @@
+//go:build no_docker
+
+package docker
+
+import (
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ sources.DockerConfig, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/engine/elasticsearch/elasticsearch.go
+++ b/pkg/engine/elasticsearch/elasticsearch.go
@@ -1,4 +1,6 @@
-package engine
+//go:build !no_elasticsearch
+
+package elasticsearch
 
 import (
 	"runtime"
@@ -7,13 +9,14 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/elasticsearch"
 )
 
-// ScanElasticsearch scans a Elasticsearch installation.
-func (e *Engine) ScanElasticsearch(ctx context.Context, c sources.ElasticsearchConfig) (sources.JobProgressRef, error) {
+// Scan scans a Elasticsearch installation.
+func Scan(ctx context.Context, c sources.ElasticsearchConfig, e *engine.Engine) (sources.JobProgressRef, error) {
 	connection := &sourcespb.Elasticsearch{
 		Nodes:          c.Nodes,
 		Username:       c.Username,
@@ -35,11 +38,11 @@ func (e *Engine) ScanElasticsearch(ctx context.Context, c sources.ElasticsearchC
 	}
 
 	sourceName := "trufflehog - Elasticsearch"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, elasticsearch.SourceType)
+	sourceID, jobID, _ := e.SourceManager().GetIDs(ctx, sourceName, elasticsearch.SourceType)
 
 	elasticsearchSource := &elasticsearch.Source{}
 	if err := elasticsearchSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return sources.JobProgressRef{}, err
 	}
-	return e.sourceManager.EnumerateAndScan(ctx, sourceName, elasticsearchSource)
+	return e.SourceManager().EnumerateAndScan(ctx, sourceName, elasticsearchSource)
 }

--- a/pkg/engine/elasticsearch/elasticsearch_disabled.go
+++ b/pkg/engine/elasticsearch/elasticsearch_disabled.go
@@ -1,0 +1,14 @@
+//go:build no_elasticsearch
+
+package elasticsearch
+
+import (
+	"context"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ sources.ElasticsearchConfig, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -36,9 +36,12 @@ import (
 
 var detectionTimeout = detectors.DefaultResponseTimeout
 
-var errOverlap = errors.New(
-	"More than one detector has found this result. For your safety, verification has been disabled." +
-		"You can override this behavior by using the --allow-verification-overlap flag.",
+var (
+	ErrSourceDisabled = errors.New("trufflehog was compiled without this source")
+	errOverlap        = errors.New(
+		"More than one detector has found this result. For your safety, verification has been disabled." +
+			"You can override this behavior by using the --allow-verification-overlap flag.",
+	)
 )
 
 // Metrics for the scan engine for external consumption.
@@ -220,6 +223,10 @@ type Engine struct {
 	notificationWorkerMultiplier int
 	// verificationOverlapWorkerMultiplier is used to calculate the number of verification overlap workers.
 	verificationOverlapWorkerMultiplier int
+}
+
+func (e *Engine) SourceManager() *sources.SourceManager {
+	return e.sourceManager
 }
 
 // NewEngine creates a new Engine instance with the provided configuration.

--- a/pkg/engine/filesystem/filesystem.go
+++ b/pkg/engine/filesystem/filesystem.go
@@ -1,4 +1,6 @@
-package engine
+//go:build !no_filesystem
+
+package filesystem
 
 import (
 	"runtime"
@@ -7,13 +9,14 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/filesystem"
 )
 
-// ScanFileSystem scans a given file system.
-func (e *Engine) ScanFileSystem(ctx context.Context, c sources.FilesystemConfig) (sources.JobProgressRef, error) {
+// Scan scans a given file system.
+func Scan(ctx context.Context, c sources.FilesystemConfig, e *engine.Engine) (sources.JobProgressRef, error) {
 	connection := &sourcespb.Filesystem{
 		Paths:            c.Paths,
 		IncludePathsFile: c.IncludePathsFile,
@@ -27,11 +30,11 @@ func (e *Engine) ScanFileSystem(ctx context.Context, c sources.FilesystemConfig)
 	}
 
 	sourceName := "trufflehog - filesystem"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, filesystem.SourceType)
+	sourceID, jobID, _ := e.SourceManager().GetIDs(ctx, sourceName, filesystem.SourceType)
 
 	fileSystemSource := &filesystem.Source{}
 	if err := fileSystemSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return sources.JobProgressRef{}, err
 	}
-	return e.sourceManager.EnumerateAndScan(ctx, sourceName, fileSystemSource)
+	return e.SourceManager().EnumerateAndScan(ctx, sourceName, fileSystemSource)
 }

--- a/pkg/engine/filesystem/filesystem_disabled.go
+++ b/pkg/engine/filesystem/filesystem_disabled.go
@@ -1,0 +1,13 @@
+//go:build no_filesystem
+
+package filesystem
+
+import (
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ sources.FilesystemConfig, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/engine/filesystem/filesystem_integration_test.go
+++ b/pkg/engine/filesystem/filesystem_integration_test.go
@@ -1,7 +1,6 @@
-//go:build integration
-// +build integration
+//go:build !no_filesystem && integration
 
-package engine
+package filesystem
 
 import (
 	"os"
@@ -9,7 +8,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/defaults"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
@@ -61,17 +63,17 @@ func TestFilesystem(t *testing.T) {
 
 	// Run the scan.
 	ctx := context.Background()
-	e, err := NewEngine(ctx, &Config{
-		Detectors:     DefaultDetectors(),
+	e, err := engine.NewEngine(ctx, &engine.Config{
+		Detectors:     defaults.DefaultDetectors(),
 		SourceManager: sources.NewManager(),
 		Verify:        false,
 	})
 	assert.NoError(t, err)
 	e.Start(ctx)
-	_, err = e.ScanFileSystem(ctx, sources.FilesystemConfig{
+	_, err = Scan(ctx, sources.FilesystemConfig{
 		Paths:            []string{rootDir},
 		ExcludePathsFile: filepath.Join(configDir, "exclude"),
-	})
+	}, e)
 	assert.NoError(t, err)
 
 	err = e.Finish(ctx)

--- a/pkg/engine/gcs/gcs_disabled.go
+++ b/pkg/engine/gcs/gcs_disabled.go
@@ -1,0 +1,13 @@
+//go:build no_gcs
+
+package gcs
+
+import (
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ sources.GCSConfig, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/engine/git/git.go
+++ b/pkg/engine/git/git.go
@@ -1,4 +1,6 @@
-package engine
+//go:build !no_git
+
+package git
 
 import (
 	"runtime"
@@ -7,13 +9,14 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/git"
 )
 
-// ScanGit scans any git source.
-func (e *Engine) ScanGit(ctx context.Context, c sources.GitConfig) (sources.JobProgressRef, error) {
+// Scan scans any git source.
+func Scan(ctx context.Context, c sources.GitConfig, e *engine.Engine) (sources.JobProgressRef, error) {
 	connection := &sourcespb.Git{
 		Head:             c.HeadRef,
 		Base:             c.BaseRef,
@@ -32,12 +35,12 @@ func (e *Engine) ScanGit(ctx context.Context, c sources.GitConfig) (sources.JobP
 	}
 
 	sourceName := "trufflehog - git"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, git.SourceType)
+	sourceID, jobID, _ := e.SourceManager().GetIDs(ctx, sourceName, git.SourceType)
 
 	gitSource := &git.Source{}
 	if err := gitSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return sources.JobProgressRef{}, err
 	}
 
-	return e.sourceManager.EnumerateAndScan(ctx, sourceName, gitSource)
+	return e.SourceManager().EnumerateAndScan(ctx, sourceName, gitSource)
 }

--- a/pkg/engine/git/git_disabled.go
+++ b/pkg/engine/git/git_disabled.go
@@ -1,0 +1,13 @@
+//go:build no_git
+
+package git
+
+import (
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ sources.GitConfig, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/engine/github/github.go
+++ b/pkg/engine/github/github.go
@@ -1,4 +1,6 @@
-package engine
+//go:build !no_github && !no_git
+
+package github
 
 import (
 	gogit "github.com/go-git/go-git/v5"
@@ -6,14 +8,15 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/git"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/github"
 )
 
-// ScanGitHub scans GitHub with the provided options.
-func (e *Engine) ScanGitHub(ctx context.Context, c sources.GithubConfig) (sources.JobProgressRef, error) {
+// Scan scans GitHub with the provided options.
+func Scan(ctx context.Context, c sources.GithubConfig, e *engine.Engine) (sources.JobProgressRef, error) {
 	connection := sourcespb.GitHub{
 		Endpoint:                   c.Endpoint,
 		Organizations:              c.Orgs,
@@ -52,12 +55,12 @@ func (e *Engine) ScanGitHub(ctx context.Context, c sources.GithubConfig) (source
 	scanOptions := git.NewScanOptions(opts...)
 
 	sourceName := "trufflehog - github"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, github.SourceType)
+	sourceID, jobID, _ := e.SourceManager().GetIDs(ctx, sourceName, github.SourceType)
 
 	githubSource := &github.Source{}
 	if err := githubSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, c.Concurrency); err != nil {
 		return sources.JobProgressRef{}, err
 	}
 	githubSource.WithScanOptions(scanOptions)
-	return e.sourceManager.EnumerateAndScan(ctx, sourceName, githubSource)
+	return e.SourceManager().EnumerateAndScan(ctx, sourceName, githubSource)
 }

--- a/pkg/engine/github/github_disabled.go
+++ b/pkg/engine/github/github_disabled.go
@@ -1,0 +1,17 @@
+//go:build no_github || no_git
+
+package github
+
+import (
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ sources.GithubConfig, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}
+
+func ScanExperimental(_ context.Context, _ sources.GitHubExperimentalConfig, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/engine/github/github_experimental.go
+++ b/pkg/engine/github/github_experimental.go
@@ -1,4 +1,6 @@
-package engine
+//go:build !no_github && !no_git
+
+package github
 
 import (
 	"fmt"
@@ -9,6 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/git"
@@ -16,8 +19,8 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/github_experimental"
 )
 
-// ScanGitHubExperimental scans GitHub using an experimental feature. Consider all functionality to be in an alpha release here.
-func (e *Engine) ScanGitHubExperimental(ctx context.Context, c sources.GitHubExperimentalConfig) (sources.JobProgressRef, error) {
+// ScanExperimental scans GitHub using an experimental feature. Consider all functionality to be in an alpha release here.
+func ScanExperimental(ctx context.Context, c sources.GitHubExperimentalConfig, e *engine.Engine) (sources.JobProgressRef, error) {
 	connection := sourcespb.GitHubExperimental{
 		Repository:         c.Repository,
 		ObjectDiscovery:    c.ObjectDiscovery,
@@ -53,12 +56,12 @@ func (e *Engine) ScanGitHubExperimental(ctx context.Context, c sources.GitHubExp
 	scanOptions := git.NewScanOptions(opts...)
 
 	sourceName := "trufflehog - github experimental (alpha release)"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, github.SourceType)
+	sourceID, jobID, _ := e.SourceManager().GetIDs(ctx, sourceName, github.SourceType)
 
 	githubExperimentalSource := &github_experimental.Source{}
 	if err := githubExperimentalSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return sources.JobProgressRef{}, err
 	}
 	githubExperimentalSource.WithScanOptions(scanOptions)
-	return e.sourceManager.EnumerateAndScan(ctx, sourceName, githubExperimentalSource)
+	return e.SourceManager().EnumerateAndScan(ctx, sourceName, githubExperimentalSource)
 }

--- a/pkg/engine/gitlab/gitlab.go
+++ b/pkg/engine/gitlab/gitlab.go
@@ -1,4 +1,6 @@
-package engine
+//go:build !no_gitlab && !no_git
+
+package gitlab
 
 import (
 	"fmt"
@@ -9,14 +11,15 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/git"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/gitlab"
 )
 
-// ScanGitLab scans GitLab with the provided configuration.
-func (e *Engine) ScanGitLab(ctx context.Context, c sources.GitlabConfig) (sources.JobProgressRef, error) {
+// Scan scans GitLab with the provided configuration.
+func Scan(ctx context.Context, c sources.GitlabConfig, e *engine.Engine) (sources.JobProgressRef, error) {
 	logOptions := &gogit.LogOptions{}
 	opts := []git.ScanOption{
 		git.ScanOptionFilter(c.Filter),
@@ -59,12 +62,12 @@ func (e *Engine) ScanGitLab(ctx context.Context, c sources.GitlabConfig) (source
 	}
 
 	sourceName := "trufflehog - gitlab"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, gitlab.SourceType)
+	sourceID, jobID, _ := e.SourceManager().GetIDs(ctx, sourceName, gitlab.SourceType)
 
 	gitlabSource := &gitlab.Source{}
 	if err := gitlabSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return sources.JobProgressRef{}, err
 	}
 	gitlabSource.WithScanOptions(scanOptions)
-	return e.sourceManager.EnumerateAndScan(ctx, sourceName, gitlabSource)
+	return e.SourceManager().EnumerateAndScan(ctx, sourceName, gitlabSource)
 }

--- a/pkg/engine/gitlab/gitlab_disabled.go
+++ b/pkg/engine/gitlab/gitlab_disabled.go
@@ -1,0 +1,13 @@
+//go:build no_gitlab || no_git
+
+package gitlab
+
+import (
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ sources.GitlabConfig, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/engine/gitlab/gitlab_integration_test.go
+++ b/pkg/engine/gitlab/gitlab_integration_test.go
@@ -1,23 +1,25 @@
-//go:build integration
-// +build integration
+//go:build (!no_gitlab || !no_git) && integration
 
-package engine
+package gitlab
 
 import (
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/defaults"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
 func TestGitLab(t *testing.T) {
 	// Run the scan.
 	ctx := context.Background()
-	e, err := NewEngine(ctx, &Config{
-		Detectors:     DefaultDetectors(),
+	e, err := engine.NewEngine(ctx, &engine.Config{
+		Detectors:     defaults.DefaultDetectors(),
 		SourceManager: sources.NewManager(),
 		Verify:        false,
 	})
@@ -28,9 +30,9 @@ func TestGitLab(t *testing.T) {
 	if err != nil {
 		t.Fatal(fmt.Errorf("failed to access secret: %v", err))
 	}
-	_, err = e.ScanGitLab(ctx, sources.GitlabConfig{
+	_, err = Scan(ctx, sources.GitlabConfig{
 		Token: secret.MustGetField("GITLAB_TOKEN"),
-	})
+	}, e)
 	assert.NoError(t, err)
 
 	err = e.Finish(ctx)

--- a/pkg/engine/huggingface/huggingface.go
+++ b/pkg/engine/huggingface/huggingface.go
@@ -1,40 +1,20 @@
-package engine
+//go:build !no_huggingface && !no_git
+
+package huggingface
 
 import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/huggingface"
 )
 
-// HuggingFaceConfig represents the configuration for HuggingFace.
-type HuggingfaceConfig struct {
-	Endpoint           string
-	Models             []string
-	Spaces             []string
-	Datasets           []string
-	Organizations      []string
-	Users              []string
-	IncludeModels      []string
-	IgnoreModels       []string
-	IncludeSpaces      []string
-	IgnoreSpaces       []string
-	IncludeDatasets    []string
-	IgnoreDatasets     []string
-	SkipAllModels      bool
-	SkipAllSpaces      bool
-	SkipAllDatasets    bool
-	IncludeDiscussions bool
-	IncludePrs         bool
-	Token              string
-	Concurrency        int
-}
-
-// ScanGitHub scans HuggingFace with the provided options.
-func (e *Engine) ScanHuggingface(ctx context.Context, c HuggingfaceConfig) (sources.JobProgressRef, error) {
+// Scan scans HuggingFace with the provided options.
+func Scan(ctx context.Context, c sources.HuggingfaceConfig, e *engine.Engine) (sources.JobProgressRef, error) {
 	connection := sourcespb.Huggingface{
 		Endpoint:           c.Endpoint,
 		Models:             c.Models,
@@ -70,11 +50,11 @@ func (e *Engine) ScanHuggingface(ctx context.Context, c HuggingfaceConfig) (sour
 	}
 
 	sourceName := "trufflehog - huggingface"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, sourcespb.SourceType_SOURCE_TYPE_HUGGINGFACE)
+	sourceID, jobID, _ := e.SourceManager().GetIDs(ctx, sourceName, sourcespb.SourceType_SOURCE_TYPE_HUGGINGFACE)
 
 	huggingfaceSource := &huggingface.Source{}
 	if err := huggingfaceSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, c.Concurrency); err != nil {
 		return sources.JobProgressRef{}, err
 	}
-	return e.sourceManager.EnumerateAndScan(ctx, sourceName, huggingfaceSource)
+	return e.SourceManager().EnumerateAndScan(ctx, sourceName, huggingfaceSource)
 }

--- a/pkg/engine/huggingface/huggingface_disabled.go
+++ b/pkg/engine/huggingface/huggingface_disabled.go
@@ -1,0 +1,13 @@
+//go:build no_huggingface || no_git
+
+package huggingface
+
+import (
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ sources.HuggingfaceConfig, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/engine/jenkins/jenkins_disabled.go
+++ b/pkg/engine/jenkins/jenkins_disabled.go
@@ -1,0 +1,13 @@
+//go:build no_jenkins
+
+package jenkins
+
+import (
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ sources.JenkinsConfig, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/engine/postman/postman.go
+++ b/pkg/engine/postman/postman.go
@@ -1,4 +1,6 @@
-package engine
+//go:build !no_postman
+
+package postman
 
 import (
 	"errors"
@@ -7,13 +9,14 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/postman"
 )
 
-// ScanPostman scans Postman with the provided options.
-func (e *Engine) ScanPostman(ctx context.Context, c sources.PostmanConfig) (sources.JobProgressRef, error) {
+// Scan scans Postman with the provided options.
+func Scan(ctx context.Context, c sources.PostmanConfig, e *engine.Engine) (sources.JobProgressRef, error) {
 	connection := sourcespb.Postman{
 		Workspaces:          c.Workspaces,
 		Collections:         c.Collections,
@@ -53,7 +56,7 @@ func (e *Engine) ScanPostman(ctx context.Context, c sources.PostmanConfig) (sour
 	}
 
 	sourceName := "trufflehog - postman"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, postman.SourceType)
+	sourceID, jobID, _ := e.SourceManager().GetIDs(ctx, sourceName, postman.SourceType)
 
 	postmanSource := &postman.Source{
 		DetectorKeywords: keywords,
@@ -61,5 +64,5 @@ func (e *Engine) ScanPostman(ctx context.Context, c sources.PostmanConfig) (sour
 	if err := postmanSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, c.Concurrency); err != nil {
 		return sources.JobProgressRef{}, err
 	}
-	return e.sourceManager.EnumerateAndScan(ctx, sourceName, postmanSource)
+	return e.SourceManager().EnumerateAndScan(ctx, sourceName, postmanSource)
 }

--- a/pkg/engine/postman/postman_disabled.go
+++ b/pkg/engine/postman/postman_disabled.go
@@ -1,0 +1,14 @@
+//go:build no_postman
+
+package postman
+
+import (
+	"context"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ sources.PostmanConfig, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/engine/s3/s3.go
+++ b/pkg/engine/s3/s3.go
@@ -1,4 +1,6 @@
-package engine
+//go:build !no_s3
+
+package s3
 
 import (
 	"fmt"
@@ -8,14 +10,15 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/credentialspb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/s3"
 )
 
-// ScanS3 scans S3 buckets.
-func (e *Engine) ScanS3(ctx context.Context, c sources.S3Config) (sources.JobProgressRef, error) {
+// Scan scans S3 buckets.
+func Scan(ctx context.Context, c sources.S3Config, e *engine.Engine) (sources.JobProgressRef, error) {
 	connection := &sourcespb.S3{
 		Credential: &sourcespb.S3_Unauthenticated{},
 	}
@@ -62,11 +65,11 @@ func (e *Engine) ScanS3(ctx context.Context, c sources.S3Config) (sources.JobPro
 	}
 
 	sourceName := "trufflehog - s3"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, s3.SourceType)
+	sourceID, jobID, _ := e.SourceManager().GetIDs(ctx, sourceName, s3.SourceType)
 
 	s3Source := &s3.Source{}
 	if err := s3Source.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return sources.JobProgressRef{}, err
 	}
-	return e.sourceManager.EnumerateAndScan(ctx, sourceName, s3Source)
+	return e.SourceManager().EnumerateAndScan(ctx, sourceName, s3Source)
 }

--- a/pkg/engine/s3/s3_disabled.go
+++ b/pkg/engine/s3/s3_disabled.go
@@ -1,0 +1,13 @@
+//go:build no_s3
+
+package s3
+
+import (
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ sources.S3Config, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/engine/syslog/syslog_disabled.go
+++ b/pkg/engine/syslog/syslog_disabled.go
@@ -1,0 +1,13 @@
+//go:build no_syslog
+
+package syslog
+
+import (
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ sources.SyslogConfig, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/engine/travisci/travisci.go
+++ b/pkg/engine/travisci/travisci.go
@@ -1,4 +1,6 @@
-package engine
+//go:build !no_travisci
+
+package travisci
 
 import (
 	"runtime"
@@ -7,13 +9,14 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/travisci"
 )
 
-// ScanTravisCI scans TravisCI logs.
-func (e *Engine) ScanTravisCI(ctx context.Context, token string) (sources.JobProgressRef, error) {
+// Scan scans TravisCI logs.
+func Scan(ctx context.Context, token string, e *engine.Engine) (sources.JobProgressRef, error) {
 	connection := &sourcespb.TravisCI{
 		Credential: &sourcespb.TravisCI_Token{
 			Token: token,
@@ -28,11 +31,11 @@ func (e *Engine) ScanTravisCI(ctx context.Context, token string) (sources.JobPro
 	}
 
 	sourceName := "trufflehog - Travis CI"
-	sourceID, jobID, _ := e.sourceManager.GetIDs(ctx, sourceName, travisci.SourceType)
+	sourceID, jobID, _ := e.SourceManager().GetIDs(ctx, sourceName, travisci.SourceType)
 
 	travisSource := &travisci.Source{}
 	if err := travisSource.Init(ctx, sourceName, jobID, sourceID, true, &conn, runtime.NumCPU()); err != nil {
 		return sources.JobProgressRef{}, err
 	}
-	return e.sourceManager.EnumerateAndScan(ctx, sourceName, travisSource)
+	return e.SourceManager().EnumerateAndScan(ctx, sourceName, travisSource)
 }

--- a/pkg/engine/travisci/travisci_disabled.go
+++ b/pkg/engine/travisci/travisci_disabled.go
@@ -1,0 +1,13 @@
+//go:build no_travisci
+
+package travisci
+
+import (
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+)
+
+func Scan(_ context.Context, _ string, _ *engine.Engine) (sources.JobProgressRef, error) {
+	return sources.JobProgressRef{}, engine.ErrSourceDisabled
+}

--- a/pkg/sources/circleci/circleci.go
+++ b/pkg/sources/circleci/circleci.go
@@ -1,3 +1,5 @@
+//go:build !no_circleci
+
 package circleci
 
 import (
@@ -8,13 +10,13 @@ import (
 	"sync/atomic"
 
 	"github.com/go-errors/errors"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"

--- a/pkg/sources/circleci/circleci_test.go
+++ b/pkg/sources/circleci/circleci_test.go
@@ -1,3 +1,5 @@
+//go:build !no_circleci
+
 package circleci
 
 import (

--- a/pkg/sources/docker/docker.go
+++ b/pkg/sources/docker/docker.go
@@ -1,3 +1,5 @@
+//go:build !no_docker
+
 package docker
 
 import (

--- a/pkg/sources/docker/docker_test.go
+++ b/pkg/sources/docker/docker_test.go
@@ -1,3 +1,5 @@
+//go:build !no_docker
+
 package docker
 
 import (

--- a/pkg/sources/docker/metrics.go
+++ b/pkg/sources/docker/metrics.go
@@ -1,3 +1,5 @@
+//go:build !no_docker
+
 package docker
 
 import (

--- a/pkg/sources/elasticsearch/api.go
+++ b/pkg/sources/elasticsearch/api.go
@@ -1,3 +1,5 @@
+//go:build !no_elasticsearch
+
 package elasticsearch
 
 import (

--- a/pkg/sources/elasticsearch/elasticsearch.go
+++ b/pkg/sources/elasticsearch/elasticsearch.go
@@ -1,3 +1,5 @@
+//go:build !no_elasticsearch
+
 package elasticsearch
 
 import (
@@ -7,6 +9,10 @@ import (
 	es "github.com/elastic/go-elasticsearch/v8"
 	"github.com/go-errors/errors"
 	"github.com/go-logr/logr"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
@@ -14,9 +20,6 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sanitizer"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
-	"golang.org/x/sync/errgroup"
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 )
 
 const SourceType = sourcespb.SourceType_SOURCE_TYPE_ELASTICSEARCH

--- a/pkg/sources/elasticsearch/elasticsearch_integration_test.go
+++ b/pkg/sources/elasticsearch/elasticsearch_integration_test.go
@@ -1,5 +1,4 @@
-//go:build integration
-// +build integration
+//go:build !no_elasticsearch && integration
 
 package elasticsearch
 

--- a/pkg/sources/elasticsearch/unit_of_work.go
+++ b/pkg/sources/elasticsearch/unit_of_work.go
@@ -1,3 +1,5 @@
+//go:build !no_elasticsearch
+
 package elasticsearch
 
 import "fmt"

--- a/pkg/sources/elasticsearch/unit_of_work_test.go
+++ b/pkg/sources/elasticsearch/unit_of_work_test.go
@@ -1,3 +1,5 @@
+//go:build !no_elasticsearch
+
 package elasticsearch
 
 import (

--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -1,3 +1,5 @@
+//go:build !no_filesystem
+
 package filesystem
 
 import (

--- a/pkg/sources/filesystem/filesystem_test.go
+++ b/pkg/sources/filesystem/filesystem_test.go
@@ -1,3 +1,5 @@
+//go:build !no_filesystem
+
 package filesystem
 
 import (

--- a/pkg/sources/gcs/gcs.go
+++ b/pkg/sources/gcs/gcs.go
@@ -1,3 +1,5 @@
+//go:build !no_gcs
+
 package gcs
 
 import (

--- a/pkg/sources/gcs/gcs_integration_test.go
+++ b/pkg/sources/gcs/gcs_integration_test.go
@@ -1,5 +1,4 @@
-//go:build integration
-// +build integration
+//go:build !no_gcs && integration
 
 package gcs
 

--- a/pkg/sources/gcs/gcs_manager.go
+++ b/pkg/sources/gcs/gcs_manager.go
@@ -1,3 +1,5 @@
+//go:build !no_gcs
+
 package gcs
 
 import (

--- a/pkg/sources/gcs/gcs_manager_test.go
+++ b/pkg/sources/gcs/gcs_manager_test.go
@@ -1,3 +1,5 @@
+//go:build !no_gcs
+
 package gcs
 
 import (

--- a/pkg/sources/gcs/gcs_test.go
+++ b/pkg/sources/gcs/gcs_test.go
@@ -1,3 +1,5 @@
+//go:build !no_gcs
+
 package gcs
 
 import (

--- a/pkg/sources/git/cmd_check.go
+++ b/pkg/sources/git/cmd_check.go
@@ -1,3 +1,5 @@
+//go:build !no_git
+
 package git
 
 import (

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -1,3 +1,5 @@
+//go:build !no_git
+
 package git
 
 import (

--- a/pkg/sources/git/git_disabled.go
+++ b/pkg/sources/git/git_disabled.go
@@ -1,0 +1,13 @@
+//go:build no_git
+
+package git
+
+import (
+	"errors"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+)
+
+func PrepareRepo(ctx context.Context, uriString string) (string, bool, error) {
+	return "", false, errors.New("trufflehog was compiled without the Git source")
+}

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -1,3 +1,5 @@
+//go:build !no_git
+
 package git
 
 import (

--- a/pkg/sources/git/scan_options.go
+++ b/pkg/sources/git/scan_options.go
@@ -1,7 +1,10 @@
+//go:build !no_git
+
 package git
 
 import (
 	"github.com/go-git/go-git/v5"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 )
 

--- a/pkg/sources/git/unit.go
+++ b/pkg/sources/git/unit.go
@@ -1,3 +1,5 @@
+//go:build !no_git
+
 package git
 
 import (

--- a/pkg/sources/git/unit_test.go
+++ b/pkg/sources/git/unit_test.go
@@ -1,3 +1,5 @@
+//go:build !no_git
+
 package git
 
 import (

--- a/pkg/sources/github/connector.go
+++ b/pkg/sources/github/connector.go
@@ -1,8 +1,11 @@
+//go:build !no_github && !no_git
+
 package github
 
 import (
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/google/go-github/v67/github"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 

--- a/pkg/sources/github/connector_app.go
+++ b/pkg/sources/github/connector_app.go
@@ -1,3 +1,5 @@
+//go:build !no_github && !no_git
+
 package github
 
 import (
@@ -7,6 +9,7 @@ import (
 	"github.com/bradleyfalzon/ghinstallation/v2"
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/google/go-github/v67/github"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/credentialspb"

--- a/pkg/sources/github/connector_basicauth.go
+++ b/pkg/sources/github/connector_basicauth.go
@@ -1,3 +1,5 @@
+//go:build !no_github && !no_git
+
 package github
 
 import (
@@ -5,6 +7,7 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/google/go-github/v67/github"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/credentialspb"

--- a/pkg/sources/github/connector_token.go
+++ b/pkg/sources/github/connector_token.go
@@ -1,3 +1,5 @@
+//go:build !no_github && !no_git
+
 package github
 
 import (
@@ -7,10 +9,11 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/google/go-github/v67/github"
+	"golang.org/x/oauth2"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources/git"
-	"golang.org/x/oauth2"
 )
 
 type tokenConnector struct {

--- a/pkg/sources/github/connector_unauthenticated.go
+++ b/pkg/sources/github/connector_unauthenticated.go
@@ -1,3 +1,5 @@
+//go:build !no_github && !no_git
+
 package github
 
 import (

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -1,3 +1,5 @@
+//go:build !no_github && !no_git
+
 package github
 
 import (

--- a/pkg/sources/github/github_integration_test.go
+++ b/pkg/sources/github/github_integration_test.go
@@ -1,5 +1,4 @@
-//go:build integration
-// +build integration
+//go:build integration && !no_github
 
 package github
 

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -1,3 +1,5 @@
+//go:build !no_github && !no_git
+
 package github
 
 import (

--- a/pkg/sources/github/metrics.go
+++ b/pkg/sources/github/metrics.go
@@ -1,3 +1,5 @@
+//go:build !no_github && !no_git
+
 package github
 
 import (

--- a/pkg/sources/github/repo.go
+++ b/pkg/sources/github/repo.go
@@ -1,3 +1,5 @@
+//go:build !no_github && !no_git
+
 package github
 
 import (

--- a/pkg/sources/github_experimental/github_experimental.go
+++ b/pkg/sources/github_experimental/github_experimental.go
@@ -1,3 +1,5 @@
+//go:build !no_github && !no_git
+
 package github_experimental
 
 import (

--- a/pkg/sources/github_experimental/object_discovery.go
+++ b/pkg/sources/github_experimental/object_discovery.go
@@ -1,3 +1,5 @@
+//go:build !no_github && !no_git
+
 package github_experimental
 
 import (

--- a/pkg/sources/github_experimental/repo.go
+++ b/pkg/sources/github_experimental/repo.go
@@ -1,3 +1,5 @@
+//go:build !no_github && !no_git
+
 package github_experimental
 
 import (

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -1,3 +1,5 @@
+//go:build !no_gitlab && !no_git
+
 package gitlab
 
 import (

--- a/pkg/sources/gitlab/gitlab_integration_test.go
+++ b/pkg/sources/gitlab/gitlab_integration_test.go
@@ -1,5 +1,4 @@
-//go:build integration
-// +build integration
+//go:build (!no_gitlab || !no_git) && integration
 
 package gitlab
 

--- a/pkg/sources/gitlab/gitlab_test.go
+++ b/pkg/sources/gitlab/gitlab_test.go
@@ -1,3 +1,5 @@
+//go:build !no_gitlab && !no_git
+
 package gitlab
 
 import (

--- a/pkg/sources/gitlab/metrics.go
+++ b/pkg/sources/gitlab/metrics.go
@@ -1,3 +1,5 @@
+//go:build !no_gitlab && !no_git
+
 package gitlab
 
 import (

--- a/pkg/sources/huggingface/client.go
+++ b/pkg/sources/huggingface/client.go
@@ -1,3 +1,5 @@
+//go:build !no_huggingface && !no_git
+
 package huggingface
 
 import (

--- a/pkg/sources/huggingface/huggingface.go
+++ b/pkg/sources/huggingface/huggingface.go
@@ -1,3 +1,5 @@
+//go:build !no_huggingface && !no_git
+
 package huggingface
 
 import (

--- a/pkg/sources/huggingface/huggingface_client_test.go
+++ b/pkg/sources/huggingface/huggingface_client_test.go
@@ -1,3 +1,5 @@
+//go:build !no_huggingface && !no_git
+
 package huggingface
 
 import (

--- a/pkg/sources/huggingface/huggingface_test.go
+++ b/pkg/sources/huggingface/huggingface_test.go
@@ -1,3 +1,5 @@
+//go:build !no_huggingface && !no_git
+
 package huggingface
 
 import (

--- a/pkg/sources/huggingface/repo.go
+++ b/pkg/sources/huggingface/repo.go
@@ -1,3 +1,5 @@
+//go:build !no_huggingface && !no_git
+
 package huggingface
 
 import (

--- a/pkg/sources/jenkins/jenkins.go
+++ b/pkg/sources/jenkins/jenkins.go
@@ -1,3 +1,5 @@
+//go:build !no_jenkins
+
 package jenkins
 
 import (

--- a/pkg/sources/jenkins/jenkins_integration_test.go
+++ b/pkg/sources/jenkins/jenkins_integration_test.go
@@ -1,5 +1,4 @@
-//go:build localInfra
-// +build localInfra
+//go:build localInfra && !no_jenkins
 
 package jenkins
 

--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -1,3 +1,5 @@
+//go:build !no_postman
+
 package postman
 
 import (

--- a/pkg/sources/postman/postman_client.go
+++ b/pkg/sources/postman/postman_client.go
@@ -1,3 +1,5 @@
+//go:build !no_postman
+
 package postman
 
 import (

--- a/pkg/sources/postman/postman_test.go
+++ b/pkg/sources/postman/postman_test.go
@@ -1,3 +1,5 @@
+//go:build !no_postman
+
 package postman
 
 import (

--- a/pkg/sources/postman/substitution.go
+++ b/pkg/sources/postman/substitution.go
@@ -1,3 +1,5 @@
+//go:build !no_postman
+
 package postman
 
 import (

--- a/pkg/sources/postman/substitution_test.go
+++ b/pkg/sources/postman/substitution_test.go
@@ -1,3 +1,5 @@
+//go:build !no_postman
+
 package postman
 
 import (

--- a/pkg/sources/s3/checkpointer.go
+++ b/pkg/sources/s3/checkpointer.go
@@ -1,3 +1,5 @@
+//go:build !no_s3
+
 package s3
 
 import (

--- a/pkg/sources/s3/checkpointer_test.go
+++ b/pkg/sources/s3/checkpointer_test.go
@@ -1,3 +1,5 @@
+//go:build !no_s3
+
 package s3
 
 import (

--- a/pkg/sources/s3/metrics.go
+++ b/pkg/sources/s3/metrics.go
@@ -1,3 +1,5 @@
+//go:build !no_s3
+
 package s3
 
 import (

--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -1,3 +1,5 @@
+//go:build !no_s3
+
 package s3
 
 import (

--- a/pkg/sources/s3/s3_integration_test.go
+++ b/pkg/sources/s3/s3_integration_test.go
@@ -1,5 +1,4 @@
-//go:build integration
-// +build integration
+//go:build !no_s3 && integration
 
 package s3
 

--- a/pkg/sources/s3/s3_test.go
+++ b/pkg/sources/s3/s3_test.go
@@ -1,3 +1,5 @@
+//go:build !no_s3
+
 package s3
 
 import (

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -295,6 +295,29 @@ type GitlabConfig struct {
 	ExcludeRepos []string
 }
 
+// HuggingFaceConfig represents the configuration for HuggingFace.
+type HuggingfaceConfig struct {
+	Endpoint           string
+	Models             []string
+	Spaces             []string
+	Datasets           []string
+	Organizations      []string
+	Users              []string
+	IncludeModels      []string
+	IgnoreModels       []string
+	IncludeSpaces      []string
+	IgnoreSpaces       []string
+	IncludeDatasets    []string
+	IgnoreDatasets     []string
+	SkipAllModels      bool
+	SkipAllSpaces      bool
+	SkipAllDatasets    bool
+	IncludeDiscussions bool
+	IncludePrs         bool
+	Token              string
+	Concurrency        int
+}
+
 // FilesystemConfig defines the optional configuration for a filesystem source.
 type FilesystemConfig struct {
 	// Paths is the list of files and directories to scan.
@@ -303,6 +326,14 @@ type FilesystemConfig struct {
 	IncludePathsFile string
 	// ExcludePathsFile is the path to a file containing a list of regexps to exclude from the scan.
 	ExcludePathsFile string
+}
+
+type JenkinsConfig struct {
+	Endpoint              string
+	Username              string
+	Password              string
+	Header                string
+	InsecureSkipVerifyTLS bool
 }
 
 // S3Config defines the optional configuration for an S3 source.

--- a/pkg/sources/syslog/syslog.go
+++ b/pkg/sources/syslog/syslog.go
@@ -1,3 +1,5 @@
+//go:build !no_syslog
+
 package syslog
 
 import (

--- a/pkg/sources/travisci/travisci.go
+++ b/pkg/sources/travisci/travisci.go
@@ -1,3 +1,5 @@
+//go:build !no_travisci
+
 package travisci
 
 import (
@@ -6,13 +8,13 @@ import (
 
 	"github.com/go-errors/errors"
 	"github.com/shuheiktgw/go-travis"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"

--- a/pkg/sources/travisci/travisci_test.go
+++ b/pkg/sources/travisci/travisci_test.go
@@ -1,3 +1,5 @@
+//go:build !no_travisci
+
 package travisci
 
 import (

--- a/pkg/tui/common/common.go
+++ b/pkg/tui/common/common.go
@@ -1,8 +1,11 @@
+//go:build !no_tui
+
 package common
 
 import (
 	"github.com/aymanbagabas/go-osc52"
 	zone "github.com/lrstanley/bubblezone"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/tui/keymap"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/tui/styles"
 )

--- a/pkg/tui/common/component.go
+++ b/pkg/tui/common/component.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package common
 
 import (

--- a/pkg/tui/common/error.go
+++ b/pkg/tui/common/error.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package common
 
 import tea "github.com/charmbracelet/bubbletea"

--- a/pkg/tui/common/style.go
+++ b/pkg/tui/common/style.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package common
 
 import (

--- a/pkg/tui/common/utils.go
+++ b/pkg/tui/common/utils.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package common
 
 import (

--- a/pkg/tui/components/confirm/confirm.go
+++ b/pkg/tui/components/confirm/confirm.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package confirm
 
 import (

--- a/pkg/tui/components/footer/footer.go
+++ b/pkg/tui/components/footer/footer.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package footer
 
 import (

--- a/pkg/tui/components/formfield/formfield.go
+++ b/pkg/tui/components/formfield/formfield.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package formfield
 
 import (

--- a/pkg/tui/components/header/header.go
+++ b/pkg/tui/components/header/header.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package header
 
 import (

--- a/pkg/tui/components/selector/selector.go
+++ b/pkg/tui/components/selector/selector.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package selector
 
 import (

--- a/pkg/tui/components/statusbar/statusbar.go
+++ b/pkg/tui/components/statusbar/statusbar.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package statusbar
 
 import (

--- a/pkg/tui/components/tabs/tabs.go
+++ b/pkg/tui/components/tabs/tabs.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package tabs
 
 import (

--- a/pkg/tui/components/textinput/textinput.go
+++ b/pkg/tui/components/textinput/textinput.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package textinput
 
 import (

--- a/pkg/tui/components/textinputs/textinputs.go
+++ b/pkg/tui/components/textinputs/textinputs.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package textinputs
 
 // from https://github.com/charmbracelet/bubbletea/blob/master/examples/textinputs/main.go

--- a/pkg/tui/components/viewport/viewport.go
+++ b/pkg/tui/components/viewport/viewport.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package viewport
 
 import (

--- a/pkg/tui/keymap/keymap.go
+++ b/pkg/tui/keymap/keymap.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package keymap
 
 import "github.com/charmbracelet/bubbles/key"

--- a/pkg/tui/pages/analyze_form/analyze_form.go
+++ b/pkg/tui/pages/analyze_form/analyze_form.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package analyze_form
 
 import (

--- a/pkg/tui/pages/analyze_keys/analyze_keys.go
+++ b/pkg/tui/pages/analyze_keys/analyze_keys.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package analyze_keys
 
 import (

--- a/pkg/tui/pages/contact_enterprise/contact_enterprise.go
+++ b/pkg/tui/pages/contact_enterprise/contact_enterprise.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package contact_enterprise
 
 import (

--- a/pkg/tui/pages/source_configure/item.go
+++ b/pkg/tui/pages/source_configure/item.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package source_configure
 
 type Item struct {

--- a/pkg/tui/pages/source_configure/run_component.go
+++ b/pkg/tui/pages/source_configure/run_component.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package source_configure
 
 import (

--- a/pkg/tui/pages/source_configure/source_component.go
+++ b/pkg/tui/pages/source_configure/source_component.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package source_configure
 
 import (

--- a/pkg/tui/pages/source_configure/source_configure.go
+++ b/pkg/tui/pages/source_configure/source_configure.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package source_configure
 
 import (

--- a/pkg/tui/pages/source_configure/trufflehog_component.go
+++ b/pkg/tui/pages/source_configure/trufflehog_component.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package source_configure
 
 import (

--- a/pkg/tui/pages/source_configure/trufflehog_configure.go
+++ b/pkg/tui/pages/source_configure/trufflehog_configure.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package source_configure
 
 import (

--- a/pkg/tui/pages/source_select/item.go
+++ b/pkg/tui/pages/source_select/item.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package source_select
 
 type SourceItem struct {

--- a/pkg/tui/pages/source_select/source_select.go
+++ b/pkg/tui/pages/source_select/source_select.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package source_select
 
 import (

--- a/pkg/tui/pages/view_oss/view_oss.go
+++ b/pkg/tui/pages/view_oss/view_oss.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package view_oss
 
 import (

--- a/pkg/tui/pages/wizard_intro/item.go
+++ b/pkg/tui/pages/wizard_intro/item.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package wizard_intro
 
 import (

--- a/pkg/tui/pages/wizard_intro/wizard_intro.go
+++ b/pkg/tui/pages/wizard_intro/wizard_intro.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package wizard_intro
 
 import (

--- a/pkg/tui/sources/circleci/circleci.go
+++ b/pkg/tui/sources/circleci/circleci.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package circleci
 
 import (

--- a/pkg/tui/sources/docker/docker.go
+++ b/pkg/tui/sources/docker/docker.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package docker
 
 import (

--- a/pkg/tui/sources/elasticsearch/elasticsearch.go
+++ b/pkg/tui/sources/elasticsearch/elasticsearch.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package elasticsearch
 
 import (

--- a/pkg/tui/sources/filesystem/filesystem.go
+++ b/pkg/tui/sources/filesystem/filesystem.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package filesystem
 
 import (

--- a/pkg/tui/sources/gcs/gcs.go
+++ b/pkg/tui/sources/gcs/gcs.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package gcs
 
 import (

--- a/pkg/tui/sources/git/git.go
+++ b/pkg/tui/sources/git/git.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package git
 
 import (

--- a/pkg/tui/sources/github/github.go
+++ b/pkg/tui/sources/github/github.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package github
 
 import (

--- a/pkg/tui/sources/gitlab/gitlab.go
+++ b/pkg/tui/sources/gitlab/gitlab.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package gitlab
 
 import (

--- a/pkg/tui/sources/huggingface/huggingface.go
+++ b/pkg/tui/sources/huggingface/huggingface.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package huggingface
 
 import (

--- a/pkg/tui/sources/jenkins/jenkins.go
+++ b/pkg/tui/sources/jenkins/jenkins.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package jenkins
 
 import (

--- a/pkg/tui/sources/postman/postman.go
+++ b/pkg/tui/sources/postman/postman.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package postman
 
 import (

--- a/pkg/tui/sources/s3/s3.go
+++ b/pkg/tui/sources/s3/s3.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package s3
 
 import (

--- a/pkg/tui/sources/sources.go
+++ b/pkg/tui/sources/sources.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package sources
 
 import (

--- a/pkg/tui/sources/syslog/syslog.go
+++ b/pkg/tui/sources/syslog/syslog.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package syslog
 
 import (

--- a/pkg/tui/styles/styles.go
+++ b/pkg/tui/styles/styles.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package styles
 
 import (

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1,3 +1,5 @@
+//go:build !no_tui
+
 package tui
 
 import (
@@ -8,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	zone "github.com/lrstanley/bubblezone"
+
 	"github.com/trufflesecurity/trufflehog/v3/pkg/analyzer"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/analyzer/analyzers"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/tui/common"
@@ -221,7 +224,7 @@ func (ui *TUI) View() string {
 	)
 }
 
-func Run(args []string) []string {
+func Run(args []string) ([]string, error) {
 	c := common.Common{
 		Copy:   nil,
 		Styles: styles.DefaultStyles(),
@@ -241,7 +244,7 @@ func Run(args []string) []string {
 		analyzer.Run(m.analyzerType, m.analyzerInfo)
 		os.Exit(0)
 	}
-	return m.args
+	return m.args, nil
 }
 
 func (ui *TUI) activePage() page {

--- a/pkg/tui/tui_disabled.go
+++ b/pkg/tui/tui_disabled.go
@@ -1,0 +1,11 @@
+//go:build no_tui
+
+package tui
+
+import (
+	"errors"
+)
+
+func Run(args []string) ([]string, error) {
+	return nil, errors.New("trufflehog was compiled without this feature")
+}


### PR DESCRIPTION
### Description:

Inspired by https://trufflesecurity.com/blog/introducing-trufflehog-s-burp-suite-extension-a-techical-deep-dive:

> Extension size bloat: TruffleHog is ~170Mb.

**Pros**

- Significantly reduces how long it takes to run `go build` due to sources I don't use
- Lets me build an 80Mb binary (saving between 50-70Mb)
```sh
$ go build -tags "no_circleci,no_docker,no_elasticsearch,no_gcs,no_git,no_github,no_gitlab,no_huggingface,no_jenkins,no_postman,no_s3,no_syslog,no_travisci" -ldflags="-s -w"
$ ls -lh ./trufflehog
-rwxr-xr-x. 1 user user 80M Mar 13 22:39 ./trufflehog
```

**Cons**

- Awkward; adds a separate `_disabled.go` file for each source
- Niche feature

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
