### PR TITLE
[fix] - Sonarcloud detector

### DIFF
--- a/pkg/detectors/sonarcloud/sonarcloud.go
+++ b/pkg/detectors/sonarcloud/sonarcloud.go
@@ -21,7 +21,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"sonar"}) + `\b([0-9a-z]{40})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"sonar"}) + `(?:^|[^@])\b([0-9a-z]{40})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/sonarcloud/sonarcloud_test.go
+++ b/pkg/detectors/sonarcloud/sonarcloud_test.go
@@ -45,6 +45,11 @@ func TestSonarCloud_Pattern(t *testing.T) {
 			input: fmt.Sprintf("%s = '%s'", keyword, invalidPattern),
 			want:  []string{},
 		},
+		{
+			name:  "invalid pattern - token directly preceded by @",
+			input: fmt.Sprintf("%s token = '@%s'", keyword, validPattern),
+			want:  []string{},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### Description:
A supply chain attack on the popular GitHub Action [tj-actions/changed-files](https://github.com/tj-actions/changed-files) caused many repositories to leak their secrets (see [blog post from stepsecurity](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised) who discovered it a few days ago). The compromise is also being tracked as a vulnerability, and has been assigned [CVE-2025-30066](https://nvd.nist.gov/vuln/detail/CVE-2025-30066).
To avoid such supply chain attacks, [github recommends](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) to pin to the specific commit SHA instead of version tags or branches.

However, by following github's recommendation, `trufflehog` would alert the following which is clearly a false-positive:
```
      - name: Analyze with SonarCloud
        uses: SonarSource/sonarqube-scan-action@bfd4e558cda28cda6b5defafb9232d191be8c203 # v4
```

To fix this, I adapted trufflehog's Sonarcloud detector so that a SHA commit hashes prefixed with an @ sign do not trigger an alert.

I also added an Unit test to cover the case.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
