### PR TITLE
Update sentry endpoint

### DIFF
--- a/pkg/detectors/sentrytoken/v1/sentrytoken.go
+++ b/pkg/detectors/sentrytoken/v1/sentrytoken.go
@@ -98,17 +98,7 @@ func VerifyToken(ctx context.Context, client *http.Client, token string) (map[st
 
 	switch resp.StatusCode {
 	case http.StatusOK:
-		var organizations []Organization
-		if err = json.NewDecoder(resp.Body).Decode(&organizations); err != nil {
-			return nil, false, err
-		}
-
-		var extraData = make(map[string]string)
-		for _, org := range organizations {
-			extraData[fmt.Sprintf("orginzation_%s", org.ID)] = org.Name
-		}
-
-		return extraData, true, nil
+		return nil, true, nil
 	case http.StatusForbidden:
 		var APIResp interface{}
 		if err = json.NewDecoder(resp.Body).Decode(&APIResp); err != nil {

--- a/pkg/detectors/sentrytoken/v1/sentrytoken.go
+++ b/pkg/detectors/sentrytoken/v1/sentrytoken.go
@@ -81,7 +81,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func VerifyToken(ctx context.Context, client *http.Client, token string) (map[string]string, bool, error) {
 	// api docs: https://docs.sentry.io/api/organizations/
 	// this api will return 200 for user auth tokens with scope of org:<>
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://sentry.io/api/0/organizations/", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://sentry.io/api/0/auth/validate", nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/detectors/sentrytoken/v1/sentrytoken.go
+++ b/pkg/detectors/sentrytoken/v1/sentrytoken.go
@@ -81,7 +81,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func VerifyToken(ctx context.Context, client *http.Client, token string) (map[string]string, bool, error) {
 	// api docs: https://docs.sentry.io/api/organizations/
 	// this api will return 200 for user auth tokens with scope of org:<>
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://sentry.io/api/0/auth/validate", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://sentry.io/api/0/auth/validate/", nil)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/detectors/sentrytoken/v1/sentrytoken_integration_test.go
+++ b/pkg/detectors/sentrytoken/v1/sentrytoken_integration_test.go
@@ -52,7 +52,6 @@ func TestSentryToken_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_SentryToken,
 					Verified:     true,
-					ExtraData:    map[string]string{"orginzation_4508567357947904": "Truffle Security"},
 				},
 			},
 			wantErr: false,

--- a/pkg/detectors/sentrytoken/v2/sentrytoken_integration_test.go
+++ b/pkg/detectors/sentrytoken/v2/sentrytoken_integration_test.go
@@ -52,7 +52,6 @@ func TestSentryToken_FromChunk(t *testing.T) {
 				{
 					DetectorType: detectorspb.DetectorType_SentryToken,
 					Verified:     true,
-					ExtraData:    map[string]string{"orginzation_4508567357947904": "Truffle Security"},
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
`https://sentry.io/api/0/organizations/` is out. `https://sentry.io/api/0/auth/validate` is _in_. Tested this w/ a valid and invalid token. Seems to be working

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
