### PR TITLE
removed vebiage saying we don't trigger aws canary tokens, as we do.

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ Depending on the event type (push or PR), we calculate the number of commits pre
 
 ### Canary detection
 
-TruffleHog statically detects [https://canarytokens.org/](https://canarytokens.org/) and lets you know when they're present without setting them off. You can learn more here: [https://trufflesecurity.com/canaries](https://trufflesecurity.com/canaries)
+TruffleHog statically detects [https://canarytokens.org/](https://canarytokens.org/).
 
 ![image](https://github.com/trufflesecurity/trufflehog/assets/52866392/74ace530-08c5-4eaf-a169-84a73e328f6f)
 


### PR DESCRIPTION
Our detector triggers AWS Canary tokens, updating verbiage to not say otherwise.
