### PR TITLE
[Fix] AWS User Agent issue

### DIFF
--- a/pkg/detectors/aws/access_keys/canary.go
+++ b/pkg/detectors/aws/access_keys/canary.go
@@ -5,11 +5,9 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/aws/middleware"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 )
 
 const thinkstMessage = "This is an AWS canary token generated at canarytokens.org."
@@ -60,7 +58,7 @@ func (s scanner) verifyCanary(ctx context.Context, resIDMatch, resSecretMatch st
 		return false, "", err
 	}
 	svc := sns.NewFromConfig(cfg, func(o *sns.Options) {
-		o.APIOptions = append(o.APIOptions, middleware.AddUserAgentKeyValue("User-Agent", common.UserAgent()))
+		o.APIOptions = append(o.APIOptions, replaceUserAgentMiddleware)
 	})
 
 	// Prep vars and Publish to SNS


### PR DESCRIPTION
### Description:
It has been reported that since, we replaced the native verification call by aws SDK code, The User-Agent is being sent something like 
`aws-sdk-go-v2/1.36.3 ua/2.1 os/linux lang/go#1.23.7 md/GOOS#linux md/GOARCH#amd64 api/sts#1.33.17 User-Agent/TruffleHog [SUFFIX] m/E,e` 

instead of 

`TruffleHog [SUFFIX]`

This PR remove all the default values and just set the one used by TruffleHog like Default SaneHttpClient. Adding the Debug Request log, ran with `--user-agent-suffix basit`:
<img width="404" alt="Screenshot 2025-04-09 at 1 07 42 PM" src="https://github.com/user-attachments/assets/d7b9d502-94e1-44c9-8d4e-0aea6eaffc8b" />

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
