### PR TITLE
[Fix] Fixed Okta Detector Integration Test Case input

### DIFF
--- a/pkg/detectors/okta/okta_integration_test.go
+++ b/pkg/detectors/okta/okta_integration_test.go
@@ -88,7 +88,7 @@ func TestOkta_FromChunk(t *testing.T) {
 			wantVerificationErr: false,
 		},
 		{
-			name: "found, verified but unexpected api surface",
+			name: "found verifiable secret, verification failed due to unexpected API response",
 			s:    Scanner{client: common.ConstantResponseHttpClient(404, "")},
 			args: args{
 				ctx:    context.Background(),

--- a/pkg/detectors/okta/okta_integration_test.go
+++ b/pkg/detectors/okta/okta_integration_test.go
@@ -92,7 +92,7 @@ func TestOkta_FromChunk(t *testing.T) {
 			s:    Scanner{client: common.ConstantResponseHttpClient(404, "")},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a okta secret %s within oktaDomain %s", secretInactive, domain)),
+				data:   []byte(fmt.Sprintf("You can find a okta secret %s within oktaDomain %s", secret, domain)),
 				verify: true,
 			},
 			want: []detectors.Result{


### PR DESCRIPTION
### Description:
Fixed the Okta detector integration test -- in test case where an unexpected error is expected on an otherwise verifiable secret, an inactive secret was being sent as input

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
