### PR TITLE
Stop logging chunks

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -785,7 +785,7 @@ func (e *Engine) scannerWorker(ctx context.Context) {
 			decodeLatency.WithLabelValues(decoder.Type().String(), chunk.SourceName).Observe(float64(decodeTime))
 
 			if decoded == nil {
-				ctx.Logger().V(5).Info("decoder not applicable for chunk", "decoder", decoder.Type().String(), "chunk", chunk)
+				ctx.Logger().V(5).Info("decoder not applicable for chunk", "decoder", decoder.Type().String())
 				continue
 			}
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -785,7 +785,7 @@ func (e *Engine) scannerWorker(ctx context.Context) {
 			decodeLatency.WithLabelValues(decoder.Type().String(), chunk.SourceName).Observe(float64(decodeTime))
 
 			if decoded == nil {
-				ctx.Logger().V(5).Info("decoder not applicable for chunk", "decoder", decoder.Type().String())
+				// This means that the decoder didn't understand this chunk and isn't applicable to it.
 				continue
 			}
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We should not be logging raw chunks, even at level 5 after decoder failures. Removing the chunk from the message makes it effectively useless, so I removed the message entirely.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
