### PR TITLE
Improved Besttime detector regex pattern

### DIFF
--- a/pkg/detectors/besttime/besttime.go
+++ b/pkg/detectors/besttime/besttime.go
@@ -22,7 +22,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"besttime"}) + `(pri_[a-f0-9]{32})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"besttime"}) + `\b(pri_[a-f0-9]{32})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/besttime/besttime.go
+++ b/pkg/detectors/besttime/besttime.go
@@ -22,7 +22,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"besttime"}) + `\b([0-9A-Za-z_]{36})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"besttime"}) + `(pri_[a-f0-9]{32})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/besttime/besttime_test.go
+++ b/pkg/detectors/besttime/besttime_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 var (
-	validPattern   = "4K1WTb2ysVeg_jHDwtwhH68K9MuOjiTtXQCS"
+	validPattern   = "pri_099889f14d114dfaae476569b395eade"
 	complexPattern = `
 	func main() {
-		url := "https://api.example.com/v1/besttime/keys/4K1WTb2ysVeg_jHDwtwhH68K9MuOjiTtXQCS"
+		url := "https://api.example.com/v1/besttime/keys/pri_099889f14d114dfaae476569b395eade"
 
 		// Create a new request with the secret as a header
 		req, err := http.NewRequest("GET", url, http.NoBody)
@@ -52,12 +52,12 @@ func TestBestTime_Pattern(t *testing.T) {
 		{
 			name:  "valid pattern",
 			input: fmt.Sprintf("besttime credentials: %s", validPattern),
-			want:  []string{"4K1WTb2ysVeg_jHDwtwhH68K9MuOjiTtXQCS"},
+			want:  []string{"pri_099889f14d114dfaae476569b395eade"},
 		},
 		{
 			name:  "valid pattern - complex",
 			input: complexPattern,
-			want:  []string{"4K1WTb2ysVeg_jHDwtwhH68K9MuOjiTtXQCS"},
+			want:  []string{"pri_099889f14d114dfaae476569b395eade"},
 		},
 		{
 			name:  "invalid pattern",


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
BestTime private API keys always begin with the `pri_` prefix and consist exclusively of lowercase letters from a to f and digits from 0 to 9. The total length of the key, including the `pri_` prefix, is exactly 36 characters.
I generated 5-6 keys and all satisfy this new pattern.
API Docs: https://documentation.besttime.app/#introduction

### Tests:
![Screenshot from 2025-04-16 11-45-12](https://github.com/user-attachments/assets/1d915032-7b52-41f4-87de-b47f073def84)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
