### PR TITLE
(Fix) Exclude trailing quotes and commas in Password

### DIFF
--- a/pkg/common/patterns.go
+++ b/pkg/common/patterns.go
@@ -48,9 +48,9 @@ func (r RegexState) Matches(data []byte) []string {
 
 	res := make([]string, 0, len(matches))
 
-	// trim off spaces and different quote types ('").
+	// trim off all white spaces and different quote types ('"") & some special characters (,;).
 	for i := range matches {
-		res = append(res, strings.Trim(matches[i][1], `"' )`))
+		res = append(res, strings.Trim(strings.TrimSpace(matches[i][1]), `"' ),;`))
 	}
 
 	return res

--- a/pkg/common/patterns_test.go
+++ b/pkg/common/patterns_test.go
@@ -70,10 +70,20 @@ func TestUsernameRegexCheck(t *testing.T) {
 	testString := `username = "johnsmith123"
                    username='johnsmith123'
 				   username:="johnsmith123"
+				   username:="johnsmith123",
+				   username:="johnsmith123";
                    username = johnsmith123
                    username=johnsmith123`
 
-	expectedStr := []string{"johnsmith123", "johnsmith123", "johnsmith123", "johnsmith123", "johnsmith123"}
+	expectedStr := []string{
+		"johnsmith123",
+		"johnsmith123",
+		"johnsmith123",
+		"johnsmith123",
+		"johnsmith123",
+		"johnsmith123",
+		"johnsmith123",
+	}
 
 	usernameRegexMatches := usernameRegexPat.Matches([]byte(testString))
 
@@ -90,12 +100,24 @@ func TestPasswordRegexCheck(t *testing.T) {
 	testString := `password = "johnsmith123$!"
                    password='johnsmith123$!'
 				   password:="johnsmith123$!"
+				   password:="johnsmith123$!",
+				   password:="johnsmith123$!";
+				   password:="johnsmi',th123$!";
                    password = johnsmith123$!
                    password=johnsmith123$!
 				   PasswordAuthenticator(username, "johnsmith123$!")`
 
-	expectedStr := []string{"johnsmith123$!", "johnsmith123$!", "johnsmith123$!", "johnsmith123$!", "johnsmith123$!",
-		"johnsmith123$!"}
+	expectedStr := []string{
+		"johnsmith123$!",
+		"johnsmith123$!",
+		"johnsmith123$!",
+		"johnsmith123$!",
+		"johnsmith123$!",
+		"johnsmi',th123$!",
+		"johnsmith123$!",
+		"johnsmith123$!",
+		"johnsmith123$!",
+	}
 
 	passwordRegexMatches := passwordRegexPat.Matches([]byte(testString))
 


### PR DESCRIPTION
### Description:
This PR remove trailing `,`, `"` `;` from Passwords. This function is mainly used in `snowflake` and `couchbase` detectors.


Test outputs:
```
$ go test ./pkg/common/patterns.go ./pkg/common/patterns_test.go 
ok  	command-line-arguments	1.258s
$ go test ./pkg/detectors/snowflake/
ok  	github.com/trufflesecurity/trufflehog/v3/pkg/detectors/snowflake	1.883s
$ go test ./pkg/detectors/couchbase/
ok  	github.com/trufflesecurity/trufflehog/v3/pkg/detectors/couchbase	3.656s
```

This PR also fixes #3833 . 

```
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

2025-04-22T14:49:55+05:00	info-0	trufflehog	running source	{"source_manager_worker_id": "W4bWF", "with_units": true}
Verification issue: lookup company-sf_preprod.privatelink.snowflakecomputing.com: no such host
Detector Type: Snowflake
Decoder Type: PLAIN
Raw result: Hello@'12345
Account: company-sf_preprod.privatelink
Username: AN234554AD
Line: 5

```


### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
