### PR TITLE
Don't die on workspace request failure to Postman API

### DIFF
--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -182,7 +182,10 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 	for _, workspaceID := range s.conn.Workspaces {
 		w, err := s.client.GetWorkspace(ctx, workspaceID)
 		if err != nil {
-			return fmt.Errorf("error getting workspace %s: %w", workspaceID, err)
+			// Log and move on, because sometimes the Postman API seems to give us workspace IDs
+			// that we don't have access to, so we don't want to kill the scan because of it.
+			ctx.Logger().Error(err, "error getting workspace %s", workspaceID)
+			continue
 		}
 		s.SetProgressOngoing(fmt.Sprintf("Scanning workspace %s", workspaceID), "")
 		ctx.Logger().V(2).Info("scanning workspace from workspaces given", "workspace", workspaceID)

--- a/pkg/sources/postman/postman_client.go
+++ b/pkg/sources/postman/postman_client.go
@@ -294,7 +294,10 @@ func (c *Client) EnumerateWorkspaces(ctx context.Context) ([]Workspace, error) {
 	for i, workspace := range workspacesObj.Workspaces {
 		tempWorkspace, err := c.GetWorkspace(ctx, workspace.ID)
 		if err != nil {
-			return nil, fmt.Errorf("could not get workspace %q (%s) during enumeration: %w", workspace.Name, workspace.ID, err)
+			// Log and move on, because sometimes the Postman API seems to give us workspace IDs
+			// that we don't have access to, so we don't want to kill the scan because of it.
+			ctx.Logger().Error(err, "could not get workspace %q (%s) during enumeration", workspace.Name, workspace.ID)
+			continue
 		}
 		workspacesObj.Workspaces[i] = tempWorkspace
 


### PR DESCRIPTION
Right now when the Postman source is scanning the postman API, if it gets *any* error back from the API it stops the whole scan.  We should probably just log and continue if this happens, so this makes that change for requests to the *workspace* endpoint

This issue popped up when investigating a logged problem with making requests to the Postman API and (likely) sending either a bad collection/workspace id or (also possible) sending a collection or workspace id that we don't have permission to explore to the Postman API.  Still worth looking more into that, but I think that making these errors less visible is worth the tradeoff for still getting _something_ out of a scan.

[Related PR for collections](https://github.com/trufflesecurity/trufflehog/pull/4094)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
