### PR TITLE
[Fix] Added Shannon Entropy Check In AccuWeather Detector

### DIFF
--- a/pkg/detectors/accuweather/accuweather_test.go
+++ b/pkg/detectors/accuweather/accuweather_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 var (
-	validPattern   = "dqftwc490oPc%xae67sBSF741M56%sd091a"
-	invalidPattern = "dqftwc490oPc%xae67sBSF741M56=sd091a"
+	validPattern           = "DqFtwc490oPc%xaE67sBSF741M56%sd091A"
+	invalidPattern         = "DqFtwc490oPc%xaE67sBSF741M56=sd091A"
+	validPatternLowEntropy = "DsFtwfaEsAPS%eaEsaESEsFesfMsfMsDmdA"
 )
 
 func TestAccuWeather_Pattern(t *testing.T) {
@@ -38,6 +39,11 @@ func TestAccuWeather_Pattern(t *testing.T) {
 		{
 			name:  "invalid pattern",
 			input: fmt.Sprintf("accuweather = '%s'", invalidPattern),
+			want:  nil,
+		},
+		{
+			name:  "valid pattern - Shannon entropy below threshold",
+			input: fmt.Sprintf("accuweather = '%s'", validPatternLowEntropy),
 			want:  nil,
 		},
 	}


### PR DESCRIPTION
### Description:
Added a Shannon entropy test on the detected secret in the AccuWeather detector which has a broad regex.
Calculated entropy of 17 API secrets, which ranges from `~4.27-4.8`.
Added low entropy secret test case in pattern test

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
