### PR TITLE
Remove unnecessary verbosity call when logging error

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -937,7 +937,7 @@ func (e *Engine) verificationOverlapWorker(ctx context.Context) {
 				results, err := detector.FromData(ctx, false, match)
 				cancel()
 				if err != nil {
-					ctx.Logger().V(2).Error(
+					ctx.Logger().Error(
 						err, "error finding results in chunk during verification overlap",
 						"detector", detector.Key.Type().String(),
 					)

--- a/pkg/sources/docker/docker.go
+++ b/pkg/sources/docker/docker.go
@@ -237,7 +237,7 @@ func getHistoryEntries(ctx context.Context, imgInfo imageInfo, layers []v1.Layer
 				if err == nil {
 					e.layerDigest = digest.String()
 				} else {
-					ctx.Logger().V(2).Error(err, "cannot associate layer with history entry: layer digest failed",
+					ctx.Logger().Error(err, "cannot associate layer with history entry: layer digest failed",
 						"layerIndex", layerIndex, "historyIndex", historyIndex)
 				}
 			} else {


### PR DESCRIPTION
Errors are always logged, and do not have a verbosity.  This call can be removed.

https://github.com/go-logr/logr/commit/f8fce6ada1c095494b8f84f8e367fc849c736794#diff-792a9b98675a458cdbd537bf51c36acec5d9f0bf8eea4ad2ba441cf54be5017dR58

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
