### PR TITLE
Update PreCommit.md with latest pre-commit stage names

### DIFF
--- a/PreCommit.md
+++ b/PreCommit.md
@@ -97,7 +97,7 @@ repos:
         description: Detect secrets in your data.
         entry: bash -c 'trufflehog git file://. --since-commit HEAD --results=verified,unknown --fail'
         language: system
-        stages: ["commit", "push"]
+        stages: ["pre-commit", "pre-push"]
 ```
 
 2. Install the pre-commit hook:


### PR DESCRIPTION
### Description:
hook id `trufflehog` uses deprecated pre-commit stage names (commit, push) which will be removed in a future version. Using latest standard of pre-commit stage names.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
