### PR TITLE
postman_client.IDNameUUID becomes IdNameUid

### DIFF
--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -266,18 +266,18 @@ func (s *Source) scanWorkspace(ctx context.Context, chunksChan chan *sources.Chu
 
 	// gather and scan environment variables
 	for _, envID := range workspace.Environments {
-		envVars, err := s.client.GetEnvironmentVariables(ctx, envID.UUID)
+		envVars, err := s.client.GetEnvironmentVariables(ctx, envID.Uid)
 		if err != nil {
-			ctx.Logger().Error(err, "could not get env variables", "environment_uuid", envID.UUID)
+			ctx.Logger().Error(err, "could not get env variables", "environment_uuid", envID.Uid)
 			continue
 		}
-		if shouldSkip(envID.UUID, s.conn.IncludeEnvironments, s.conn.ExcludeEnvironments) {
+		if shouldSkip(envID.Uid, s.conn.IncludeEnvironments, s.conn.ExcludeEnvironments) {
 			continue
 		}
 		metadata.Type = ENVIRONMENT_TYPE
-		metadata.Link = LINK_BASE_URL + "environments/" + envID.UUID
+		metadata.Link = LINK_BASE_URL + "environments/" + envID.Uid
 		metadata.FullID = envVars.ID
-		metadata.EnvironmentID = envID.UUID
+		metadata.EnvironmentID = envID.Uid
 		metadata.EnvironmentName = envVars.Name
 
 		ctx.Logger().V(2).Info("scanning environment vars", "environment_uuid", metadata.FullID)
@@ -300,10 +300,10 @@ func (s *Source) scanWorkspace(ctx context.Context, chunksChan chan *sources.Chu
 	// at this point we have all the possible
 	// substitutions from Environment variables
 	for _, collectionID := range workspace.Collections {
-		if shouldSkip(collectionID.UUID, s.conn.IncludeCollections, s.conn.ExcludeCollections) {
+		if shouldSkip(collectionID.Uid, s.conn.IncludeCollections, s.conn.ExcludeCollections) {
 			continue
 		}
-		collection, err := s.client.GetCollection(ctx, collectionID.UUID)
+		collection, err := s.client.GetCollection(ctx, collectionID.Uid)
 		if err != nil {
 			// Log and move on, because sometimes the Postman API seems to give us collection IDs
 			// that we don't have access to, so we don't want to kill the scan because of it.

--- a/pkg/sources/postman/postman_client.go
+++ b/pkg/sources/postman/postman_client.go
@@ -22,25 +22,25 @@ const (
 )
 
 type Workspace struct {
-	ID              string       `json:"id"`
-	Name            string       `json:"name"`
-	Type            string       `json:"type"`
-	Description     string       `json:"description"`
-	Visibility      string       `json:"visibility"`
-	CreatedBy       string       `json:"createdBy"`
-	UpdatedBy       string       `json:"updatedBy"`
-	CreatedAt       string       `json:"createdAt"`
-	UpdatedAt       string       `json:"updatedAt"`
-	Collections     []IDNameUUID `json:"collections"`
-	Environments    []IDNameUUID `json:"environments"`
+	ID              string      `json:"id"`
+	Name            string      `json:"name"`
+	Type            string      `json:"type"`
+	Description     string      `json:"description"`
+	Visibility      string      `json:"visibility"`
+	CreatedBy       string      `json:"createdBy"`
+	UpdatedBy       string      `json:"updatedBy"`
+	CreatedAt       string      `json:"createdAt"`
+	UpdatedAt       string      `json:"updatedAt"`
+	Collections     []IdNameUid `json:"collections"`
+	Environments    []IdNameUid `json:"environments"`
 	CollectionsRaw  []Collection
 	EnvironmentsRaw []VariableData
 }
 
-type IDNameUUID struct {
+type IdNameUid struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
-	UUID string `json:"uid"`
+	Uid  string `json:"uid"`
 }
 
 type KeyValue struct {


### PR DESCRIPTION
This is misleadingly named.  This field actually represents a thing called `uid`, which is a field sometimes provided by the Postman API, and is usually a concatenation of a user id and an object ID.  The object ID usually looks like a UUID, but this field is strictly never a UUID.

So we rename the field and the struct to (which is named based on it's fields)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
