### PR TITLE
Postman Code Uses Consistent Casing for Id Var Names

### DIFF
--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -146,7 +146,7 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 		if err = json.Unmarshal(contents, &env); err != nil {
 			return err
 		}
-		s.scanVariableData(ctx, chunksChan, Metadata{EnvironmentID: env.ID, EnvironmentName: env.Name, fromLocal: true, Link: envPath, LocationType: source_metadatapb.PostmanLocationType_ENVIRONMENT_VARIABLE}, env)
+		s.scanVariableData(ctx, chunksChan, Metadata{EnvironmentID: env.Id, EnvironmentName: env.Name, fromLocal: true, Link: envPath, LocationType: source_metadatapb.PostmanLocationType_ENVIRONMENT_VARIABLE}, env)
 	}
 
 	// Scan local collections
@@ -174,7 +174,7 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 			}
 		}
 		basename := path.Base(workspacePath)
-		workspace.ID = strings.TrimSuffix(basename, filepath.Ext(basename))
+		workspace.Id = strings.TrimSuffix(basename, filepath.Ext(basename))
 		s.scanLocalWorkspace(ctx, chunksChan, workspace, workspacePath)
 	}
 
@@ -219,9 +219,9 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 		}
 		ctx.Logger().V(2).Info("enumerated workspaces", "workspaces", workspaces)
 		for _, workspace := range workspaces {
-			s.SetProgressOngoing(fmt.Sprintf("Scanning workspace %s", workspace.ID), "")
+			s.SetProgressOngoing(fmt.Sprintf("Scanning workspace %s", workspace.Id), "")
 			if err = s.scanWorkspace(ctx, chunksChan, workspace); err != nil {
-				return fmt.Errorf("error scanning workspace %s: %w", workspace.ID, err)
+				return fmt.Errorf("error scanning workspace %s: %w", workspace.Id, err)
 			}
 		}
 	}
@@ -235,12 +235,12 @@ func (s *Source) scanLocalWorkspace(ctx context.Context, chunksChan chan *source
 	s.resetKeywords()
 
 	metadata := Metadata{
-		WorkspaceUUID: workspace.ID,
+		WorkspaceUUID: workspace.Id,
 		fromLocal:     true,
 	}
 
 	for _, environment := range workspace.EnvironmentsRaw {
-		metadata.Link = strings.TrimSuffix(path.Base(filePath), path.Ext(filePath)) + "/environments/" + environment.ID + ".json"
+		metadata.Link = strings.TrimSuffix(path.Base(filePath), path.Ext(filePath)) + "/environments/" + environment.Id + ".json"
 		metadata.LocationType = source_metadatapb.PostmanLocationType_ENVIRONMENT_VARIABLE
 		s.scanVariableData(ctx, chunksChan, metadata, environment)
 		metadata.LocationType = source_metadatapb.PostmanLocationType_UNKNOWN_POSTMAN
@@ -258,7 +258,7 @@ func (s *Source) scanWorkspace(ctx context.Context, chunksChan chan *sources.Chu
 
 	// initiate metadata to track the tree structure of postman data
 	metadata := Metadata{
-		WorkspaceUUID: workspace.ID,
+		WorkspaceUUID: workspace.Id,
 		WorkspaceName: workspace.Name,
 		CreatedBy:     workspace.CreatedBy,
 		Type:          "workspace",
@@ -276,7 +276,7 @@ func (s *Source) scanWorkspace(ctx context.Context, chunksChan chan *sources.Chu
 		}
 		metadata.Type = ENVIRONMENT_TYPE
 		metadata.Link = LINK_BASE_URL + "environments/" + envID.Uid
-		metadata.FullID = envVars.ID
+		metadata.FullID = envVars.Id
 		metadata.EnvironmentID = envID.Uid
 		metadata.EnvironmentName = envVars.Name
 
@@ -391,7 +391,7 @@ func (s *Source) scanItem(ctx context.Context, chunksChan chan *sources.Chunk, c
 			metadata.Link = LINK_BASE_URL + REQUEST_TYPE + "/" + item.Uid
 		} else {
 			// Route to collection.json
-			metadata.FullID = item.ID
+			metadata.FullID = item.Id
 		}
 		s.scanHTTPRequest(ctx, chunksChan, metadata, item.Request)
 	}

--- a/pkg/sources/postman/postman_client.go
+++ b/pkg/sources/postman/postman_client.go
@@ -22,7 +22,7 @@ const (
 )
 
 type Workspace struct {
-	ID              string      `json:"id"`
+	Id              string      `json:"id"`
 	Name            string      `json:"name"`
 	Type            string      `json:"type"`
 	Description     string      `json:"description"`
@@ -38,7 +38,7 @@ type Workspace struct {
 }
 
 type IdNameUid struct {
-	ID   string `json:"id"`
+	Id   string `json:"id"`
 	Name string `json:"name"`
 	Uid  string `json:"uid"`
 }
@@ -53,7 +53,7 @@ type KeyValue struct {
 }
 
 type VariableData struct {
-	ID        string     `json:"id"` // For globals and envs, this is just the UUID, not the full ID.
+	Id        string     `json:"id"` // For globals and envs, this is just the UUID, not the full ID.
 	Name      string     `json:"name"`
 	KeyValues []KeyValue `json:"values"`
 	Owner     string     `json:"owner"`
@@ -105,7 +105,7 @@ type Info struct {
 type Item struct {
 	Name        string     `json:"name"`
 	Items       []Item     `json:"item,omitempty"`
-	ID          string     `json:"id,omitempty"`
+	Id          string     `json:"id,omitempty"`
 	Auth        Auth       `json:"auth,omitempty"`
 	Events      []Event    `json:"event,omitempty"`
 	Variable    []KeyValue `json:"variable,omitempty"`
@@ -173,7 +173,7 @@ type URL struct {
 }
 
 type Response struct {
-	ID              string          `json:"id"`
+	Id              string          `json:"id"`
 	Name            string          `json:"name,omitempty"`
 	OriginalRequest Request         `json:"originalRequest,omitempty"`
 	HeaderRaw       json.RawMessage `json:"header,omitempty"`
@@ -292,11 +292,11 @@ func (c *Client) EnumerateWorkspaces(ctx context.Context) ([]Workspace, error) {
 	}
 
 	for i, workspace := range workspacesObj.Workspaces {
-		tempWorkspace, err := c.GetWorkspace(ctx, workspace.ID)
+		tempWorkspace, err := c.GetWorkspace(ctx, workspace.Id)
 		if err != nil {
 			// Log and move on, because sometimes the Postman API seems to give us workspace IDs
 			// that we don't have access to, so we don't want to kill the scan because of it.
-			ctx.Logger().Error(err, "could not get workspace %q (%s) during enumeration", workspace.Name, workspace.ID)
+			ctx.Logger().Error(err, "could not get workspace %q (%s) during enumeration", workspace.Name, workspace.Id)
 			continue
 		}
 		workspacesObj.Workspaces[i] = tempWorkspace


### PR DESCRIPTION
We were going back and forth on this.  This normalizes it all - but doesn't include places where it's used as _part_ of a variable name.  That change is incoming.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
