### PR TITLE
WIP - Send Postman Correct ID When Getting Collection

### DIFF
--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -303,7 +303,7 @@ func (s *Source) scanWorkspace(ctx context.Context, chunksChan chan *sources.Chu
 		if shouldSkip(collectionID.UUID, s.conn.IncludeCollections, s.conn.ExcludeCollections) {
 			continue
 		}
-		collection, err := s.client.GetCollection(ctx, collectionID.UUID)
+		collection, err := s.client.GetCollection(ctx, collectionID.ID)
 		if err != nil {
 			// Log and move on, because sometimes the Postman API seems to give us collection IDs
 			// that we don't have access to, so we don't want to kill the scan because of it.


### PR DESCRIPTION
So this was a doozy (and I only found it by rampaging around renaming things into something that seemed more consistent for me - see nearby commits).

Postman has two identifiers for most objects in most contexts:
 - `id`: This is a unique identifier for the object, and is (at least) shaped like a UUID
 - `uid`:  Same as ID, except that the creating users's ID is concatenated as a prefix. - IMPORTANT NOTE - This is NOT a UUID

Notably, the collections APIs all ask for the collection _id_ as the URL path parameter specifying the collection you want to grab info for, _not_ the uid.  This could be an ambiguity in the API docs (maybe it accepts both?  Maybe it _sometimes_ accepts both?), but it's not clear to me right now.

The naming of our variables here aren't very clear unless you're deep in the thick of it (and maybe not even clear then).  What happened here (it looks like) is that someone mistook a `uid` for something that made sense to stuff into a "UUID"-suffixed variable.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
