### PR TITLE
test(sources/s3): fix missing region error

### DIFF
--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -158,7 +158,7 @@ func (s *Source) newClient(ctx context.Context, region, roleArn string) (*s3.Cli
 
 	if roleArn != "" {
 		// The config loaded here will be used to retrieve and refresh temporary credentials from AssumeRole
-		cfg, err := config.LoadDefaultConfig(ctx, config.WithCredentialsProvider(credsProvider))
+		cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region), config.WithCredentialsProvider(credsProvider))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
### Description:

Fixes #4069.

@rosecodym Apologies. I overlooked this and mistakenly assumed that the CI environment had the `AWS_REGION` variable set. Unfortunately, it doesn't, and that caused the failure on the `main` branch. This PR should fix that.

https://github.com/trufflesecurity/trufflehog/actions/runs/14910724831/job/41884134392#step:6:1277

```
=== FAIL: pkg/sources/s3 TestSource_Chunks/gets_chunks_after_assuming_role (unknown)
2025-05-08T16:06:01Z	info-0	context	Creating checkpointer	{"timeout": 30}
    s3_test.go:123: Source.Chunks() error = role "arn:aws:iam::619888638459:role/s3-test-assume-role" could not list any s3 buckets for scanning: operation error S3: ListBuckets, get identity: get credentials: failed to refresh cached credentials, operation error STS: AssumeRole, failed to resolve service endpoint, endpoint rule error, Invalid Configuration: Missing Region, wantErr false
```


### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
