### PR TITLE
fix: update README docs for shallow cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,20 +537,27 @@ If you're incorporating TruffleHog into a standalone workflow and aren't running
 
 ```
 ...
-      - shell: bash
-        run: |
-          if [ "${{ github.event_name }}" == "push" ]; then
-            echo "depth=$(($(jq length <<< '${{ toJson(github.event.commits) }}') + 2))" >> $GITHUB_ENV
-            echo "branch=${{ github.ref_name }}" >> $GITHUB_ENV
-          fi
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "depth=$((${{ github.event.pull_request.commits }}+2))" >> $GITHUB_ENV
-            echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
-          fi
-      - uses: actions/checkout@v3
+       - uses: actions/github-script@v7
+        id: git-intel
         with:
-          ref: ${{env.branch}}
-          fetch-depth: ${{env.depth}}
+          script: |
+            let depth = 0;
+            let branch = "";
+            if (context.eventName == "push")  {
+              depth = context.payload.commits.length
+              branch = context.ref
+            }
+            if (context.eventName == "pull_request") {
+              depth = context.payload.pull_request.commits
+              branch = context.payload.pull_request.head.ref
+            }
+            depth = depth + 2
+            core.info(`Will fetch ${depth} commits from ${branch}.`)
+            return { "depth": depth, "branch": branch }
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{steps.git-intel.outputs.result.branch}}
+          fetch-depth: ${{steps.git-intel.outputs.result.depth}}
       - uses: trufflesecurity/trufflehog@main
         with:
           extra_args: --results=verified,unknown


### PR DESCRIPTION
Current example for using trufflehog in GitHub actions with shallow cloning is unfortunately susceptible to a quoting injection.

Specifically, if any of the commits include the single quote mark, the whole workflow terminates with a syntax error because the `jq` can no longer calculate length of the commits array. In fact, `jq` is not even launched because it's really bash waiting for the single quote to be terminated when evaluating this expression:

```bash
$(jq length <<< '${{ toJson(github.event.commits) }}')
```

This can be triggered with an example commit message of `that's my commit`. In such case, the `toJson()` produces something similar to this:

```jsonc
[
    {
      "author": {
        "email": "skrobul@skrobul.com",
        "name": "Marek Skrobacki",
        "username": "skrobul"
      },
      // ...
      "id": "1743e414cff505efac7e38128974cfa39cd56332",
      "message": "that's my commit",
      "timestamp": "2025-05-13T10:33:04-05:00",
      // ...
    }
  ]
```

While technically the input here could be sanitized with additional filtering, I believe using shell scripting for this is far from ideal.

My alternative proposal uses GitHub's native `github-script` which offers slightly more safety and avoids shell escaping issues.