### PR TITLE
(fix) validation to ensure only one of --org or --repo is provided for Github source

### DIFF
--- a/main.go
+++ b/main.go
@@ -722,6 +722,9 @@ func runSingleScan(ctx context.Context, cmd string, cfg engine.Config) (metrics,
 		if len(*githubScanOrgs) == 0 && len(*githubScanRepos) == 0 {
 			return scanMetrics, fmt.Errorf("invalid config: you must specify at least one organization or repository")
 		}
+		if len(*githubScanRepos) > 0 && len(*githubScanOrgs) > 0 {
+			return scanMetrics, fmt.Errorf("invalid config: you cannot specify both organizations and repositories")
+		}
 
 		cfg := sources.GithubConfig{
 			Endpoint:                   *githubScanEndpoint,

--- a/main.go
+++ b/main.go
@@ -722,8 +722,8 @@ func runSingleScan(ctx context.Context, cmd string, cfg engine.Config) (metrics,
 		if len(*githubScanOrgs) == 0 && len(*githubScanRepos) == 0 {
 			return scanMetrics, fmt.Errorf("invalid config: you must specify at least one organization or repository")
 		}
-		if len(*githubScanRepos) > 0 && len(*githubScanOrgs) > 0 {
-			return scanMetrics, fmt.Errorf("invalid config: you cannot specify both organizations and repositories")
+		if len(*githubScanOrgs) > 0 && len(*githubScanRepos) > 0 {
+			return scanMetrics, fmt.Errorf("invalid config: you cannot specify both organizations and repositories at the same time")
 		}
 
 		cfg := sources.GithubConfig{


### PR DESCRIPTION
### Description:
This PR fixes the input validation logic to ensure that for github source,  either `--org` or `--repo` provided, but not both at the same time. This helps prevent ambiguous behavior and enforces clarity in how the GitHub data is being targeted.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
