### PR TITLE
chore: run setup-go after checkout

### DIFF
--- a/.github/workflows/detector-tests.yml
+++ b/.github/workflows/detector-tests.yml
@@ -14,8 +14,8 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
-      - uses: actions/setup-go@v5
       - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
       - name: Install gotestsum
         uses: jaxxstorm/action-install-gh-release@v1.14.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,10 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: "1.24"
-      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -10,16 +10,16 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: "1.24"
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
 
       - name: Run Head
         run: |

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -7,12 +7,12 @@ jobs:
   smoke:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: "1.24"
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Smoke
         run: |
           set -e
@@ -22,12 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: "1.24"
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Run trufflehog
         run: |
           set -e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,12 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: "1.24"
-      - name: Checkout code
-        uses: actions/checkout@v4
       - id: "auth"
         uses: "google-github-actions/auth@v2"
         with:
@@ -59,11 +59,11 @@ jobs:
       actions: "read"
       contents: "read"
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: "1.24"
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Test
         run: make test-community


### PR DESCRIPTION
### Description:

https://github.com/actions/setup-go/blob/main/README.md#caching-dependency-files-and-build-outputs

`actions/setup-go` uses the `go.sum` file to determine the cache key for Go modules. If it runs before `actions/checkout`, the `go.sum` file isn't available yet, so the cache cannot be properly restored.

This results in cache misses, as shown in the warnings below:

![image](https://github.com/user-attachments/assets/d66fc7ee-d15c-461e-8620-063c0c9b5745)

![image](https://github.com/user-attachments/assets/2970c8a9-0fbc-4d79-8f54-556d1365f033)

This PR fixes the issue by ensuring that all `actions/setup-go` steps are placed after `actions/checkout`, allowing `go.sum` to be present when the cache key is generated.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
