### PR TITLE
Fixed Shopify detector line number

### DIFF
--- a/pkg/detectors/shopify/shopify.go
+++ b/pkg/detectors/shopify/shopify.go
@@ -53,6 +53,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				Raw:          []byte(key + domainRes),
 			}
 
+			// set key as the primary secret for engine to find the line number
+			s1.SetPrimarySecretValue(key)
+
 			if verify {
 				req, err := http.NewRequestWithContext(ctx, "GET", "https://"+domainRes+"/admin/oauth/access_scopes.json", nil)
 				if err != nil {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Currently the Shopify detector is not reporting the correct line number for secrets in the results. It uses multiple regex patterns and appends both findings into the Raw field. The engine then uses this Raw value to locate the line number of the secret. However, because the findings are merged, the engine fails to match the actual secret and defaults to line number 1.

### Tests:
Before Change:
![Screenshot from 2025-05-19 15-23-27](https://github.com/user-attachments/assets/52402777-1920-49d3-8557-53b9571e7843)
After Change:
![Screenshot from 2025-05-19 15-23-48](https://github.com/user-attachments/assets/0acfdfe9-d85d-4cf7-b4d4-86e3dce4bcb5)


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
