### PR TITLE
Add per-chunk detection logging

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1048,7 +1048,14 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 	}
 	defer common.Recover(ctx)
 
-	ctx = context.WithValue(ctx, "detector", data.detector.Key.Loggable())
+	ctx = context.WithValues(ctx,
+		"detector", data.detector.Key.Loggable(),
+		"decoder_type", data.decoder.String(),
+		"chunk_source_name", data.chunk.SourceName,
+		"chunk_source_id", data.chunk.SourceID,
+		"chunk_source_metadata", data.chunk.SourceMetadata.String())
+
+	ctx.Logger().V(4).Info("Starting to detect chunk")
 
 	isFalsePositive := detectors.GetFalsePositiveCheck(data.detector.Detector)
 
@@ -1119,6 +1126,8 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 	}
 
 	matchesPerChunk.Observe(float64(matchCount))
+
+	ctx.Logger().V(4).Info("Finished detecting chunk")
 
 	data.wgDoneFn()
 }


### PR DESCRIPTION
I'm interested in ruling out any issues after the Postman source hands off a generated chunk to the chunks chan, so I'm adding this bit of loggin to the detector worker.  This will let us match items before and after the chunks chan.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
