### PR TITLE
Reduce verbosity of chunk trace logging

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1055,7 +1055,7 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 		"chunk_source_id", data.chunk.SourceID,
 		"chunk_source_metadata", data.chunk.SourceMetadata.String())
 
-	ctx.Logger().V(4).Info("Starting to detect chunk")
+	ctx.Logger().V(5).Info("Starting to detect chunk")
 
 	isFalsePositive := detectors.GetFalsePositiveCheck(data.detector.Detector)
 
@@ -1127,7 +1127,7 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 
 	matchesPerChunk.Observe(float64(matchCount))
 
-	ctx.Logger().V(4).Info("Finished detecting chunk")
+	ctx.Logger().V(5).Info("Finished detecting chunk")
 
 	data.wgDoneFn()
 }


### PR DESCRIPTION
These log lines are hit super frequently - we really only want them to show up when we are at trace level.  Reducing them here.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
