### PR TITLE
[chore] Bump TestMaxDiffSize timeout from 10s to 30s

### DIFF
--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -1437,7 +1437,7 @@ func TestMaxDiffSize(t *testing.T) {
 	bigReader := strings.NewReader(builder.String())
 
 	diffChan := make(chan *Diff, 1)                                          // Buffer to prevent blocking
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second) // Timeout to prevent long wait
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second) // Timeout to prevent long wait
 	defer cancel()
 
 	go func() {

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -1437,7 +1437,7 @@ func TestMaxDiffSize(t *testing.T) {
 	bigReader := strings.NewReader(builder.String())
 
 	diffChan := make(chan *Diff, 1)                                          // Buffer to prevent blocking
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second) // Timeout to prevent long wait
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second) // Timeout to prevent long wait
 	defer cancel()
 
 	go func() {


### PR DESCRIPTION

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This test started to fail in GitHub CI. Will this fix it?

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
