### PR TITLE
Enhanced smartsheets detector

### DIFF
--- a/pkg/detectors/smartsheets/smartsheets.go
+++ b/pkg/detectors/smartsheets/smartsheets.go
@@ -22,7 +22,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"smartsheet", "sheet"}) + `\b([a-zA-Z0-9]{37})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"sheet"}) + `\b([a-zA-Z0-9]{37})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/smartsheets/smartsheets.go
+++ b/pkg/detectors/smartsheets/smartsheets.go
@@ -28,7 +28,7 @@ var (
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"smartsheet", "sheet"}
+	return []string{"smartsheet"}
 }
 
 // FromData will find and optionally verify Smartsheets secrets in a given set of bytes.

--- a/pkg/detectors/smartsheets/smartsheets.go
+++ b/pkg/detectors/smartsheets/smartsheets.go
@@ -3,9 +3,10 @@ package smartsheets
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
+	"io"
 	"net/http"
-	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -21,42 +22,35 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"smartsheets"}) + `\b([a-zA-Z0-9]{37})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"smartsheet", "sheet"}) + `\b([a-zA-Z0-9]{37})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"smartsheets"}
+	return []string{"smartsheet", "sheet"}
 }
 
 // FromData will find and optionally verify Smartsheets secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
 	dataStr := string(data)
 
-	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
+	var uniqueKeys = make(map[string]struct{})
 
-	for _, match := range matches {
-		resMatch := strings.TrimSpace(match[1])
+	for _, matche := range keyPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueKeys[matche[1]] = struct{}{}
+	}
 
+	for key := range uniqueKeys {
 		s1 := detectors.Result{
 			DetectorType: detectorspb.DetectorType_Smartsheets,
-			Raw:          []byte(resMatch),
+			Raw:          []byte(key),
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.smartsheet.com/2.0/sheets", nil)
-			if err != nil {
-				continue
-			}
-			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
-			res, err := client.Do(req)
-			if err == nil {
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					s1.Verified = true
-				}
-			}
+			isVerified, verificationErr := verifySmartSheetsToken(ctx, client, key)
+			s1.Verified = isVerified
+			s1.SetVerificationError(verificationErr)
 		}
 
 		results = append(results, s1)
@@ -71,4 +65,32 @@ func (s Scanner) Type() detectorspb.DetectorType {
 
 func (s Scanner) Description() string {
 	return "Smartsheets is a platform for work management and automation. Smartsheets API keys can be used to access and modify data and automate workflows within the platform."
+}
+
+func verifySmartSheetsToken(ctx context.Context, client *http.Client, token string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.smartsheet.com/2.0/sheets", http.NoBody)
+	if err != nil {
+		return false, err
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusUnauthorized:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
 }

--- a/pkg/detectors/smartsheets/smartsheets_test.go
+++ b/pkg/detectors/smartsheets/smartsheets_test.go
@@ -28,8 +28,9 @@ func TestSmartsheets_Pattern(t *testing.T) {
 			want: []string{"MVE7zmdxouvunYkowLzaudyX7tvMpkqJ3q52C"},
 		},
 		{
-			name: "valid pattern - with keyword sheet",
+			name: "valid pattern - with prefixRegex sheet",
 			input: `
+			# smartsheet credentials
 			sheet_id := "MVE7zmdxouvunFAKELzaudyX7tvMpkqJ3q52d"
 			`,
 			want: []string{"MVE7zmdxouvunFAKELzaudyX7tvMpkqJ3q52d"},
@@ -37,6 +38,7 @@ func TestSmartsheets_Pattern(t *testing.T) {
 		{
 			name: "valid pattern - ignore duplicate",
 			input: `
+			# smartsheet duplicate credentials
 			sheet_id1 := "MVE7zmdxouvunFAKELzaudyX7tvMpkqJ3q52d"
 			sheet_id2 := "MVE7zmdxouvunFAKELzaudyX7tvMpkqJ3q52d"
 			`,
@@ -56,6 +58,7 @@ func TestSmartsheets_Pattern(t *testing.T) {
 		{
 			name: "invalid pattern",
 			input: `
+			# smartsheet secret
 			sheet_id = MVE7?mdxouvunYkowLzaudyX7tvMpkqJ3q52C
 			`,
 			want: []string{},

--- a/pkg/detectors/smartsheets/smartsheets_test.go
+++ b/pkg/detectors/smartsheets/smartsheets_test.go
@@ -2,19 +2,12 @@ package smartsheets
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
-)
-
-var (
-	validPattern   = "MVE7zmdxouvunYkowLzaudyX7tvMpkqJ3q52C"
-	invalidPattern = "MVE7?mdxouvunYkowLzaudyX7tvMpkqJ3q52C"
-	keyword        = "smartsheets"
 )
 
 func TestSmartsheets_Pattern(t *testing.T) {
@@ -26,24 +19,46 @@ func TestSmartsheets_Pattern(t *testing.T) {
 		want  []string
 	}{
 		{
-			name:  "valid pattern - with keyword smartsheets",
-			input: fmt.Sprintf("%s token = '%s'", keyword, validPattern),
-			want:  []string{validPattern},
+			name: "valid pattern - with keyword smartsheet and sheet",
+			input: `
+			# do not share these secrets
+			# list all sheets
+			sheets := getsmartsheet("MVE7zmdxouvunYkowLzaudyX7tvMpkqJ3q52C")
+			`,
+			want: []string{"MVE7zmdxouvunYkowLzaudyX7tvMpkqJ3q52C"},
 		},
 		{
-			name:  "valid pattern - ignore duplicate",
-			input: fmt.Sprintf("%s token = '%s' | '%s'", keyword, validPattern, validPattern),
-			want:  []string{validPattern},
+			name: "valid pattern - with keyword sheet",
+			input: `
+			sheet_id := "MVE7zmdxouvunFAKELzaudyX7tvMpkqJ3q52d"
+			`,
+			want: []string{"MVE7zmdxouvunFAKELzaudyX7tvMpkqJ3q52d"},
 		},
 		{
-			name:  "valid pattern - key out of prefix range",
-			input: fmt.Sprintf("%s keyword is not close to the real key in the data\n = '%s'", keyword, validPattern),
-			want:  []string{},
+			name: "valid pattern - ignore duplicate",
+			input: `
+			sheet_id1 := "MVE7zmdxouvunFAKELzaudyX7tvMpkqJ3q52d"
+			sheet_id2 := "MVE7zmdxouvunFAKELzaudyX7tvMpkqJ3q52d"
+			`,
+			want: []string{"MVE7zmdxouvunFAKELzaudyX7tvMpkqJ3q52d"},
 		},
 		{
-			name:  "invalid pattern",
-			input: fmt.Sprintf("%s = '%s'", keyword, invalidPattern),
-			want:  []string{},
+			name: "valid pattern - key out of prefix range",
+			input: `
+			# below is the smartsheet secret
+			# use this secret to list sheets
+			# do not share this
+
+			sslist := listAll("MVE7zmdxouvunFAKELzaudyX7tvMpkqJ3q52d")
+			`,
+			want: []string{},
+		},
+		{
+			name: "invalid pattern",
+			input: `
+			sheet_id = MVE7?mdxouvunYkowLzaudyX7tvMpkqJ3q52C
+			`,
+			want: []string{},
 		},
 	}
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
One user requested to add keyword `sheet` for the smartsheets detector. This PR also update the existing keyword `smartsheets` to `smartsheet` so we can look for both. Some enhancement to verification and pattern test cases.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
