### PR TITLE
Bump the Postman client timeout

### DIFF
--- a/pkg/sources/postman/postman.go
+++ b/pkg/sources/postman/postman.go
@@ -18,7 +18,6 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/go-errors/errors"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
@@ -121,7 +120,6 @@ func (s *Source) Init(ctx context.Context, name string, jobId sources.JobID, sou
 			return errors.New("Postman token is empty")
 		}
 		s.client = NewClient(conn.GetToken(), s.metrics)
-		s.client.HTTPClient = common.RetryableHTTPClientTimeout(10)
 		log.RedactGlobally(conn.GetToken())
 	case *sourcespb.Postman_Unauthenticated:
 		s.client = nil

--- a/pkg/sources/postman/postman_client.go
+++ b/pkg/sources/postman/postman_client.go
@@ -8,9 +8,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"golang.org/x/time/rate"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 )
 
@@ -214,7 +215,10 @@ func NewClient(postmanToken string, metrics *metrics) *Client {
 	}
 
 	c := &Client{
-		HTTPClient:                        http.DefaultClient,
+		// Requests for large objects (usually collections) take a long time.  While we don't think that _every_
+		// request will take this long, some might take 5 seconds or more.  This seems reasonable, but we should
+		// be very cautious about bumping it further
+		HTTPClient:                        common.RetryableHTTPClientTimeout(30),
 		Headers:                           bh,
 		WorkspaceAndCollectionRateLimiter: rate.NewLimiter(rate.Every(time.Second), 1),
 		GeneralRateLimiter:                rate.NewLimiter(rate.Every(time.Second/5), 1),


### PR DESCRIPTION
Sometimes when we're getting really large collections, these requests can take a long time.  Bumping timeouts isn't likely the best solution long term, but it should help now.

Also moved where we define the http client into the postman client itself and cleaned up some import ordering


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
