### PR TITLE
Fix false positives detection in LarkSuite token regex

### DIFF
--- a/pkg/detectors/larksuite/larksuite.go
+++ b/pkg/detectors/larksuite/larksuite.go
@@ -34,9 +34,9 @@ const (
 var (
 	defaultClient = common.SaneHttpClient()
 	tokenPats     = map[tokenType]*regexp.Regexp{
-		TenantAccessToken: regexp.MustCompile(detectors.PrefixRegex([]string{"lark", "larksuite", "tenant"}) + `\b(t-[a-z0-9A-Z_.]{14,50})\b`),
-		UserAccessToken:   regexp.MustCompile(detectors.PrefixRegex([]string{"lark", "larksuite", "user"}) + `\b(u-[a-z0-9A-Z_.]{14,50})\b`),
-		AppAccessToken:    regexp.MustCompile(detectors.PrefixRegex([]string{"lark", "larksuite", "app"}) + `\b(a-[a-z0-9A-Z_.]{14,50})\b`),
+		TenantAccessToken: regexp.MustCompile(detectors.PrefixRegex([]string{"lark", "larksuite", "tenant"}) + `(?:^|[^-])\b(t-[a-z0-9A-Z_.]{14,50})\b(?:[^-]|$)`),
+		UserAccessToken:   regexp.MustCompile(detectors.PrefixRegex([]string{"lark", "larksuite", "user"}) + `(?:^|[^-])\b(u-[a-z0-9A-Z_.]{14,50})\b(?:[^-]|$)`),
+		AppAccessToken:    regexp.MustCompile(detectors.PrefixRegex([]string{"lark", "larksuite", "app"}) + `(?:^|[^-])\b(a-[a-z0-9A-Z_.]{14,50})\b(?:[^-]|$)`),
 	}
 
 	verificationUrls = map[tokenType]string{


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This commit fixes the issue mentioned in https://github.com/trufflesecurity/trufflehog/issues/4101
It cleans up the regex used for checking access tokens in LarkSuite.
Currently "\b" only covers non word characters (letters, numbers, underscore). It does not include dashes which is popularly used in URLs and other naming conventions. 

I have also included a test which checks for invalid tokens.

### Checklist:
* [ :heavy_check_mark: ] Tests passing (`make test-community`)?
* [ :heavy_check_mark: ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
