### PR TITLE
Add delimiter for Razorpay RawV2

### DIFF
--- a/pkg/detectors/razorpay/razorpay.go
+++ b/pkg/detectors/razorpay/razorpay.go
@@ -48,7 +48,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_RazorPay,
 				Raw:          []byte(key),
-				RawV2:        []byte(key + secret),
+				RawV2:        []byte(key + ":" + secret),
 				Redacted:     key,
 			}
 

--- a/pkg/detectors/razorpay/razorpay_test.go
+++ b/pkg/detectors/razorpay/razorpay_test.go
@@ -30,7 +30,7 @@ func TestRazorPay_Pattern(t *testing.T) {
 		{
 			name:  "valid pattern - with keyword razorpay",
 			input: fmt.Sprintf("%s token - '%s'\n%s token - '%s'\n", keyword, validKey, keyword, validSecret),
-			want:  []string{validKey + validSecret},
+      want:  []string{validKey + ":" + validSecret},
 		},
 		{
 			name:  "invalid pattern",


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
In Razorpay detector "RawV2" value shows key & secret but there is no delimiter between them.

This PR adds a delimiter `:` between key and secret for RawV2 similar to [aws](https://github.com/trufflesecurity/trufflehog/blob/1ca22a6b9cbfd9839c62b670a00f21621109a5a1/pkg/detectors/aws/access_keys/accesskey.go#L140C5-L140C55)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
