### PR TITLE
[fix] Report the unit in a single scan job

### DIFF
--- a/pkg/sources/job_progress.go
+++ b/pkg/sources/job_progress.go
@@ -355,6 +355,10 @@ func (m JobProgressMetrics) PercentComplete() int {
 		// Fallback to the source's self-reported percent complete if
 		// the unit information isn't available.
 		return int(m.SourcePercent)
+	} else if den == 0 {
+		// This should never happen. Return an invalid value so we can
+		// trace it back to here if we ever see it.
+		return -1
 	}
 	return int(num * 100 / den)
 }

--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -417,6 +417,7 @@ func (s *SourceManager) scan(ctx context.Context, source Source, report *JobProg
 		}
 	}()
 
+	report.ReportUnit(unit)
 	report.TrackProgress(source.GetProgress())
 	if ctx.Value("job_id") == "" {
 		ctx = context.WithValue(ctx, "job_id", report.JobID)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
`ReportUnit` tracks the total number of units for progress reporting. This correctly reports it for scans that don't do any enumeration (i.e. a `SCAN` job).

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
