### PR TITLE
Fix typo: remove duplicated 'about' in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 **...and more**
 
-To learn more about about TruffleHog and its features and capabilities, visit our [product page](https://trufflesecurity.com/trufflehog?gclid=CjwKCAjwouexBhAuEiwAtW_Zx5IW87JNj97Ci7heFnA5ar6-DuNzT2Y5nIl9DuZ-FOUqx0Qg3vb9nxoClcEQAvD_BwE).
+To learn more about TruffleHog and its features and capabilities, visit our [product page](https://trufflesecurity.com/trufflehog?gclid=CjwKCAjwouexBhAuEiwAtW_Zx5IW87JNj97Ci7heFnA5ar6-DuNzT2Y5nIl9DuZ-FOUqx0Qg3vb9nxoClcEQAvD_BwE).
 
 </div>
 


### PR DESCRIPTION
### Description:
This PR fixes a minor typo in the README.md where the word "about" was duplicated in the sentence:

> "To learn more about about TruffleHog..."

It has been corrected to:

> "To learn more about TruffleHog..."

Closes #4210

### Checklist:
* [x] No tests needed – documentation-only fix.
* [x] No linting needed – no code was modified.
