### PR TITLE
Update ngrok.go detector to handle 403s properly

### DIFF
--- a/pkg/detectors/ngrok/ngrok.go
+++ b/pkg/detectors/ngrok/ngrok.go
@@ -99,6 +99,8 @@ func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, 
 		return true, nil
 	case http.StatusUnauthorized:
 		return false, nil
+	case http.StatusForbidden:
+		return false, nil
 	case http.StatusBadRequest:
 		bodyBytes, err := io.ReadAll(res.Body)
 		if err != nil {


### PR DESCRIPTION
Ngrok is returning 403s when the auth token is invalid, which isn't being handled currently by the detector. This causes the verification request to fail both in the CLI and in the enterprise GUI.

e.g. `{"error_code":"ERR_NGROK_203","status_code":403,"msg":"The API authentication you specified is properly formed, but it is invalid"}`

### Description:
Adds a new case to handle 403 Forbidden responses per documentation: [https://go.dev/src/net/http/status.go](https://go.dev/src/net/http/status.go)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
