### PR TITLE
Log recursion limiting

### DIFF
--- a/pkg/sources/postman/substitution.go
+++ b/pkg/sources/postman/substitution.go
@@ -57,7 +57,7 @@ func (s *Source) buildSubstituteSet(metadata Metadata, data string, maxRecursion
 	combos := make(map[string]struct{})
 
 	// Call buildSubstitution with initial depth of 0 and the maxRecursionDepth
-	s.buildSubstitution(data, metadata, &combos, 0, maxRecursionDepth)
+	s.buildSubstitution(data, metadata, combos, 0, maxRecursionDepth)
 
 	for combo := range combos {
 		ret = append(ret, combo)
@@ -75,20 +75,20 @@ func (s *Source) buildSubstituteSet(metadata Metadata, data string, maxRecursion
 func (s *Source) buildSubstitution(
 	data string,
 	metadata Metadata,
-	combos *map[string]struct{},
+	combos map[string]struct{},
 	depth int,
 	maxRecursionDepth int,
 ) {
 	// Limit recursion depth to prevent stack overflow
 	if depth > maxRecursionDepth {
-		(*combos)[data] = struct{}{}
+		combos[data] = struct{}{}
 		return
 	}
 
 	matches := removeDuplicateStr(subRe.FindAllString(data, -1))
 	if len(matches) == 0 {
 		// No more substitutions to make, add to combos
-		(*combos)[data] = struct{}{}
+		combos[data] = struct{}{}
 		return
 	}
 
@@ -124,7 +124,7 @@ func (s *Source) buildSubstitution(
 
 	// If no substitutions were made, add the current data
 	if !substitutionMade {
-		(*combos)[data] = struct{}{}
+		combos[data] = struct{}{}
 	}
 }
 

--- a/pkg/sources/postman/substitution_test.go
+++ b/pkg/sources/postman/substitution_test.go
@@ -5,6 +5,8 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 
 func TestNewSubstitution(t *testing.T) {
@@ -63,6 +65,8 @@ func TestSource_KeywordCombinations(t *testing.T) {
 }
 
 func TestSource_BuildSubstituteSet(t *testing.T) {
+	ctx := context.Background()
+
 	s := &Source{
 		sub: NewSubstitution(),
 	}
@@ -89,7 +93,7 @@ func TestSource_BuildSubstituteSet(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		result := s.buildSubstituteSet(metadata, tc.data, DefaultMaxRecursionDepth)
+		result := s.buildSubstituteSet(ctx, metadata, tc.data, DefaultMaxRecursionDepth)
 		if !reflect.DeepEqual(result, tc.expected) {
 			t.Errorf("Expected substitution set: %v, got: %v", tc.expected, result)
 		}
@@ -158,6 +162,8 @@ func TestSource_FormatAndInjectKeywords(t *testing.T) {
 }
 
 func TestSource_BuildSubstitution_RecursionLimit(t *testing.T) {
+	ctx := context.Background()
+
 	s := &Source{
 		sub: NewSubstitution(),
 	}
@@ -229,9 +235,9 @@ func TestSource_BuildSubstitution_RecursionLimit(t *testing.T) {
 
 			// Use custom maxDepth if provided, otherwise use default
 			if tc.maxDepth > 0 {
-				s.buildSubstitution(tc.data, metadata, combos, 0, tc.maxDepth)
+				s.buildSubstitution(ctx, tc.data, metadata, combos, 0, tc.maxDepth)
 			} else {
-				s.buildSubstitution(tc.data, metadata, combos, 0, DefaultMaxRecursionDepth)
+				s.buildSubstitution(ctx, tc.data, metadata, combos, 0, DefaultMaxRecursionDepth)
 			}
 
 			var result []string

--- a/pkg/sources/postman/substitution_test.go
+++ b/pkg/sources/postman/substitution_test.go
@@ -229,9 +229,9 @@ func TestSource_BuildSubstitution_RecursionLimit(t *testing.T) {
 
 			// Use custom maxDepth if provided, otherwise use default
 			if tc.maxDepth > 0 {
-				s.buildSubstitution(tc.data, metadata, &combos, 0, tc.maxDepth)
+				s.buildSubstitution(tc.data, metadata, combos, 0, tc.maxDepth)
 			} else {
-				s.buildSubstitution(tc.data, metadata, &combos, 0, DefaultMaxRecursionDepth)
+				s.buildSubstitution(tc.data, metadata, combos, 0, DefaultMaxRecursionDepth)
 			}
 
 			var result []string


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We put in a variable substitution recursion limit, and I want to know how often we're bumping against that.

I also found a potential recursion problem: if `Item`s can refer to each other we can create a cycle we'll never break out of, so I committed a little fix for that too. If it's annoying I can break it out into its own change (very happy to do this)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
