### PR TITLE
Gitparse test: Decreased MaxDiffSize in gitparse TestMaxDiffSize() function

### DIFF
--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -1430,11 +1430,7 @@ index 0000000..5af88a8
 `
 
 func TestMaxDiffSize(t *testing.T) {
-	// Feels bad to skip tests forever and then just forget about them.  Skip for a while.
-	if time.Now().Before(time.Date(2025, time.July, 1, 0, 0, 0, 0, time.UTC)) {
-		t.Skip("This is failing intermittently.  Skipping for now")
-	}
-	parser := NewParser()
+	parser := NewParser(WithMaxDiffSize(1024 * 1024)) // Setting max diff size to 1MB for the test
 	builder := strings.Builder{}
 	builder.WriteString(singleCommitSingleDiff)
 


### PR DESCRIPTION
### Description:
The gitparse `TestMaxDiffSize()` test creates a diff for testing purposes based on the default `MaxDiffSize` of the parser which is 2GB, which was exceeding the test timeout of 10 seconds and failing.
This updates the test, by initializing the parser with the max diff of 1MB, so the test finishes significantly faster.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
