### PR TITLE
feat: allow changing Docker image for scan job

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,8 @@ TruffleHog statically detects [https://canarytokens.org/](https://canarytokens.o
     base:
     # Scan commits until here (usually dev branch).
     head: # optional
+    # Docker image to use for scanning, defaults to ghcr.io/trufflesecurity/trufflehog.
+    image: # optional
     # Extra args to be passed to the trufflehog cli.
     extra_args: --log-level=2 --results=verified,unknown
 ```

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     default: ""
     description: Extra args to be passed to the trufflehog cli.
     required: false
+  image:
+    default: "ghcr.io/trufflesecurity/trufflehog"
+    description: Docker image to use for scanning.
+    required: false
   version:
     default: "latest"
     description: Scan with this trufflehog cli version.
@@ -36,6 +40,7 @@ runs:
         HEAD: ${{ inputs.head }}
         ARGS: ${{ inputs.extra_args }}
         COMMIT_IDS: ${{ toJson(github.event.commits.*.id) }}
+        IMAGE: ${{ inputs.image }}
         VERSION: ${{ inputs.version }}
       run: |
         ##########################################
@@ -94,7 +99,7 @@ runs:
         ##          Run TruffleHog              ##
         ##########################################
         docker run --rm -v .:/tmp -w /tmp \
-        ghcr.io/trufflesecurity/trufflehog:${VERSION} \
+        "${IMAGE}:${VERSION}" \
         git file:///tmp/ \
         --since-commit \
         ${BASE:-''} \


### PR DESCRIPTION
### Description:

Allows changing Docker image used for the scan job, this is useful if the Docker images should be pulled from a different place than the GitHub Container Registry. Such situations usually occur with air-gapped systems or places where Docker registry access is restricted.

Fixes #4241.

### Checklist:

* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
  * Not really applicable as the change does not touch Go code, but no, fails with:
```
❯ make lint
golangci-lint run --enable bodyclose --enable copyloopvar --enable misspell --out-format=colored-line-number --timeout 10m
Error: unknown flag: --out-format
Failed executing command with error: unknown flag: --out-format
make: *** [lint] Error 3
```

My version information:

```
❯ golangci-lint --version
golangci-lint has version 2.1.6 built with go1.24.2 from eabc263 on 2025-05-04T15:36:41Z
```
