### PR TITLE
Move default detectors ownership to OSS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,6 +20,8 @@ pkg/detectors/ @trufflesecurity/OSS
 pkg/common/ @trufflesecurity/OSS
 pkg/custom_detectors/ @trufflesecurity/OSS
 pkg/analzyers/ @trufflesecurity/OSS
+pkg/engine/defaults/defaults.go @trufflesecurity/OSS
+pkg/engine/defaults/defaults_test.go @trufflesecurity/OSS
 
 # critical detectors
 pkg/detectors/aws/ @trufflesecurity/backend


### PR DESCRIPTION
This directory holds only detector information, but it's in `/engine`, so its codeownership has been incorrectly assigned to non-OSS teams. Moving it to a detector-related spot created an import cycle that I don't want to deal with right now, so instead I'm just tweaking CODEOWNERS.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
