### PR TITLE
Disable s3 filter test

### DIFF
--- a/pkg/sources/s3/s3_test.go
+++ b/pkg/sources/s3/s3_test.go
@@ -98,7 +98,7 @@ func TestSource_Chunks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.name == "gets chunks after assuming role" {
-				t.Skip("SCAN-436")
+				t.Skip("skipping until our test environment stabilizes enough that we know how we're going to handle this")
 			}
 
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)

--- a/pkg/sources/s3/s3_test.go
+++ b/pkg/sources/s3/s3_test.go
@@ -97,6 +97,10 @@ func TestSource_Chunks(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "gets chunks after assuming role" {
+				t.Skip("SCAN-436")
+			}
+
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 			defer cancel()
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
There have been some changes to our AWS test environment that are causing this test to fail. This PR disables the test until the environment stabilizes and we decide on a path forward.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
