### PR TITLE
Fix TestChunkUnit

### DIFF
--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -587,13 +587,14 @@ func TestChunkUnit(t *testing.T) {
 	}, &reporter)
 	assert.NoError(t, err)
 
-	// Error path.
+	// Error path - should return fatal error for missing directory.
 	err = s.ChunkUnit(ctx, SourceUnit{
 		ID:   "/file/not/found",
 		Kind: UnitDir,
 	}, &reporter)
-	assert.NoError(t, err)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "directory does not exist")
 
 	assert.Equal(t, 22, len(reporter.Chunks))
-	assert.Equal(t, 1, len(reporter.ChunkErrs))
+	assert.Equal(t, 0, len(reporter.ChunkErrs))
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We have updated the `TestChunkUnit` to expect fatal error when directory doesn't exist, instead of treating it as a non-fatal chunk error. 

#### Reason For Change:
Since we have made `missing directory` a fatal error in `scanDir` in this [PR](https://github.com/trufflesecurity/trufflehog/pull/3419), the [test](https://github.com/trufflesecurity/trufflehog/actions/runs/15856609844/job/44703429185?pr=4262#step:6:1025) is now failing.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
