### PR TITLE
Allow users to exit the TUI when there are extra args

### DIFF
--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -143,10 +143,16 @@ func (ui *TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			switch {
 			case key.Matches(msg, ui.common.KeyMap.Help):
 			case key.Matches(msg, ui.common.KeyMap.CmdQuit) && ui.activePage() != sourceConfigurePage:
+				ui.args = nil
 				return ui, tea.Quit
 			case key.Matches(msg, ui.common.KeyMap.Quit):
+				ui.args = nil
 				return ui, tea.Quit
-			case ui.activePage() > 0 && key.Matches(msg, ui.common.KeyMap.Back):
+			case key.Matches(msg, ui.common.KeyMap.Back):
+				if ui.activePage() == wizardIntroPage {
+					ui.args = nil
+					return ui, tea.Quit
+				}
 				_ = ui.popHistory()
 				return ui, nil
 			}
@@ -159,6 +165,7 @@ func (ui *TUI) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			switch item {
 			case wizard_intro.Quit:
+				ui.args = nil
 				cmds = append(cmds, tea.Quit)
 			case wizard_intro.ViewOSSProject:
 				ui.setActivePage(viewOSSProjectPage)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This fixes a bug when trying to exit after starting the TUI with args such as `trufflehog analyze` or `trufflehog analyze github`.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
