### PR TITLE
[chore] Write --help to stdout

### DIFF
--- a/main.go
+++ b/main.go
@@ -275,8 +275,9 @@ func init() {
 
 	cli.Version("trufflehog " + version.BuildVersion)
 
-	// Support -h for help
+	// Support -h for help and write it to stdout.
 	cli.HelpFlag.Short('h')
+	cli.UsageWriter(os.Stdout)
 
 	// Check if the TUI environment variable is set.
 	if ok, err := strconv.ParseBool(os.Getenv("TUI_PARENT")); err == nil {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The [GNU CLI Guidelines](https://www.gnu.org/prep/standards/html_node/_002d_002dhelp.html) suggest writing `--help` to stdout. The default for `kingpin` is to use stderr, so this PR updates it.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
