### PR TITLE
Suppress AWS SDK checksum skip warnings for S3

### DIFF
--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -166,6 +166,7 @@ func (s *Source) newClient(ctx context.Context, region, roleArn string) (*s3.Cli
 		stsClient := sts.NewFromConfig(cfg)
 		provider := stscreds.NewAssumeRoleProvider(stsClient, roleArn, func(options *stscreds.AssumeRoleOptions) {
 			options.RoleSessionName = "trufflehog"
+			options.DisableLogOutputChecksumValidationSkipped = true
 		})
 		// From https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html#specify-credentials-programmatically:
 		//   "If you explicitly configure a provider on aws.Config directly,

--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -166,7 +166,6 @@ func (s *Source) newClient(ctx context.Context, region, roleArn string) (*s3.Cli
 		stsClient := sts.NewFromConfig(cfg)
 		provider := stscreds.NewAssumeRoleProvider(stsClient, roleArn, func(options *stscreds.AssumeRoleOptions) {
 			options.RoleSessionName = "trufflehog"
-			options.DisableLogOutputChecksumValidationSkipped = true
 		})
 		// From https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html#specify-credentials-programmatically:
 		//   "If you explicitly configure a provider on aws.Config directly,
@@ -183,7 +182,9 @@ func (s *Source) newClient(ctx context.Context, region, roleArn string) (*s3.Cli
 		return nil, err
 	}
 
-	return s3.NewFromConfig(cfg), nil
+	return s3.NewFromConfig(cfg, func(options *s3.Options) {
+		options.DisableLogOutputChecksumValidationSkipped = true
+	}), nil
 }
 
 // getBucketsToScan returns a list of S3 buckets to scan.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Suppress the output of AWS SDK warnings related to missing checksums when accessing items in S3.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
