### PR TITLE
Support sub-unit resumption in filesystem scans

### DIFF
--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -520,10 +520,9 @@ func (p *Progress) GetProgress() *Progress {
 // way to access the EncodedResumeInfo for Sources to enable saving and
 // resuming progress mid SourceUnit scan.
 //
-// In majority of cases, synchronization like this is not needed. However,
-// there are edge-cases that warrant this: headless and OSS scans. Two types of
-// scans *that can't even be resumed*, but the alternative is to make the
-// Source aware of that, complicating the implementation even more.
+// This level of synchronization is only necessary when multiple concurrent
+// invocations of ChunkUnit consume/mutate the same Progress object. The source
+// manager executes scans this way under certain circumstances.
 //
 // Usage:
 //  - id should be the SourceUnit ID


### PR DESCRIPTION
Additionally adds utility methods to the `Progress` struct to make concurrent access to the `EncodedResumeInfo` more ergonomic.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Adds support for sub-unit resumption to the filesystem source by utilizing the existing `EncodedResumeInfo` field.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
