### PR TITLE
Removed stored logger from HuggingFace source

### DIFF
--- a/pkg/sources/huggingface/client.go
+++ b/pkg/sources/huggingface/client.go
@@ -150,11 +150,11 @@ func (c *HFClient) get(ctx context.Context, url string, target interface{}) erro
 	}
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return errors.New("invalid API key.")
+		return errors.New("invalid API key")
 	}
 
 	if resp.StatusCode == http.StatusForbidden {
-		return errors.New("access to this repo is restricted and you are not in the authorized list. Visit the repository to ask for access.")
+		return errors.New("access to this repo is restricted and you are not in the authorized list. Visit the repository to ask for access")
 	}
 
 	defer resp.Body.Close()

--- a/pkg/sources/huggingface/repo.go
+++ b/pkg/sources/huggingface/repo.go
@@ -56,11 +56,13 @@ func (s *Source) cloneRepo(
 
 	switch s.conn.GetCredential().(type) {
 	case *sourcespb.Huggingface_Unauthenticated:
+		ctx.Logger().V(2).Info("cloning repo without authentication", "repo_url", repoURL)
 		path, repo, err = git.CloneRepoUsingUnauthenticated(ctx, repoURL)
 		if err != nil {
 			return "", nil, err
 		}
 	case *sourcespb.Huggingface_Token:
+		ctx.Logger().V(2).Info("cloning repo with token authentication", "repo_url", repoURL)
 		path, repo, err = git.CloneRepoUsingToken(ctx, s.huggingfaceToken, repoURL, "", true)
 		if err != nil {
 			return "", nil, err


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR remove the stored logger for HuggingFace source and instead log using the loggers attached to context objects passed into the source’s entry points.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
