### PR TITLE
chore: updated defaults.go references in documentation for adding new detectors

### DIFF
--- a/hack/docs/Adding_Detectors_Internal.md
+++ b/hack/docs/Adding_Detectors_Internal.md
@@ -57,7 +57,7 @@ Note: Be sure to update the tests to reference the new secret values in GSM, or 
 
 3. Add a 'version' field in ExtraData for both existing and new detector versions.
 
-4. Update the existing detector in DefaultDetectors in `/pkg/engine/defaults.go`
+4. Update the existing detector in DefaultDetectors in `/pkg/engine/defaults/defaults.go`
 
 5. Proceed from step 3 of [Creating a new Secret Scanner](#creating-a-new-secret-scanner)
 
@@ -87,7 +87,7 @@ Note: Be sure to update the tests to reference the new secret values in GSM, or 
       4. Found and unverified (indeterminately due to an unexpected API response)
       5. Not found
       6. Any false positive cases that you come across
-   5. Add your new detector to DefaultDetectors in `/pkg/engine/defaults.go`
+   5. Add your new detector to DefaultDetectors in `/pkg/engine/defaults/defaults.go`
    6. Create a merge request for review. CI tests must be passing.
 
 ## Addendum

--- a/hack/docs/Adding_Detectors_external.md
+++ b/hack/docs/Adding_Detectors_external.md
@@ -53,7 +53,7 @@ Note: Be sure to update the tests to reference the new secret values in GSM, or 
 
 3. Add a 'version' field in ExtraData for both existing and new detector versions.
 
-4. Update the existing detector in DefaultDetectors in `/pkg/engine/defaults.go`
+4. Update the existing detector in DefaultDetectors in `/pkg/engine/defaults/defaults.go`
 
 5. Proceed from step 3 of [Creating a new Secret Scanner](#creating-a-new-secret-scanner)
 
@@ -71,8 +71,8 @@ Note: Be sure to update the tests to reference the new secret values in GSM, or 
    ```
 4. Add the Secret Detector to TruffleHog's Default Detectors
 
-   Add the secret scanner to the [`pkg/engine/defaults.go`](https://github.com/trufflesecurity/trufflehog/blob/main/pkg/engine/defaults.go) file like [`github.com/trufflesecurity/trufflehog/v3/pkg/detectors/<detector_name>`](https://github.com/trufflesecurity/trufflehog/blob/b71ea27a696bdf1c3141f637fda4ee4936c2f2d6/pkg/engine/defaults.go#L9) and 
-   [`<detector_name>.Scanner{}`](https://github.com/trufflesecurity/trufflehog/blob/b71ea27a696bdf1c3141f637fda4ee4936c2f2d6/pkg/engine/defaults.go#L1546)
+   Add the secret scanner to the [`pkg/engine/defaults/defaults.go`](https://github.com/trufflesecurity/trufflehog/blob/main/pkg/engine/defaults/defaults.go) file like [`github.com/trufflesecurity/trufflehog/v3/pkg/detectors/<detector_name>`](https://github.com/trufflesecurity/trufflehog/blob/b71ea27a696bdf1c3141f637fda4ee4936c2f2d6/pkg/engine/defaults/defaults.go#L9) and 
+   [`<detector_name>.Scanner{}`](https://github.com/trufflesecurity/trufflehog/blob/b71ea27a696bdf1c3141f637fda4ee4936c2f2d6/pkg/engine/defaults/defaults.go#L1546)
 
 5. Complete the Secret Detector.
 
@@ -83,7 +83,7 @@ Note: Be sure to update the tests to reference the new secret values in GSM, or 
    2. Update the verifier code to use a non-destructive API call that can determine whether the secret is valid or not.
       * Make sure you understand [verification indeterminacy](#verification-indeterminacy).
    3. Create a [test for the detector](#testing-the-detector).
-   4. Add your new detector to DefaultDetectors in `/pkg/engine/defaults.go`.
+   4. Add your new detector to DefaultDetectors in `/pkg/engine/defaults/defaults.go`.
    5. Create a pull request for review.
 
 ### Testing the Detector


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The documentation for adding a new secret detector was not updated after this change moving [‎pkg/engine/defaults.go](https://github.com/trufflesecurity/trufflehog/commit/8f2ebc924e8dc4ae882a322ea61f3b984b485cb8#diff-096ee050bb4e8cf27dbec7f01b6f3b84277efa4a30c2ddeb2cb0870c0cfb6812) to [pkg/engine/defaults/defaults.go](https://github.com/trufflesecurity/trufflehog/commit/8f2ebc924e8dc4ae882a322ea61f3b984b485cb8#diff-096ee050bb4e8cf27dbec7f01b6f3b84277efa4a30c2ddeb2cb0870c0cfb6812):

* https://github.com/trufflesecurity/trufflehog/commit/8f2ebc924e8dc4ae882a322ea61f3b984b485cb8#diff-096ee050bb4e8cf27dbec7f01b6f3b84277efa4a30c2ddeb2cb0870c0cfb6812

The documentation should maintain accuracy as new contributors are expected to read the documentation for adding new detectors. The previous references to the `pkg/engine/defaults.go` file directed to a 404 not found page. This can lead to confusion if/when new contributors are reading the hack documentation for adding a new detector.
