### PR TITLE
removed duplicate detector entries from engine defaults

### DIFF
--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -1600,6 +1600,7 @@ func buildDetectorList() []detectors.Detector {
 		&survicate.Scanner{},
 		&swell.Scanner{},
 		&swiftype.Scanner{},
+		&tableau.Scanner{},
 		&tailscale.Scanner{},
 		&tallyfy.Scanner{},
 		&tatumio.Scanner{},
@@ -1724,10 +1725,6 @@ func buildDetectorList() []detectors.Detector {
 		&zohocrm.Scanner{},
 		&zonkafeedback.Scanner{},
 		&zulipchat.Scanner{},
-		&stripepaymentintent.Scanner{},
-		&tableau.Scanner{},
-		&bitbucketapppassword.Scanner{},
-		&hasura.Scanner{},
 	}
 }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Duplicate detector entries were introduced in this PR: https://github.com/trufflesecurity/trufflehog/pull/4261
Hence, we were getting the following warnings:
```
2025-07-30T12:09:22+05:00	info-0	trufflehog	possible duplicate detector configured	{"detector": "StripePaymentIntent"}
2025-07-30T12:09:22+05:00	info-0	trufflehog	possible duplicate detector configured	{"detector": "BitbucketAppPassword"}
2025-07-30T12:09:22+05:00	info-0	trufflehog	possible duplicate detector configured	{"detector": "Hasura"}
```

This PR addresses the issue by:
- Removing the duplicate entries from the engine defaults file
- Alphabetically sorting the newly added Tableau detector within the list

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
