### PR TITLE
Missed Smartsheet Tokens

### DIFF
--- a/pkg/detectors/smartsheets/smartsheets.go
+++ b/pkg/detectors/smartsheets/smartsheets.go
@@ -22,7 +22,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"sheet"}) + `\b([a-zA-Z0-9]{37})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"sheet"}) + `\b([a-zA-Z0-9]{26}|[a-zA-Z0-9]{37})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/smartsheets/smartsheets_test.go
+++ b/pkg/detectors/smartsheets/smartsheets_test.go
@@ -56,6 +56,31 @@ func TestSmartsheets_Pattern(t *testing.T) {
 			want: []string{},
 		},
 		{
+			name: "valid pattern - 26 characters",
+			input: `
+			# smartsheet credentials
+			sheet_token := "fakeiq999fakeecyfake3ifake"
+			`,
+			want: []string{"fakeiq999fakeecyfake3ifake"},
+		},
+		{
+			name: "valid pattern - 26 and 37 characters",
+			input: `
+			# smartsheet multiple length credentials
+			sheet_token := "fakeiq999fakeecyfake3ifake"
+			sheet_token2 := "fakezmdxfakenFAKELzhonda7tvMpkqJ3fake"
+			`,
+			want: []string{"fakeiq999fakeecyfake3ifake", "fakezmdxfakenFAKELzhonda7tvMpkqJ3fake"},
+		},
+		{
+			name: "invalid pattern - 30 characters",
+			input: `
+			# smartsheet invalid credentials
+			sheet_token := "fakeiq999fakeecyfake3ifakeuiop"
+			`,
+			want: []string{},
+		},
+		{
 			name: "invalid pattern",
 			input: `
 			# smartsheet secret


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR updates the Smartsheet API token detector to support both the current and legacy token formats.

### Background
TruffleHog’s existing Smartsheet detector only recognizes the newer 37-character tokens. However, per [Smartsheet's documentation](https://help.smartsheet.com/articles/2482389-generate-API-key), legacy 26-character tokens are still valid and in use.

### Changes
- Updated the regex pattern to match exactly 26-character or 37-character alphanumeric tokens.
- Avoids matching token lengths in between (e.g., 30-char strings), keeping detection precise and avoiding false positives.
- Added pattern test cases for the updated length.

Reference: https://help.smartsheet.com/articles/2482389-generate-API-key 

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
