### PR TITLE
Fixed syslog source panic on invalid or chunked input

### DIFF
--- a/main.go
+++ b/main.go
@@ -179,7 +179,7 @@ var (
 	syslogProtocol = syslogScan.Flag("protocol", "Protocol to listen on. udp or tcp").String()
 	syslogTLSCert  = syslogScan.Flag("cert", "Path to TLS cert.").String()
 	syslogTLSKey   = syslogScan.Flag("key", "Path to TLS key.").String()
-	syslogFormat   = syslogScan.Flag("format", "Log format. Can be rfc3164 or rfc5424").String()
+	syslogFormat   = syslogScan.Flag("format", "Log format. Can be rfc3164 or rfc5424").Required().String()
 
 	circleCiScan      = cli.Command("circleci", "Scan CircleCI")
 	circleCiScanToken = circleCiScan.Flag("token", "CircleCI token. Can also be provided with environment variable").Envar("CIRCLECI_TOKEN").Required().String()
@@ -450,7 +450,6 @@ func run(state overseer.State) {
 
 	// OSS Default APK handling on
 	feature.EnableAPKHandler.Store(true)
-
 
 	// OSS Default Use Git Mirror on
 	feature.UseGitMirror.Store(true)

--- a/pkg/sources/syslog/syslog.go
+++ b/pkg/sources/syslog/syslog.go
@@ -270,8 +270,11 @@ func (s *Source) monitorConnection(ctx context.Context, conn net.Conn, chunksCha
 		ctx.Logger().V(5).Info(string(input))
 		metadata, err := s.parseSyslogMetadata(input, remote.String())
 		if err != nil {
-			ctx.Logger().V(2).Info("failed to generate metadata", "error", err)
+			// set metadata as empty to avoid panics in case parsing failed
+			metadata = &source_metadatapb.MetaData{}
+			ctx.Logger().V(2).Error(err, "failed to generate metadata")
 		}
+
 		chunksChan <- &sources.Chunk{
 			SourceName:     s.syslog.sourceName,
 			SourceID:       s.syslog.sourceID,
@@ -317,8 +320,11 @@ func (s *Source) acceptUDPConnections(ctx context.Context, netListener net.Packe
 		}
 		metadata, err := s.parseSyslogMetadata(input, remote.String())
 		if err != nil {
+			// set metadata as empty to avoid panics in case parsing failed
+			metadata = &source_metadatapb.MetaData{}
 			ctx.Logger().V(2).Info("failed to parse metadata", "error", err)
 		}
+
 		chunksChan <- &sources.Chunk{
 			SourceName:     s.syslog.sourceName,
 			SourceID:       s.syslog.sourceID,

--- a/pkg/sources/syslog/syslog_test.go
+++ b/pkg/sources/syslog/syslog_test.go
@@ -84,7 +84,7 @@ func TestSource_parseSyslogMetadata(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "success - wrong format",
+			name: "fail - wrong format",
 			args: args{
 				format: "rfc5424",
 				input:  []byte("Test message"),

--- a/pkg/sources/syslog/syslog_test.go
+++ b/pkg/sources/syslog/syslog_test.go
@@ -1,0 +1,120 @@
+package syslog
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
+)
+
+func TestSource_parseSyslogMetadata(t *testing.T) {
+	type args struct {
+		format string
+		input  []byte
+		remote string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *source_metadatapb.MetaData
+		wantErr bool
+	}{
+		{
+			name: "success - rfc5424",
+			args: args{
+				format: "rfc5424",
+				input:  []byte("<14>1 2025-08-05T12:00:00Z my-host my-app 1234 ID47 - Test message"),
+				remote: "127.0.0.1:5140",
+			},
+			want: &source_metadatapb.MetaData{
+				Data: &source_metadatapb.MetaData_Syslog{
+					Syslog: &source_metadatapb.Syslog{
+						Hostname:  "my-host",
+						Appname:   "my-app",
+						Procid:    "1234",
+						Timestamp: "2025-08-05 12:00:00 +0000 UTC",
+						Client:    "127.0.0.1:5140",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success - rfc5424",
+			args: args{
+				format: "rfc5424",
+				input:  []byte("<34>1 2023-08-05T14:30:22.123Z webserver nginx 1234 access-log - 192.168.1.100 GET /index.html 200"),
+				remote: "127.0.0.1:5140",
+			},
+			want: &source_metadatapb.MetaData{
+				Data: &source_metadatapb.MetaData_Syslog{
+					Syslog: &source_metadatapb.Syslog{
+						Hostname:  "webserver",
+						Appname:   "nginx",
+						Procid:    "1234",
+						Timestamp: "2023-08-05 14:30:22.123 +0000 UTC",
+						Client:    "127.0.0.1:5140",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success - rfc3164",
+			args: args{
+				format: "rfc3164",
+				input:  []byte("<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8"),
+				remote: "127.0.0.1:5140",
+			},
+			want: &source_metadatapb.MetaData{
+				Data: &source_metadatapb.MetaData_Syslog{
+					Syslog: &source_metadatapb.Syslog{
+						Hostname:  "mymachine",
+						Timestamp: "2025-10-11 22:14:15 +0000 UTC",
+						Client:    "127.0.0.1:5140",
+						Facility:  "4",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success - wrong format",
+			args: args{
+				format: "rfc5424",
+				input:  []byte("Test message"),
+				remote: "127.0.0.1:5140",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Source{}
+
+			conn, err := anypb.New(&sourcespb.Syslog{
+				Format: tt.args.format,
+			})
+			assert.NoError(t, err)
+
+			err = s.Init(context.Background(), "test", 0, 0, false, conn, 5)
+			assert.NoError(t, err)
+
+			got, err := s.parseSyslogMetadata(tt.args.input, tt.args.remote)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Source.parseSyslogMetadata() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Source.parseSyslogMetadata() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Fixes: #3858 

This PR fixes a panic in syslog that occurs when the input is in an invalid format or chunked at 8096 bytes. It also makes the `--format` flag required. Additionally, if TruffleHog fails to parse the input into the specified format, it ensures that the metadata is not nil, preventing potential panics. Tests have been added for various types of parsing scenarios.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
