### PR TITLE
Fix error-wrapping for callback in common.RecoverWithHandler

### DIFF
--- a/pkg/common/recover.go
+++ b/pkg/common/recover.go
@@ -40,7 +40,13 @@ func RecoverWithHandler(ctx context.Context, callback func(error)) {
 		ctx.Logger().Error(fmt.Errorf("panic"), panicStack,
 			"recover", err,
 		)
-		callback(fmt.Errorf("panic: %e", err))
+
+		switch v := err.(type) {
+		case error:
+			callback(fmt.Errorf("panic: %w", v))
+		default:
+			callback(fmt.Errorf("panic: %v", v))
+		}
 	}
 }
 


### PR DESCRIPTION
### Description:

Fixes a mistake in RecoverWithHandler added just a few days ago.  This earlier typo masked a type mismatch that had to be handled too.  The result of recover() is any, but mostly errors and sometimes strings.

### Checklist:
* [X] Tests passing (`make test-community`)?
* [X] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
