### PR TITLE
docs: Add installation method with gah

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,22 @@ git clone https://github.com/trufflesecurity/trufflehog.git
 cd trufflehog; go install
 ```
 
+### Using gah (only Linux and macOS)
+
+Install the latest version:
+
+```bash
+gah install trufflehog
+```
+
+Install a specific version:
+
+```bash
+gah install trufflehog --tag=<ReleaseTag like v3.56.0>
+```
+
+Note: [gah](https://github.com/marverix/gah) will verify the checksum signature using openssl and digest assigned to the related asset
+
 ### Using installation script
 
 ```bash


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Hello!
This PR adds to the documentation installation method using [gah](https://github.com/marverix/gah):
> gah is an GitHub Releases app installer, that DOES NOT REQUIRE SUDO! It is a simple bash script that downloads the latest release of an app from GitHub and installs it in ~/.local/bin. It is designed to be used with apps that are distributed as a single binary file.

### Checklist:
* [N/A] Tests passing (`make test-community`)?
* [N/A] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
