### PR TITLE
Add support for AWS account allow and deny lists

### DIFF
--- a/pkg/detectors/account_filter.go
+++ b/pkg/detectors/account_filter.go
@@ -1,0 +1,79 @@
+package detectors
+
+// AccountFilter implements account-based filtering functionality that detectors can embed
+// to gain allow and deny list capabilities for account IDs.
+type AccountFilter struct {
+	allowedAccounts map[string]struct{}
+	deniedAccounts  map[string]struct{}
+}
+
+// SetAllowedAccounts configures the allowed account IDs.
+// If set, only accounts in this list will be verified.
+func (a *AccountFilter) SetAllowedAccounts(accountIDs []string) {
+	if len(accountIDs) == 0 {
+		a.allowedAccounts = nil
+		return
+	}
+
+	accounts := make(map[string]struct{}, len(accountIDs))
+	for _, accountID := range accountIDs {
+		accounts[accountID] = struct{}{}
+	}
+	a.allowedAccounts = accounts
+}
+
+// SetDeniedAccounts configures the denied account IDs.
+// Accounts in this list will never be verified.
+func (a *AccountFilter) SetDeniedAccounts(accountIDs []string) {
+	if len(accountIDs) == 0 {
+		a.deniedAccounts = nil
+		return
+	}
+
+	accounts := make(map[string]struct{}, len(accountIDs))
+	for _, accountID := range accountIDs {
+		accounts[accountID] = struct{}{}
+	}
+	a.deniedAccounts = accounts
+}
+
+// ShouldSkipAccount checks if an account ID should be skipped for verification
+// based on allow and deny lists.
+//
+// Precedence: deny list > allow list (if account is in both, it's denied)
+func (a *AccountFilter) ShouldSkipAccount(accountID string) bool {
+	// Check deny list first - takes precedence
+	if len(a.deniedAccounts) > 0 {
+		if _, isDenied := a.deniedAccounts[accountID]; isDenied {
+			return true
+		}
+	}
+
+	// Check allow list - if populated, account must be in it
+	if len(a.allowedAccounts) > 0 {
+		if _, isAllowed := a.allowedAccounts[accountID]; !isAllowed {
+			return true
+		}
+	}
+
+	// Account is allowed for verification
+	return false
+}
+
+// IsInDenyList checks if an account ID is in the deny list
+func (a *AccountFilter) IsInDenyList(accountID string) bool {
+	if len(a.deniedAccounts) == 0 {
+		return false
+	}
+	_, isDenied := a.deniedAccounts[accountID]
+	return isDenied
+}
+
+// IsInAllowList checks if an account ID is in the allow list
+func (a *AccountFilter) IsInAllowList(accountID string) bool {
+	if len(a.allowedAccounts) == 0 {
+		return false
+	}
+	_, isAllowed := a.allowedAccounts[accountID]
+	return isAllowed
+}

--- a/pkg/detectors/account_filter_test.go
+++ b/pkg/detectors/account_filter_test.go
@@ -1,0 +1,112 @@
+package detectors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmbeddedAccountFilter(t *testing.T) {
+	type Scanner struct{ AccountFilter }
+
+	t.Run("no filtering configured - should not skip", func(t *testing.T) {
+		var s Scanner // Fresh instance for this test
+
+		shouldSkip := s.ShouldSkipAccount("test-account")
+		assert.False(t, shouldSkip)
+		assert.False(t, s.IsInDenyList("test-account"))
+		assert.False(t, s.IsInAllowList("test-account"))
+	})
+
+	t.Run("allowed accounts only", func(t *testing.T) {
+		var s Scanner // Fresh instance for this test
+		s.SetAllowedAccounts([]string{"allowed-account-1", "allowed-account-2"})
+
+		// Account in allow list - should not skip
+		shouldSkip := s.ShouldSkipAccount("allowed-account-1")
+		assert.False(t, shouldSkip)
+		assert.True(t, s.IsInAllowList("allowed-account-1"))
+
+		// Account not in allow list - should skip
+		shouldSkip = s.ShouldSkipAccount("other-account")
+		assert.True(t, shouldSkip)
+		assert.False(t, s.IsInAllowList("other-account"))
+	})
+
+	t.Run("denied accounts only", func(t *testing.T) {
+		var s Scanner // Fresh instance for this test
+		s.SetDeniedAccounts([]string{"denied-account-1", "denied-account-2"})
+
+		// Account in deny list - should skip
+		shouldSkip := s.ShouldSkipAccount("denied-account-1")
+		assert.True(t, shouldSkip)
+		assert.True(t, s.IsInDenyList("denied-account-1"))
+
+		// Account not in deny list - should not skip (no allow list restrictions)
+		shouldSkip = s.ShouldSkipAccount("other-account")
+		assert.False(t, shouldSkip)
+		assert.False(t, s.IsInDenyList("other-account"))
+	})
+
+	t.Run("deny list takes precedence over allow list", func(t *testing.T) {
+		var s Scanner // Fresh instance for this test
+		s.SetAllowedAccounts([]string{"conflicted-account", "allowed-only-account"})
+		s.SetDeniedAccounts([]string{"conflicted-account"}) // Same account in both lists
+
+		// Account is in both allow and deny lists - deny takes precedence
+		shouldSkip := s.ShouldSkipAccount("conflicted-account")
+		assert.True(t, shouldSkip)
+		assert.True(t, s.IsInDenyList("conflicted-account"))
+		assert.True(t, s.IsInAllowList("conflicted-account"))
+
+		// Account only in allow list - should not skip
+		shouldSkip = s.ShouldSkipAccount("allowed-only-account")
+		assert.False(t, shouldSkip)
+		assert.False(t, s.IsInDenyList("allowed-only-account"))
+		assert.True(t, s.IsInAllowList("allowed-only-account"))
+	})
+
+	t.Run("allow list with denied account not in allow list", func(t *testing.T) {
+		var s Scanner                                     // Fresh instance for this test
+		s.SetAllowedAccounts([]string{"trusted-account"}) // Allow one account
+		s.SetDeniedAccounts([]string{"blocked-account"})  // Deny different account
+
+		// Account in deny list (not in allow list) - should skip due to deny list
+		shouldSkip := s.ShouldSkipAccount("blocked-account")
+		assert.True(t, shouldSkip)
+		assert.True(t, s.IsInDenyList("blocked-account"))
+		assert.False(t, s.IsInAllowList("blocked-account"))
+
+		// Account in allow list (not in deny list) - should not skip
+		shouldSkip = s.ShouldSkipAccount("trusted-account")
+		assert.False(t, shouldSkip)
+		assert.False(t, s.IsInDenyList("trusted-account"))
+		assert.True(t, s.IsInAllowList("trusted-account"))
+
+		// Account in neither list - should skip due to allow list restriction
+		shouldSkip = s.ShouldSkipAccount("unknown-account")
+		assert.True(t, shouldSkip)
+		assert.False(t, s.IsInDenyList("unknown-account"))
+		assert.False(t, s.IsInAllowList("unknown-account"))
+	})
+
+	t.Run("clearing lists", func(t *testing.T) {
+		var s Scanner // Fresh instance for this test
+		s.SetAllowedAccounts([]string{"initial-allowed"})
+		s.SetDeniedAccounts([]string{"initial-denied"})
+
+		// Verify initial state
+		assert.True(t, s.ShouldSkipAccount("random-account")) // Not in allow list
+		assert.True(t, s.ShouldSkipAccount("initial-denied")) // In deny list
+
+		// Clear allowed accounts with nil
+		s.SetAllowedAccounts(nil)
+		assert.False(t, s.ShouldSkipAccount("random-account")) // No allow list restriction
+		assert.True(t, s.ShouldSkipAccount("initial-denied"))  // Still in deny list
+
+		// Clear denied accounts with empty slice
+		s.SetDeniedAccounts([]string{})
+		assert.False(t, s.ShouldSkipAccount("initial-denied"))  // No longer denied
+		assert.False(t, s.ShouldSkipAccount("initial-allowed")) // No restrictions
+	})
+}

--- a/pkg/detectors/aws/access_keys/accesskey_test.go
+++ b/pkg/detectors/aws/access_keys/accesskey_test.go
@@ -92,3 +92,108 @@ func TestAWS_Pattern(t *testing.T) {
 		})
 	}
 }
+
+func TestAWS_shouldSkipAccountVerification(t *testing.T) {
+	testCases := []struct {
+		name               string
+		scanner            scanner
+		accountID          string
+		expectedShouldSkip bool
+		expectedReason     string
+	}{
+		{
+			name: "no filtering configured - should not skip",
+			scanner: scanner{
+				allowedAccounts: map[string]struct{}{},
+				deniedAccounts:  map[string]struct{}{},
+			},
+			accountID:          "123456789012",
+			expectedShouldSkip: false,
+			expectedReason:     "",
+		},
+		{
+			name: "account in deny list - should skip",
+			scanner: scanner{
+				allowedAccounts: map[string]struct{}{},
+				deniedAccounts:  map[string]struct{}{"123456789012": {}},
+			},
+			accountID:          "123456789012",
+			expectedShouldSkip: true,
+			expectedReason:     "Account ID is in the deny list for verification",
+		},
+		{
+			name: "account not in allow list - should skip",
+			scanner: scanner{
+				allowedAccounts: map[string]struct{}{"999888777666": {}},
+				deniedAccounts:  map[string]struct{}{},
+			},
+			accountID:          "123456789012",
+			expectedShouldSkip: true,
+			expectedReason:     "Account ID is not in the allow list for verification",
+		},
+		{
+			name: "account in allow list - should not skip",
+			scanner: scanner{
+				allowedAccounts: map[string]struct{}{"123456789012": {}},
+				deniedAccounts:  map[string]struct{}{},
+			},
+			accountID:          "123456789012",
+			expectedShouldSkip: false,
+			expectedReason:     "",
+		},
+		{
+			name: "account in both allow and deny list - deny takes precedence",
+			scanner: scanner{
+				allowedAccounts: map[string]struct{}{"123456789012": {}},
+				deniedAccounts:  map[string]struct{}{"123456789012": {}},
+			},
+			accountID:          "123456789012",
+			expectedShouldSkip: true,
+			expectedReason:     "Account ID is in the deny list for verification",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			shouldSkip, reason := tc.scanner.shouldSkipAccountVerification(tc.accountID)
+
+			if shouldSkip != tc.expectedShouldSkip {
+				t.Errorf("Expected shouldSkip=%v, got shouldSkip=%v", tc.expectedShouldSkip, shouldSkip)
+			}
+
+			if reason != tc.expectedReason {
+				t.Errorf("Expected reason=%q, got reason=%q", tc.expectedReason, reason)
+			}
+		})
+	}
+}
+
+func TestAWS_WithAllowedAccounts(t *testing.T) {
+	accounts := []string{"123456789012", "999888777666"}
+	s := New(WithAllowedAccounts(accounts))
+
+	// Test that allowed accounts are properly configured
+	shouldSkip, reason := s.shouldSkipAccountVerification("123456789012")
+	require.False(t, shouldSkip)
+	require.Empty(t, reason)
+
+	// Test that non-allowed accounts are skipped
+	shouldSkip, reason = s.shouldSkipAccountVerification("111222333444")
+	require.True(t, shouldSkip)
+	require.Equal(t, "Account ID is not in the allow list for verification", reason)
+}
+
+func TestAWS_WithDeniedAccounts(t *testing.T) {
+	accounts := []string{"123456789012", "999888777666"}
+	s := New(WithDeniedAccounts(accounts))
+
+	// Test that denied accounts are properly skipped
+	shouldSkip, reason := s.shouldSkipAccountVerification("123456789012")
+	require.True(t, shouldSkip)
+	require.Equal(t, "Account ID is in the deny list for verification", reason)
+
+	// Test that non-denied accounts are not skipped
+	shouldSkip, reason = s.shouldSkipAccountVerification("111222333444")
+	require.False(t, shouldSkip)
+	require.Empty(t, reason)
+}

--- a/pkg/detectors/aws/common.go
+++ b/pkg/detectors/aws/common.go
@@ -7,6 +7,12 @@ const (
 	RequiredSecretEntropy = 4.25
 )
 
+// Verification error messages
+const (
+	VerificationErrAccountIDInDenyList     = "Account ID is in the deny list for verification"
+	VerificationErrAccountIDNotInAllowList = "Account ID is not in the allow list for verification"
+)
+
 var SecretPat = regexp.MustCompile(`(?:[^A-Za-z0-9+/]|\A)([A-Za-z0-9+/]{40})(?:[^A-Za-z0-9+/]|\z)`)
 
 type IdentityResponse struct {

--- a/pkg/detectors/aws/session_keys/sessionkeys_test.go
+++ b/pkg/detectors/aws/session_keys/sessionkeys_test.go
@@ -95,94 +95,19 @@ func TestAWSSessionKey_Pattern(t *testing.T) {
 	}
 }
 
-func TestAWSSessionKey_shouldSkipAccountVerification(t *testing.T) {
-	testCases := []struct {
-		name               string
-		scanner            scanner
-		accountID          string
-		expectedShouldSkip bool
-		expectedReason     string
-	}{
-		{
-			name: "no filtering configured - should not skip",
-			scanner: scanner{
-				allowedAccounts: map[string]struct{}{},
-				deniedAccounts:  map[string]struct{}{},
-			},
-			accountID:          "123456789012",
-			expectedShouldSkip: false,
-			expectedReason:     "",
-		},
-		{
-			name: "account in deny list - should skip",
-			scanner: scanner{
-				allowedAccounts: map[string]struct{}{},
-				deniedAccounts:  map[string]struct{}{"123456789012": {}},
-			},
-			accountID:          "123456789012",
-			expectedShouldSkip: true,
-			expectedReason:     "Account ID is in the deny list for verification",
-		},
-		{
-			name: "account not in allow list - should skip",
-			scanner: scanner{
-				allowedAccounts: map[string]struct{}{"999888777666": {}},
-				deniedAccounts:  map[string]struct{}{},
-			},
-			accountID:          "123456789012",
-			expectedShouldSkip: true,
-			expectedReason:     "Account ID is not in the allow list for verification",
-		},
-		{
-			name: "account in allow list - should not skip",
-			scanner: scanner{
-				allowedAccounts: map[string]struct{}{"123456789012": {}},
-				deniedAccounts:  map[string]struct{}{},
-			},
-			accountID:          "123456789012",
-			expectedShouldSkip: false,
-			expectedReason:     "",
-		},
-		{
-			name: "account in both allow and deny list - deny takes precedence",
-			scanner: scanner{
-				allowedAccounts: map[string]struct{}{"123456789012": {}},
-				deniedAccounts:  map[string]struct{}{"123456789012": {}},
-			},
-			accountID:          "123456789012",
-			expectedShouldSkip: true,
-			expectedReason:     "Account ID is in the deny list for verification",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			shouldSkip, reason := tc.scanner.shouldSkipAccountVerification(tc.accountID)
-
-			if shouldSkip != tc.expectedShouldSkip {
-				t.Errorf("Expected shouldSkip=%v, got shouldSkip=%v", tc.expectedShouldSkip, shouldSkip)
-			}
-
-			if reason != tc.expectedReason {
-				t.Errorf("Expected reason=%q, got reason=%q", tc.expectedReason, reason)
-			}
-		})
-	}
-}
-
 func TestAWSSessionKey_WithAllowedAccounts(t *testing.T) {
 	accounts := []string{"123456789012", "999888777666"}
 	s := New(WithAllowedAccounts(accounts))
 
 	// Test that allowed accounts are properly configured
-	shouldSkip, reason := s.shouldSkipAccountVerification("123456789012")
+	shouldSkip := s.ShouldSkipAccount("123456789012")
 	require.False(t, shouldSkip)
-	require.Empty(t, reason)
+	require.True(t, s.IsInAllowList("123456789012"))
 
 	// Test that non-allowed accounts are skipped
-	shouldSkip, reason = s.shouldSkipAccountVerification("111222333444")
+	shouldSkip = s.ShouldSkipAccount("111222333444")
 	require.True(t, shouldSkip)
-	require.Equal(t, "Account ID is not in the allow list for verification", reason)
+	require.False(t, s.IsInAllowList("111222333444"))
 }
 
 func TestAWSSessionKey_WithDeniedAccounts(t *testing.T) {
@@ -190,12 +115,12 @@ func TestAWSSessionKey_WithDeniedAccounts(t *testing.T) {
 	s := New(WithDeniedAccounts(accounts))
 
 	// Test that denied accounts are properly skipped
-	shouldSkip, reason := s.shouldSkipAccountVerification("123456789012")
+	shouldSkip := s.ShouldSkipAccount("123456789012")
 	require.True(t, shouldSkip)
-	require.Equal(t, "Account ID is in the deny list for verification", reason)
+	require.True(t, s.IsInDenyList("123456789012"))
 
 	// Test that non-denied accounts are not skipped
-	shouldSkip, reason = s.shouldSkipAccountVerification("111222333444")
+	shouldSkip = s.ShouldSkipAccount("111222333444")
 	require.False(t, shouldSkip)
-	require.Empty(t, reason)
+	require.False(t, s.IsInDenyList("111222333444"))
 }


### PR DESCRIPTION
### Description:
Enables customers to configure optional allow and deny lists for AWS verification

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
