### PR TITLE
Fix error propagation and a typo in verification logic

### DIFF
--- a/pkg/detectors/airtableoauth/airtableoauth.go
+++ b/pkg/detectors/airtableoauth/airtableoauth.go
@@ -75,7 +75,7 @@ func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, 
 	endpoint := "https://api.airtable.com/v0/meta/whoami"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))

--- a/pkg/detectors/airtablepersonalaccesstoken/airtablepersonalaccesstoken.go
+++ b/pkg/detectors/airtablepersonalaccesstoken/airtablepersonalaccesstoken.go
@@ -70,7 +70,7 @@ func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, 
 	endpoint := "https://api.airtable.com/v0/meta/whoami"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))

--- a/pkg/detectors/alchemy/alchemy.go
+++ b/pkg/detectors/alchemy/alchemy.go
@@ -68,7 +68,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, map[string]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://eth-mainnet.g.alchemy.com/v2/"+token+"/getNFTs/?owner=vitalik.eth", nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	res, err := client.Do(req)

--- a/pkg/detectors/atlassian/v1/atlassian.go
+++ b/pkg/detectors/atlassian/v1/atlassian.go
@@ -91,7 +91,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, *OrgRes, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.atlassian.com/admin/v1/orgs", nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))

--- a/pkg/detectors/atlassian/v2/atlassian.go
+++ b/pkg/detectors/atlassian/v2/atlassian.go
@@ -91,7 +91,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, *OrgRes, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.atlassian.com/admin/v1/orgs", nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))

--- a/pkg/detectors/azure_entra/refreshtoken/refreshtoken.go
+++ b/pkg/detectors/azure_entra/refreshtoken/refreshtoken.go
@@ -186,7 +186,7 @@ func verifyMatch(ctx context.Context, client *http.Client, refreshToken string, 
 	tokenUrl := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenantId)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenUrl, bytes.NewBufferString(data.Encode()))
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 

--- a/pkg/detectors/bingsubscriptionkey/bingsubscriptionkey.go
+++ b/pkg/detectors/bingsubscriptionkey/bingsubscriptionkey.go
@@ -62,7 +62,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, subscriptionKey string) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.bing.microsoft.com/v7.0/search?q=trufflehog", nil)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 
 	req.Header.Add("Ocp-Apim-Subscription-Key", subscriptionKey)

--- a/pkg/detectors/box/box.go
+++ b/pkg/detectors/box/box.go
@@ -74,7 +74,7 @@ func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, 
 	url := "https://api.box.com/2.0/users/me"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	req.Header = http.Header{"Authorization": []string{"Bearer " + token}}

--- a/pkg/detectors/boxoauth/boxoauth.go
+++ b/pkg/detectors/boxoauth/boxoauth.go
@@ -109,10 +109,13 @@ func verifyMatch(ctx context.Context, client *http.Client, id string, secret str
 		_ = res.Body.Close()
 	}()
 
-	// We are using malformed request to check if the client id and secret are correct
-	// box oauth api returns 400 status code even if they are correct
-	// so we need to check the response body for the error message with 'unauthorized_client' keyword
-	// or if invalid_client keyword is present then the client id & secret are incorrect
+	// We are using malformed request to check if the client id and secret are valid.
+	// In this case, the Box OAuth API returns a 400 status code even if the credentials are valid.
+	//
+	// - If the client ID/secret are valid, the response contains "unauthorized_client"
+	// - If the credentials are invalid, the response contains "invalid_client"
+	//
+	// So we check the response body for one of these keywords.
 	switch res.StatusCode {
 	case http.StatusBadRequest:
 		{
@@ -120,8 +123,14 @@ func verifyMatch(ctx context.Context, client *http.Client, id string, secret str
 			if err != nil {
 				return false, nil, err
 			}
-			verified := !strings.Contains(string(bodyBytes), "unauthorized_client")
-			return verified, nil, nil
+			body := string(bodyBytes)
+			if strings.Contains(body, "unauthorized_client") {
+				return true, nil, nil
+			} else if strings.Contains(body, "invalid_client") {
+				return false, nil, nil
+			} else {
+				return false, nil, fmt.Errorf("response body missing expected keyword")
+			}
 		}
 	default:
 		return false, nil, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)

--- a/pkg/detectors/boxoauth/boxoauth.go
+++ b/pkg/detectors/boxoauth/boxoauth.go
@@ -120,13 +120,8 @@ func verifyMatch(ctx context.Context, client *http.Client, id string, secret str
 			if err != nil {
 				return false, nil, err
 			}
-			body := string(bodyBytes)
-
-			if strings.Contains(body, "unauthorized_client") {
-				return true, nil, nil
-			}
-
-			return false, nil, nil
+			verified := !strings.Contains(string(bodyBytes), "unauthorized_client")
+			return verified, nil, nil
 		}
 	default:
 		return false, nil, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)

--- a/pkg/detectors/boxoauth/boxoauth.go
+++ b/pkg/detectors/boxoauth/boxoauth.go
@@ -95,7 +95,7 @@ func verifyMatch(ctx context.Context, client *http.Client, id string, secret str
 	payload := strings.NewReader("grant_type=client_credentials&client_id=" + id + "&client_secret=" + secret)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, payload)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	req.Header = http.Header{"content-type": []string{"application/x-www-form-urlencoded"}}

--- a/pkg/detectors/captaindata/v2/captaindata.go
+++ b/pkg/detectors/captaindata/v2/captaindata.go
@@ -80,7 +80,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, projId, apiKey string) (bool, map[string]string, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.captaindata.co/v3/workspace", nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 	req.Header.Set("Authorization", "x-api-key "+apiKey)
 	req.Header.Set("x-project-id", projId)

--- a/pkg/detectors/docker/docker_auth_config.go
+++ b/pkg/detectors/docker/docker_auth_config.go
@@ -150,7 +150,7 @@ func verifyMatch(ctx logContext.Context, client *http.Client, registry string, u
 	// Build the request.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, registryUrl, nil)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 
 	req.Header.Set("Authorization", "Basic "+basicAuth)

--- a/pkg/detectors/endorlabs/endorlabs.go
+++ b/pkg/detectors/endorlabs/endorlabs.go
@@ -83,7 +83,7 @@ func verifyMatch(ctx context.Context, client *http.Client, key, secret string) (
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.endorlabs.com/v1/auth/api-key", strings.NewReader(authData))
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	req.Header.Add("Content-Type", "application/json")

--- a/pkg/detectors/eraser/eraser.go
+++ b/pkg/detectors/eraser/eraser.go
@@ -76,7 +76,7 @@ func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, 
 	url := "https://app.eraser.io/api/render/elements"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, payload)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	req.Header = http.Header{"Authorization": []string{"Bearer " + token}}

--- a/pkg/detectors/flexport/flexport.go
+++ b/pkg/detectors/flexport/flexport.go
@@ -72,7 +72,7 @@ func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, 
 	url := "https://logistics-api.flexport.com/logistics/api/2024-04/webhooks"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 

--- a/pkg/detectors/gcpapplicationdefaultcredentials/gcpapplicationdefaultcredentials.go
+++ b/pkg/detectors/gcpapplicationdefaultcredentials/gcpapplicationdefaultcredentials.go
@@ -140,7 +140,7 @@ func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, 
 	// Build request to call an IAM endpoint
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://iam.googleapis.com/v1/roles", nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	// If we are not using a faketransport, leave it as is because the test wants to modify the response. Otherwise, set the retrieved token to the client.

--- a/pkg/detectors/groq/groq.go
+++ b/pkg/detectors/groq/groq.go
@@ -76,7 +76,7 @@ func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, 
 	// This endpoint will return a JSON list of all active models.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.groq.com/openai/v1/models", nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 	req.Header.Add("Authorization", "Bearer "+token)
 

--- a/pkg/detectors/harness/harness.go
+++ b/pkg/detectors/harness/harness.go
@@ -90,7 +90,7 @@ API Reference: https://apidocs.harness.io/tag/User/#operation/getCurrentUserInfo
 func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, map[string]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://app.harness.io/ng/api/user/currentUser", nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	req.Header.Set("x-api-key", token)

--- a/pkg/detectors/langsmith/langsmith.go
+++ b/pkg/detectors/langsmith/langsmith.go
@@ -67,7 +67,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, apiKey string) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.smith.langchain.com/api/v1/api-key", http.NoBody)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 
 	req.Header.Set("X-API-Key", apiKey)

--- a/pkg/detectors/netlify/v1/netlify_v1.go
+++ b/pkg/detectors/netlify/v1/netlify_v1.go
@@ -77,7 +77,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, verificationUrl, nil)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	res, err := client.Do(req)

--- a/pkg/detectors/netlify/v2/netlify_v2.go
+++ b/pkg/detectors/netlify/v2/netlify_v2.go
@@ -77,7 +77,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, verificationUrl, nil)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	res, err := client.Do(req)

--- a/pkg/detectors/nvapi/nvapi.go
+++ b/pkg/detectors/nvapi/nvapi.go
@@ -73,7 +73,7 @@ func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, 
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.ngc.nvidia.com/v3/keys/get-caller-info", strings.NewReader(data.Encode()))
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")

--- a/pkg/detectors/onfleet/onfleet.go
+++ b/pkg/detectors/onfleet/onfleet.go
@@ -69,7 +69,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, map[string]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://onfleet.com/api/v2/organization", nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 	data := fmt.Sprintf("%s:", token)
 	encoded := b64.StdEncoding.EncodeToString([]byte(data))

--- a/pkg/detectors/opsgenie/opsgenie.go
+++ b/pkg/detectors/opsgenie/opsgenie.go
@@ -110,7 +110,7 @@ func verifyMatch(ctx context.Context, client *http.Client, key string) (bool, ma
 	case http.StatusOK:
 		var accountRes accountResponse
 		if err := json.NewDecoder(res.Body).Decode(&accountRes); err != nil {
-			return false, nil, nil
+			return false, nil, err
 		}
 
 		extraData := map[string]string{

--- a/pkg/detectors/pagarme/pagarme.go
+++ b/pkg/detectors/pagarme/pagarme.go
@@ -75,7 +75,7 @@ func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, 
 	req.Header.Set("Content-Type", "application/json")
 
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	res, err := client.Do(req)

--- a/pkg/detectors/plaidkey/plaidkey.go
+++ b/pkg/detectors/plaidkey/plaidkey.go
@@ -108,7 +108,7 @@ func verifyMatch(ctx context.Context, client *http.Client, id string, secret str
 	url := "https://" + env + ".plaid.com/item/get"
 	req, err := http.NewRequestWithContext(ctx, "POST", url, payload)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	req.Header.Add("Content-Type", "application/json")

--- a/pkg/detectors/robinhoodcrypto/robinhoodcrypto.go
+++ b/pkg/detectors/robinhoodcrypto/robinhoodcrypto.go
@@ -114,7 +114,7 @@ func verifyMatch(ctx context.Context, client *http.Client, apiKey, base64Private
 
 	req, err := http.NewRequestWithContext(ctx, method, "https://trading.robinhood.com/"+path, strings.NewReader(body))
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	// Set the required headers.

--- a/pkg/detectors/saladcloudapikey/saladcloudapikey.go
+++ b/pkg/detectors/saladcloudapikey/saladcloudapikey.go
@@ -74,7 +74,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, map[string]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.salad.com/api/public", nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	req.Header.Set("Salad-Api-Key", token)

--- a/pkg/detectors/sumologickey/sumologickey.go
+++ b/pkg/detectors/sumologickey/sumologickey.go
@@ -113,7 +113,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, endpoint string, id string, key string) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s/api/v1/users", endpoint), nil)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 
 	req.SetBasicAuth(id, key)

--- a/pkg/detectors/twitchaccesstoken/twitchaccesstoken.go
+++ b/pkg/detectors/twitchaccesstoken/twitchaccesstoken.go
@@ -68,7 +68,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, map[string]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://id.twitch.tv/oauth2/validate", nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	req.Header.Add("Authorization", fmt.Sprintf("OAuth %s", token))

--- a/pkg/detectors/typeform/v2/typeform.go
+++ b/pkg/detectors/typeform/v2/typeform.go
@@ -86,7 +86,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, secret string) (bool, *TypeFormResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.typeform.com/me", nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", secret))
 	res, err := client.Do(req)

--- a/pkg/detectors/webexbot/webexbot.go
+++ b/pkg/detectors/webexbot/webexbot.go
@@ -80,7 +80,7 @@ type response struct {
 func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, map[string]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://webexapis.com/v1/people/me", nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("Accept", "application/json")

--- a/pkg/detectors/weightsandbiases/weightsandbiases.go
+++ b/pkg/detectors/weightsandbiases/weightsandbiases.go
@@ -82,7 +82,7 @@ func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, 
 	const baseURL = "https://api.wandb.ai/graphql"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL, bytes.NewBufferString(query))
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	authHeader := base64.StdEncoding.EncodeToString([]byte("api:" + token))

--- a/pkg/detectors/wiz/wiz.go
+++ b/pkg/detectors/wiz/wiz.go
@@ -91,7 +91,7 @@ func verifyMatch(ctx context.Context, client *http.Client, clientID, clientSecre
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://auth.app.wiz.io/oauth/token", strings.NewReader(authData.Encode()))
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	req.Header.Add("Encoding", "UTF-8")

--- a/pkg/detectors/xai/xai.go
+++ b/pkg/detectors/xai/xai.go
@@ -70,7 +70,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func verifyMatch(ctx context.Context, client *http.Client, apiKey string) (bool, map[string]string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.x.ai/v1/api-key", nil)
 	if err != nil {
-		return false, nil, nil
+		return false, nil, err
 	}
 
 	req.Header.Add("Content-Type", "application/json")


### PR DESCRIPTION
### Description:
When developing a new detector, I found that a typo in verification logic error handling had been repeated in a few dozen detectors. This PR fixes those typos, and also fixes a logic error found in the verification logic in the Box OAuth detector.

In particular, several detectors would silently ignore an error from a call to `http.NewRequestWithContext` when performing verification. Such an error is unlikely (a malformed URL, for example), but if it did occur, the finding would be incorrectly classified as `unverified`, when in fact it is `unknown`.

Additionally, the Box OAuth detector verification had the status flipped.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
