### PR TITLE
Fix broken filter in Trufflehog Enterprise UI (Hosted Scanner for Github cannot filter on Repo)

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -248,7 +248,7 @@ func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, so
 
 	s.filteredRepoCache = s.newFilteredRepoCache(aCtx,
 		simple.NewCache[string](),
-		append(s.conn.GetRepositories(), s.conn.GetIncludeRepos()...),
+		s.conn.GetIncludeRepos(),
 		s.conn.GetIgnoreRepos(),
 	)
 	s.repos = s.conn.Repositories

--- a/pkg/sources/github/repo.go
+++ b/pkg/sources/github/repo.go
@@ -218,17 +218,13 @@ func (s *Source) processRepos(ctx context.Context, target string, reporter sourc
 			}
 
 			repoName, repoURL := r.GetFullName(), r.GetCloneURL()
-			if s.filteredRepoCache.includeRepo(repoName) && !s.filteredRepoCache.ignoreRepo(repoName) {
-				s.totalRepoSize += r.GetSize()
-				s.filteredRepoCache.Set(repoName, repoURL)
-				s.cacheRepoInfo(r)
-				if err := reporter.UnitOk(ctx, RepoUnit{Name: repoName, URL: repoURL}); err != nil {
-					return err
-				}
-				logger.V(3).Info("repo attributes", "name", repoName, "kb_size", r.GetSize(), "repo_url", repoURL)
-			} else {
-				logger.V(3).Info("skipping repo due to filter", "name", repoName)
+			s.totalRepoSize += r.GetSize()
+			s.filteredRepoCache.Set(repoName, repoURL)
+			s.cacheRepoInfo(r)
+			if err := reporter.UnitOk(ctx, RepoUnit{Name: repoName, URL: repoURL}); err != nil {
+				return err
 			}
+			logger.V(3).Info("repo attributes", "name", repoName, "kb_size", r.GetSize(), "repo_url", repoURL)
 		}
 
 		if res.NextPage == 0 {

--- a/pkg/sources/github/repo.go
+++ b/pkg/sources/github/repo.go
@@ -218,7 +218,6 @@ func (s *Source) processRepos(ctx context.Context, target string, reporter sourc
 			}
 
 			repoName, repoURL := r.GetFullName(), r.GetCloneURL()
-			// FIX: Apply filtering BEFORE adding to cache
 			if s.filteredRepoCache.includeRepo(repoName) && !s.filteredRepoCache.ignoreRepo(repoName) {
 				s.totalRepoSize += r.GetSize()
 				s.filteredRepoCache.Set(repoName, repoURL)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The fix separates repository filtering patterns from direct repository URLs and applies filtering before processing, ensuring that only repositories matching the IncludeRepos glob patterns are scanned instead of scanning all repositories in an organization.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
