### PR TITLE
Fix nondeterminism in custom detectors

### DIFF
--- a/pkg/custom_detectors/custom_detectors.go
+++ b/pkg/custom_detectors/custom_detectors.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"maps"
 	"net/http"
 	"regexp"
+	"slices"
 	"strings"
 
 	"golang.org/x/sync/errgroup"
@@ -214,7 +216,8 @@ func (c *CustomRegexWebhook) createResults(ctx context.Context, match map[string
 	}
 
 	var raw string
-	for key, values := range match {
+	for _, key := range slices.Sorted(maps.Keys(match)) {
+		values := match[key]
 		// values[0] contains the entire regex match.
 		secret := values[0]
 		if len(values) > 1 {

--- a/pkg/custom_detectors/custom_detectors_test.go
+++ b/pkg/custom_detectors/custom_detectors_test.go
@@ -538,7 +538,7 @@ func TestDetectorValidations(t *testing.T) {
 					DetectorType: detectorspb.DetectorType_CustomRegex,
 					DetectorName: "test",
 					Verified:     false,
-					Raw:          []byte("MyStrongP@sswordc392c9837d69b44c764cbf260b-e6184"),
+					Raw:          []byte("c392c9837d69b44c764cbf260b-e6184MyStrongP@ssword"),
 				},
 			},
 		},


### PR DESCRIPTION
Previously, a custom detector configured to use multiple patterns would produce its results from a match in a nondeterministic order. This behavior could be seen by running the custom detectors test in a loop, e.g.,

    $ cd pkg/custom_detectors
    $ while true; do go test; done

This is likely to reveal sporadic test failures.

This nondeterminism was a result of producing results by iterating over a map, which has unspecified order in Go.

The fix: sort the intermediate map data structure prior to producing results.