### PR TITLE
refactor: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/pkg/decoders/base64_test.go
+++ b/pkg/decoders/base64_test.go
@@ -155,7 +155,7 @@ func BenchmarkFromChunkSmall(b *testing.B) {
 	d := Base64{}
 	data := detectors.MustGetBenchmarkData()["small"]
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		d.FromChunk(&sources.Chunk{Data: data})
 	}
 }
@@ -164,7 +164,7 @@ func BenchmarkFromChunkMedium(b *testing.B) {
 	d := Base64{}
 	data := detectors.MustGetBenchmarkData()["medium"]
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		d.FromChunk(&sources.Chunk{Data: data})
 	}
 }
@@ -173,7 +173,7 @@ func BenchmarkFromChunkLarge(b *testing.B) {
 	d := Base64{}
 	data := detectors.MustGetBenchmarkData()["big"]
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		d.FromChunk(&sources.Chunk{Data: data})
 	}
 }

--- a/pkg/decoders/escaped_unicode_bench_test.go
+++ b/pkg/decoders/escaped_unicode_bench_test.go
@@ -60,49 +60,49 @@ var (
 
 // Benchmark individual decoder functions
 func BenchmarkDecodeOriginalEscape(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decodeEscaped(originalUnicodeData)
 	}
 }
 
 func BenchmarkDecodeCodePoint(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decodeCodePoint(codePointData)
 	}
 }
 
 func BenchmarkDecodeBraceEscape(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decodeBraceEscape(braceEscapeData)
 	}
 }
 
 func BenchmarkDecodeLongEscape(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decodeLongEscape(longEscapeData)
 	}
 }
 
 func BenchmarkDecodePerlEscape(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decodePerlEscape(perlEscapeData)
 	}
 }
 
 func BenchmarkDecodeCssEscape(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decodeCssEscape(cssEscapeData)
 	}
 }
 
 func BenchmarkDecodeHtmlEscape(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decodeHtmlEscape(htmlEscapeData)
 	}
 }
 
 func BenchmarkDecodePercentEscape(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decodePercentEscape(percentEscapeData)
 	}
 }
@@ -118,8 +118,7 @@ func BenchmarkFromChunk_OriginalFormat(b *testing.B) {
 	decoder := &EscapedUnicode{}
 	chunk := &sources.Chunk{Data: originalUnicodeData}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decoder.FromChunk(chunk)
 	}
 }
@@ -128,8 +127,7 @@ func BenchmarkFromChunk_BraceFormat(b *testing.B) {
 	decoder := &EscapedUnicode{}
 	chunk := &sources.Chunk{Data: braceEscapeData}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decoder.FromChunk(chunk)
 	}
 }
@@ -138,8 +136,7 @@ func BenchmarkFromChunk_LongFormat(b *testing.B) {
 	decoder := &EscapedUnicode{}
 	chunk := &sources.Chunk{Data: longEscapeData}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decoder.FromChunk(chunk)
 	}
 }
@@ -148,8 +145,7 @@ func BenchmarkFromChunk_HtmlFormat(b *testing.B) {
 	decoder := &EscapedUnicode{}
 	chunk := &sources.Chunk{Data: htmlEscapeData}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decoder.FromChunk(chunk)
 	}
 }
@@ -158,8 +154,7 @@ func BenchmarkFromChunk_MixedContent(b *testing.B) {
 	decoder := &EscapedUnicode{}
 	chunk := &sources.Chunk{Data: mixedContentData}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decoder.FromChunk(chunk)
 	}
 }
@@ -168,8 +163,7 @@ func BenchmarkFromChunk_NoUnicode(b *testing.B) {
 	decoder := &EscapedUnicode{}
 	chunk := &sources.Chunk{Data: noUnicodeData}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decoder.FromChunk(chunk)
 	}
 }
@@ -178,8 +172,7 @@ func BenchmarkFromChunk_LargeData(b *testing.B) {
 	decoder := &EscapedUnicode{}
 	chunk := &sources.Chunk{Data: largeData}
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_ = decoder.FromChunk(chunk)
 	}
 }
@@ -188,8 +181,7 @@ func BenchmarkFromChunk_LargeData(b *testing.B) {
 func BenchmarkRegexMatching_AllPatterns(b *testing.B) {
 	testData := mixedContentData
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		// Simulate the pattern matching in FromChunk
 		_ = longEscapePat.Match(testData)
 		_ = braceEscapePat.Match(testData)
@@ -206,8 +198,7 @@ func BenchmarkRegexMatching_AllPatterns(b *testing.B) {
 func BenchmarkRegexMatching_NoMatch(b *testing.B) {
 	testData := noUnicodeData
 
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		// Simulate the pattern matching in FromChunk on data with no matches
 		_ = longEscapePat.Match(testData)
 		_ = braceEscapePat.Match(testData)
@@ -226,9 +217,8 @@ func BenchmarkFromChunk_MemoryAllocation(b *testing.B) {
 	decoder := &EscapedUnicode{}
 	chunk := &sources.Chunk{Data: mixedContentData}
 
-	b.ResetTimer()
 	b.ReportAllocs()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		result := decoder.FromChunk(chunk)
 		if result != nil {
 			// Prevent compiler optimization

--- a/pkg/decoders/utf16_test.go
+++ b/pkg/decoders/utf16_test.go
@@ -100,7 +100,7 @@ func BenchmarkUtf16ToUtf8(b *testing.B) {
 	// Example UTF-16LE encoded data
 	data := []byte{72, 0, 101, 0, 108, 0, 108, 0, 111, 0, 32, 0, 87, 0, 111, 0, 114, 0, 108, 0, 100, 0}
 
-	for n := 0; n < b.N; n++ {
+	for b.Loop() {
 		_, _ = utf16ToUTF8(data)
 	}
 }

--- a/pkg/decoders/utf8_test.go
+++ b/pkg/decoders/utf8_test.go
@@ -375,7 +375,7 @@ go
 away.`)
 
 func Benchmark_extractSubstrings(b *testing.B) {
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		extractSubstrings(testBytes)
 	}
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:

These changes use b.Loop() to simplify the code and improve performance
Supported by Go Team, more info: https://go.dev/blog/testing-b-loop   and   https://go.dev/issue/73137

Before:

```shell
 go test -run=^$ -bench=. ./pkg/decoders                  
goos: darwin
goarch: arm64
pkg: github.com/trufflesecurity/trufflehog/v3/pkg/decoders
cpu: Apple M4
BenchmarkFromChunkSmall-10                	 6595539	       181.3 ns/op
BenchmarkFromChunkMedium-10               	  466124	      2224 ns/op
BenchmarkFromChunkLarge-10                	33437010	        34.91 ns/op
BenchmarkDecodeOriginalEscape-10          	50474690	        42.09 ns/op
BenchmarkDecodeCodePoint-10               	  880795	      1218 ns/op
BenchmarkDecodeBraceEscape-10             	48463552	        49.64 ns/op
BenchmarkDecodeLongEscape-10              	43757558	        56.57 ns/op
BenchmarkDecodePerlEscape-10              	46256365	        68.06 ns/op
BenchmarkDecodeCssEscape-10               	50212356	        23.12 ns/op
BenchmarkDecodeHtmlEscape-10              	47056438	        59.62 ns/op
BenchmarkDecodePercentEscape-10           	50229433	        40.58 ns/op
BenchmarkFromChunk_OriginalFormat-10      	  998955	      1168 ns/op
BenchmarkFromChunk_BraceFormat-10         	 1000000	      1168 ns/op
BenchmarkFromChunk_LongFormat-10          	  603687	      2029 ns/op
BenchmarkFromChunk_HtmlFormat-10          	  999502	      1237 ns/op
BenchmarkFromChunk_MixedContent-10        	  198066	      5813 ns/op
BenchmarkFromChunk_NoUnicode-10           	  258198	      4645 ns/op
BenchmarkFromChunk_LargeData-10           	     528	   2244064 ns/op
BenchmarkRegexMatching_AllPatterns-10     	  124023	      9874 ns/op
BenchmarkRegexMatching_NoMatch-10         	  245246	      4659 ns/op
BenchmarkFromChunk_MemoryAllocation-10    	  197952	      6189 ns/op	   14398 B/op	      86 allocs/op
BenchmarkUtf16ToUtf8-10                   	28343331	        38.98 ns/op
Benchmark_extractSubstrings-10            	 5197101	       222.4 ns/op
PASS
ok  	github.com/trufflesecurity/trufflehog/v3/pkg/decoders	41.076s
```

After:

```shell
go test -run=^$ -bench=. ./pkg/decoders                   
goos: darwin
goarch: arm64
pkg: github.com/trufflesecurity/trufflehog/v3/pkg/decoders
cpu: Apple M4
BenchmarkFromChunkSmall-10                	 6542812	       172.2 ns/op
BenchmarkFromChunkMedium-10               	  642433	      1850 ns/op
BenchmarkFromChunkLarge-10                	39467463	        30.15 ns/op
BenchmarkDecodeOriginalEscape-10          	51547774	        23.02 ns/op
BenchmarkDecodeCodePoint-10               	  918812	      1209 ns/op
BenchmarkDecodeBraceEscape-10             	44588186	        25.17 ns/op
BenchmarkDecodeLongEscape-10              	45711601	        26.57 ns/op
BenchmarkDecodePerlEscape-10              	43454577	        26.05 ns/op
BenchmarkDecodeCssEscape-10               	50294870	        23.55 ns/op
BenchmarkDecodeHtmlEscape-10              	43514719	        24.98 ns/op
BenchmarkDecodePercentEscape-10           	49723412	        24.82 ns/op
BenchmarkFromChunk_OriginalFormat-10      	  960178	      1216 ns/op
BenchmarkFromChunk_BraceFormat-10         	 1000000	      1168 ns/op
BenchmarkFromChunk_LongFormat-10          	  625647	      1924 ns/op
BenchmarkFromChunk_HtmlFormat-10          	  992942	      1167 ns/op
BenchmarkFromChunk_MixedContent-10        	  202584	      5804 ns/op
BenchmarkFromChunk_NoUnicode-10           	  253852	      4512 ns/op
BenchmarkFromChunk_LargeData-10           	     536	   2221862 ns/op
BenchmarkRegexMatching_AllPatterns-10     	  125577	      9504 ns/op
BenchmarkRegexMatching_NoMatch-10         	  261069	      4548 ns/op
BenchmarkFromChunk_MemoryAllocation-10    	  195384	      5780 ns/op	   14393 B/op	      86 allocs/op
BenchmarkUtf16ToUtf8-10                   	31611598	        37.37 ns/op
Benchmark_extractSubstrings-10            	 5364784	       224.2 ns/op
PASS
ok  	github.com/trufflesecurity/trufflehog/v3/pkg/decoders	27.924s

```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
