### PR TITLE
Fix "skipping binary file" logging to show actual file name

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -768,7 +768,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 			if s.skipBinaries || feature.ForceSkipBinaries.Load() {
 				logger.V(5).Info("skipping binary file",
 					"commit", commitHash.String()[:7],
-					"path", path)
+					"path", fileName)
 				continue
 			}
 
@@ -999,7 +999,7 @@ func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string,
 			if s.skipBinaries || feature.ForceSkipBinaries.Load() {
 				logger.V(5).Info("skipping binary file",
 					"commit", commitHash.String()[:7],
-					"path", path)
+					"path", fileName)
 				continue
 			}
 


### PR DESCRIPTION
This was intended to show path:fileName, but `path` in these scopes is the repo path, not a file.  This section was moved in a refactor where `path` was the file in the old scope, and since both scopes have `path string`, it was not flagged and easy to miss. (Repo path is contextually logged in these lines as repo:path, also.)

### Checklist:
* [X] Tests passing (`make test-community`)?
* [X] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
