### PR TITLE
chore: fix feature support to append user agent suffix

### DIFF
--- a/pkg/detectors/browserstack/browserstack.go
+++ b/pkg/detectors/browserstack/browserstack.go
@@ -11,6 +11,7 @@ import (
 	regexp "github.com/wasilibs/go-re2"
 	"golang.org/x/net/publicsuffix"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
@@ -93,6 +94,13 @@ func verifyBrowserStackCredentials(ctx context.Context, client *http.Client, use
 		return false, err
 	}
 	req.Header.Add("Content-Type", "application/json")
+
+	// add feature for custom user agent if set
+	userAgent := common.UserAgent()
+	if userAgent != "TruffleHog" {
+		req.Header.Add("User-Agent", userAgent)
+	}
+
 	req.SetBasicAuth(username, accessKey)
 
 	res, err := client.Do(req)

--- a/pkg/detectors/browserstack/browserstack.go
+++ b/pkg/detectors/browserstack/browserstack.go
@@ -94,12 +94,7 @@ func verifyBrowserStackCredentials(ctx context.Context, client *http.Client, use
 		return false, err
 	}
 	req.Header.Add("Content-Type", "application/json")
-
-	// add feature for custom user agent if set
-	userAgent := common.UserAgent()
-	if userAgent != "TruffleHog" {
-		req.Header.Add("User-Agent", userAgent)
-	}
+	req.Header.Add("User-Agent", common.UserAgent())
 
 	req.SetBasicAuth(username, accessKey)
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
fixes missing feature support append suffix to `TruffleHog` User Agent header while using `--user-agent-suffix` flag.

Feature implementation was missed in this PR: https://github.com/trufflesecurity/trufflehog/pull/2208/files 

### Checklist:
* [x] Tests passing (`make test-community`)?

<img width="851" height="902" alt="image" src="https://github.com/user-attachments/assets/00163542-98b3-4349-89c7-320a788b7e9c" />

* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
