### PR TITLE
Switch to an outside action for pr approval

### DIFF
--- a/.github/workflows/pr-approval-check.yml
+++ b/.github/workflows/pr-approval-check.yml
@@ -18,7 +18,7 @@ jobs:
           private-key: ${{ secrets.PR_APPROVAL_CHECK }}
 
       - name: Require Product Eng approval
-        uses: trufflesecurity/pr-approval-check@main   # <— just the repo + tag
+        uses: trufflesecurity/pr-approval-check@v1
         with:
           org: trufflesecurity
           approver_team: product-eng


### PR DESCRIPTION
### Description:

Moves the pr approval check implementation over to its own repo and mints the github app token on demand.

This makes it more easily reusable elsewhere in our org as well.

I tested this with the trigger of `pull_request` temporarily while developing, but I've since switched it back to `pull_request_target`. Here's an example of it running: https://github.com/trufflesecurity/trufflehog/actions/runs/18958350640/job/54140379889