### PR TITLE
pr-approval-check: use separate workflow to check approvals

### DIFF
--- a/.github/workflows/pr-approval-check.yml
+++ b/.github/workflows/pr-approval-check.yml
@@ -1,26 +1,45 @@
 name: PR Approval Check
 
 on:
-  pull_request_review:
-    types: [submitted, dismissed]
-  pull_request_target:
-    types: [opened, reopened, synchronize]
+  workflow_run:
+    workflows: ["Receive PR"]
+    types: ["completed"]
+
+permissions:
+  actions: read
 
 jobs:
   approval:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
+      - name: Download artifact from triggering run
+        uses: actions/download-artifact@v6
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: prnum
+          github-token: ${{ github.token }}
+
+      - name: Read inputs
+        id: get-prnum
+        run: |
+          set -euo pipefail
+          echo "prnum=$(cat prnum.txt)" >> "$GITHUB_OUTPUT"
+
       - name: Mint installation token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.1.4
         with:
           app-id: ${{ secrets.PR_APPROVAL_CHECK_APP_ID }}
           private-key: ${{ secrets.PR_APPROVAL_CHECK }}
 
       - name: Require Product Eng approval
-        uses: trufflesecurity/pr-approval-check@v1
+        uses: trufflesecurity/pr-approval-check@workflow-triggered
         with:
           org: trufflesecurity
           approver_team: product-eng
+          owner: ${{ github.event.workflow_run.repository.owner.login }}
+          repo: ${{ github.event.workflow_run.repository.name }}
+          head: ${{ github.event.workflow_run.head_sha }}
+          number: ${{ steps.get-prnum.outputs.prnum }}
           github_token: ${{ steps.app-token.outputs.token }}
 

--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -1,0 +1,25 @@
+name: "Receive PR"
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+jobs:
+  prnum:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Determine PR Number
+        id: build
+        run: |
+          echo "PR: ${{ github.event.pull_request.number }}"
+          echo "${{ github.event.pull_request.number }}" > prnum.txt
+
+      - name: Submit
+        uses: actions/upload-artifact@v5
+        with:
+          name: prnum
+          path: prnum.txt
+          retention-days: 1
+


### PR DESCRIPTION
### Description:

With this change, github actions triggers a separate workflow run that has the right permissions to check for approvals. This fixes an issue where pull request review events on PRs from forks didn't have the right credentials.

It's a little more complicated and takes a little longer, but this gets around the github actions design, as well as a bug in github actions with how the base and head repos are reported in the `pull_request_review` event.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
