### PR TITLE
Track chunk size by source type

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -832,7 +832,7 @@ func (e *Engine) scannerWorker(ctx context.Context) {
 
 		dataSize := float64(len(chunk.Data))
 
-		scanBytesPerChunk.Observe(dataSize)
+		scanBytesPerChunk.WithLabelValues(chunk.SourceType.String()).Observe(dataSize)
 		jobBytesScanned.WithLabelValues(
 			chunk.SourceType.String(),
 			chunk.SourceName,

--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -55,13 +55,15 @@ var (
 		[]string{"source_type", "source_name"},
 	)
 
-	scanBytesPerChunk = promauto.NewHistogram(prometheus.HistogramOpts{
+	scanBytesPerChunk = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: common.MetricsNamespace,
 		Subsystem: common.MetricsSubsystem,
 		Name:      "scan_bytes_per_chunk",
 		Help:      "Total number of bytes in a chunk.",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 18),
-	})
+	},
+		[]string{"source_type"},
+	)
 
 	jobChunksScanned = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We're tracking chunk size - but _not_ by source type, which means we can't use the metric to locate potential chunking anomalies by source type. It's really easy to add a source type label, so I did.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
