### PR TITLE
Added .msg and .doc to skipArchiverMimeTypes

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -259,6 +259,8 @@ const (
 	apkMime      mimeType = "application/vnd.android.package-archive"
 	zipMime      mimeType = "application/zip"
 	jarMime      mimeType = "application/java-archive"
+	msgMime      mimeType = "application/vnd.ms-outlook"
+	docMime      mimeType = "application/msword"
 )
 
 // skipArchiverMimeTypes is a set of MIME types that should bypass archiver library processing because they are either
@@ -294,6 +296,8 @@ var skipArchiverMimeTypes = map[mimeType]struct{}{
 	tclTextMime:  {},
 	tclMime:      {},
 	apkMime:      {},
+	msgMime:      {},
+	docMime:      {},
 }
 
 // selectHandler dynamically selects and configures a FileHandler based on the provided |mimetype| type and archive flag.


### PR DESCRIPTION
Problem

When scanning Jira attachments, .msg and .doc were incorrectly identified as archives by archives.Identify(), causing extraction errors during scanning.

Root Cause

The handler flow:
Detects MIME type (.msg → application/vnd.ms-outlook, .doc → application/msword
Calls archives.Identify() to check if file is an archive
If identified as an archive, attempts extraction → errors
These files aren't archives but were being treated as such.

Solution

Added skip logic to prevent archive detection for these file types:
MIME type skip: Added application/vnd.ms-outlook and application/msword to skipArchiverMimeTypes to bypass archive detection for .msg and .doc files

Impact

Prevents previously experienced errors when scanning Jira issues with .msg or attachments
Files are handled by the default handler instead of the archive handler
Minimal impact, as this only adds skip logic for these specific file types

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
