### PR TITLE
Shadow context when enumerating GitHub

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -461,7 +461,7 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 
 			// Final filter check - only include repositories that pass the filter
 			if s.filteredRepoCache.wantRepo(repoName) {
-				ctx = context.WithValue(ctx, "repo", repo)
+				ctx := context.WithValue(ctx, "repo", repo)
 
 				repo, err := s.ensureRepoInfoCache(ctx, repo, &unitErrorReporter{reporter})
 				if err != nil {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
#4430 introduced a bug that caused the context during GitHub enumeration to acquire a new `repo` log key for each repository being enumerated, rather than having the `repo` key-value pair be _updated_. This caused drastic memory growth when lots of repositories were being scanned.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
