### PR TITLE
Redact secret for Twilio API Key [INS-169]

### DIFF
--- a/pkg/detectors/twilioapikey/twilioapikey.go
+++ b/pkg/detectors/twilioapikey/twilioapikey.go
@@ -63,7 +63,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detectorspb.DetectorType_Twilio,
 				Raw:          []byte(apiKey),
 				RawV2:        []byte(apiKey + secret),
-				Redacted:     secret,
+				Redacted:     secret[:5] + "...",
 				ExtraData:    make(map[string]string),
 			}
 

--- a/pkg/detectors/twilioapikey/twilioapikey_test.go
+++ b/pkg/detectors/twilioapikey/twilioapikey_test.go
@@ -81,3 +81,24 @@ func TestTwilioAPIKey_Pattern(t *testing.T) {
 		})
 	}
 }
+
+func TestTwilioAPIKey_SecretRedacted(t *testing.T) {
+	d := Scanner{}
+
+	results, err := d.FromData(
+		context.Background(),
+		false,
+		[]byte(fmt.Sprintf("%s token - '%s'\n%s token - '%s'\n", keyword, validAPIKey, keyword, validSecret)))
+	if err != nil {
+		t.Errorf("error = %v", err)
+		return
+	}
+
+	if len(results) == 0 {
+		t.Errorf("did not receive result")
+	}
+
+	if results[0].Redacted != validSecret[:5]+"..." {
+		t.Errorf("expected redacted secret to be '%s', got '%s'", validSecret[:5]+"...", results[0].Redacted)
+	}
+}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR fixes a bug where the full secret was being set to `Redacted` field for the Twilio API Key detector. The secret is now redacted before being set.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
