### PR TITLE
added a metric for http response size in sane http client

### DIFF
--- a/pkg/buffers/buffer/metrics.go
+++ b/pkg/buffers/buffer/metrics.go
@@ -10,28 +10,28 @@ import (
 var (
 	growCount = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "grow_count",
 		Help:      "Total number of times buffers in the pool have grown.",
 	})
 
 	growAmount = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "grow_amount",
 		Help:      "Total amount of bytes buffers in the pool have grown by.",
 	})
 
 	checkoutDurationTotal = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "checkout_duration_total_us",
 		Help:      "Total duration in microseconds of Buffer checkouts.",
 	})
 
 	checkoutDuration = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "checkout_duration_us",
 		Help:      "Duration in microseconds of Buffer checkouts.",
 		Buckets:   prometheus.ExponentialBuckets(10, 10, 7),
@@ -39,14 +39,14 @@ var (
 
 	totalBufferLength = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "total_buffer_length",
 		Help:      "Total length of all buffers combined.",
 	})
 
 	totalBufferSize = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "total_buffer_size",
 		Help:      "Total size of all buffers combined.",
 	})

--- a/pkg/buffers/pool/metrics.go
+++ b/pkg/buffers/pool/metrics.go
@@ -10,35 +10,35 @@ import (
 var (
 	activeBufferCount = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "active_buffer_count",
 		Help:      "Current number of active buffers.",
 	})
 
 	bufferCount = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "buffer_count",
 		Help:      "Total number of buffers managed by the pool.",
 	})
 
 	shrinkCount = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "shrink_count",
 		Help:      "Total number of times buffers in the pool have shrunk.",
 	})
 
 	shrinkAmount = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "shrink_amount",
 		Help:      "Total amount of bytes buffers in the pool have shrunk by.",
 	})
 
 	checkoutCount = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "checkout_count",
 		Help:      "Total number of Buffer checkouts.",
 	})

--- a/pkg/cache/metrics.go
+++ b/pkg/cache/metrics.go
@@ -40,35 +40,35 @@ func init() {
 	baseMetricsInstance = &baseCollector{
 		hits: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "hits_total",
 			Help:      "Total number of cache hits.",
 		}, []string{"cache_name"}),
 
 		misses: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "misses_total",
 			Help:      "Total number of cache misses.",
 		}, []string{"cache_name"}),
 
 		sets: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "sets_total",
 			Help:      "Total number of cache set operations.",
 		}, []string{"cache_name"}),
 
 		deletes: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "deletes_total",
 			Help:      "Total number of cache delete operations.",
 		}, []string{"cache_name"}),
 
 		clears: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "clears_total",
 			Help:      "Total number of cache clear operations.",
 		}, []string{"cache_name"}),
@@ -79,7 +79,7 @@ func init() {
 	evictionMetricsInstance = &evictionMetrics{
 		evictions: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "evictions_total",
 			Help:      "Total number of cache evictions.",
 		}, []string{"cache_name"}),

--- a/pkg/common/http.go
+++ b/pkg/common/http.go
@@ -135,6 +135,10 @@ func (t *InstrumentedTransport) RoundTrip(req *http.Request) (*http.Response, er
 	if resp != nil {
 		// record latency and increment counter for non-200 status code
 		recordHTTPResponse(sanitizedURL, resp.StatusCode, duration.Seconds())
+
+		if resp.ContentLength > 0 {
+			httpResponseBodySize.WithLabelValues(sanitizedURL).Observe(float64(resp.ContentLength))
+		}
 	}
 
 	return resp, err

--- a/pkg/common/http_metrics.go
+++ b/pkg/common/http_metrics.go
@@ -12,7 +12,7 @@ var (
 	httpRequestsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: MetricsNamespace,
-			Subsystem: "http_client",
+			Subsystem: MetricsSubsystemHTTPClient,
 			Name:      "requests_total",
 			Help:      "Total number of HTTP requests made, labeled by URL.",
 		},
@@ -22,7 +22,7 @@ var (
 	httpRequestDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: MetricsNamespace,
-			Subsystem: "http_client",
+			Subsystem: MetricsSubsystemHTTPClient,
 			Name:      "request_duration_seconds",
 			Help:      "HTTP request latency in seconds, labeled by URL.",
 			Buckets:   prometheus.DefBuckets,
@@ -33,11 +33,22 @@ var (
 	httpNon200ResponsesTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: MetricsNamespace,
-			Subsystem: "http_client",
+			Subsystem: MetricsSubsystemHTTPClient,
 			Name:      "non_200_responses_total",
 			Help:      "Total number of non-200 HTTP responses, labeled by URL and status code.",
 		},
 		[]string{"url", "status_code"},
+	)
+
+	httpResponseBodySize = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: MetricsNamespace,
+			Subsystem: "http_client",
+			Name:      "response_body_size_bytes",
+			Help:      "HTTP response body size in bytes, labeled by URL.",
+			Buckets:   prometheus.ExponentialBuckets(1024, 2, 10),
+		},
+		[]string{"url"},
 	)
 )
 

--- a/pkg/common/metrics.go
+++ b/pkg/common/metrics.go
@@ -3,6 +3,8 @@ package common
 const (
 	// MetricsNamespace is the namespace for all metrics.
 	MetricsNamespace = "trufflehog"
-	// MetricsSubsystem is the subsystem for all metrics.
-	MetricsSubsystem = "scanner"
+	// MetricsSubsystemScanner is the subsystem for all metrics.
+	MetricsSubsystemScanner = "scanner"
+	// MetricsSubsystemHTTPClient is the subsystem for HTTP client metrics.
+	MetricsSubsystemHTTPClient = "http_client"
 )

--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -11,7 +11,7 @@ var (
 	decodeLatency = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "decode_latency",
 			Help:      "Time spent decoding a chunk in microseconds",
 			Buckets:   prometheus.ExponentialBuckets(50, 2, 20),
@@ -23,7 +23,7 @@ var (
 	detectorExecutionCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "detector_execution_count",
 			Help:      "Total number of times a detector has been executed.",
 		},
@@ -38,7 +38,7 @@ var (
 	detectorExecutionDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "detector_execution_duration",
 			Help:      "Duration of detector execution in milliseconds.",
 			Buckets:   prometheus.ExponentialBuckets(1, 5, 6),
@@ -48,7 +48,7 @@ var (
 
 	jobBytesScanned = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "job_bytes_scanned",
 		Help:      "Total number of bytes scanned for a job.",
 	},
@@ -57,7 +57,7 @@ var (
 
 	scanBytesPerChunk = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "scan_bytes_per_chunk",
 		Help:      "Total number of bytes in a chunk.",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 18),
@@ -67,7 +67,7 @@ var (
 
 	jobChunksScanned = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "job_chunks_scanned",
 		Help:      "Total number of chunks scanned for a job.",
 	},
@@ -76,7 +76,7 @@ var (
 
 	detectBytesPerMatch = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "detect_bytes_per_match",
 		Help:      "Total number of bytes used to detect a credential in a match per chunk.",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 18),
@@ -84,7 +84,7 @@ var (
 
 	matchesPerChunk = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "matches_per_chunk",
 		Help:      "Total number of matches found in a chunk.",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 10),
@@ -93,7 +93,7 @@ var (
 	// Metrics around latency for the different stages of the pipeline.
 	chunksScannedLatency = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "chunk_scanned_latency",
 		Help:      "Time taken to scan a chunk in microseconds.",
 		Buckets:   prometheus.ExponentialBuckets(1, 2, 22),
@@ -101,7 +101,7 @@ var (
 
 	chunksDetectedLatency = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "chunk_detected_latency",
 		Help:      "Time taken to detect a chunk in microseconds.",
 		Buckets:   prometheus.ExponentialBuckets(50, 2, 20),
@@ -109,7 +109,7 @@ var (
 
 	chunksNotifiedLatency = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "chunk_notified_latency",
 		Help:      "Time taken to notify a chunk in milliseconds.",
 		Buckets:   prometheus.ExponentialBuckets(5, 2, 12),

--- a/pkg/handlers/metrics.go
+++ b/pkg/handlers/metrics.go
@@ -23,7 +23,7 @@ var (
 	handleFileLatency = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "handlers_file_latency_milliseconds",
 			Help:      "Latency of the HandleFile method",
 			Buckets:   prometheus.ExponentialBuckets(1, 5, 6),
@@ -33,7 +33,7 @@ var (
 	bytesProcessed = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "handlers_bytes_processed_total",
 			Help:      "Total number of bytes processed",
 		},
@@ -42,7 +42,7 @@ var (
 	filesProcessed = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "handlers_files_processed_total",
 			Help:      "Total number of files processed",
 		},
@@ -51,7 +51,7 @@ var (
 	errorsEncountered = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "handlers_errors_encountered_total",
 			Help:      "Total number of errors encountered",
 		},
@@ -60,7 +60,7 @@ var (
 	filesSkipped = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "handlers_files_skipped_total",
 			Help:      "Total number of files skipped",
 		},
@@ -69,7 +69,7 @@ var (
 	maxArchiveDepthCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "handlers_max_archive_depth_reached_total",
 			Help:      "Total number of times the maximum archive depth was reached",
 		},
@@ -78,7 +78,7 @@ var (
 	fileSize = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "handlers_file_size_bytes",
 			Help:      "Sizes of files handled by the handler",
 			Buckets:   prometheus.ExponentialBuckets(1, 2, 4),
@@ -88,7 +88,7 @@ var (
 	fileProcessingTimeouts = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "handlers_file_processing_timeouts_total",
 			Help:      "Total number of file processing timeouts encountered",
 		},

--- a/pkg/sources/docker/metrics.go
+++ b/pkg/sources/docker/metrics.go
@@ -10,7 +10,7 @@ import (
 var (
 	dockerLayersScanned = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "docker_layers_scanned",
 		Help:      "Total number of Docker layers scanned.",
 	},
@@ -18,7 +18,7 @@ var (
 
 	dockerHistoryEntriesScanned = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "docker_history_entries_scanned",
 		Help:      "Total number of Docker image history entries scanned.",
 	},
@@ -26,7 +26,7 @@ var (
 
 	dockerImagesScanned = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "docker_images_scanned",
 		Help:      "Total number of Docker images scanned.",
 	},
@@ -35,7 +35,7 @@ var (
 	dockerListImagesAPIDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "docker_list_images_api_duration_seconds",
 			Help:      "Duration of Docker list images API calls.",
 			Buckets:   prometheus.DefBuckets,

--- a/pkg/sources/git/metrics.go
+++ b/pkg/sources/git/metrics.go
@@ -65,21 +65,21 @@ func init() {
 	metricsInstance = &collector{
 		cloneOperations: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "git_clone_operations_total",
 			Help:      "Total number of git clone operations by status, reason, and exit code",
 		}, []string{"status", "reason", "exit_code"}),
 
 		commitsScanned: promauto.NewCounter(prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "git_commits_scanned_total",
 			Help:      "Total number of git commits scanned",
 		}),
 
 		reposScanned: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "git_repos_scanned_total",
 			Help:      "Total number of git repositories scanned by status (success/failure)",
 		}, []string{"status"}),

--- a/pkg/sources/github/metrics.go
+++ b/pkg/sources/github/metrics.go
@@ -10,7 +10,7 @@ import (
 var (
 	githubNumRateLimitEncountered = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "github_num_rate_limit_encountered",
 		Help:      "Total number of times Github Rate Limit was encountered",
 	},
@@ -18,7 +18,7 @@ var (
 
 	githubSecondsSpentRateLimited = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "github_seconds_spent_rate_limited",
 		Help:      "Total number of seconds spent idle due to GitHub rate limits.",
 	},
@@ -26,7 +26,7 @@ var (
 
 	githubReposEnumerated = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "github_repos_enumerated",
 		Help:      "Total number of GitHub repositories enumerated.",
 	},
@@ -34,7 +34,7 @@ var (
 
 	githubReposScanned = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "github_repos_scanned",
 		Help:      "Total number of GitHub repositories scanned.",
 	},
@@ -42,7 +42,7 @@ var (
 
 	githubOrgsEnumerated = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "github_orgs_enumerated",
 		Help:      "Total number of GitHub organizations enumerated.",
 	},

--- a/pkg/sources/gitlab/metrics.go
+++ b/pkg/sources/gitlab/metrics.go
@@ -10,7 +10,7 @@ import (
 var (
 	gitlabGroupsEnumerated = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "gitlab_groups_enumerated",
 		Help:      "Total number of GitLab groups enumerated.",
 	},
@@ -18,7 +18,7 @@ var (
 
 	gitlabReposEnumerated = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "gitlab_repos_enumerated",
 		Help:      "Total number of Gitlab repositories enumerated.",
 	},
@@ -26,7 +26,7 @@ var (
 
 	gitlabReposScanned = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "gitlab_repos_scanned",
 		Help:      "Total number of Gitlab repositories scanned.",
 	},

--- a/pkg/sources/metrics.go
+++ b/pkg/sources/metrics.go
@@ -9,7 +9,7 @@ import (
 var (
 	hooksExecTime = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "hooks_exec_time_ms",
 		Help:      "Time spent executing hooks (ms)",
 		Buckets:   []float64{5, 50, 500, 1000},
@@ -17,7 +17,7 @@ var (
 
 	hooksChannelSize = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "hooks_channel_size",
 		Help:      "Total number of metrics waiting in the finished channel.",
 	}, nil)

--- a/pkg/sources/postman/metrics.go
+++ b/pkg/sources/postman/metrics.go
@@ -14,7 +14,7 @@ type metrics struct {
 var (
 	postmanAPIRequestsMetric = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "postman_api_requests",
 		Help:      "Total number of API requests made to Postman.",
 	},
@@ -22,7 +22,7 @@ var (
 
 	postmanAPIMonthlyRequestsRemaining = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "postman_api_monthly_requests_remaining",
 		Help:      "Total number Postman API requests remaining this month.",
 	},

--- a/pkg/sources/s3/metrics.go
+++ b/pkg/sources/s3/metrics.go
@@ -35,7 +35,7 @@ func init() {
 	metricsInstance = &collector{
 		objectsScanned: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "objects_scanned_bytes",
 			Help:      "Size distribution of successfully scanned S3 objects in bytes",
 			// 64B, 512B, 4KB, 32KB, 256KB, 2MB, 16MB, 128MB, 1GB.
@@ -44,7 +44,7 @@ func init() {
 
 		objectsSkipped: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "objects_skipped_bytes",
 			Help:      "Size distribution of skipped S3 objects in bytes",
 			// 64B, 512B, 4KB, 32KB, 256KB, 2MB, 16MB, 128MB, 1GB.
@@ -53,21 +53,21 @@ func init() {
 
 		objectsErrors: promauto.NewCounterVec(prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "objects_errors_total",
 			Help:      "Total number of errors encountered during S3 scan",
 		}, []string{"bucket"}),
 
 		rolesScanned: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "roles_scanned",
 			Help:      "Number of AWS roles being scanned",
 		}, []string{"role_arn"}),
 
 		bucketsPerRole: promauto.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: common.MetricsNamespace,
-			Subsystem: common.MetricsSubsystem,
+			Subsystem: common.MetricsSubsystemScanner,
 			Name:      "buckets_per_role",
 			Help:      "Number of buckets accessible per AWS role",
 		}, []string{"role_arn"}),

--- a/pkg/writers/buffer_writer/metrics.go
+++ b/pkg/writers/buffer_writer/metrics.go
@@ -10,7 +10,7 @@ import (
 var (
 	writeSize = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "buffer_writer_write_size_bytes",
 		Help:      "Total size of data written by the BufferWriter in bytes.",
 		Buckets:   prometheus.ExponentialBuckets(100, 10, 7),
@@ -18,7 +18,7 @@ var (
 
 	totalWriteDuration = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "buffer_writer_total_write_duration_microseconds",
 		Help:      "Total duration of write operations by the BufferWriter in microseconds.",
 	})

--- a/pkg/writers/buffered_file_writer/metrics.go
+++ b/pkg/writers/buffered_file_writer/metrics.go
@@ -10,21 +10,21 @@ import (
 var (
 	totalWriteSize = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "buffered_file_writer_total_write_size_bytes",
 		Help:      "Total size of data written by the BufferedFileWriter in bytes.",
 	})
 
 	totalWriteDuration = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "buffered_file_writer_total_write_duration_microseconds",
 		Help:      "Total duration of write operations by the BufferedFileWriter in microseconds.",
 	})
 
 	diskWriteCount = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "disk_write_count",
 		Help:      "Total number of times data was written to disk by the BufferedFileWriter.",
 	})
@@ -32,7 +32,7 @@ var (
 	// The first bucket is greater than the default threshold to avoid a bucket with a zero value.
 	fileSizeHistogram = promauto.NewHistogram(prometheus.HistogramOpts{
 		Namespace: common.MetricsNamespace,
-		Subsystem: common.MetricsSubsystem,
+		Subsystem: common.MetricsSubsystemScanner,
 		Name:      "file_size_bytes",
 		Help:      "Sizes of files created by the BufferedFileWriter.",
 		Buckets:   prometheus.ExponentialBuckets(defaultThreshold*2, 4, 5),


### PR DESCRIPTION
This PR adds HTTP response body size tracking to detector API monitoring metrics.

## Changes
- Added `httpResponseBodySize` histogram metric to track response body sizes in bytes
- Metric uses exponential buckets (1KB to 512KB)
- Recording happens in `InstrumentedTransport` using `Content-Length` header

## Metric Details

**Metric name**: `trufflehog_http_client_response_body_size_bytes`  
**Type**: Histogram  
**Labels**: `url` (sanitized)  
**Buckets**: 1KB, 2KB, 4KB, 8KB, 16KB, 32KB, 64KB, 128KB, 256KB, 512KB

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
