### PR TITLE
Make Integrations team codeown source integrations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,22 @@
 * @trufflesecurity/product-eng
 
 # Scanning
+pkg/sources/ @trufflesecurity/Scanning
 pkg/writers/ @trufflesecurity/Scanning
+
+# Integrations
+pkg/sources/circleci/ @trufflesecurity/Integrations
+pkg/sources/docker/ @trufflesecurity/Integrations
+pkg/sources/elasticsearch/ @trufflesecurity/Integrations
+pkg/sources/filesystem/ @trufflesecurity/Integrations
+pkg/sources/gcs/ @trufflesecurity/Integrations
+pkg/sources/git/ @trufflesecurity/Integrations
+pkg/sources/github/ @trufflesecurity/Integrations
+pkg/sources/gitlab/ @trufflesecurity/Integrations
+pkg/sources/jenkins/ @trufflesecurity/Integrations
+pkg/sources/postman/ @trufflesecurity/Integrations
+pkg/sources/s3/ @trufflesecurity/Integrations
+pkg/sources/travisci/ @trufflesecurity/Integrations
 
 # Shared
 pkg/decoders/ @trufflesecurity/Scanning @trufflesecurity/OSS
@@ -12,7 +27,6 @@ pkg/giturl/ @trufflesecurity/Scanning  @trufflesecurity/OSS
 pkg/handlers/ @trufflesecurity/Scanning  @trufflesecurity/OSS
 pkg/iobuf/ @trufflesecurity/Scanning  @trufflesecurity/OSS
 pkg/sanitizer/ @trufflesecurity/Scanning  @trufflesecurity/OSS
-pkg/sources/ @trufflesecurity/Scanning  @trufflesecurity/OSS
 proto/ @trufflesecurity/Scanning  @trufflesecurity/OSS
 
 # OSS


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We have a dedicated team for our source integrations. This PR modifies CODEOWNERS so that they own those integrations.

It does **not** fiddle with `proto/` codeownership, because that's going to be a mess to untangle and isn't related to the actual review requests that motivated this change. It also doesn't make the Integrations team codeown our more experimental/unusual sources:
* GitHub Experimental
* Huggingface
* stdin
* syslog

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
