### PR TITLE
Add some engine tests around the Verify flag

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1170,6 +1170,11 @@ func (e *Engine) filterResults(
 	return results
 }
 
+// processResult generates a detectors.ResultWithMetadata from the provided chunk and puts it on the results channel.
+//
+// CMR: The provided chunk is wrapped in a detectableChunk, but I'm pretty sure that's purely out of convenience
+// (because that's what this function's callers are using when they call this function). We're past detection at this
+// point in the engine, so we should probably refactor that parameter into a less confusing data type.
 func (e *Engine) processResult(
 	ctx context.Context,
 	data detectableChunk,

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1171,7 +1171,7 @@ func (e *Engine) filterResults(
 }
 
 // processResult generates a detectors.ResultWithMetadata from the provided chunk and result and puts it on the results
-// channel.
+// channel, unless the result exists on a line with an ignore tag, in which case no result is generated.
 //
 // CMR: The provided chunk is wrapped in a detectableChunk, but I'm pretty sure that's purely out of convenience
 // (because that's what this function's callers are using when they call this function). We're past detection at this

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1170,7 +1170,8 @@ func (e *Engine) filterResults(
 	return results
 }
 
-// processResult generates a detectors.ResultWithMetadata from the provided chunk and puts it on the results channel.
+// processResult generates a detectors.ResultWithMetadata from the provided chunk and result and puts it on the results
+// channel.
 //
 // CMR: The provided chunk is wrapped in a detectableChunk, but I'm pretty sure that's purely out of convenience
 // (because that's what this function's callers are using when they call this function). We're past detection at this

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1323,10 +1323,10 @@ def test_something():
 
 type passthroughDetector struct{}
 
-func (p passthroughDetector) FromData(_ aCtx.Context, verify bool, _ []byte) ([]detectors.Result, error) {
+func (p passthroughDetector) FromData(_ aCtx.Context, verify bool, data []byte) ([]detectors.Result, error) {
 	return []detectors.Result{
 		{
-			Raw:      []byte("l;jaslkghl;akheg"),
+			Raw:      data,
 			Verified: verify,
 		},
 	}, nil

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/verificationcache"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/config"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
@@ -28,6 +27,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/verificationcache"
 )
 
 const fakeDetectorKeyword = "fakedetector"

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1318,3 +1318,20 @@ def test_something():
 		})
 	}
 }
+
+func TestEngine_DetectChunk_UsesVerifyFlag(t *testing.T) {
+	t.Fatalf("not implemented")
+}
+
+func TestEngine_ScannerWorker_DetectableChunkHasCorrectVerifyFlag(t *testing.T) {
+	t.Fatalf("not implemented")
+}
+
+func TestEngine_VerificationOverlapWorker_DetectableChunkHasCorrectVerifyFlag(t *testing.T) {
+	t.Run("overlap", func(t *testing.T) {
+		t.Fatalf("not implemented")
+	})
+	t.Run("no overlap", func(t *testing.T) {
+		t.Fatalf("not implemented")
+	})
+}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
I was poking around at a refactor idea (in #4558) and realized that it had no test coverage. This PR adds that test coverage. I think I uncovered a bug in the process - see a comment in one of the tests.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
