### PR TITLE
Make Integrations (shared) codeowners of proto/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,7 +27,7 @@ pkg/giturl/ @trufflesecurity/Scanning  @trufflesecurity/OSS
 pkg/handlers/ @trufflesecurity/Scanning  @trufflesecurity/OSS
 pkg/iobuf/ @trufflesecurity/Scanning  @trufflesecurity/OSS
 pkg/sanitizer/ @trufflesecurity/Scanning  @trufflesecurity/OSS
-proto/ @trufflesecurity/Scanning  @trufflesecurity/OSS
+proto/ @trufflesecurity/Scanning  @trufflesecurity/Integrations
 
 # OSS
 pkg/detectors/ @trufflesecurity/OSS


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The integrations team should codeown all the protobuf stuff, because they own the integrations that consume the message definitions. (`config.proto` is a borderline case, but that's a borderline case for _every_ team, so this solution isn't worse than any other.)

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
