### PR TITLE
[chore] Update log.AddSink docs to clarify confusing behavior

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -139,7 +139,7 @@ func AddSentry(l logr.Logger, opts sentry.ClientOptions, tags map[string]string)
 // AddSink extends an existing logr.Logger with a new sink. It returns the new
 // logr.Logger, a cleanup function, and an error. Note that values added to the
 // existing logr.Logger via [logr.WithValues] before calling this function will
-// not be propogated to the new sink, but they will continue to be written to
+// not be propagated to the new sink, but they will continue to be written to
 // the existing sink.
 func AddSink(l logr.Logger, sink logConfig) (logr.Logger, func() error, error) {
 	if sink.err != nil {

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -163,10 +163,10 @@ func TestAddSink(t *testing.T) {
 	assert.Contains(t, buf2.String(), "line 2")
 }
 
-// TestAddSinkDoesNotPropogateValues is a pinning test to document that the
-// existing functionality of AddSink will not propogate values added to the
+// TestAddSinkDoesNotPropagateValues is a pinning test to document that the
+// existing functionality of AddSink will not propagate values added to the
 // logger.
-func TestAddSinkDoesNotPropogateValues(t *testing.T) {
+func TestAddSinkDoesNotPropagateValues(t *testing.T) {
 	var buf1, buf2 bytes.Buffer
 	logger, _ := New("service-name",
 		WithConsoleSink(&buf1),


### PR DESCRIPTION
### Description:
Documents possibly unintuitive behavior of `log.AddSink`

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
