### PR TITLE
Improve Copper Detector verification with stricter status code and email matching

### DIFF
--- a/pkg/detectors/copper/copper.go
+++ b/pkg/detectors/copper/copper.go
@@ -2,6 +2,9 @@ package copper
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -26,6 +29,11 @@ var (
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"copper"}) + `\b([a-z0-9]{32})\b`)
 	idPat  = regexp.MustCompile(`\b([a-z0-9]{4,25}@[a-zA-Z0-9]{2,12}.[a-zA-Z0-9]{2,6})\b`)
 )
+
+type UserApiResponse struct {
+	Id    int    `json:"id"`
+	Email string `json:"email"`
+}
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
@@ -52,26 +60,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-
-				payload := strings.NewReader(`{
-					"page_size": 25,
-					"sort_by": "name"
-					}`)
-				req, err := http.NewRequestWithContext(ctx, "POST", "https://api.copper.com/developer_api/v1/tasks/search", payload)
-				if err != nil {
-					continue
-				}
-				req.Header.Add("X-PW-AccessToken", resMatch)
-				req.Header.Add("X-PW-Application", "developer_api")
-				req.Header.Add("X-PW-UserEmail", resIdMatch)
-				req.Header.Add("Content-Type", "application/json")
-				res, err := client.Do(req)
-				if err == nil {
-					defer res.Body.Close()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						s1.Verified = true
-					}
-				}
+				isVerified, verificationErr := verifyCopper(ctx, client, resIdMatch, resMatch)
+				s1.Verified = isVerified
+				s1.SetVerificationError(verificationErr, resMatch)
 			}
 
 			results = append(results, s1)
@@ -81,6 +72,54 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	return results, nil
+}
+
+func verifyCopper(ctx context.Context, client *http.Client, email, apiKey string) (bool, error) {
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		"https://api.copper.com/developer_api/v1/users/me",
+		http.NoBody,
+	)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Add("X-PW-AccessToken", apiKey)
+	req.Header.Add("X-PW-Application", "developer_api")
+	req.Header.Add("X-PW-UserEmail", email)
+	req.Header.Add("Content-Type", "application/json")
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		respBytes, err := io.ReadAll(res.Body)
+		if err != nil {
+			return false, err
+		}
+
+		var respBody UserApiResponse
+		if err := json.Unmarshal(respBytes, &respBody); err != nil {
+			return false, err
+		}
+
+		// strict verification with email in credentials
+		if respBody.Email == email {
+			return true, nil
+		}
+
+		return false, fmt.Errorf("email mismatch in verification response")
+	case http.StatusUnauthorized:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected status code :%d", res.StatusCode)
+	}
 }
 
 func (s Scanner) Type() detectorspb.DetectorType {

--- a/pkg/detectors/copper/copper_integration_test.go
+++ b/pkg/detectors/copper/copper_integration_test.go
@@ -1,6 +1,3 @@
-//go:build detectors
-// +build detectors
-
 package copper
 
 import (
@@ -9,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kylelemons/godebug/pretty"
-
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
@@ -96,9 +93,11 @@ func TestCopper_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				got[i].RawV2 = nil
 			}
-			if diff := pretty.Compare(got, tt.want); diff != "" {
-				t.Errorf("Copper.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret")
+			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
+				t.Errorf("Abstract.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
 		})
 	}

--- a/pkg/detectors/copper/copper_integration_test.go
+++ b/pkg/detectors/copper/copper_integration_test.go
@@ -1,3 +1,6 @@
+//go:build detectors
+// +build detectors
+
 package copper
 
 import (


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
- Switch from POST /tasks/search to GET /users/me endpoint for better reliability
- Add strict email verification comparing API response against credentials
- Refactor verification logic into verifyCopper() helper function
- Properly cleanup response bodies to avoid resource leaks

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
