### PR TITLE
Add optional git clone timeout

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ var (
 	// Add feature flags
 	forceSkipBinaries  = cli.Flag("force-skip-binaries", "Force skipping binaries.").Bool()
 	forceSkipArchives  = cli.Flag("force-skip-archives", "Force skipping archives.").Bool()
-	gitCloneTimeoutS   = cli.Flag("git-clone-timeout", "Maximum time to spend cloning a repository, in seconds.").Hidden().Int64()
+	gitCloneTimeout    = cli.Flag("git-clone-timeout", "Maximum time to spend cloning a repository, as a duration.").Hidden().Duration()
 	skipAdditionalRefs = cli.Flag("skip-additional-refs", "Skip additional references.").Bool()
 	userAgentSuffix    = cli.Flag("user-agent-suffix", "Suffix to add to User-Agent.").String()
 
@@ -452,8 +452,8 @@ func run(state overseer.State) {
 		feature.ForceSkipArchives.Store(true)
 	}
 
-	if gitCloneTimeoutS != nil {
-		feature.GitGloneTimeoutSeconds.Store(*gitCloneTimeoutS)
+	if gitCloneTimeout != nil {
+		feature.GitGloneTimeoutDuration.Store(int64(*gitCloneTimeout))
 	}
 
 	if *skipAdditionalRefs {

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -1,11 +1,13 @@
 package feature
 
-import "sync/atomic"
+import (
+	"sync/atomic"
+)
 
 var (
 	ForceSkipBinaries              atomic.Bool
 	ForceSkipArchives              atomic.Bool
-	GitGloneTimeoutSeconds         atomic.Int64
+	GitGloneTimeoutDuration        atomic.Int64
 	SkipAdditionalRefs             atomic.Bool
 	EnableAPKHandler               atomic.Bool
 	UserAgentSuffix                AtomicString

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -474,8 +474,7 @@ func CloneRepo(ctx context.Context, userInfo *url.Userinfo, gitURL string, clone
 		}
 	}
 
-	timeoutS := feature.GitGloneTimeoutSeconds.Load()
-	timeout := time.Duration(timeoutS) * time.Second
+	timeout := time.Duration(feature.GitGloneTimeoutDuration.Load())
 
 	repo, err := executeClone(ctx, cloneParams{userInfo, gitURL, args, path, authInUrl, timeout})
 	if err != nil {

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kylelemons/godebug/pretty"
 	"github.com/stretchr/testify/assert"
@@ -42,8 +43,8 @@ func TestClone_Timeout(t *testing.T) {
 	})
 
 	t.Run("a clone that times out should time out", func(t *testing.T) {
-		feature.GitGloneTimeoutSeconds.Store(1)
-		t.Cleanup(func() { feature.GitGloneTimeoutSeconds.Store(0) })
+		feature.GitGloneTimeoutDuration.Store(int64(1 * time.Nanosecond))
+		t.Cleanup(func() { feature.GitGloneTimeoutDuration.Store(0) })
 
 		_, _, err := CloneRepo(
 			ctx,


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
We have identified some uses cases in which it is preferable to time a clone out over waiting forever. These situations are unusual, so the CLI option to enable this (which I added for testing) is hidden so that we minimize the risk of baking this option into the interface.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
