### PR TITLE
Fix git clone timeout typo

### DIFF
--- a/main.go
+++ b/main.go
@@ -453,7 +453,7 @@ func run(state overseer.State) {
 	}
 
 	if gitCloneTimeout != nil {
-		feature.GitGloneTimeoutDuration.Store(int64(*gitCloneTimeout))
+		feature.GitCloneTimeoutDuration.Store(int64(*gitCloneTimeout))
 	}
 
 	if *skipAdditionalRefs {

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -7,7 +7,7 @@ import (
 var (
 	ForceSkipBinaries              atomic.Bool
 	ForceSkipArchives              atomic.Bool
-	GitGloneTimeoutDuration        atomic.Int64
+	GitCloneTimeoutDuration        atomic.Int64
 	SkipAdditionalRefs             atomic.Bool
 	EnableAPKHandler               atomic.Bool
 	UserAgentSuffix                AtomicString

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -474,7 +474,7 @@ func CloneRepo(ctx context.Context, userInfo *url.Userinfo, gitURL string, clone
 		}
 	}
 
-	timeout := time.Duration(feature.GitGloneTimeoutDuration.Load())
+	timeout := time.Duration(feature.GitCloneTimeoutDuration.Load())
 
 	repo, err := executeClone(ctx, cloneParams{userInfo, gitURL, args, path, authInUrl, timeout})
 	if err != nil {

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -43,8 +43,8 @@ func TestClone_Timeout(t *testing.T) {
 	})
 
 	t.Run("a clone that times out should time out", func(t *testing.T) {
-		feature.GitGloneTimeoutDuration.Store(int64(1 * time.Nanosecond))
-		t.Cleanup(func() { feature.GitGloneTimeoutDuration.Store(0) })
+		feature.GitCloneTimeoutDuration.Store(int64(1 * time.Nanosecond))
+		t.Cleanup(func() { feature.GitCloneTimeoutDuration.Store(0) })
 
 		_, _, err := CloneRepo(
 			ctx,


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
I misspelled an identifier in one spot and then just autocompleted to victory everywhere else. This PR fixes the typo!

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
