### PR TITLE
[INS-226] Use pinned image for Quay registry Integration test

### DIFF
--- a/pkg/sources/docker/docker_test.go
+++ b/pkg/sources/docker/docker_test.go
@@ -71,7 +71,7 @@ func TestQuayRegistry(t *testing.T) {
 		Credential: &sourcespb.Docker_Unauthenticated{
 			Unauthenticated: &credentialspb.Unauthenticated{},
 		},
-		Images: []string{"quay.io/prometheus/busybox"}, // https://quay.io/repository/prometheus/busybox
+		Images: []string{"quay.io/prometheus/node-exporter@sha256:337ff1d356b68d39cef853e8c6345de11ce7556bb34cda8bd205bcf2ed30b565"},
 	}
 
 	conn := &anypb.Any{}
@@ -109,9 +109,9 @@ func TestQuayRegistry(t *testing.T) {
 	close(chunksChan)
 	wg.Wait()
 
-	assert.Equal(t, 944, chunkCounter)
-	assert.Equal(t, 941, layerCounter)
-	assert.Equal(t, 3, historyCounter)
+	assert.Equal(t, 1302, chunkCounter)
+	assert.Equal(t, 1291, layerCounter)
+	assert.Equal(t, 11, historyCounter)
 }
 
 func TestGHCRRegistry(t *testing.T) {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The integration test for Quay Registry is failing because the image was updated to a newer version. This PR replaces the image (because it's older manifests weren't being stored in the registry) and pins it to a particular manifest. This should fix the flakiness of this test.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
