### PR TITLE
fix(detectors): update Dandelion token regex to match hex-only values

### DIFF
--- a/pkg/detectors/dandelion/dandelion.go
+++ b/pkg/detectors/dandelion/dandelion.go
@@ -22,7 +22,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"dandelion"}) + `\b([a-z0-9]{32})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"dandelion"}) + `\b([a-f0-9]{32})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/dandelion/dandelion_test.go
+++ b/pkg/detectors/dandelion/dandelion_test.go
@@ -22,7 +22,7 @@ var (
 		api:
 			auth_type: "API-Key"
 			in: "Header"
-			dandelion_secret: "xccl325526f9cp6qzh89qkgoklje5ds9"
+			dandelion_secret: "abcd1234abcd1234abcd1234abcd1234"
 			base_url: "https://api.example.com/v1/example?token=$dandelion_secret"
 			response_code: 200
 
@@ -30,7 +30,7 @@ var (
 		# - Remember to rotate the secret every 90 days.
 		# - The above credentials should only be used in a secure environment.
 	`
-	secret = "xccl325526f9cp6qzh89qkgoklje5ds9"
+	secret = "abcd1234abcd1234abcd1234abcd1234"
 )
 
 func TestDandelion_Pattern(t *testing.T) {


### PR DESCRIPTION
### Description:
Change the regex pattern from [a-z0-9]{32} to [a-f0-9]{32} to only detect valid hexadecimal tokens, reducing false positives.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small regex tightening in a single detector that may reduce matches for non-hex tokens but does not change verification or data handling logic.
> 
> **Overview**
> **Dandelion secret detection is now stricter.** The Dandelion detector regex was narrowed from any lowercase alphanumeric 32-char value to *hex-only* (`[a-f0-9]{32}`) to reduce false positives.
> 
> Tests were updated to use a hex-only sample token so the pattern test continues to validate expected matches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00f333efca1b3a6ec74b8d7a70a7fa055ea69147. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->