### PR TITLE
[INS-170] Unify JDBC URL Parsing Across Detector and Analyzer (Continued)

### DIFF
--- a/pkg/detectors/jdbc/models.go
+++ b/pkg/detectors/jdbc/models.go
@@ -1,0 +1,56 @@
+package jdbc
+
+import (
+	"context"
+)
+
+type DatabaseType int
+
+const (
+	Unknown DatabaseType = iota
+	MySQL
+	PostgreSQL
+	SQLServer
+)
+
+func (dt DatabaseType) String() string {
+	switch dt {
+	case MySQL:
+		return "mysql"
+	case PostgreSQL:
+		return "postgresql"
+	case SQLServer:
+		return "sqlserver"
+	default:
+		return "unknown"
+	}
+}
+
+type pingResult struct {
+	err         error
+	determinate bool
+}
+
+// ConnectionInfo holds parsed connection information
+type ConnectionInfo struct {
+	Host     string // includes port if specified, e.g., "host:port"
+	Database string
+	User     string
+	Password string
+	Params   map[string]string
+}
+
+type jdbcPinger interface {
+	ping(context.Context) pingResult
+}
+
+// public interfaces for analyzer
+type JDBCParser interface {
+	GetConnectionInfo() *ConnectionInfo
+	GetDBType() DatabaseType
+	BuildConnectionString() string
+}
+type JDBC interface {
+	jdbcPinger
+	JDBCParser
+}

--- a/pkg/detectors/jdbc/mysql_integration_test.go
+++ b/pkg/detectors/jdbc/mysql_integration_test.go
@@ -91,7 +91,7 @@ func TestMySQL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			j, err := ParseMySQL(logContext.Background(), tt.input)
+			j, err := parseMySQL(logContext.Background(), tt.input)
 
 			if err != nil {
 				got := result{ParseErr: true}

--- a/pkg/detectors/jdbc/mysql_test.go
+++ b/pkg/detectors/jdbc/mysql_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 
@@ -58,7 +60,7 @@ func TestParseMySQLMissingCredentials(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := logContext.AddLogger(context.Background())
-			j, err := ParseMySQL(ctx, tt.subname)
+			j, err := parseMySQL(ctx, tt.subname)
 
 			if tt.shouldBeNil {
 				if j != nil {
@@ -102,7 +104,7 @@ func TestParseMySQLUsernameRecognition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := logContext.AddLogger(context.Background())
-			j, err := ParseMySQL(ctx, tt.subname)
+			j, err := parseMySQL(ctx, tt.subname)
 			if err != nil {
 				t.Fatalf("parseMySQL() error = %v", err)
 			}
@@ -112,6 +114,147 @@ func TestParseMySQLUsernameRecognition(t *testing.T) {
 				t.Errorf("Connection string does not contain expected username '%s'\nGot: %s\nExpected: %s",
 					tt.wantUsername, mysqlConn.User, tt.wantUsername)
 			}
+		})
+	}
+}
+
+func TestMySQL_ParseJDBCURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		jdbcURL  string
+		wantHost string
+		wantDB   string
+		wantUser string
+		wantPass string
+		wantErr  bool
+	}{
+		{
+			name:     "basic URL with all parts",
+			jdbcURL:  "jdbc:mysql://root:password@localhost:3306/testdb",
+			wantHost: "tcp(localhost:3306)",
+			wantDB:   "testdb",
+			wantUser: "root",
+			wantPass: "password",
+		},
+		{
+			name:     "URL with default port",
+			jdbcURL:  "jdbc:mysql://user:pass@dbhost/mydb",
+			wantHost: "tcp(dbhost)",
+			wantDB:   "mydb",
+			wantUser: "user",
+			wantPass: "pass",
+		},
+		{
+			name:     "URL with query params for credentials",
+			jdbcURL:  "jdbc:mysql://dbhost:3307/testdb?user=admin&password=secret",
+			wantHost: "tcp(dbhost:3307)",
+			wantDB:   "testdb",
+			wantUser: "admin",
+			wantPass: "secret",
+		},
+		{
+			name:    "invalid URL - missing jdbc:mysql prefix",
+			jdbcURL: "postgresql://user:pass@localhost/db",
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL - missing //",
+			jdbcURL: "jdbc:mysql:user:pass@localhost/db",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jdbc, err := NewJDBC(logContext.Background(), tt.jdbcURL)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			info := jdbc.GetConnectionInfo()
+			assert.Equal(t, tt.wantHost, info.Host)
+			assert.Equal(t, tt.wantDB, info.Database)
+			assert.Equal(t, tt.wantUser, info.User)
+			assert.Equal(t, tt.wantPass, info.Password)
+		})
+	}
+}
+
+func TestMySQL_ParseJDBCURL_DSNAddressParsing(t *testing.T) {
+	tests := []struct {
+		name     string
+		jdbcURL  string
+		wantHost string
+	}{
+		{
+			name:     "DSN format with explicit port",
+			jdbcURL:  "jdbc:mysql://myuser:mypass@tcp(localhost:3307)/mydb",
+			wantHost: "tcp(localhost:3307)",
+		},
+		{
+			name:     "DSN format with default port",
+			jdbcURL:  "jdbc:mysql://myuser:mypass@tcp(db.example.com:3306)/testdb",
+			wantHost: "tcp(db.example.com:3306)",
+		},
+		{
+			name:     "DSN format without port",
+			jdbcURL:  "jdbc:mysql://myuser:mypass@tcp(myhost)/mydb",
+			wantHost: "tcp(myhost:3306)",
+		},
+		{
+			name:     "Simple host:port format",
+			jdbcURL:  "jdbc:mysql://root:password@mysql.server.com:3308/database",
+			wantHost: "tcp(mysql.server.com:3308)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jdbc, err := NewJDBC(logContext.Background(), tt.jdbcURL)
+			require.NoError(t, err)
+			info := jdbc.GetConnectionInfo()
+			assert.Equal(t, tt.wantHost, info.Host)
+		})
+	}
+}
+
+func TestMySQL_BuildNativeConnectionString(t *testing.T) {
+	tests := []struct {
+		name     string
+		info     *ConnectionInfo
+		wantUser string
+		wantPass string
+		wantHost string
+		wantDB   string
+	}{
+		{
+			name: "basic connection",
+			info: &ConnectionInfo{
+				Host:     "localhost",
+				Database: "testdb",
+				User:     "root",
+				Password: "secret",
+			},
+			wantUser: "root",
+			wantPass: "secret",
+			wantHost: "localhost",
+			wantDB:   "testdb",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mysqlJDBC := &MysqlJDBC{
+				ConnectionInfo: *tt.info,
+			}
+			connStr := mysqlJDBC.BuildConnectionString()
+
+			// MySQL format: [user[:password]@]tcp(host:port)/database?timeout=10s
+			assert.Contains(t, connStr, tt.wantUser)
+			assert.Contains(t, connStr, tt.wantPass)
+			assert.Contains(t, connStr, tt.wantHost)
+			assert.Contains(t, connStr, "/"+tt.wantDB)
 		})
 	}
 }

--- a/pkg/detectors/jdbc/postgres_integration_test.go
+++ b/pkg/detectors/jdbc/postgres_integration_test.go
@@ -121,7 +121,7 @@ func TestPostgres(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			j, err := ParsePostgres(logContext.Background(), tt.input)
+			j, err := parsePostgres(logContext.Background(), tt.input)
 			if err != nil {
 				got := result{ParseErr: true}
 

--- a/pkg/detectors/jdbc/postgres_test.go
+++ b/pkg/detectors/jdbc/postgres_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 
@@ -47,7 +49,7 @@ func TestParsePostgresMissingCredentials(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := logContext.AddLogger(context.Background())
-			j, err := ParsePostgres(ctx, tt.subname)
+			j, err := parsePostgres(ctx, tt.subname)
 
 			if tt.shouldBeNil {
 				if j != nil {
@@ -86,7 +88,7 @@ func TestParsePostgresUsernameRecognition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := logContext.AddLogger(context.Background())
-			j, err := ParsePostgres(ctx, tt.subname)
+			j, err := parsePostgres(ctx, tt.subname)
 			if err != nil {
 				t.Fatalf("ParsePostgres() error = %v", err)
 			}
@@ -94,6 +96,144 @@ func TestParsePostgresUsernameRecognition(t *testing.T) {
 			pgConn := j.(*PostgresJDBC)
 			if pgConn.User != tt.wantUsername {
 				t.Errorf("expected username '%s', got '%s'", tt.wantUsername, pgConn.User)
+			}
+		})
+	}
+}
+
+func TestPostgreSQLHandler_ParseJDBCURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		jdbcURL     string
+		wantHost    string
+		wantDB      string
+		wantUser    string
+		wantPass    string
+		wantSSLMode string
+		wantErr     bool
+	}{
+		{
+			name:     "basic URL with all parts",
+			jdbcURL:  "jdbc:postgresql://postgres:secret@localhost:5432/mydb",
+			wantHost: "localhost:5432",
+			wantDB:   "mydb",
+			wantUser: "postgres",
+			wantPass: "secret",
+		},
+		{
+			name:     "URL with default port",
+			jdbcURL:  "jdbc:postgresql://user:pass@dbhost/testdb",
+			wantHost: "dbhost",
+			wantDB:   "testdb",
+			wantUser: "user",
+			wantPass: "pass",
+		},
+		{
+			name:     "URL with default database",
+			jdbcURL:  "jdbc:postgresql://user:pass@dbhost:5433",
+			wantHost: "dbhost:5433",
+			wantDB:   "postgres",
+			wantUser: "user",
+			wantPass: "pass",
+		},
+		{
+			name:        "URL with SSL mode",
+			jdbcURL:     "jdbc:postgresql://user:pass@dbhost:5432/mydb?sslmode=require",
+			wantHost:    "dbhost:5432",
+			wantDB:      "mydb",
+			wantUser:    "user",
+			wantPass:    "pass",
+			wantSSLMode: "require",
+		},
+		{
+			name:    "invalid URL - missing jdbc:postgresql prefix",
+			jdbcURL: "mysql://user:pass@localhost/db",
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL - missing //",
+			jdbcURL: "jdbc:postgresql:user:pass@localhost/db",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jdbc, err := NewJDBC(logContext.Background(), tt.jdbcURL)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			info := jdbc.GetConnectionInfo()
+			assert.Equal(t, tt.wantHost, info.Host)
+			assert.Equal(t, tt.wantDB, info.Database)
+			assert.Equal(t, tt.wantUser, info.User)
+			assert.Equal(t, tt.wantPass, info.Password)
+
+			if tt.wantSSLMode != "" {
+				assert.Equal(t, tt.wantSSLMode, info.Params["sslmode"])
+			}
+		})
+	}
+}
+
+func TestPostgreSQLHandler_BuildNativeConnectionString(t *testing.T) {
+	tests := []struct {
+		name string
+		info *ConnectionInfo
+		want map[string]string // key-value pairs that should be in the connection string
+	}{
+		{
+			name: "basic connection",
+			info: &ConnectionInfo{
+				Host:     "localhost",
+				Database: "testdb",
+				User:     "postgres",
+				Password: "secret",
+				Params: map[string]string{
+					"connect_timeout": "10",
+				},
+			},
+			want: map[string]string{
+				"host":            "localhost",
+				"dbname":          "testdb",
+				"user":            "postgres",
+				"password":        "secret",
+				"connect_timeout": "10",
+			},
+		},
+		{
+			name: "with SSL mode",
+			info: &ConnectionInfo{
+				Host:     "dbhost:5433",
+				Database: "mydb",
+				User:     "user",
+				Password: "pass",
+				Params:   map[string]string{"sslmode": "require"},
+			},
+			want: map[string]string{
+				"host":     "dbhost",
+				"port":     "5433",
+				"dbname":   "mydb",
+				"sslmode":  "require",
+				"user":     "user",
+				"password": "pass",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jdbc := &PostgresJDBC{
+				ConnectionInfo: *tt.info,
+			}
+
+			connStr := jdbc.BuildConnectionString()
+			// Verify all expected key-value pairs are in the connection string
+			for key, expectedValue := range tt.want {
+				expectedPair := key + "=" + expectedValue
+				assert.Contains(t, connStr, expectedPair)
 			}
 		})
 	}

--- a/pkg/detectors/jdbc/sqlserver_test.go
+++ b/pkg/detectors/jdbc/sqlserver_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 
@@ -54,7 +56,7 @@ func TestParseSqlServerMissingCredentials(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := logContext.AddLogger(context.Background())
 
-			j, err := ParseSqlServer(ctx, tt.subname)
+			j, err := parseSqlServer(ctx, tt.subname)
 
 			if tt.shouldBeNil {
 				if j != nil {
@@ -101,7 +103,7 @@ func TestParseSqlServerUserIgnoredBug2(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := logContext.AddLogger(context.Background())
 
-			j, err := ParseSqlServer(ctx, tt.subname)
+			j, err := parseSqlServer(ctx, tt.subname)
 			if err != nil {
 				t.Fatalf("parseSqlServer() error = %v", err)
 			}
@@ -112,6 +114,109 @@ func TestParseSqlServerUserIgnoredBug2(t *testing.T) {
 				t.Errorf("Connection string does not contain expected username '%s'\nGot: %s\nExpected to contain: %s",
 					tt.wantUsername, sqlServerConn.User, tt.wantUsername)
 			}
+		})
+	}
+}
+
+func TestSQLServerHandler_ParseJDBCURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		jdbcURL  string
+		wantHost string
+		wantDB   string
+		wantUser string
+		wantPass string
+		wantErr  bool
+	}{
+		{
+			name:     "basic URL with semicolon params",
+			jdbcURL:  "jdbc:sqlserver://localhost:1433;database=testdb;user=sa;password=Pass123",
+			wantHost: "localhost:1433",
+			wantDB:   "testdb",
+			wantUser: "sa",
+			wantPass: "Pass123",
+		},
+		{
+			name:     "URL with default port and database",
+			jdbcURL:  "jdbc:sqlserver://dbhost;user=testuser;password=secret",
+			wantHost: "dbhost:1433",
+			wantDB:   "master",
+			wantUser: "testuser",
+			wantPass: "secret",
+		},
+		{
+			name:     "URL with port in host",
+			jdbcURL:  "jdbc:sqlserver://server.example.com:1434;databaseName=mydb;userId=admin;pwd=admin123",
+			wantHost: "server.example.com:1434",
+			wantDB:   "mydb",
+			wantUser: "admin",
+			wantPass: "admin123",
+		},
+		{
+			name:    "invalid URL - missing jdbc:sqlserver prefix",
+			jdbcURL: "jdbc:mysql://localhost/db",
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL - missing //",
+			jdbcURL: "jdbc:sqlserver:localhost;database=test",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jdbc, err := NewJDBC(logContext.Background(), tt.jdbcURL)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			info := jdbc.GetConnectionInfo()
+			assert.Equal(t, tt.wantHost, info.Host)
+			assert.Equal(t, tt.wantDB, info.Database)
+			assert.Equal(t, tt.wantUser, info.User)
+			assert.Equal(t, tt.wantPass, info.Password)
+		})
+	}
+}
+
+func TestSQLServerHandler_BuildNativeConnectionString(t *testing.T) {
+	tests := []struct {
+		name     string
+		info     *ConnectionInfo
+		wantUser string
+		wantPass string
+		wantHost string
+		wantDB   string
+	}{
+		{
+			name: "basic connection",
+			info: &ConnectionInfo{
+				Host:     "localhost",
+				Database: "testdb",
+				User:     "sa",
+				Password: "Pass123",
+			},
+			wantUser: "sa",
+			wantPass: "Pass123",
+			wantHost: "localhost",
+			wantDB:   "testdb",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jdbc := &SqlServerJDBC{
+				ConnectionInfo: *tt.info,
+			}
+			connStr := jdbc.BuildConnectionString()
+
+			// SQL Server format: sqlserver://user:password@host:port?database=db&connection+timeout=10
+			assert.Contains(t, connStr, tt.wantUser)
+			assert.Contains(t, connStr, tt.wantPass)
+			assert.Contains(t, connStr, tt.wantHost)
+			assert.Contains(t, connStr, "database="+tt.wantDB)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR serves as an extension of #4574 by further refactoring the detector to unify code across JDBC's detector and analyzer.
Changes here will make better sense when viewed in conjunction with the corresponding [analyzer PR](https://github.com/trufflesecurity/integrations/pull/81).

Instead of publicizing seperate methods like `parseMySQL` and `buildMySQLConnectionString`, I've now added methods like `GetConnectionInfo`, `GetDBType` and `BuildConnectionString` to the existing `JDBC` interface, so that both the detector and analyzer can directly use the `NewJDBC` method and then call the methods they need.

Tests for parsing and building connection strings have been moved from the analyzer to the detector as well.


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
