### PR TITLE
Rework JWT detector to better block local IPs

### DIFF
--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -18,15 +18,21 @@ import (
 // Detector defines an interface for scanning for and verifying secrets.
 type Detector interface {
 	// FromData will scan bytes for results and optionally verify them.
+	//
+	// FromData can be called concurrently from multiple goroutines.
+	// Any modification to the receiver or to global variables will need to to use some kind of synchronization.
 	FromData(ctx context.Context, verify bool, data []byte) ([]Result, error)
+
 	// Keywords are used for efficiently pre-filtering chunks using substring operations.
 	// Use unique identifiers that are part of the secret if you can, or the provider name.
 	//
 	// When multiple keywords are provided, they are is treated as a *union* of filtering terms.
 	// That is, if any of the keywords are found in a chunk, the chunk will be run through the detector.
 	Keywords() []string
+
 	// Type returns the DetectorType number from detectors.proto for the given detector.
 	Type() detectorspb.DetectorType
+
 	// Description returns a description for the result being detected
 	Description() string
 }
@@ -93,7 +99,7 @@ type Result struct {
 	// DetectorName is the name of the Detector. Used for custom detectors.
 	DetectorName string
 	// Verified indicates whether the result was verified or not.
-	Verified     bool
+	Verified bool
 	// VerificationFromCache indicates whether this result's verification result came from the verification cache rather
 	// than an actual remote request.
 	VerificationFromCache bool
@@ -293,7 +299,7 @@ func MustGetBenchmarkData() map[string][]byte {
 	for key, size := range sizes {
 		// Generating a byte slice of a specific size with random data.
 		content := make([]byte, size)
-		for i := range(size) {
+		for i := range size {
 			randomByte, err := rand.Int(rand.Reader, big.NewInt(256))
 			if err != nil {
 				panic(err)

--- a/pkg/detectors/http.go
+++ b/pkg/detectors/http.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/feature"
 )
 
@@ -162,13 +163,15 @@ func WithTimeout(timeout time.Duration) ClientOption {
 }
 
 func NewDetectorHttpClient(opts ...ClientOption) *http.Client {
-	httpClient := &http.Client{
+	client := &http.Client{
 		Transport: NewDetectorTransport(nil),
 		Timeout:   DefaultResponseTimeout,
 	}
 
 	for _, opt := range opts {
-		opt(httpClient)
+		opt(client)
 	}
-	return httpClient
+
+	client.Transport = common.NewInstrumentedTransport(client.Transport)
+	return client
 }

--- a/pkg/detectors/http.go
+++ b/pkg/detectors/http.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -44,13 +45,11 @@ var overrideOnce sync.Once
 // It is guaranteed to only run once, subsequent calls will have no effect.
 // This should be called before any scans are started.
 func OverrideDetectorTimeout(timeout time.Duration) {
-    overrideOnce.Do(func() {
-        DetectorHttpClientWithLocalAddresses.Timeout = timeout
-        DetectorHttpClientWithNoLocalAddresses.Timeout = timeout
-    })
+	overrideOnce.Do(func() {
+		DetectorHttpClientWithLocalAddresses.Timeout = timeout
+		DetectorHttpClientWithNoLocalAddresses.Timeout = timeout
+	})
 }
-
-
 
 // ClientOption defines a function type that modifies an http.Client.
 type ClientOption func(*http.Client)
@@ -139,10 +138,8 @@ func WithNoLocalIP() ClientOption {
 				return nil, err
 			}
 
-			for _, ip := range ips {
-				if isLocalIP(ip) {
-					return nil, ErrNoLocalIP
-				}
+			if slices.ContainsFunc(ips, isLocalIP) {
+				return nil, ErrNoLocalIP
 			}
 
 			return originalDialContext(ctx, network, net.JoinHostPort(host, port))


### PR DESCRIPTION
This PR updates the JWT detector to more simply and more robustly prevent making requests to local IPs.

The previous implementation did its checking at the hostname level, but this approach doesn't work in general when redirects are involved. The new implementation has less code and does its checking at the HTTP transport level, after DNS resolution.

This PR also adds HTTP instrumentation to the `DetectorHttpClientWith*` clients, as already exists in `SaneHttpClient`. This change should give us insight into some blind spots, as the `DetectorHttpClientWith*` clients are used in a few dozen existing detectors and previously had no HTTP instrumentation.