### PR TITLE
[INS-233] Added support to verify token against all datadog domains

### DIFF
--- a/pkg/detectors/datadogtoken/datadogtoken.go
+++ b/pkg/detectors/datadogtoken/datadogtoken.go
@@ -23,7 +23,16 @@ var _ detectors.Detector = (*Scanner)(nil)
 var _ detectors.EndpointCustomizer = (*Scanner)(nil)
 var _ detectors.CloudProvider = (*Scanner)(nil)
 
-func (Scanner) CloudEndpoint() string { return "https://api.datadoghq.com" }
+func (Scanner) CloudEndpoint() string { return "" }
+
+var datadogAPIBaseURLs = []string{
+	"https://api.us5.datadoghq.com/api", // Default domain
+	"https://api.app.datadoghq.com/api",
+	"https://api.us3.datadoghq.com/api",
+	"https://api.app.datadoghq.eu/api",
+	"https://api.app.ddog-gov.com/api",
+	"https://api.ap1.datadoghq.com/api",
+}
 
 var (
 	client = common.SaneHttpClient()
@@ -104,6 +113,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	appMatches := appPat.FindAllStringSubmatch(dataStr, -1)
 	apiMatches := apiPat.FindAllStringSubmatch(dataStr, -1)
+	endpoints := s.Endpoints(datadogAPIBaseURLs...)
 
 	for _, apiMatch := range apiMatches {
 		resApiMatch := strings.TrimSpace(apiMatch[1])
@@ -121,7 +131,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				for _, baseURL := range s.Endpoints() {
+				for _, baseURL := range endpoints {
 					req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/api/v2/users", nil)
 					if err != nil {
 						continue
@@ -165,7 +175,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				for _, baseURL := range s.Endpoints() {
+				for _, baseURL := range endpoints {
 					req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/api/v1/validate", nil)
 					if err != nil {
 						continue

--- a/pkg/detectors/datadogtoken/datadogtoken.go
+++ b/pkg/detectors/datadogtoken/datadogtoken.go
@@ -156,6 +156,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 									setOrganizationInfo(serviceResponse.Included, &s1)
 								}
 							}
+							// break the loop once we've successfully validated the token against a baseURL
+							break
 						}
 					}
 				}
@@ -188,6 +190,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
 							s1.AnalysisInfo = map[string]string{"apiKey": resApiMatch}
+							// break the loop once we've successfully validated the token against a baseURL
+							break
 						}
 					}
 				}

--- a/pkg/detectors/datadogtoken/datadogtoken_integration_test.go
+++ b/pkg/detectors/datadogtoken/datadogtoken_integration_test.go
@@ -92,6 +92,9 @@ func TestDatadogToken_FromChunk(t *testing.T) {
 					ExtraData: map[string]string{
 						"Type": "APIKeyOnly",
 					},
+					AnalysisInfo: map[string]string{
+						"apiKey": apiKey,
+					},
 				},
 			},
 			wantErr: false,
@@ -115,6 +118,7 @@ func TestDatadogToken_FromChunk(t *testing.T) {
 			// use default cloud endpoint
 			s.UseCloudEndpoint(true)
 			s.SetCloudEndpoint(s.CloudEndpoint())
+			s.UseFoundEndpoints(true)
 
 			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {

--- a/pkg/detectors/datadogtoken/datadogtoken_test.go
+++ b/pkg/detectors/datadogtoken/datadogtoken_test.go
@@ -2,6 +2,7 @@ package datadogtoken
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,85 +11,185 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 )
 
-var (
-	validPattern = `
-		# Datadog Configuration File: config.yaml
-		database:
-			host: $DB_HOST
-			port: $DB_PORT
-			username: $DB_USERNAME
-			password: $DB_PASS  # IMPORTANT: Do not share this password publicly
-
-		api:
-			auth_type: "API-Key"
-			in: "Header"
-			dd_api_secret: "FKNwdbyfYTmGUm5DK3yHEuK-BBQf0fVG"
-			dd_app: "iHxNanzZ8vjrmbjXK7NJLrwpGw2czdSh90PKH6VL"
-			base_url: "https://api.example.com/v1/example"
-			response_code: 200
-
-		# Notes:
-		# - Remember to rotate the secret every 90 days.
-		# - The above credentials should only be used in a secure environment.
-	`
-	secret = "iHxNanzZ8vjrmbjXK7NJLrwpGw2czdSh90PKH6VLFKNwdbyfYTmGUm5DK3yHEuK-BBQf0fVG"
-)
-
-func TestDataDogToken_Pattern(t *testing.T) {
+func TestDataDogToken_Pattern_WithValidAPIandAppKey(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 
-	tests := []struct {
-		name  string
-		input string
-		want  []string
-	}{
-		{
-			name:  "valid pattern",
-			input: validPattern,
-			want:  []string{secret},
-		},
+	input := `
+			dd_api_secret: "FKNwdbyfYTmGUm5DK3yHEuK-BBQf0fVG"
+			dd_app: "iHxNanzZ8vjrmbjXK7NJLrwpGw2czdSh90PKH6VL"
+			base_url1: "https://api.us5.datadoghq.com"
+			base_url2: "https://api.app.ddog-gov.com"
+	`
+	want := []string{"iHxNanzZ8vjrmbjXK7NJLrwpGw2czdSh90PKH6VLFKNwdbyfYTmGUm5DK3yHEuK-BBQf0fVG"}
+	wantedResultType := "Application+APIKey"
+	matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(input))
+	if len(matchedDetectors) == 0 {
+		t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), input)
+		return
+	}
+	results, err := d.FromData(context.Background(), false, []byte(input))
+	if err != nil {
+		t.Errorf("error = %v", err)
+		return
+	}
+	if len(results) != len(want) {
+		if len(results) == 0 {
+			t.Errorf("did not receive result")
+		} else {
+			t.Errorf("expected %d results, only received %d", len(want), len(results))
+		}
+		return
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
-			if len(matchedDetectors) == 0 {
-				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
-				return
-			}
+	actual := make(map[string]struct{}, len(results))
+	for _, r := range results {
+		if len(r.RawV2) > 0 {
+			actual[string(r.RawV2)] = struct{}{}
+		} else {
+			actual[string(r.Raw)] = struct{}{}
+		}
+		if r.ExtraData["Type"] != wantedResultType {
+			t.Errorf("expected result type %s, got %s", wantedResultType, r.ExtraData["Type"])
+		}
+	}
+	expected := make(map[string]struct{}, len(want))
+	for _, v := range want {
+		expected[v] = struct{}{}
+	}
 
-			results, err := d.FromData(context.Background(), false, []byte(test.input))
-			if err != nil {
-				t.Errorf("error = %v", err)
-				return
-			}
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("%s diff: (-want +got)\n%s", "TestDataDogToken_Pattern_WithValidAPIKeyOnly", diff)
+	}
+}
 
-			if len(results) != len(test.want) {
-				if len(results) == 0 {
-					t.Errorf("did not receive result")
-				} else {
-					t.Errorf("expected %d results, only received %d", len(test.want), len(results))
-				}
-				return
-			}
+func TestDataDogToken_Pattern_WithValidAPIKeyOnly(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 
-			actual := make(map[string]struct{}, len(results))
-			for _, r := range results {
-				if len(r.RawV2) > 0 {
-					actual[string(r.RawV2)] = struct{}{}
-				} else {
-					actual[string(r.Raw)] = struct{}{}
-				}
-			}
-			expected := make(map[string]struct{}, len(test.want))
-			for _, v := range test.want {
-				expected[v] = struct{}{}
-			}
+	input := `
+			dd_api_secret: "FKNwdbyfYTmGUm5DK3yHEuK-BBQf0fVG"
+			base_url: "https://api.us5.datadoghq.com"
+			response_code: 200
+	`
+	want := []string{"FKNwdbyfYTmGUm5DK3yHEuK-BBQf0fVG"}
+	wantedResultType := "APIKeyOnly"
+	matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(input))
+	if len(matchedDetectors) == 0 {
+		t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), input)
+		return
+	}
+	results, err := d.FromData(context.Background(), false, []byte(input))
+	if err != nil {
+		t.Errorf("error = %v", err)
+		return
+	}
+	if len(results) != len(want) {
+		if len(results) == 0 {
+			t.Errorf("did not receive result")
+		} else {
+			t.Errorf("expected %d results, only received %d", len(want), len(results))
+		}
+		return
+	}
 
-			if diff := cmp.Diff(expected, actual); diff != "" {
-				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
-			}
-		})
+	actual := make(map[string]struct{}, len(results))
+	for _, r := range results {
+		if len(r.RawV2) > 0 {
+			actual[string(r.RawV2)] = struct{}{}
+		} else {
+			actual[string(r.Raw)] = struct{}{}
+		}
+		if r.ExtraData["Type"] != wantedResultType {
+			t.Errorf("expected result type %s, got %s", wantedResultType, r.ExtraData["Type"])
+		}
+	}
+	expected := make(map[string]struct{}, len(want))
+	for _, v := range want {
+		expected[v] = struct{}{}
+	}
+
+	if diff := cmp.Diff(expected, actual); diff != "" {
+		t.Errorf("%s diff: (-want +got)\n%s", "TestDataDogToken_Pattern_WithValidAPIKeyOnly", diff)
+	}
+}
+
+func TestDataDogToken_NoSecrets(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+
+	input := `
+			base_url1: "https://api.us5.datadoghq.com"
+			base_url2: "https://api.app.ddog-gov.com"
+	`
+	matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(input))
+	if len(matchedDetectors) == 0 {
+		t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), input)
+		return
+	}
+	results, err := d.FromData(context.Background(), false, []byte(input))
+	if err != nil {
+		t.Errorf("error = %v", err)
+		return
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, received %d", len(results))
+	}
+}
+
+func TestDataDogToken_InvalidSecrets(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+
+	input := `
+			dd_api_secret: "@FKNwdbyfYTmGUm5DK3yHEuK"
+			base_url1: "https://api.us5.datadoghq.com"
+			base_url2: "https://api.app.ddog-gov.com"
+	`
+	matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(input))
+	if len(matchedDetectors) == 0 {
+		t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), input)
+		return
+	}
+	results, err := d.FromData(context.Background(), false, []byte(input))
+	if err != nil {
+		t.Errorf("error = %v", err)
+		return
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, received %d", len(results))
+	}
+}
+
+func Test_ConfigureEndpoints_WithEndpoints(t *testing.T) {
+	s := Scanner{}
+	customEndpoints := []string{
+		"api.app.datadoghq.eu",
+		"api.ap1.ddog-gov.com",
+	}
+	s.UseFoundEndpoints(true)
+	s.UseCloudEndpoint(true)
+	s.SetCloudEndpoint(s.CloudEndpoint())
+	endpoints := s.confiureEndpoints(customEndpoints...)
+	if len(endpoints) != len(customEndpoints) {
+		t.Errorf("expected %d endpoints, got %d", len(customEndpoints), len(endpoints))
+	}
+	for i, endpoint := range endpoints {
+		if endpoint != fmt.Sprintf("https://%s", customEndpoints[i]) {
+			t.Errorf("expected endpoint %s, got %s", customEndpoints[i], endpoint)
+		}
+	}
+}
+func Test_ConfigureEndpoints_WithoutEndpoints(t *testing.T) {
+	s := Scanner{}
+	s.UseFoundEndpoints(true)
+	s.UseCloudEndpoint(true)
+	s.SetCloudEndpoint(s.CloudEndpoint())
+	endpoints := s.confiureEndpoints()
+	if len(endpoints) != 1 {
+		t.Errorf("expected 1 endpoint, got %d", len(endpoints))
+	}
+	if endpoints[0] != defaultDatadogAPIBaseURL {
+		t.Errorf("expected default endpoint %s, got %s", defaultDatadogAPIBaseURL, endpoints[0])
 	}
 }

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1230,7 +1230,7 @@ func TestEngineInitializesCloudProviderDetectors(t *testing.T) {
 	for _, det := range e.detectors {
 		if endpoints, ok := det.(interface{ Endpoints(...string) []string }); ok {
 			id := config.GetDetectorID(det)
-			if len(endpoints.Endpoints()) == 0 && det.Type() != detectorspb.DetectorType_ArtifactoryAccessToken && det.Type() != detectorspb.DetectorType_TableauPersonalAccessToken { // artifactory and tableau does not have any cloud endpoint
+			if len(endpoints.Endpoints()) == 0 && det.Type() != detectorspb.DetectorType_ArtifactoryAccessToken && det.Type() != detectorspb.DetectorType_TableauPersonalAccessToken && det.Type() != detectorspb.DetectorType_DatadogToken { // artifactory and tableau does not have any cloud endpoint and datadog has multiple endpoints
 				t.Fatalf("detector %q Endpoints() is empty", id.String())
 			}
 			count++


### PR DESCRIPTION
### Description:

- Previously, API/App key verification was done against a single Datadog endpoint.
- Now, the verification iterates over multiple endpoints:
-The key is tested against each endpoint in order.
-if verification succeeds on any endpoint, the loop breaks immediately.
-If no endpoint succeeds, the key is marked as unverified.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
