### PR TITLE
feat: add Rancher/Cattle token detector

### DIFF
--- a/pkg/detectors/ranchertoken/ranchertoken.go
+++ b/pkg/detectors/ranchertoken/ranchertoken.go
@@ -1,0 +1,188 @@
+package ranchertoken
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+type Scanner struct {
+	client *http.Client
+}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	defaultClient = common.SaneHttpClient()
+
+	// Pattern to match Rancher/Cattle tokens with context
+	// Token format: 54-64 lowercase alphanumeric characters
+	// Handles various formats: env files, shell exports, YAML configs, Terraform HCL
+	tokenPat = regexp.MustCompile(`(?i)(?:export\s+)?(?:CATTLE_TOKEN|RANCHER_TOKEN|CATTLE_BOOTSTRAP_PASSWORD|RANCHER_API_TOKEN|RANCHER_SECRET_KEY|token_key)[\w]*\s*[=:]\s*["']?([a-z0-9]{54,64})\b["']?`)
+
+	// Pattern for YAML-style value on the next line (e.g., Kubernetes manifests)
+	yamlValuePat = regexp.MustCompile(`(?i)(?:name:\s*(?:CATTLE_TOKEN|RANCHER_TOKEN|CATTLE_BOOTSTRAP_PASSWORD|RANCHER_API_TOKEN|RANCHER_SECRET_KEY))[\s\S]{0,50}value:\s*["']?([a-z0-9]{54,64})\b["']?`)
+
+	// Pattern to extract server URL from common variable names
+	serverPat = regexp.MustCompile(`(?i)(?:CATTLE_SERVER|RANCHER_URL|RANCHER_SERVER|rancher_api_url|api_url)\s*[=:]\s*["']?(https?://[^\s"']+)["']?`)
+)
+
+// Keywords are used for efficiently pre-filtering chunks.
+func (s Scanner) Keywords() []string {
+	return []string{"cattle_token", "rancher_token", "cattle_bootstrap", "rancher_api_token", "rancher_secret", "rancher2"}
+}
+
+// FromData will find and optionally verify Rancher tokens in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	// Find all token matches from both patterns
+	tokenMatches := tokenPat.FindAllStringSubmatch(dataStr, -1)
+	yamlMatches := yamlValuePat.FindAllStringSubmatch(dataStr, -1)
+
+	// Combine all matches
+	allMatches := append(tokenMatches, yamlMatches...)
+	if len(allMatches) == 0 {
+		return nil, nil
+	}
+
+	// Find server URLs from context
+	var serverURLs []string
+	serverMatches := serverPat.FindAllStringSubmatch(dataStr, -1)
+	for _, match := range serverMatches {
+		url := strings.TrimSpace(match[1])
+		// Normalize URL - remove trailing slash
+		url = strings.TrimRight(url, "/")
+		serverURLs = append(serverURLs, url)
+	}
+
+	// Track unique tokens to avoid duplicates
+	uniqueTokens := make(map[string]struct{})
+
+	for _, match := range allMatches {
+		token := strings.TrimSpace(match[1])
+
+		// Skip if we've already processed this token
+		if _, exists := uniqueTokens[token]; exists {
+			continue
+		}
+
+		// Verify token is lowercase alphanumeric (the (?i) flag makes regex case-insensitive)
+		if !isValidRancherToken(token) {
+			continue
+		}
+
+		uniqueTokens[token] = struct{}{}
+
+		result := detectors.Result{
+			DetectorType: detectorspb.DetectorType_RancherToken,
+			Raw:          []byte(token),
+		}
+
+		if verify {
+			client := s.client
+			if client == nil {
+				client = defaultClient
+			}
+
+			// Try to verify against any found server URLs
+			verified := false
+			var verificationErr error
+
+			for _, serverURL := range serverURLs {
+				verified, verificationErr = verifyRancherToken(ctx, client, serverURL, token)
+				if verified {
+					result.ExtraData = map[string]string{
+						"server": serverURL,
+					}
+					break
+				}
+				// If we get a determinate failure (401), continue to try other URLs
+				// If we get an indeterminate failure, we should report it
+				if verificationErr != nil {
+					break
+				}
+			}
+
+			result.Verified = verified
+			result.SetVerificationError(verificationErr, token)
+		}
+
+		results = append(results, result)
+	}
+
+	return results, nil
+}
+
+// verifyRancherToken verifies the token against the Rancher API.
+// Endpoint: GET {server}/v3
+// Header: Authorization: Bearer {token}
+// Success: HTTP 200 with JSON containing "apiVersion"
+// Failure: HTTP 401
+func verifyRancherToken(ctx context.Context, client *http.Client, serverURL, token string) (bool, error) {
+	url := fmt.Sprintf("%s/v3", serverURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	req.Header.Set("Accept", "application/json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer res.Body.Close()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		// Read response body to check for apiVersion
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			return false, err
+		}
+		// Check if response contains apiVersion (basic check)
+		if strings.Contains(string(body), "apiVersion") {
+			return true, nil
+		}
+		// Response doesn't contain expected content
+		return false, nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		// Determinately not verified
+		return false, nil
+	default:
+		// Indeterminate failure
+		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
+}
+
+func (s Scanner) Type() detectorspb.DetectorType {
+	return detectorspb.DetectorType_RancherToken
+}
+
+func (s Scanner) Description() string {
+	return "Rancher is a Kubernetes management platform. Rancher/Cattle tokens can be used to access and manage Kubernetes clusters with full admin privileges."
+}
+
+// isValidRancherToken validates that the token is lowercase alphanumeric and 54-64 characters
+func isValidRancherToken(token string) bool {
+	if len(token) < 54 || len(token) > 64 {
+		return false
+	}
+	for _, c := range token {
+		if !((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/detectors/ranchertoken/ranchertoken_test.go
+++ b/pkg/detectors/ranchertoken/ranchertoken_test.go
@@ -1,0 +1,152 @@
+package ranchertoken
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+)
+
+func TestRancherToken_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+
+	// Test tokens - all 54 characters (lowercase alphanumeric)
+	token54a := "jswpl27hs8pd88rmw2mgfgrjtpljp85fd5v7rhdwr2s6z22hvt6vjt"           // 54 chars
+	token54b := "k7mnp9qr4st2vwx8yz3abc5def1ghi6jkl0mno8pqr2stu4vwx9yz1"           // 54 chars (added 1)
+	token54c := "xz9yw8vt7sr6qp5on4ml3kj2ih1gf0ed9cb8az7yx6wv5ut4sr3qp1"           // 54 chars (added 1)
+	token54d := "ab1cd2ef3gh4ij5kl6mn7op8qr9st0uv1wx2yz3ab4cd5ef6gh7ij8"           // 54 chars (removed k)
+	token54e := "mn9op8qr7st6uv5wx4yz3ab2cd1ef0gh9ij8kl7mn6op5qr4st3uv2"           // 54 chars
+	token54f := "wx4yz3ab2cd1ef0gh9ij8kl7mn6op5qr4st3uv2wx1yz0ab9cd8ef7"           // 54 chars
+	token54g := "gh9ij8kl7mn6op5qr4st3uv2wx1yz0ab9cd8ef7gh6ij5kl4mn3op2"           // 54 chars
+	token64 := "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01"  // 64 chars (valid max)
+	token53 := "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopq"             // 53 chars (too short)
+	token65 := "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz012" // 65 chars (too long)
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name: "valid pattern - env file",
+			input: `
+# .env file
+CATTLE_SERVER=https://rancher.example.com
+CATTLE_TOKEN=` + token54a + `
+`,
+			want: []string{token54a},
+		},
+		{
+			name: "valid pattern - rancher_token variable with export",
+			input: `
+export RANCHER_TOKEN=` + token54b + `
+`,
+			want: []string{token54b},
+		},
+		{
+			name: "valid pattern - kubernetes yaml",
+			input: `
+# Kubernetes deployment
+env:
+  - name: CATTLE_TOKEN
+    value: ` + token54c + `
+`,
+			want: []string{token54c},
+		},
+		{
+			name: "valid pattern - terraform provider",
+			input: `
+provider "rancher2" {
+  api_url   = "https://rancher.example.com"
+  token_key = "` + token54d + `"
+}
+`,
+			want: []string{token54d},
+		},
+		{
+			name:  "valid pattern - rancher api token",
+			input: `RANCHER_API_TOKEN=` + token54e,
+			want:  []string{token54e},
+		},
+		{
+			name:  "valid pattern - cattle bootstrap password",
+			input: `CATTLE_BOOTSTRAP_PASSWORD=` + token54f,
+			want:  []string{token54f},
+		},
+		{
+			name:  "valid pattern - rancher secret key with quotes",
+			input: `RANCHER_SECRET_KEY = "` + token54g + `"`,
+			want:  []string{token54g},
+		},
+		{
+			name:  "valid pattern - 60 char token (within 54-64 range)",
+			input: `CATTLE_TOKEN=` + token64,
+			want:  []string{token64},
+		},
+		{
+			name:  "invalid - too short (53 chars)",
+			input: `CATTLE_TOKEN=` + token53,
+			want:  nil,
+		},
+		{
+			name:  "invalid - too long (65 chars)",
+			input: `CATTLE_TOKEN=` + token65,
+			want:  nil,
+		},
+		{
+			name:  "invalid - uppercase chars",
+			input: `CATTLE_TOKEN=JSWPL27HS8PD88RMW2MGFGRJTPLJP85FD5V7RHDWR2S6Z22HVT6VJT`,
+			want:  nil,
+		},
+		{
+			name: "invalid - no context (should not detect random string)",
+			input: `
+random_data = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuv"
+`,
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(matchedDetectors) == 0 && len(test.want) > 0 {
+				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			if err != nil {
+				t.Errorf("error = %v", err)
+				return
+			}
+
+			if len(results) != len(test.want) {
+				t.Errorf("expected %d result(s), got %d", len(test.want), len(results))
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.RawV2) > 0 {
+					actual[string(r.RawV2)] = struct{}{}
+				} else {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -596,6 +596,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/rabbitmq"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/railwayapp"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/ramp"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/ranchertoken"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/rapidapi"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/rawg"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/razorpay"
@@ -1475,6 +1476,7 @@ func buildDetectorList() []detectors.Detector {
 		&rabbitmq.Scanner{},
 		&railwayapp.Scanner{},
 		&ramp.Scanner{},
+		&ranchertoken.Scanner{},
 		&rapidapi.Scanner{},
 		// &raven.Scanner{},
 		&rawg.Scanner{},

--- a/pkg/pb/detectorspb/detectors.pb.go
+++ b/pkg/pb/detectorspb/detectors.pb.go
@@ -1146,6 +1146,7 @@ const (
 	DetectorType_PhraseAccessToken                       DetectorType = 1037
 	DetectorType_Photoroom                               DetectorType = 1038
 	DetectorType_JWT                                     DetectorType = 1039
+	DetectorType_RancherToken                            DetectorType = 1040
 )
 
 // Enum value maps for DetectorType.
@@ -2187,6 +2188,7 @@ var (
 		1037: "PhraseAccessToken",
 		1038: "Photoroom",
 		1039: "JWT",
+		1040: "RancherToken",
 	}
 	DetectorType_value = map[string]int32{
 		"Alibaba":                               0,
@@ -3225,6 +3227,7 @@ var (
 		"PhraseAccessToken":                 1037,
 		"Photoroom":                         1038,
 		"JWT":                               1039,
+		"RancherToken":                      1040,
 	}
 )
 

--- a/proto/detectors.proto
+++ b/proto/detectors.proto
@@ -1049,6 +1049,7 @@ enum DetectorType {
   PhraseAccessToken = 1037;
   Photoroom = 1038;
   JWT = 1039;
+  RancherToken = 1040;
 }
 
 message Result {


### PR DESCRIPTION
Fixes #4622

## Summary
- Adds new detector for Rancher/Cattle tokens (54-64 lowercase alphanumeric chars)
- Pattern detects tokens in env files, shell exports, YAML configs, and Terraform HCL
- Context-aware detection requires CATTLE_TOKEN, RANCHER_TOKEN, CATTLE_BOOTSTRAP_PASSWORD, RANCHER_API_TOKEN, or RANCHER_SECRET_KEY variable names
- Validates against Rancher API v3 endpoint with Bearer auth

## Test plan
- [x] All pattern tests pass (env files, YAML, Terraform, various variable names)
- [x] Edge cases tested (too short, too long, uppercase tokens)
- [x] No false positives on context-free alphanumeric strings
- [x] go build passes
- [x] gofmt and go vet clean