### PR TITLE
Reduce false positives in DatadogToken detector

### DIFF
--- a/pkg/detectors/datadogtoken/datadogtoken.go
+++ b/pkg/detectors/datadogtoken/datadogtoken.go
@@ -3,10 +3,13 @@ package datadogtoken
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
+	"regexp"
 	"strings"
+	"unicode"
 
-	regexp "github.com/wasilibs/go-re2"
+	regexp2 "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -29,8 +32,14 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	appPat = regexp.MustCompile(detectors.PrefixRegex([]string{"datadog", "dd"}) + `\b([a-zA-Z-0-9]{40})\b`)
-	apiPat = regexp.MustCompile(detectors.PrefixRegex([]string{"datadog", "dd"}) + `\b([a-zA-Z-0-9]{32})\b`)
+	appPat = regexp2.MustCompile(detectors.PrefixRegex([]string{"datadog", "dd"}) + `\b([a-zA-Z-0-9]{40})\b`)
+	apiPat = regexp2.MustCompile(detectors.PrefixRegex([]string{"datadog", "dd"}) + `\b([a-zA-Z-0-9]{32})\b`)
+
+	// False positive detection patterns
+	npmIntegrityPat     = regexp.MustCompile(`sha(256|384|512|1)-[A-Za-z0-9+/=]+`)
+	goModuleChecksumPat = regexp.MustCompile(`h[0-9]+:[A-Za-z0-9+/=]+=`)
+	urlEncodedPathPat   = regexp.MustCompile(`%3[Aa]|https?://[^\s]+`)
+	sopsEncryptedPat    = regexp.MustCompile(`ENC\[AES256_GCM,data:[A-Za-z0-9+/=]+`)
 )
 
 type userServiceResponse struct {
@@ -92,6 +101,248 @@ func setOrganizationInfo(opt []*options, s1 *detectors.Result) {
 
 }
 
+// hasDigit checks if a string contains at least one digit.
+func hasDigit(s string) bool {
+	for _, r := range s {
+		if unicode.IsDigit(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// isNpmIntegrityHash checks if a match is part of an npm package integrity hash.
+// Pattern: "integrity": "sha512-...==" or sha256-/sha384-/sha1-
+func isNpmIntegrityHash(dataStr string, match string, startIdx, endIdx int) bool {
+	// Extract context around the match (±200 chars or to line boundaries)
+	contextStart := startIdx - 200
+	if contextStart < 0 {
+		contextStart = 0
+	}
+	contextEnd := endIdx + 200
+	if contextEnd > len(dataStr) {
+		contextEnd = len(dataStr)
+	}
+	context := dataStr[contextStart:contextEnd]
+
+	// Check if match is preceded by sha*- and followed by == or =
+	if npmIntegrityPat.MatchString(context) {
+		// Check if the match is within an integrity hash pattern
+		matchPos := strings.Index(context, match)
+		if matchPos > 0 {
+			beforeMatch := context[:matchPos]
+			afterMatch := context[matchPos+len(match):]
+			// Check for sha*- prefix and ==/= suffix
+			if (strings.Contains(beforeMatch, "sha512-") || strings.Contains(beforeMatch, "sha256-") ||
+				strings.Contains(beforeMatch, "sha384-") || strings.Contains(beforeMatch, "sha1-")) &&
+				(strings.HasPrefix(afterMatch, "==") || strings.HasPrefix(afterMatch, "=")) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isGoModuleChecksum checks if a match is part of a Go module checksum.
+// Pattern: h1:...= or go.mod h1:...=
+func isGoModuleChecksum(dataStr string, match string, startIdx, endIdx int) bool {
+	// Extract context around the match (±200 chars or to line boundaries)
+	contextStart := startIdx - 200
+	if contextStart < 0 {
+		contextStart = 0
+	}
+	contextEnd := endIdx + 200
+	if contextEnd > len(dataStr) {
+		contextEnd = len(dataStr)
+	}
+	context := dataStr[contextStart:contextEnd]
+
+	// Check if match is preceded by h1: (or h2:, h3:, etc.) and followed by =
+	if goModuleChecksumPat.MatchString(context) {
+		matchPos := strings.Index(context, match)
+		if matchPos > 0 {
+			beforeMatch := context[:matchPos]
+			afterMatch := context[matchPos+len(match):]
+			// Check for h1:/h2:/h3: prefix and = suffix
+			if (strings.Contains(beforeMatch, "h1:") || strings.Contains(beforeMatch, "h2:") ||
+				strings.Contains(beforeMatch, "h3:") || strings.Contains(beforeMatch, "go.mod")) &&
+				strings.HasPrefix(afterMatch, "=") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isUrlEncodedPath checks if a match is part of a URL-encoded path.
+// Pattern: Contains %3A (URL-encoded colon) or is within a URL
+func isUrlEncodedPath(dataStr string, match string, startIdx, endIdx int) bool {
+	// Extract context around the match (±200 chars or to line boundaries)
+	contextStart := startIdx - 200
+	if contextStart < 0 {
+		contextStart = 0
+	}
+	contextEnd := endIdx + 200
+	if contextEnd > len(dataStr) {
+		contextEnd = len(dataStr)
+	}
+	context := dataStr[contextStart:contextEnd]
+
+	// Check if context contains URL-encoded patterns or URL structure
+	if strings.Contains(context, "%3A") || strings.Contains(context, "%3a") {
+		return true
+	}
+	// Check if it's within a URL pattern
+	if urlEncodedPathPat.MatchString(context) {
+		matchPos := strings.Index(context, match)
+		if matchPos > 0 {
+			beforeMatch := context[:matchPos]
+			// Check if there's a URL pattern before the match
+			if strings.Contains(beforeMatch, "http://") || strings.Contains(beforeMatch, "https://") ||
+				strings.Contains(beforeMatch, "app.datadoghq.com") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isSopsEncrypted checks if a match is part of SOPS-encrypted data.
+// Pattern: ENC[AES256_GCM,data:...] or similar SOPS encryption patterns
+func isSopsEncrypted(dataStr string, match string, startIdx, endIdx int) bool {
+	// Extract context around the match (±200 chars or to line boundaries)
+	contextStart := startIdx - 200
+	if contextStart < 0 {
+		contextStart = 0
+	}
+	contextEnd := endIdx + 200
+	if contextEnd > len(dataStr) {
+		contextEnd = len(dataStr)
+	}
+	context := dataStr[contextStart:contextEnd]
+
+	// Check if context contains SOPS encryption pattern
+	if sopsEncryptedPat.MatchString(context) {
+		matchPos := strings.Index(context, match)
+		if matchPos > 0 {
+			beforeMatch := context[:matchPos]
+			// Check if match is within ENC[...] pattern
+			if strings.Contains(beforeMatch, "ENC[") || strings.Contains(beforeMatch, "data:") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isRepeatedCharacter checks if a string consists of the same character repeated.
+// This filters out test/placeholder values like "11111111111111111111111111111111"
+func isRepeatedCharacter(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	firstChar := s[0]
+	for i := 1; i < len(s); i++ {
+		if s[i] != firstChar {
+			return false
+		}
+	}
+	return true
+}
+
+// isBase64Certificate checks if a match is part of a base64-encoded certificate.
+// Pattern: caBundle, certificate fields, or -----BEGIN CERTIFICATE----- markers
+// Note: Match might be from BASE64-decoded content, so we check the original dataStr context
+func isBase64Certificate(dataStr string, match string, startIdx, endIdx int) bool {
+	// Extract larger context around the match (±2000 chars to catch certificate fields)
+	contextStart := startIdx - 2000
+	if contextStart < 0 {
+		contextStart = 0
+	}
+	contextEnd := endIdx + 2000
+	if contextEnd > len(dataStr) {
+		contextEnd = len(dataStr)
+	}
+	context := dataStr[contextStart:contextEnd]
+
+	// Check if context contains certificate-related keywords (check both original and decoded contexts)
+	certKeywords := []string{
+		"caBundle",
+		"caBundle:",
+		"certificate",
+		"cert:",
+		"-----BEGIN CERTIFICATE-----",
+		"-----END CERTIFICATE-----",
+		"BEGIN CERTIFICATE",
+		"END CERTIFICATE",
+		"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0t", // Base64 of "-----BEGIN CERTIFICATE-----"
+	}
+
+	for _, keyword := range certKeywords {
+		if strings.Contains(context, keyword) {
+			// Find all occurrences of the keyword
+			keywordPos := strings.Index(context, keyword)
+			matchPosInContext := startIdx - contextStart
+
+			// If keyword appears before the match, check distance
+			if keywordPos >= 0 && keywordPos < matchPosInContext {
+				// Check if match is within reasonable distance (within 1500 chars)
+				if matchPosInContext-keywordPos < 1500 {
+					return true
+				}
+			}
+			// Also check if keyword appears after match (certificate might span the match)
+			if keywordPos >= 0 && keywordPos > matchPosInContext {
+				if keywordPos-matchPosInContext < 1500 {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// isLikelyFalsePositive checks if a matched string is likely a false positive.
+func isLikelyFalsePositive(dataStr string, match string, startIdx, endIdx int) bool {
+	// Filter 1: Only letters (no digits) - likely service names/identifiers
+	if !hasDigit(match) {
+		return true
+	}
+
+	// Filter 2: Repeated characters (test/placeholder values like "11111111111111111111111111111111")
+	if isRepeatedCharacter(match) {
+		return true
+	}
+
+	// Filter 3: NPM integrity hash
+	if isNpmIntegrityHash(dataStr, match, startIdx, endIdx) {
+		return true
+	}
+
+	// Filter 4: Go module checksum
+	if isGoModuleChecksum(dataStr, match, startIdx, endIdx) {
+		return true
+	}
+
+	// Filter 5: URL-encoded path
+	if isUrlEncodedPath(dataStr, match, startIdx, endIdx) {
+		return true
+	}
+
+	// Filter 6: SOPS-encrypted data
+	if isSopsEncrypted(dataStr, match, startIdx, endIdx) {
+		return true
+	}
+
+	// Filter 7: Base64-encoded certificate
+	if isBase64Certificate(dataStr, match, startIdx, endIdx) {
+		return true
+	}
+
+	return false
+}
+
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
@@ -102,14 +353,31 @@ func (s Scanner) Keywords() []string {
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
 	dataStr := string(data)
 
-	appMatches := appPat.FindAllStringSubmatch(dataStr, -1)
-	apiMatches := apiPat.FindAllStringSubmatch(dataStr, -1)
+	appMatches := appPat.FindAllStringSubmatchIndex(dataStr, -1)
+	apiMatches := apiPat.FindAllStringSubmatchIndex(dataStr, -1)
 
-	for _, apiMatch := range apiMatches {
-		resApiMatch := strings.TrimSpace(apiMatch[1])
+	for _, apiMatchIdx := range apiMatches {
+		if len(apiMatchIdx) < 4 {
+			continue
+		}
+		resApiMatch := strings.TrimSpace(dataStr[apiMatchIdx[2]:apiMatchIdx[3]])
+
+		// Filter out false positives for API key
+		if isLikelyFalsePositive(dataStr, resApiMatch, apiMatchIdx[2], apiMatchIdx[3]) {
+			continue
+		}
+
 		appIncluded := false
-		for _, appMatch := range appMatches {
-			resAppMatch := strings.TrimSpace(appMatch[1])
+		for _, appMatchIdx := range appMatches {
+			if len(appMatchIdx) < 4 {
+				continue
+			}
+			resAppMatch := strings.TrimSpace(dataStr[appMatchIdx[2]:appMatchIdx[3]])
+
+			// Filter out false positives for Application key
+			if isLikelyFalsePositive(dataStr, resAppMatch, appMatchIdx[2], appMatchIdx[3]) {
+				continue
+			}
 
 			s1 := detectors.Result{
 				DetectorType: detectorspb.DetectorType_DatadogToken,
@@ -131,7 +399,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					req.Header.Add("DD-APPLICATION-KEY", resAppMatch)
 					res, err := client.Do(req)
 					if err == nil {
-						defer res.Body.Close()
+						defer func() {
+							_, _ = io.Copy(io.Discard, res.Body)
+							_ = res.Body.Close()
+						}()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
 							s1.AnalysisInfo = map[string]string{"apiKey": resApiMatch, "appKey": resAppMatch}
@@ -174,7 +445,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					req.Header.Add("DD-API-KEY", resApiMatch)
 					res, err := client.Do(req)
 					if err == nil {
-						defer res.Body.Close()
+						defer func() {
+							_, _ = io.Copy(io.Discard, res.Body)
+							_ = res.Body.Close()
+						}()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
 							s1.AnalysisInfo = map[string]string{"apiKey": resApiMatch}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

Fixes #4631

### Description:
Reduce false positives in DatadogToken detector by filtering out legitimate code identifiers, checksums, encrypted data, and test values that match the detector pattern.

**Changes:**
- Add filter to exclude letters-only matches (no digits)
- Add filter to exclude repeated characters (test/placeholder values)
- Add filter to exclude NPM integrity hashes (`sha512-...==` patterns)
- Add filter to exclude Go module checksums (`h1:...=` patterns)
- Add filter to exclude URL-encoded paths (`%3A` patterns)
- Add filter to exclude SOPS-encrypted data (`ENC[AES256_GCM,data:...]` patterns)
- Add filter to exclude base64-encoded certificates (`caBundle` patterns)
- Fix lint errors by properly handling `res.Body.Close()` errors

This reduces false positives from legitimate code identifiers, checksums, encrypted data, and test values while still detecting real Datadog API and Application keys that contain digits and have higher entropy.

**Problem:**
The DatadogToken detector was flagging any 32-character or 40-character alphanumeric string near the keywords "datadog" or "dd" as a potential secret, including:
- URL-encoded service names in paths (e.g., `service%3Amy-app-service-name`)
- NPM package integrity hashes (e.g., substrings from `sha512-...==` patterns)
- Go module checksums (e.g., substrings from `h1:...=` patterns)
- SOPS-encrypted data (e.g., substrings from `ENC[AES256_GCM,data:...]` patterns)
- Test/placeholder values (e.g., `11111111111111111111111111111111`)
- Base64-encoded certificates (e.g., substrings from `caBundle` fields)

**Solution:**
Added `isLikelyFalsePositive()` helper function with multiple filters:
1. **Letters-only filter** - Excludes strings with no digits (service names/identifiers)
2. **Repeated characters filter** - Excludes test/placeholder values like `11111111111111111111111111111111`
3. **NPM integrity hash filter** - Detects `sha512-...==` patterns in package.json files
4. **Go module checksum filter** - Detects `h1:...=` patterns in go.sum/go.mod files
5. **URL-encoded path filter** - Detects `%3A` patterns and URL structures
6. **SOPS-encrypted data filter** - Detects `ENC[AES256_GCM,data:...]` patterns
7. **Base64 certificate filter** - Detects `caBundle` and certificate-related fields

**Implementation Details:**
- Modified `FromData()` to use `FindAllStringSubmatchIndex()` to get match positions for context extraction
- Added context-aware filtering that checks surrounding text (±200 chars for most patterns, ±2000 chars for certificates) to detect patterns
- Filters are applied before processing matches to avoid unnecessary verification calls
- Each filter function extracts context around the match and checks for specific patterns (e.g., `sha512-`, `h1:`, `%3A`, `ENC[`, `caBundle`)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

