### PR TITLE
[INS-165] Jdbc detector integration tests fix

### DIFF
--- a/pkg/detectors/jdbc/jdbc_integration_test.go
+++ b/pkg/detectors/jdbc/jdbc_integration_test.go
@@ -29,8 +29,8 @@ func TestJdbcVerified(t *testing.T) {
 	postgresUser := gofakeit.Username()
 	postgresPass := gofakeit.Password(true, true, true, false, false, 10)
 	postgresDB := gofakeit.Word()
-	postgresContainer, err := postgres.RunContainer(ctx,
-		testcontainers.WithImage("postgres:13-alpine"),
+	postgresContainer, err := postgres.Run(ctx,
+		"postgres:13-alpine",
 		postgres.WithDatabase(postgresDB),
 		postgres.WithUsername(postgresUser),
 		postgres.WithPassword(postgresPass),
@@ -56,8 +56,8 @@ func TestJdbcVerified(t *testing.T) {
 	mysqlUser := gofakeit.Username()
 	mysqlPass := gofakeit.Password(true, true, true, false, false, 10)
 	mysqlDatabase := gofakeit.Word()
-	mysqlC, err := mysql.RunContainer(ctx,
-		mysql.WithDatabase(mysqlDatabase),
+	mysqlC, err := mysql.Run(ctx,
+		"mysql:8.0.36",
 		mysql.WithUsername(mysqlUser),
 		mysql.WithPassword(mysqlPass),
 	)
@@ -79,8 +79,8 @@ func TestJdbcVerified(t *testing.T) {
 	sqlServerPass := gofakeit.Password(true, true, true, false, false, 10)
 	sqlServerDatabase := "master"
 
-	mssqlContainer, err := mssql.RunContainer(ctx,
-		testcontainers.WithImage("mcr.microsoft.com/azure-sql-edge"),
+	mssqlContainer, err := mssql.Run(ctx,
+		"mcr.microsoft.com/azure-sql-edge",
 		mssql.WithAcceptEULA(),
 		mssql.WithPassword(sqlServerPass),
 	)
@@ -125,6 +125,10 @@ func TestJdbcVerified(t *testing.T) {
 					Verified:     true,
 					Redacted: fmt.Sprintf("jdbc:postgresql://%s:%s/%s?sslmode=disable&password=%s&user=%s",
 						postgresHost, postgresPort.Port(), postgresDB, strings.Repeat("*", len(postgresPass)), postgresUser),
+					AnalysisInfo: map[string]string{
+						"connection_string": fmt.Sprintf("jdbc:postgresql://%s:%s/%s?sslmode=disable&password=%s&user=%s",
+							postgresHost, postgresPort.Port(), postgresDB, postgresPass, postgresUser),
+					},
 				},
 			},
 			wantErr: false,
@@ -143,6 +147,10 @@ func TestJdbcVerified(t *testing.T) {
 					Verified:     true,
 					Redacted: fmt.Sprintf(`jdbc:mysql://%s:%s@tcp(%s:%s)/%s`,
 						mysqlUser, strings.Repeat("*", len(mysqlPass)), mysqlHost, mysqlPort.Port(), mysqlDatabase),
+					AnalysisInfo: map[string]string{
+						"connection_string": fmt.Sprintf(`jdbc:mysql://%s:%s@tcp(%s:%s)/%s`,
+							mysqlUser, mysqlPass, mysqlHost, mysqlPort.Port(), mysqlDatabase),
+					},
 				},
 			},
 			wantErr: false,
@@ -161,6 +169,10 @@ func TestJdbcVerified(t *testing.T) {
 					Verified:     true,
 					Redacted: fmt.Sprintf("jdbc:sqlserver://odbc:server=%s;port=%s;database=%s;password=%s",
 						sqlServerHost, sqlServerPort.Port(), sqlServerDatabase, strings.Repeat("*", len(sqlServerPass))),
+					AnalysisInfo: map[string]string{
+						"connection_string": fmt.Sprintf("jdbc:sqlserver://odbc:server=%s;port=%s;database=%s;password=%s",
+							sqlServerHost, sqlServerPort.Port(), sqlServerDatabase, sqlServerPass),
+					},
 				},
 			},
 			wantErr: false,

--- a/pkg/detectors/jdbc/mysql_integration_test.go
+++ b/pkg/detectors/jdbc/mysql_integration_test.go
@@ -23,7 +23,8 @@ func TestMySQL(t *testing.T) {
 
 	ctx := context.Background()
 
-	mysqlC, err := mysql.RunContainer(ctx,
+	mysqlC, err := mysql.Run(ctx,
+		"mysql:8.0.36",
 		mysql.WithDatabase(mysqlDatabase),
 		mysql.WithUsername(mysqlUser),
 		mysql.WithPassword(mysqlPass),

--- a/pkg/detectors/jdbc/postgres_integration_test.go
+++ b/pkg/detectors/jdbc/postgres_integration_test.go
@@ -6,7 +6,6 @@ package jdbc
 import (
 	"context"
 	"fmt"
-	"log"
 	"testing"
 	"time"
 
@@ -34,8 +33,8 @@ func TestPostgres(t *testing.T) {
 	t.Log("dbName: ", dbName)
 
 	ctx := context.Background()
-	postgresContainer, err := postgres.RunContainer(ctx,
-		testcontainers.WithImage("postgres:13-alpine"),
+	postgresContainer, err := postgres.Run(ctx,
+		"postgres:13-alpine",
 		postgres.WithDatabase(dbName),
 		postgres.WithUsername(user),
 		postgres.WithPassword(pass),
@@ -55,10 +54,6 @@ func TestPostgres(t *testing.T) {
 	port, err := postgresContainer.MappedPort(ctx, "5432")
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	if err != nil {
-		log.Fatalf("failed to start container: %s", err)
 	}
 	defer postgresContainer.Terminate(ctx)
 

--- a/pkg/detectors/jdbc/sqlserver_integration_test.go
+++ b/pkg/detectors/jdbc/sqlserver_integration_test.go
@@ -96,5 +96,4 @@ func TestSqlServer(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
-	//a
 }

--- a/pkg/detectors/jdbc/sqlserver_integration_test.go
+++ b/pkg/detectors/jdbc/sqlserver_integration_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/brianvoe/gofakeit/v7"
 	"github.com/stretchr/testify/assert"
-	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/mssql"
 	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
@@ -22,8 +21,8 @@ func TestSqlServer(t *testing.T) {
 	sqlServerPass := gofakeit.Password(true, true, true, false, false, 10)
 	sqlServerDB := "master"
 
-	mssqlContainer, err := mssql.RunContainer(ctx,
-		testcontainers.WithImage("mcr.microsoft.com/azure-sql-edge"),
+	mssqlContainer, err := mssql.Run(ctx,
+		"mcr.microsoft.com/azure-sql-edge",
 		mssql.WithAcceptEULA(),
 		mssql.WithPassword(sqlServerPass),
 	)
@@ -62,7 +61,7 @@ func TestSqlServer(t *testing.T) {
 			want: result{pingOk: true, pingDeterminate: true},
 		},
 		{
-			input: "//server=badhost;user id=sa;database=master;password=",
+			input: fmt.Sprintf("//server=badhost;user id=sa;database=master;password=%s", sqlServerPass),
 			want:  result{pingOk: false, pingDeterminate: false},
 		},
 		{
@@ -97,4 +96,5 @@ func TestSqlServer(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+	//a
 }


### PR DESCRIPTION
### Description:
Some of the integration test in jdbc detectors were not working, Also we were using deprecated functions from the packages.
This PR updated/removes the deprecated code. 

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
