### PR TITLE
Trufflehog datadog credential detection

### DIFF
--- a/pkg/detectors/datadogtoken/datadogtoken.go
+++ b/pkg/detectors/datadogtoken/datadogtoken.go
@@ -29,8 +29,10 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	appPat = regexp.MustCompile(detectors.PrefixRegex([]string{"datadog", "dd"}) + `\b([a-zA-Z-0-9]{40})\b`)
-	apiPat = regexp.MustCompile(detectors.PrefixRegex([]string{"datadog", "dd"}) + `\b([a-zA-Z-0-9]{32})\b`)
+	// Datadog keys are often documented next to long URLs; allow a larger span so the keyword isn't "pushed away"
+	// by comment/URL tails.
+	appPat = regexp.MustCompile(detectors.PrefixRegexWithMaxDistance([]string{"datadog", "dd"}, 200) + `\b([a-zA-Z-0-9]{40})\b`)
+	apiPat = regexp.MustCompile(detectors.PrefixRegexWithMaxDistance([]string{"datadog", "dd"}, 200) + `\b([a-zA-Z-0-9]{32})\b`)
 )
 
 type userServiceResponse struct {

--- a/pkg/detectors/datadogtoken/datadogtoken_test.go
+++ b/pkg/detectors/datadogtoken/datadogtoken_test.go
@@ -38,6 +38,16 @@ func TestDataDogToken_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 
+	longURLCommentBetweenKeywordAndKey := `
+class DATADOG {
+	// Use this link to find the API Key https://app.datadoghq.com/organization-settings/api-keys?filter=tray&id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+	static API_KEY = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1";
+	// Use this link to find the APP KEY https://app.datadoghq.com/organization-settings/application-keys?filter=tray&id=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+	static APP_KEY = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2";
+}
+`
+	longURLCommentBetweenKeywordAndKeySecret := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"
+
 	tests := []struct {
 		name  string
 		input string
@@ -47,6 +57,11 @@ func TestDataDogToken_Pattern(t *testing.T) {
 			name:  "valid pattern",
 			input: validPattern,
 			want:  []string{secret},
+		},
+		{
+			name:  "keyword far due to long URL/comment tail",
+			input: longURLCommentBetweenKeywordAndKey,
+			want:  []string{longURLCommentBetweenKeywordAndKeySecret},
 		},
 	}
 

--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"errors"
+	"fmt"
 	"math/big"
 	"net/url"
 	"strings"
@@ -260,9 +261,22 @@ func CleanResults(results []Result) []Result {
 // 40 characters of the capturing group that follows.
 // This can help prevent false positives.
 func PrefixRegex(keywords []string) string {
+	return PrefixRegexWithMaxDistance(keywords, 40)
+}
+
+// PrefixRegexWithMaxDistance is like PrefixRegex, but allows callers to tune
+// how far the keyword may appear from the capturing group that follows.
+//
+// This is intentionally a byte/character window, not a "line" window. Some
+// detectors may need a larger span to tolerate long URLs/comments without
+// widening the window globally for every detector.
+func PrefixRegexWithMaxDistance(keywords []string, maxChars int) string {
+	if maxChars < 0 {
+		maxChars = 0
+	}
 	pre := `(?i:`
 	middle := strings.Join(keywords, "|")
-	post := `)(?:.|[\n\r]){0,40}?`
+	post := fmt.Sprintf(`)(?:.|[\n\r]){0,%d}?`, maxChars)
 	return pre + middle + post
 }
 


### PR DESCRIPTION
### Description:
This PR addresses an issue where DataDog secrets were not detected when the "datadog" keyword was separated from the key by a long comment or URL. The previous `PrefixRegex` function had a hardcoded 40-character proximity limit, which was insufficient for these scenarios.

The changes introduce a configurable proximity window for `PrefixRegex` and specifically increase the DataDog detector's window to 200 characters to ensure detection in cases involving long comments or URLs. A regression test matching the reported scenario has been added.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

---
<a href="https://cursor.com/background-agent?bcId=bc-c60ff2b4-6755-44f3-bc12-9e9c92eda203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c60ff2b4-6755-44f3-bc12-9e9c92eda203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

