### PR TITLE
Add exponential backoff retry logic in Twilio detector

### DIFF
--- a/pkg/detectors/twilio/twilio.go
+++ b/pkg/detectors/twilio/twilio.go
@@ -23,7 +23,7 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = common.SaneHttpClient()
+	defaultClient = common.RetryableHTTPClient()
 	sidPat        = regexp.MustCompile(`\bAC[0-9a-f]{32}\b`)
 	keyPat        = regexp.MustCompile(`\b[0-9a-f]{32}\b`)
 )


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

## Summary

Adds retry logic with exponential backoff to the Twilio detector by switching from `SaneHttpClient` to `RetryableHTTPClient`.

## Changes
- Replace `common.SaneHttpClient()` with `common.RetryableHTTPClient()` in the Twilio detector

## Behavior
- Retries up to 3 times on transient failures (429, 5xx, network errors)
- Exponential backoff between retries

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
