### PR TITLE
Remove ResultWithMetadata.Data

### DIFF
--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -207,8 +207,6 @@ type ResultWithMetadata struct {
 	// SourceName is the name of the Source.
 	SourceName string
 	Result
-	// Data from the sources.Chunk which this result was emitted for
-	Data []byte
 	// DetectorDescription is the description of the Detector.
 	DetectorDescription string
 	// DecoderType is the type of decoder that was used to generate this result's data.
@@ -225,7 +223,6 @@ func CopyMetadata(chunk *sources.Chunk, result Result) ResultWithMetadata {
 		SourceType:     chunk.SourceType,
 		SourceName:     chunk.SourceName,
 		Result:         result,
-		Data:           chunk.Data,
 	}
 }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The `ResultWithMetadata` struct has an unused `Data` field. This causes some unnecessary concern entanglement, so this PR removes it.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
