### PR TITLE
Switch out default HTTP client use in detectors

### DIFF
--- a/pkg/analyzer/analyzers/airtable/common/common.go
+++ b/pkg/analyzer/analyzers/airtable/common/common.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/analyzer/analyzers"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 )
 
 func CallAirtableAPI(token string, method string, url string) (*http.Response, error) {
@@ -21,7 +22,7 @@ func CallAirtableAPI(token string, method string, url string) (*http.Response, e
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := detectors.DetectorHttpClientWithNoLocalAddresses.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/analyzer/analyzers/airtable/common/common.go
+++ b/pkg/analyzer/analyzers/airtable/common/common.go
@@ -91,7 +91,7 @@ func fetchBaseSchema(token string, baseID string) (*Schema, error) {
 	if !exists {
 		return nil, fmt.Errorf("endpoint for GetBaseSchemaEndpoint does not exist")
 	}
-	url := strings.Replace(endpoint.URL, "{baseID}", baseID, -1)
+	url := strings.ReplaceAll(endpoint.URL, "{baseID}", baseID)
 	resp, err := CallAirtableAPI(token, endpoint.Method, url)
 	if err != nil {
 		return nil, err

--- a/pkg/analyzer/analyzers/figma/requests.go
+++ b/pkg/analyzer/analyzers/figma/requests.go
@@ -10,7 +10,7 @@ func callAPIEndpoint(client *http.Client, token string, endpoint endpoint) (*htt
 		return nil, err
 	}
 	req.Header.Set("X-FIGMA-TOKEN", token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/detectors/d7network/d7network.go
+++ b/pkg/detectors/d7network/d7network.go
@@ -47,7 +47,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				continue
 			}
 			req.Header.Add("Authorization", "Basic "+resMatch)
-			res, err := http.DefaultClient.Do(req)
+			res, err := detectors.DetectorHttpClientWithNoLocalAddresses.Do(req)
 			if err == nil {
 				defer res.Body.Close()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {

--- a/pkg/detectors/gcp/gcp.go
+++ b/pkg/detectors/gcp/gcp.go
@@ -229,7 +229,7 @@ func fetchServiceAccountCerts(ctx context.Context, certsURL string) (map[string]
 	}
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := detectors.DetectorHttpClientWithNoLocalAddresses.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/detectors/gcp/gcp.go
+++ b/pkg/detectors/gcp/gcp.go
@@ -248,7 +248,7 @@ func fetchServiceAccountCerts(ctx context.Context, certsURL string) (map[string]
 }
 
 // parsePrivateKey parses a PEM-encoded private key
-func parsePrivateKey(privateKeyPEM string) (interface{}, error) {
+func parsePrivateKey(privateKeyPEM string) (any, error) {
 	block, _ := pem.Decode([]byte(privateKeyPEM))
 	if block == nil {
 		return nil, nil

--- a/pkg/handlers/apk_test.go
+++ b/pkg/handlers/apk_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
-	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 
 func TestAPKHandler(t *testing.T) {
@@ -45,7 +44,7 @@ func TestAPKHandler(t *testing.T) {
 			}
 			defer newReader.Close()
 
-			archiveChan := handler.HandleFile(logContext.Background(), newReader)
+			archiveChan := handler.HandleFile(context.Background(), newReader)
 
 			chunkCount := 0
 			secretCount := 0
@@ -72,7 +71,7 @@ func TestAPKHandler(t *testing.T) {
 func TestOpenInvalidAPK(t *testing.T) {
 	reader := strings.NewReader("invalid apk")
 
-	ctx := logContext.AddLogger(context.Background())
+	ctx := context.AddLogger(context.Background())
 	handler := apkHandler{}
 
 	rdr, err := newFileReader(ctx, io.NopCloser(reader))
@@ -104,7 +103,7 @@ func TestOpenValidZipInvalidAPK(t *testing.T) {
 	defer newReader.Close()
 
 	archiveChan := make(chan DataOrErr)
-	ctx := logContext.AddLogger(context.Background())
+	ctx := context.AddLogger(context.Background())
 
 	err = handler.processAPK(ctx, newReader, archiveChan)
 	assert.Contains(t, err.Error(), "resources.arsc file not found")


### PR DESCRIPTION
This PR updates a handful of detectors that use `http.DefaultClient` for liveness verification to instead use `detectors.DetectorHttpClientWithNoLocalAddresses`. This latter client avoids SSRF by ignoring redirects and blocking access to non-routing IPs, and also adds HTTP instrumentation.

This PR also fixes a few code nits reported by `staticcheck`.
