### PR TITLE
refactor(source/engine): move link generation and update from engine to source specific functions

### DIFF
--- a/pkg/giturl/helpers.go
+++ b/pkg/giturl/helpers.go
@@ -1,0 +1,46 @@
+package giturl
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// TrimGitSuffix removes the .git suffix from a repository URL.
+func TrimGitSuffix(repo string) string {
+	return strings.TrimSuffix(repo, ".git")
+}
+
+// EncodeSpecialChars encodes special characters in file paths that would
+// break URL parsing. Specifically handles %, [, and ].
+func EncodeSpecialChars(path string) string {
+	path = strings.ReplaceAll(path, "%", "%25")
+	path = strings.ReplaceAll(path, "[", "%5B")
+	path = strings.ReplaceAll(path, "]", "%5D")
+	return path
+}
+
+// IsGistURL returns true if the repository URL is a GitHub gist.
+func IsGistURL(repo string) bool {
+	return strings.Contains(repo, "gist.github.com")
+}
+
+// IsWikiURL returns true if the repository URL is a GitHub wiki.
+func IsWikiURL(repo string) bool {
+	return strings.HasSuffix(repo, ".wiki.git")
+}
+
+// TrimWikiSuffix removes the .wiki.git suffix from a repository URL.
+func TrimWikiSuffix(repo string) string {
+	return strings.TrimSuffix(repo, ".wiki.git")
+}
+
+// CleanGistFilename converts a filename to the format used in gist URLs.
+// Dots in filenames are replaced with hyphens.
+func CleanGistFilename(filename string) string {
+	return strings.ReplaceAll(filename, ".", "-")
+}
+
+// TrimFileExtension removes the file extension from a path.
+func TrimFileExtension(path string) string {
+	return strings.TrimSuffix(path, filepath.Ext(path))
+}

--- a/pkg/giturl/helpers_test.go
+++ b/pkg/giturl/helpers_test.go
@@ -1,0 +1,140 @@
+package giturl
+
+import "testing"
+
+func TestTrimGitSuffix(t *testing.T) {
+	tests := []struct {
+		name string
+		repo string
+		want string
+	}{
+		{"with .git suffix", "https://github.com/owner/repo.git", "https://github.com/owner/repo"},
+		{"without .git suffix", "https://github.com/owner/repo", "https://github.com/owner/repo"},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TrimGitSuffix(tt.repo); got != tt.want {
+				t.Errorf("TrimGitSuffix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEncodeSpecialChars(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"no special chars", "path/to/file.go", "path/to/file.go"},
+		{"percent sign", "path/with%percent.go", "path/with%25percent.go"},
+		{"square brackets", "path/with[brackets].go", "path/with%5Bbrackets%5D.go"},
+		{"all special chars", "path%[test].go", "path%25%5Btest%5D.go"},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := EncodeSpecialChars(tt.path); got != tt.want {
+				t.Errorf("EncodeSpecialChars() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsGistURL(t *testing.T) {
+	tests := []struct {
+		name string
+		repo string
+		want bool
+	}{
+		{"github gist", "https://gist.github.com/user/abc123.git", true},
+		{"github repo", "https://github.com/owner/repo.git", false},
+		{"empty string", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsGistURL(tt.repo); got != tt.want {
+				t.Errorf("IsGistURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsWikiURL(t *testing.T) {
+	tests := []struct {
+		name string
+		repo string
+		want bool
+	}{
+		{"github wiki", "https://github.com/owner/repo.wiki.git", true},
+		{"github repo", "https://github.com/owner/repo.git", false},
+		{"empty string", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsWikiURL(tt.repo); got != tt.want {
+				t.Errorf("IsWikiURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrimWikiSuffix(t *testing.T) {
+	tests := []struct {
+		name string
+		repo string
+		want string
+	}{
+		{"with .wiki.git suffix", "https://github.com/owner/repo.wiki.git", "https://github.com/owner/repo"},
+		{"without suffix", "https://github.com/owner/repo.git", "https://github.com/owner/repo.git"},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TrimWikiSuffix(tt.repo); got != tt.want {
+				t.Errorf("TrimWikiSuffix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCleanGistFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     string
+	}{
+		{"single extension", "config.yaml", "config-yaml"},
+		{"multiple extensions", "config.yaml.example", "config-yaml-example"},
+		{"no extension", "README", "README"},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CleanGistFilename(tt.filename); got != tt.want {
+				t.Errorf("CleanGistFilename() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTrimFileExtension(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"with extension", "docs/README.md", "docs/README"},
+		{"without extension", "docs/README", "docs/README"},
+		{"empty string", "", ""},
+		{"hidden file", ".gitignore", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := TrimFileExtension(tt.path); got != tt.want {
+				t.Errorf("TrimFileExtension() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -46,6 +46,12 @@ type Chunk struct {
 
 	// Verify specifies whether any secrets in the Chunk should be verified.
 	Verify bool
+
+	// UpdateLink is a source-specific function for updating line numbers in links.
+	// This function is provided by the source at initialization time and allows
+	// the engine to update links without knowing provider-specific formats.
+	// Can be nil for sources that don't support link updating.
+	SourceUpdateLink func(link string, line int64) string
 }
 
 // ChunkingTarget specifies criteria for a targeted chunking process.


### PR DESCRIPTION
## Description:

### Changes:
  - Add UpdateLink function pointer to Chunk struct for source-specific link updates
  - Implement generateLink and updateLink functions in GitHub source for all repo types
  - Extract common URL manipulation helpers to pkg/giturl/helpers.go
  - Update engine.go to call chunk.UpdateLink directly instead of UpdateLink function
  - Mark SupportsLineNumbers as deprecated (used for backward compatibility only)
  - Update Git source to pass UpdateLink function pointer from configuration
  - Add unit tests for GitHub link generation and updating

### End Goal & Future Work

Current State (This PR)

- GitHub only: Implements source-specific link generation via function pointers
- Other sources: Fall back to centralized giturl.GenerateLink() / UpdateLink()
- Engine: Checks chunk.SourceUpdateLink != nil first, then falls back to SupportsLineNumbers()

Final State (After All Iterations)

```
// Sources own their link logic
github.Init() → sets UpdateLinkFunc: s.updateLink
gitlab.Init() → sets UpdateLinkFunc: s.updateLink
bitbucket.Init() → sets UpdateLinkFunc: s.updateLink

...

// Engine stays simple
if chunk.SourceUpdateLink != nil {
    updatedLink := chunk.SourceUpdateLink(link, line)
    // Done. No provider detection needed.
}
```

What Gets Removed

- giturl.GenerateLink() - each source implements its own
- giturl.UpdateLinkLineNumber() - replaced by source functions
- SupportsLineNumbers() - replaced by nil check
- Provider detection logic in giturl package

### Note:
We can also remove the `giturl` package entirely and move the helper functions elsewhere.

Once this gets approved, we can iteratively implement this on all git flavored sources and remove the deprecated functions entirely.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
