### PR TITLE
fix: typos in comments

### DIFF
--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -20,7 +20,7 @@ type Detector interface {
 	// FromData will scan bytes for results and optionally verify them.
 	//
 	// FromData can be called concurrently from multiple goroutines.
-	// Any modification to the receiver or to global variables will need to to use some kind of synchronization.
+	// Any modification to the receiver or to global variables will need to use some kind of synchronization.
 	FromData(ctx context.Context, verify bool, data []byte) ([]Result, error)
 
 	// Keywords are used for efficiently pre-filtering chunks using substring operations.

--- a/pkg/detectors/jwt/jwt.go
+++ b/pkg/detectors/jwt/jwt.go
@@ -98,7 +98,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		case "HS256", "HS384", "HS512":
 			// The JWT *might* be valid, but we can't in general do signature verification on HMAC-based algorithms.
 			// We don't have a suitable status to represent this situation in trufflehog.
-			// (The `unknown` status is intended to indicate that an error occurred to to external environment conditions, like trannsient network errors.)
+			// (The `unknown` status is intended to indicate that an error occurred to external environment conditions, like trannsient network errors.)
 			// So instead, to avoid possible false positives, totally skip HMAC-based JWTs; don't even create results for them.
 			continue
 		}

--- a/pkg/detectors/jwt/jwt.go
+++ b/pkg/detectors/jwt/jwt.go
@@ -98,7 +98,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		case "HS256", "HS384", "HS512":
 			// The JWT *might* be valid, but we can't in general do signature verification on HMAC-based algorithms.
 			// We don't have a suitable status to represent this situation in trufflehog.
-			// (The `unknown` status is intended to indicate that an error occurred to external environment conditions, like trannsient network errors.)
+			// (The `unknown` status is intended to indicate that an error occurred due to external environmental conditions, like transient network errors.)
 			// So instead, to avoid possible false positives, totally skip HMAC-based JWTs; don't even create results for them.
 			continue
 		}


### PR DESCRIPTION
Fix typos: `to to` → `to` (x2)