### PR TITLE
Include key info for analyze

### DIFF
--- a/pkg/detectors/aws/access_keys/accesskey.go
+++ b/pkg/detectors/aws/access_keys/accesskey.go
@@ -154,6 +154,10 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				ExtraData: map[string]string{
 					"resource_type": aws.ResourceTypes[idMatch[:4]],
 				},
+				AnalysisInfo: map[string]string{
+					"access_key_id":     idMatch,
+					"secret_access_key": secretMatch,
+				},
 			}
 
 			// Decode the AWS Account ID.


### PR DESCRIPTION
The AWS detector needs to provide key info to make analyzing the results possible.