### PR TITLE
Stop using detectableChunk in processResult

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -559,7 +559,7 @@ func TestProcessResult_SourceSupportsLineNumbers_LinkUpdated(t *testing.T) {
 	// Arrange: Create an engine
 	e := Engine{results: make(chan detectors.ResultWithMetadata, 1)}
 
-	// Arrange: Create a chunk
+	// Arrange: Create a Chunk
 	chunk := sources.Chunk{
 		Data: []byte("abcde\nswordfish"),
 		SourceMetadata: &source_metadatapb.MetaData{
@@ -592,7 +592,7 @@ func TestProcessResult_IgnoreLinePresent_NothingGenerated(t *testing.T) {
 	// Arrange: Create an engine
 	e := Engine{results: make(chan detectors.ResultWithMetadata, 1)}
 
-	// Arrange: Create a detectableChunk
+	// Arrange: Create a Chunk
 	chunk := sources.Chunk{
 		Data: []byte("swordfish trufflehog:ignore"),
 		SourceMetadata: &source_metadatapb.MetaData{
@@ -622,7 +622,7 @@ func TestProcessResult_AllFieldsCopied(t *testing.T) {
 	// Arrange: Create an engine
 	e := Engine{results: make(chan detectors.ResultWithMetadata, 1)}
 
-	// Arrange: Create a detectableChunk
+	// Arrange: Create a Chunk
 	chunk := sources.Chunk{
 		SourceName: "test source",
 		SourceID:   1,

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -559,21 +559,18 @@ func TestProcessResult_SourceSupportsLineNumbers_LinkUpdated(t *testing.T) {
 	// Arrange: Create an engine
 	e := Engine{results: make(chan detectors.ResultWithMetadata, 1)}
 
-	// Arrange: Create a detectableChunk
-	data := detectableChunk{
-		chunk: sources.Chunk{
-			Data: []byte("abcde\nswordfish"),
-			SourceMetadata: &source_metadatapb.MetaData{
-				Data: &source_metadatapb.MetaData_Github{
-					Github: &source_metadatapb.Github{
-						Line: 1,
-						Link: "https://github.com/org/repo/blob/abcdef/file.txt#L1",
-					},
+	// Arrange: Create a chunk
+	chunk := sources.Chunk{
+		Data: []byte("abcde\nswordfish"),
+		SourceMetadata: &source_metadatapb.MetaData{
+			Data: &source_metadatapb.MetaData_Github{
+				Github: &source_metadatapb.Github{
+					Line: 1,
+					Link: "https://github.com/org/repo/blob/abcdef/file.txt#L1",
 				},
 			},
-			SourceType: sourcespb.SourceType_SOURCE_TYPE_GIT,
 		},
-		detector: &ahocorasick.DetectorMatch{Detector: fakeDetectorV1{}},
+		SourceType: sourcespb.SourceType_SOURCE_TYPE_GIT,
 	}
 
 	// Arrange: Create a Result
@@ -583,7 +580,7 @@ func TestProcessResult_SourceSupportsLineNumbers_LinkUpdated(t *testing.T) {
 	}
 
 	// Act
-	e.processResult(context.AddLogger(t.Context()), data, result, nil)
+	e.processResult(context.AddLogger(t.Context()), result, chunk, 0, "", nil)
 
 	// Assert that the link has been correctly updated
 	require.Len(t, e.results, 1)
@@ -596,19 +593,16 @@ func TestProcessResult_IgnoreLinePresent_NothingGenerated(t *testing.T) {
 	e := Engine{results: make(chan detectors.ResultWithMetadata, 1)}
 
 	// Arrange: Create a detectableChunk
-	data := detectableChunk{
-		chunk: sources.Chunk{
-			Data: []byte("swordfish trufflehog:ignore"),
-			SourceMetadata: &source_metadatapb.MetaData{
-				Data: &source_metadatapb.MetaData_Git{
-					Git: &source_metadatapb.Git{
-						Line: 1,
-					},
+	chunk := sources.Chunk{
+		Data: []byte("swordfish trufflehog:ignore"),
+		SourceMetadata: &source_metadatapb.MetaData{
+			Data: &source_metadatapb.MetaData_Git{
+				Git: &source_metadatapb.Git{
+					Line: 1,
 				},
 			},
-			SourceType: sourcespb.SourceType_SOURCE_TYPE_GIT,
 		},
-		detector: &ahocorasick.DetectorMatch{Detector: fakeDetectorV1{}},
+		SourceType: sourcespb.SourceType_SOURCE_TYPE_GIT,
 	}
 
 	// Arrange: Create a Result
@@ -618,7 +612,7 @@ func TestProcessResult_IgnoreLinePresent_NothingGenerated(t *testing.T) {
 	}
 
 	// Act
-	e.processResult(context.AddLogger(t.Context()), data, result, nil)
+	e.processResult(context.AddLogger(t.Context()), result, chunk, 0, "", nil)
 
 	// Assert that no results were generated
 	assert.Empty(t, e.results)
@@ -629,26 +623,22 @@ func TestProcessResult_AllFieldsCopied(t *testing.T) {
 	e := Engine{results: make(chan detectors.ResultWithMetadata, 1)}
 
 	// Arrange: Create a detectableChunk
-	data := detectableChunk{
-		chunk: sources.Chunk{
-			SourceName: "test source",
-			SourceID:   1,
-			JobID:      2,
-			SecretID:   3,
-			SourceMetadata: &source_metadatapb.MetaData{
-				Data: &source_metadatapb.MetaData_Docker{
-					Docker: &source_metadatapb.Docker{
-						File:  "file",
-						Image: "image",
-						Layer: "layer",
-						Tag:   "tag",
-					},
+	chunk := sources.Chunk{
+		SourceName: "test source",
+		SourceID:   1,
+		JobID:      2,
+		SecretID:   3,
+		SourceMetadata: &source_metadatapb.MetaData{
+			Data: &source_metadatapb.MetaData_Docker{
+				Docker: &source_metadatapb.Docker{
+					File:  "file",
+					Image: "image",
+					Layer: "layer",
+					Tag:   "tag",
 				},
 			},
-			SourceType: sourcespb.SourceType_SOURCE_TYPE_DOCKER,
 		},
-		decoder:  detectorspb.DecoderType_PLAIN,
-		detector: &ahocorasick.DetectorMatch{Detector: fakeDetectorV1{}},
+		SourceType: sourcespb.SourceType_SOURCE_TYPE_DOCKER,
 	}
 
 	// Arrange: Create a Result
@@ -662,12 +652,12 @@ func TestProcessResult_AllFieldsCopied(t *testing.T) {
 	}
 
 	// Act
-	e.processResult(context.AddLogger(t.Context()), data, result, nil)
+	e.processResult(context.AddLogger(t.Context()), result, chunk, detectorspb.DecoderType_PLAIN, "a detector that detects", nil)
 
 	// Assert that the single generated result has the correct fields
 	require.Len(t, e.results, 1)
 	r := <-e.results
-	if diff := cmp.Diff(data.chunk.SourceMetadata, r.SourceMetadata, protocmp.Transform()); diff != "" {
+	if diff := cmp.Diff(chunk.SourceMetadata, r.SourceMetadata, protocmp.Transform()); diff != "" {
 		t.Errorf("metadata mismatch (-want +got):\n%s", diff)
 	}
 	assert.Equal(t, map[string]string{"key": "value"}, r.ExtraData)
@@ -682,6 +672,7 @@ func TestProcessResult_AllFieldsCopied(t *testing.T) {
 	assert.Equal(t, "test source", r.SourceName)
 	assert.Equal(t, sourcespb.SourceType_SOURCE_TYPE_DOCKER, r.SourceType)
 	assert.Equal(t, detectorspb.DecoderType_PLAIN, r.DecoderType)
+	assert.Equal(t, "a detector that detects", r.DetectorDescription)
 }
 
 func TestProcessResult_FalsePositiveFlagSetCorrectly(t *testing.T) {
@@ -722,10 +713,6 @@ func TestProcessResult_FalsePositiveFlagSetCorrectly(t *testing.T) {
 			// Arrange: Create an Engine
 			e := Engine{results: make(chan detectors.ResultWithMetadata, 1)}
 
-			// Arrange: Create a detectableChunk
-			// (It needs a DetectorMatch to avoid a panic.)
-			data := detectableChunk{detector: &ahocorasick.DetectorMatch{Detector: fakeDetectorV1{}}}
-
 			// Arrange: Create a Result
 			res := detectors.Result{
 				Raw:      []byte("something not nil"), // The false positive check is not run when Raw is nil
@@ -736,7 +723,7 @@ func TestProcessResult_FalsePositiveFlagSetCorrectly(t *testing.T) {
 			isFalsePositive := func(_ detectors.Result) (bool, string) { return tt.isFalsePositive, "" }
 
 			// Act
-			e.processResult(context.AddLogger(t.Context()), data, res, isFalsePositive)
+			e.processResult(context.AddLogger(t.Context()), res, sources.Chunk{}, 0, "", isFalsePositive)
 
 			// Assert that the single generated result has the correct false positive flag
 			require.Len(t, e.results, 1)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The `processResult` function took a `detectableChunk` as a parameter, but that was purely out of convenience, because callers originally happened to have that type available. We later added more callers that didn't have a `detectableChunk` available, so they had to _synthesize_ one. This was tolerable, but we're exploring more refactors that will introduce `processResult` callers that _cannot_ synthesize a `detectableChunk` (because they don't have the right information available). This PR therefore modifies the signature of `processResult` to require _only_ the necessary information so that we're not sandbagged by this unrelated structure down the road.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
