### PR TITLE
fix(github): preserve trailing hyphens in repository names

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -1138,10 +1138,16 @@ func getRepoURLParts(repoURLString string) (string, []string, error) {
 		repoURL.User = nil
 	}
 
+	// Use Host and Path directly instead of reconstructing via String().
+	// This preserves special characters like trailing hyphens in repo names
+	// that might be lost during URL reconstruction.
+	// See: https://github.com/trufflesecurity/trufflehog/issues/4679
+	host := repoURL.Host
+	path := strings.TrimPrefix(repoURL.Path, "/")
+	path = strings.TrimSuffix(path, ".git")
+
 	urlString := repoURL.String()
-	trimmedURL := strings.TrimPrefix(urlString, repoURL.Scheme+"://")
-	trimmedURL = strings.TrimSuffix(trimmedURL, ".git")
-	urlParts := strings.Split(trimmedURL, "/")
+	urlParts := append([]string{host}, strings.Split(path, "/")...)
 
 	// Validate
 	switch len(urlParts) {

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -973,6 +973,52 @@ func TestGetRepoURLParts(t *testing.T) {
 	}
 }
 
+func TestGetRepoURLPartsWithTrailingHyphen(t *testing.T) {
+	// Test for https://github.com/trufflesecurity/trufflehog/issues/4679
+	// Repository names ending with a hyphen should be preserved correctly.
+	testCases := []struct {
+		name     string
+		url      string
+		expected []string
+	}{
+		{
+			name:     "https with trailing hyphen",
+			url:      "https://github.com/MYORG/my-repo-name-.git",
+			expected: []string{"github.com", "MYORG", "my-repo-name-"},
+		},
+		{
+			name:     "https with trailing hyphen no .git",
+			url:      "https://github.com/MYORG/my-repo-.git",
+			expected: []string{"github.com", "MYORG", "my-repo-"},
+		},
+		{
+			name:     "ssh with trailing hyphen",
+			url:      "ssh://git@github.com/MYORG/test-repo-.git",
+			expected: []string{"github.com", "MYORG", "test-repo-"},
+		},
+		{
+			name:     "multiple hyphens with trailing",
+			url:      "https://github.com/org-name/my-test-repo-.git",
+			expected: []string{"github.com", "org-name", "my-test-repo-"},
+		},
+		{
+			name:     "single trailing hyphen repo",
+			url:      "https://github.com/Org/-.git",
+			expected: []string{"github.com", "Org", "-"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, parts, err := getRepoURLParts(tc.url)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			assert.Equal(t, tc.expected, parts)
+		})
+	}
+}
+
 func TestGetGistID(t *testing.T) {
 	tests := []struct {
 		trimmedURL []string


### PR DESCRIPTION
### Description:

Fix a bug where repository names ending with a hyphen (e.g., `my-repo-`) would have the trailing hyphen stripped when parsing the URL, causing 404 errors when trying to access the repository via the GitHub API.

**Root cause:** The `getRepoURLParts()` function reconstructed the URL via `url.URL.String()` and then re-parsed it by splitting on `/`. This process could lose trailing special characters in certain edge cases.

**Fix:** Use `repoURL.Host` and `repoURL.Path` directly instead of reconstructing via `String()`, which preserves the original path including any trailing hyphens.

**Example of the bug:**
```
Input URL: https://github.com/MYORG/my-repo-name-
Expected API call: GET /repos/MYORG/my-repo-name-
Actual API call:   GET /repos/MYORG/my-repo-name  (missing trailing hyphen)
```

Fixes #4679

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

### Testing notes:

New unit tests added in `TestGetRepoURLPartsWithTrailingHyphen` covering edge cases for trailing hyphens in repository names (https, ssh, multiple hyphens, single `-` repo name).