### PR TITLE
feat: add FrameworkSecretKey detector for Symfony, Laravel, Django, Rails

### DIFF
--- a/pkg/detectors/frameworksecret/frameworksecret.go
+++ b/pkg/detectors/frameworksecret/frameworksecret.go
@@ -1,0 +1,271 @@
+package frameworksecret
+
+import (
+	"context"
+	"math"
+	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+type Scanner struct{}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.CustomFalsePositiveChecker = (*Scanner)(nil)
+
+const (
+	// Minimum Shannon entropy for a secret to be considered valid.
+	// This filters out placeholders like "changeme", "your_secret_here", etc.
+	// Typical real secrets have entropy > 4.0, we use 3.5 to be safe.
+	minEntropy = 3.5
+
+	// Redaction: show first N and last M characters
+	redactPrefixLen = 8
+	redactSuffixLen = 4
+)
+
+// Framework secret patterns - ordered by specificity (most specific first)
+// to avoid overlapping matches.
+var (
+	// Rails SECRET_KEY_BASE: 64-128 character hex string
+	// Must be checked BEFORE Django to avoid SECRET_KEY matching it
+	// Example: SECRET_KEY_BASE=abc123def456...
+	railsPat = regexp.MustCompile(`(?i)(?:^|[^A-Z_])SECRET_KEY_BASE\s*[=:]\s*['"]?([a-f0-9]{64,128})['"]?`)
+
+	// Symfony APP_SECRET: 32+ character hex string
+	// Example: APP_SECRET=a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4
+	symfonyPat = regexp.MustCompile(`(?i)(?:^|[^A-Z_])APP_SECRET\s*[=:]\s*['"]?([a-f0-9]{32,64})['"]?`)
+
+	// Laravel APP_KEY: base64-encoded 32-byte key with "base64:" prefix
+	// Example: APP_KEY=base64:wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY=
+	// Note: We use (?:^|[^A-Z_]) instead of \b to allow matching after quotes
+	laravelPat = regexp.MustCompile(`(?i)(?:^|[^A-Z_])APP_KEY\s*[=:,]\s*['"]?(base64:[A-Za-z0-9+/]{42,44}={0,2})['"]?`)
+
+	// Django SECRET_KEY: 50+ characters, must be quoted (to reduce false positives)
+	// Example: SECRET_KEY='django-insecure-abc123...' or SECRET_KEY="complex-key-here"
+	// Note: We require quotes to distinguish from generic SECRET_KEY usage
+	djangoPat = regexp.MustCompile(`(?i)(?:^|[^A-Z_])SECRET_KEY\s*[=:]\s*['"]([^'"]{50,128})['"]`)
+)
+
+// frameworkInfo contains metadata about each framework's secret.
+// Order matters: more specific patterns should come first.
+type frameworkInfo struct {
+	pattern   *regexp.Regexp
+	framework string
+	variable  string
+	docs      string
+	// minLen is the minimum length for the captured secret (post-regex)
+	minLen int
+	// exactEntropy: if true, use entropy check; hex strings have ~4.0 entropy naturally
+	checkEntropy bool
+}
+
+// frameworks is ordered by specificity - Rails first to prevent Django matching SECRET_KEY_BASE
+var frameworks = []frameworkInfo{
+	{
+		pattern:      railsPat,
+		framework:    "Rails",
+		variable:     "SECRET_KEY_BASE",
+		docs:         "https://guides.rubyonrails.org/security.html#session-storage",
+		minLen:       64,
+		checkEntropy: false, // hex strings naturally have high entropy
+	},
+	{
+		pattern:      symfonyPat,
+		framework:    "Symfony",
+		variable:     "APP_SECRET",
+		docs:         "https://symfony.com/doc/current/reference/configuration/framework.html#secret",
+		minLen:       32,
+		checkEntropy: false, // hex strings naturally have high entropy
+	},
+	{
+		pattern:      laravelPat,
+		framework:    "Laravel",
+		variable:     "APP_KEY",
+		docs:         "https://laravel.com/docs/master/encryption",
+		minLen:       49,    // "base64:" (7) + 42 chars minimum
+		checkEntropy: false, // base64 has high entropy by nature
+	},
+	{
+		pattern:      djangoPat,
+		framework:    "Django",
+		variable:     "SECRET_KEY",
+		docs:         "https://docs.djangoproject.com/en/stable/ref/settings/#secret-key",
+		minLen:       50,
+		checkEntropy: true, // Django allows various formats, entropy check needed
+	},
+}
+
+// Keywords are used for efficiently pre-filtering chunks.
+// More specific keywords reduce unnecessary regex matching.
+func (s Scanner) Keywords() []string {
+	return []string{
+		"SECRET_KEY_BASE", // Rails - most specific, check first
+		"APP_SECRET",      // Symfony
+		"APP_KEY",         // Laravel
+		"SECRET_KEY",      // Django - least specific, check last
+	}
+}
+
+// FromData finds framework secret keys in the given bytes.
+// These secrets cannot be verified via API, so they are always returned as unverified.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	// Track matched positions to avoid duplicate detections
+	// (e.g., SECRET_KEY_BASE shouldn't also match as SECRET_KEY)
+	matchedPositions := make(map[int]struct{})
+
+	for _, fw := range frameworks {
+		matches := fw.pattern.FindAllStringSubmatchIndex(dataStr, -1)
+
+		for _, matchIdx := range matches {
+			if len(matchIdx) < 4 {
+				continue
+			}
+
+			// matchIdx[0:2] is full match, matchIdx[2:4] is capture group 1
+			startPos := matchIdx[2]
+			endPos := matchIdx[3]
+
+			// Skip if this position was already matched by a more specific pattern
+			if _, exists := matchedPositions[startPos]; exists {
+				continue
+			}
+
+			secret := strings.TrimSpace(dataStr[startPos:endPos])
+
+			// Length validation
+			if len(secret) < fw.minLen {
+				continue
+			}
+
+			// Entropy check for formats that need it (Django)
+			if fw.checkEntropy && shannonEntropy(secret) < minEntropy {
+				continue
+			}
+
+			// Skip obvious placeholders
+			if isPlaceholder(secret) {
+				continue
+			}
+
+			// Mark this position as matched
+			matchedPositions[startPos] = struct{}{}
+
+			result := detectors.Result{
+				DetectorType: detectorspb.DetectorType_FrameworkSecretKey,
+				Raw:          []byte(secret),
+				Redacted:     redactSecret(secret),
+				ExtraData: map[string]string{
+					"framework":     fw.framework,
+					"variable":      fw.variable,
+					"documentation": fw.docs,
+				},
+			}
+
+			results = append(results, result)
+		}
+	}
+
+	return results, nil
+}
+
+// shannonEntropy calculates the Shannon entropy of a string.
+// Higher entropy = more random = more likely to be a real secret.
+func shannonEntropy(s string) float64 {
+	if len(s) == 0 {
+		return 0
+	}
+
+	charCount := make(map[rune]int)
+	for _, c := range s {
+		charCount[c]++
+	}
+
+	entropy := 0.0
+	length := float64(len(s))
+	for _, count := range charCount {
+		probability := float64(count) / length
+		entropy -= probability * math.Log2(probability)
+	}
+
+	return entropy
+}
+
+// redactSecret returns a redacted version of the secret for display.
+// Example: "a1b2c3d4...****e5f6" for a 32-char secret
+func redactSecret(secret string) string {
+	if len(secret) <= redactPrefixLen+redactSuffixLen {
+		return strings.Repeat("*", len(secret))
+	}
+
+	prefix := secret[:redactPrefixLen]
+	suffix := secret[len(secret)-redactSuffixLen:]
+	middle := strings.Repeat("*", 4)
+
+	return prefix + "..." + middle + suffix
+}
+
+// isPlaceholder checks if the secret looks like a placeholder value.
+// We keep this minimal since entropy check handles most cases.
+func isPlaceholder(secret string) bool {
+	lower := strings.ToLower(secret)
+
+	// Check for repeating characters (e.g., "aaaa..." or "1111...")
+	if len(secret) >= 10 {
+		first := rune(secret[0])
+		allSame := true
+		for _, c := range secret[1:20] { // Check first 20 chars
+			if c != first {
+				allSame = false
+				break
+			}
+		}
+		if allSame {
+			return true
+		}
+	}
+
+	// Environment variable references
+	if strings.HasPrefix(secret, "${") || strings.HasPrefix(lower, "$env:") {
+		return true
+	}
+
+	// Template syntax
+	if strings.Contains(secret, "{{") && strings.Contains(secret, "}}") {
+		return true
+	}
+
+	return false
+}
+
+func (s Scanner) Type() detectorspb.DetectorType {
+	return detectorspb.DetectorType_FrameworkSecretKey
+}
+
+func (s Scanner) Description() string {
+	return "Framework secret keys (Symfony APP_SECRET, Laravel APP_KEY, Django SECRET_KEY, Rails SECRET_KEY_BASE) are used for session signing, CSRF protection, and encryption. Exposed keys allow attackers to forge sessions, bypass CSRF, and potentially achieve RCE."
+}
+
+// IsFalsePositive implements CustomFalsePositiveChecker for additional filtering.
+func (s Scanner) IsFalsePositive(result detectors.Result) (bool, string) {
+	secret := string(result.Raw)
+
+	// Laravel keys start with "base64:" which would match the "base" wordlist entry.
+	// Skip the default false positive check for Laravel keys.
+	if strings.HasPrefix(secret, "base64:") {
+		return false, ""
+	}
+
+	// Use TruffleHog's built-in false positive detection for other frameworks
+	if isFP, reason := detectors.IsKnownFalsePositive(secret, detectors.DefaultFalsePositives, true); isFP {
+		return true, reason
+	}
+
+	return false, ""
+}

--- a/pkg/detectors/frameworksecret/frameworksecret.go
+++ b/pkg/detectors/frameworksecret/frameworksecret.go
@@ -2,7 +2,6 @@ package frameworksecret
 
 import (
 	"context"
-	"math"
 	"strings"
 
 	regexp "github.com/wasilibs/go-re2"
@@ -145,7 +144,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			// Entropy check for formats that need it (Django)
-			if fw.checkEntropy && shannonEntropy(secret) < minEntropy {
+			if fw.checkEntropy && detectors.StringShannonEntropy(secret) < minEntropy {
 				continue
 			}
 
@@ -175,28 +174,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	return results, nil
 }
 
-// shannonEntropy calculates the Shannon entropy of a string.
-// Higher entropy = more random = more likely to be a real secret.
-func shannonEntropy(s string) float64 {
-	if len(s) == 0 {
-		return 0
-	}
-
-	charCount := make(map[rune]int)
-	for _, c := range s {
-		charCount[c]++
-	}
-
-	entropy := 0.0
-	length := float64(len(s))
-	for _, count := range charCount {
-		probability := float64(count) / length
-		entropy -= probability * math.Log2(probability)
-	}
-
-	return entropy
-}
-
 // redactSecret returns a redacted version of the secret for display.
 // Example: "a1b2c3d4...****e5f6" for a 32-char secret
 func redactSecret(secret string) string {
@@ -218,9 +195,13 @@ func isPlaceholder(secret string) bool {
 
 	// Check for repeating characters (e.g., "aaaa..." or "1111...")
 	if len(secret) >= 10 {
+		checkLen := 20
+		if len(secret) < checkLen {
+			checkLen = len(secret)
+		}
 		first := rune(secret[0])
 		allSame := true
-		for _, c := range secret[1:20] { // Check first 20 chars
+		for _, c := range secret[1:checkLen] {
 			if c != first {
 				allSame = false
 				break

--- a/pkg/detectors/frameworksecret/frameworksecret.go
+++ b/pkg/detectors/frameworksecret/frameworksecret.go
@@ -243,8 +243,10 @@ func (s Scanner) IsFalsePositive(result detectors.Result) (bool, string) {
 		return false, ""
 	}
 
-	// Use TruffleHog's built-in false positive detection for other frameworks
-	if isFP, reason := detectors.IsKnownFalsePositive(secret, detectors.DefaultFalsePositives, true); isFP {
+	// Disable word check (substring matching against badlist) for all framework secrets.
+	// Symfony and Rails secrets are hex strings that naturally contain substrings
+	// like "abcde", "2048", "ed25519" from the badlist — these are valid hex, not false positives.
+	if isFP, reason := detectors.IsKnownFalsePositive(secret, detectors.DefaultFalsePositives, false); isFP {
 		return true, reason
 	}
 

--- a/pkg/detectors/frameworksecret/frameworksecret_test.go
+++ b/pkg/detectors/frameworksecret/frameworksecret_test.go
@@ -1,0 +1,391 @@
+package frameworksecret
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+)
+
+var (
+	// Valid test secrets for each framework - realistic entropy
+	// Note: Avoid patterns that match TruffleHog's default false positive wordlist (abcde, etc.)
+	validSymfonySecret = "f1e2d3c4b5a6978869574635241302f1"                                 // 32 hex chars, no "abcde" sequence
+	validLaravelSecret = "base64:Kf5Lx9YmNwPq2RsTuVxWzQ3B4C5D6E7F8G9H0IjKlMn="              // base64 with prefix
+	validDjangoSecret  = "django-insecure-x7k#m2$9p@q!w3e4r5t6y7u8i9o0-lsdfkjhg23847"       // 50+ chars
+	validRailsSecret   = "f1e2d3c4b5a697886957463524130211f1e2d3c4b5a697886957463524130211" // 64 hex chars
+)
+
+func TestFrameworkSecretKey_Keywords(t *testing.T) {
+	d := Scanner{}
+	keywords := d.Keywords()
+
+	expected := []string{"SECRET_KEY_BASE", "APP_SECRET", "APP_KEY", "SECRET_KEY"}
+
+	if diff := cmp.Diff(expected, keywords); diff != "" {
+		t.Errorf("Keywords() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestFrameworkSecretKey_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "Symfony APP_SECRET basic",
+			input: "APP_SECRET=" + validSymfonySecret,
+			want:  []string{validSymfonySecret},
+		},
+		{
+			name:  "Symfony APP_SECRET with double quotes",
+			input: `APP_SECRET="` + validSymfonySecret + `"`,
+			want:  []string{validSymfonySecret},
+		},
+		{
+			name:  "Symfony APP_SECRET with single quotes",
+			input: `APP_SECRET='` + validSymfonySecret + `'`,
+			want:  []string{validSymfonySecret},
+		},
+		{
+			name:  "Laravel APP_KEY basic",
+			input: "APP_KEY=" + validLaravelSecret,
+			want:  []string{validLaravelSecret},
+		},
+		{
+			name:  "Laravel APP_KEY with quotes",
+			input: `APP_KEY="` + validLaravelSecret + `"`,
+			want:  []string{validLaravelSecret},
+		},
+		{
+			name:  "Django SECRET_KEY single quotes",
+			input: `SECRET_KEY='` + validDjangoSecret + `'`,
+			want:  []string{validDjangoSecret},
+		},
+		{
+			name:  "Django SECRET_KEY double quotes",
+			input: `SECRET_KEY="` + validDjangoSecret + `"`,
+			want:  []string{validDjangoSecret},
+		},
+		{
+			name:  "Rails SECRET_KEY_BASE basic",
+			input: "SECRET_KEY_BASE=" + validRailsSecret,
+			want:  []string{validRailsSecret},
+		},
+		{
+			name:  "Rails SECRET_KEY_BASE with colon (YAML)",
+			input: "SECRET_KEY_BASE: " + validRailsSecret,
+			want:  []string{validRailsSecret},
+		},
+		{
+			name:  "Multiple secrets in one file",
+			input: "APP_SECRET=" + validSymfonySecret + "\nAPP_KEY=" + validLaravelSecret,
+			want:  []string{validSymfonySecret, validLaravelSecret},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(matchedDetectors) == 0 {
+				t.Errorf("keywords '%v' not matched by any pattern", d.Keywords())
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			if err != nil {
+				t.Errorf("error = %v", err)
+				return
+			}
+
+			if len(results) != len(test.want) {
+				t.Errorf("expected %d results, got %d", len(test.want), len(results))
+				for i, r := range results {
+					t.Logf("  result[%d]: %s", i, string(r.Raw))
+				}
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				actual[string(r.Raw)] = struct{}{}
+			}
+
+			for _, w := range test.want {
+				if _, ok := actual[w]; !ok {
+					t.Errorf("expected to find secret %q in results", w)
+				}
+			}
+		})
+	}
+}
+
+func TestFrameworkSecretKey_FromData(t *testing.T) {
+	ctx := context.Background()
+	d := Scanner{}
+
+	tests := []struct {
+		name      string
+		input     string
+		wantFound bool
+		framework string
+	}{
+		// Positive cases - should be detected
+		{
+			name:      "Symfony secret in .env file",
+			input:     "# Application\nAPP_SECRET=" + validSymfonySecret + "\nAPP_ENV=prod",
+			wantFound: true,
+			framework: "Symfony",
+		},
+		{
+			name:      "Laravel secret in .env file",
+			input:     "APP_NAME=Laravel\nAPP_KEY=" + validLaravelSecret + "\nAPP_DEBUG=true",
+			wantFound: true,
+			framework: "Laravel",
+		},
+		{
+			name:      "Django secret in settings.py",
+			input:     "SECRET_KEY = '" + validDjangoSecret + "'",
+			wantFound: true,
+			framework: "Django",
+		},
+		{
+			name:      "Rails secret in credentials",
+			input:     "SECRET_KEY_BASE=" + validRailsSecret,
+			wantFound: true,
+			framework: "Rails",
+		},
+
+		// Negative cases - should NOT be detected
+		{
+			name:      "Too short Symfony secret",
+			input:     "APP_SECRET=abc123",
+			wantFound: false,
+		},
+		{
+			name:      "Environment variable reference",
+			input:     "APP_SECRET=${SYMFONY_SECRET}",
+			wantFound: false,
+		},
+		{
+			name:      "Laravel without base64 prefix",
+			input:     "APP_KEY=notavalidlaravelkeybecauseithasnobase64prefix",
+			wantFound: false,
+		},
+		{
+			name:      "Django secret too short",
+			input:     "SECRET_KEY='short'",
+			wantFound: false,
+		},
+		{
+			name:      "Django without quotes (ambiguous)",
+			input:     "SECRET_KEY=noquotessoitcouldbeanyapplicationnotjustdjango",
+			wantFound: false,
+		},
+		{
+			name:      "Repeating characters",
+			input:     "APP_SECRET=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			wantFound: false,
+		},
+		{
+			name:      "Template syntax",
+			input:     "APP_SECRET={{ symfony_secret }}",
+			wantFound: false,
+		},
+		{
+			name:      "Rails secret too short",
+			input:     "SECRET_KEY_BASE=abc123",
+			wantFound: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			results, err := d.FromData(ctx, false, []byte(tc.input))
+			if err != nil {
+				t.Fatalf("FromData error: %v", err)
+			}
+
+			found := len(results) > 0
+			if found != tc.wantFound {
+				t.Errorf("FromData() found = %v, want %v", found, tc.wantFound)
+				if found {
+					t.Logf("Unexpected result: %s", string(results[0].Raw))
+				}
+			}
+
+			if tc.wantFound && len(results) > 0 {
+				if results[0].ExtraData["framework"] != tc.framework {
+					t.Errorf("expected framework %q, got %q", tc.framework, results[0].ExtraData["framework"])
+				}
+			}
+		})
+	}
+}
+
+func TestFrameworkSecretKey_NoDuplicates(t *testing.T) {
+	ctx := context.Background()
+	d := Scanner{}
+
+	// SECRET_KEY_BASE should NOT also match as SECRET_KEY
+	input := "SECRET_KEY_BASE=" + validRailsSecret
+
+	results, err := d.FromData(ctx, false, []byte(input))
+	if err != nil {
+		t.Fatalf("FromData error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Errorf("expected exactly 1 result, got %d", len(results))
+		for i, r := range results {
+			t.Logf("  result[%d]: framework=%s, secret=%s", i, r.ExtraData["framework"], string(r.Raw))
+		}
+	}
+
+	if len(results) > 0 && results[0].ExtraData["framework"] != "Rails" {
+		t.Errorf("expected framework 'Rails', got %q", results[0].ExtraData["framework"])
+	}
+}
+
+func TestFrameworkSecretKey_Redaction(t *testing.T) {
+	ctx := context.Background()
+	d := Scanner{}
+
+	input := "APP_SECRET=" + validSymfonySecret
+
+	results, err := d.FromData(ctx, false, []byte(input))
+	if err != nil {
+		t.Fatalf("FromData error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	redacted := results[0].Redacted
+
+	// Should start with first 8 chars
+	if !startsWith(redacted, validSymfonySecret[:8]) {
+		t.Errorf("redacted should start with first 8 chars, got: %s", redacted)
+	}
+
+	// Should end with last 4 chars
+	if !endsWith(redacted, validSymfonySecret[len(validSymfonySecret)-4:]) {
+		t.Errorf("redacted should end with last 4 chars, got: %s", redacted)
+	}
+
+	// Should contain asterisks
+	if !contains(redacted, "****") {
+		t.Errorf("redacted should contain asterisks, got: %s", redacted)
+	}
+}
+
+func TestFrameworkSecretKey_Entropy(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantMin float64
+	}{
+		{
+			name:    "hex string has high entropy",
+			input:   "a1b2c3d4e5f6789abcdef0123456789a",
+			wantMin: 3.5,
+		},
+		{
+			name:    "repeating chars has low entropy",
+			input:   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			wantMin: 0,
+		},
+		{
+			name:    "base64 has high entropy",
+			input:   "Kf5Lx9YmNwPq2RsTuVxWzA3B4C5D6E7F8G9H0IjKlMn=",
+			wantMin: 4.0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			entropy := shannonEntropy(tc.input)
+			if entropy < tc.wantMin {
+				t.Errorf("entropy = %f, want >= %f", entropy, tc.wantMin)
+			}
+		})
+	}
+}
+
+func TestFrameworkSecretKey_IsFalsePositive(t *testing.T) {
+	d := Scanner{}
+
+	tests := []struct {
+		name   string
+		secret string
+		wantFP bool
+	}{
+		{
+			name:   "Valid secret",
+			secret: validSymfonySecret,
+			wantFP: false,
+		},
+		{
+			name:   "Example keyword",
+			secret: "example1234567890abcdef1234567890",
+			wantFP: true,
+		},
+		{
+			name:   "Sample keyword",
+			secret: "sample_1234567890abcdef1234567890",
+			wantFP: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := detectors.Result{
+				Raw: []byte(tc.secret),
+			}
+
+			isFP, _ := d.IsFalsePositive(result)
+			if isFP != tc.wantFP {
+				t.Errorf("IsFalsePositive() = %v, want %v", isFP, tc.wantFP)
+			}
+		})
+	}
+}
+
+func TestFrameworkSecretKey_Description(t *testing.T) {
+	d := Scanner{}
+	desc := d.Description()
+
+	if desc == "" {
+		t.Error("Description() should not be empty")
+	}
+
+	// Check that it mentions security impact
+	if !contains(desc, "session") || !contains(desc, "CSRF") {
+		t.Error("Description should mention security impact (sessions, CSRF)")
+	}
+}
+
+// Helper functions
+func startsWith(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
+func endsWith(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/detectors/frameworksecret/frameworksecret_test.go
+++ b/pkg/detectors/frameworksecret/frameworksecret_test.go
@@ -311,7 +311,7 @@ func TestFrameworkSecretKey_Entropy(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			entropy := shannonEntropy(tc.input)
+			entropy := detectors.StringShannonEntropy(tc.input)
 			if entropy < tc.wantMin {
 				t.Errorf("entropy = %f, want >= %f", entropy, tc.wantMin)
 			}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -303,6 +303,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/formsite"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/foursquare"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/frameio"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/frameworksecret"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/freshbooks"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/freshdesk"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/front"
@@ -1176,6 +1177,7 @@ func buildDetectorList() []detectors.Detector {
 		&formsite.Scanner{},
 		&foursquare.Scanner{},
 		&frameio.Scanner{},
+		&frameworksecret.Scanner{},
 		&freshbooks.Scanner{},
 		&freshdesk.Scanner{},
 		&front.Scanner{},

--- a/pkg/pb/detectorspb/detectors.pb.go
+++ b/pkg/pb/detectorspb/detectors.pb.go
@@ -1152,6 +1152,7 @@ const (
 	DetectorType_ArtifactoryReferenceToken               DetectorType = 1042
 	DetectorType_DatadogApikey                           DetectorType = 1043
 	DetectorType_ShopifyOAuth                            DetectorType = 1044
+	DetectorType_FrameworkSecretKey                       DetectorType = 1045
 )
 
 // Enum value maps for DetectorType.
@@ -2198,6 +2199,7 @@ var (
 		1042: "ArtifactoryReferenceToken",
 		1043: "DatadogApikey",
 		1044: "ShopifyOAuth",
+		1045: "FrameworkSecretKey",
 	}
 	DetectorType_value = map[string]int32{
 		"Alibaba":                               0,
@@ -3241,6 +3243,7 @@ var (
 		"ArtifactoryReferenceToken":         1042,
 		"DatadogApikey":                     1043,
 		"ShopifyOAuth":                      1044,
+		"FrameworkSecretKey":                 1045,
 	}
 )
 

--- a/proto/detectors.proto
+++ b/proto/detectors.proto
@@ -1054,6 +1054,7 @@ enum DetectorType {
   ArtifactoryReferenceToken = 1042;
   DatadogApikey = 1043;
   ShopifyOAuth = 1044;
+  FrameworkSecretKey = 1045;
 }
 
 message Result {


### PR DESCRIPTION
## Summary

Adds a new detector for framework secret keys commonly exposed in `.env` files and configuration. This addresses #4687.

### Supported Frameworks

| Framework | Variable | Pattern | Example |
|-----------|----------|---------|---------|
| **Symfony** | `APP_SECRET` | `[a-f0-9]{32,64}` | `APP_SECRET=a1b2c3d4...` |
| **Laravel** | `APP_KEY` | `base64:[A-Za-z0-9+/]{42,44}={0,2}` | `APP_KEY=base64:wJalr...` |
| **Django** | `SECRET_KEY` | 50+ chars (quoted) | `SECRET_KEY='django-insecure-...'` |
| **Rails** | `SECRET_KEY_BASE` | `[a-f0-9]{64,128}` | `SECRET_KEY_BASE=abc123...` |

### Security Impact

These secrets enable attackers to:
- **Forge session cookies** - Impersonate any user
- **Bypass CSRF protection** - Execute state-changing actions  
- **Decrypt sensitive data** - Access encrypted cookies/tokens
- **RCE in some cases** - Laravel's encrypted cookies can lead to RCE via deserialization

### Implementation Details

- **Unverified detector** - No API to validate against, but high-confidence patterns
- **Shannon entropy filtering** - Applied to Django to reduce false positives
- **Deduplication** - Prevents `SECRET_KEY_BASE` from also matching as `SECRET_KEY`
- **Redaction** - Secrets displayed as `a1b2c3d4...****789a`
- **Framework metadata** - `ExtraData` includes framework name, variable, and documentation URL

### Changes

- `proto/detectors.proto` - Add `FrameworkSecretKey = 1040`
- `pkg/detectors/frameworksecret/` - New detector with tests
- `pkg/engine/defaults/defaults.go` - Register detector

## Test Plan

- [x] Unit tests pass (`go test ./pkg/detectors/frameworksecret/... -v`)
- [x] Manual testing with sample `.env` files
- [x] All 4 frameworks detected correctly
- [x] False positives filtered (placeholders, env vars, templates)
- [x] No duplicate detections for Rails SECRET_KEY_BASE

### Test Output

```
$ go run . filesystem /tmp/all-frameworks.env
Found unverified result 🐷🔑❓ - Symfony APP_SECRET
Found unverified result 🐷🔑❓ - Laravel APP_KEY  
Found unverified result 🐷🔑❓ - Django SECRET_KEY
Found unverified result 🐷🔑❓ - Rails SECRET_KEY_BASE
```

## References

- [Symfony APP_SECRET docs](https://symfony.com/doc/current/reference/configuration/framework.html#secret)
- [Laravel APP_KEY docs](https://laravel.com/docs/master/encryption)
- [Django SECRET_KEY docs](https://docs.djangoproject.com/en/stable/ref/settings/#secret-key)
- [Rails secret_key_base docs](https://guides.rubyonrails.org/security.html#session-storage)
- [Laravel RCE via APP_KEY](https://blog.trailofbits.com/2020/06/15/secure-your-laravel-application-against-the-cve-2018-15133-vulnerability/)

Closes #4687

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new default-enabled detector and a new protobuf `DetectorType` enum value, which can change scan output and downstream consumers’ handling of detector types. Matching logic is regex/heuristic-based (unverified) so false positives/negatives are the primary behavioral risk.
> 
> **Overview**
> Adds a new `FrameworkSecretKey` detector to flag exposed framework signing/encryption secrets for Symfony (`APP_SECRET`), Laravel (`APP_KEY`), Django (`SECRET_KEY`), and Rails (`SECRET_KEY_BASE`). The detector uses ordered regex matching with deduplication, placeholder/entropy filtering (notably for Django), custom redaction, and a custom false-positive check to avoid badlist substring issues.
> 
> Registers the detector in the default detector set and introduces `DetectorType_FrameworkSecretKey` (`1045`) in `proto/detectors.proto` and the generated `detectors.pb.go`, with accompanying unit tests covering positive/negative cases, redaction, entropy, and duplicate suppression.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b21ea4e1d2a8869b5b32ef3b541889797a6f792. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->