### PR TITLE
Skip failing Git Engine test

### DIFF
--- a/pkg/engine/git_test.go
+++ b/pkg/engine/git_test.go
@@ -124,6 +124,7 @@ func TestGitEngine(t *testing.T) {
 }
 
 func TestGitEngineWithMirrorAndBareClones(t *testing.T) {
+	t.Skip("INS-289")
 	ctx := context.Background()
 
 	parent, err := os.MkdirTemp("", "trufflehog-test-keys-*")


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
It appears that one of our test repositories got deleted somehow. It's causing a test to fail. I'm skipping this test while we investigate this, so that it unblocks other merges.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
