### PR TITLE
Re-enable Git Engine Test

### DIFF
--- a/pkg/engine/git_test.go
+++ b/pkg/engine/git_test.go
@@ -124,7 +124,6 @@ func TestGitEngine(t *testing.T) {
 }
 
 func TestGitEngineWithMirrorAndBareClones(t *testing.T) {
-	t.Skip("INS-289")
 	ctx := context.Background()
 
 	parent, err := os.MkdirTemp("", "trufflehog-test-keys-*")


### PR DESCRIPTION
The `TestGitEngineWithMirrorAndBareClones` test was temporarily skipped because the `trufflesecurity/test_keys` repo was inaccessible. The repo has now been restored, so this PR re-enables the test.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
