### PR TITLE
Added Analysis info to tableau detector

### DIFF
--- a/pkg/detectors/tableau/tableau.go
+++ b/pkg/detectors/tableau/tableau.go
@@ -97,6 +97,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					result.Verified = isVerified
 					maps.Copy(result.ExtraData, extraData)
 					result.SetVerificationError(verificationErr, tokenName, tokenSecret, endpoint)
+					if isVerified {
+						result.AnalysisInfo = map[string]string{"tokenName": tokenName, "patSecret": tokenSecret, "endpoint": endpoint}
+					}
 				}
 				results = append(results, result)
 			}

--- a/pkg/detectors/tableau/tableau_integration_test.go
+++ b/pkg/detectors/tableau/tableau_integration_test.go
@@ -69,6 +69,11 @@ func TestTableau_FromChunk(t *testing.T) {
 						"verification_status":   "valid",
 						"auth_token_received":   "true",
 					},
+					AnalysisInfo: map[string]string{
+						"endpoint":  tableauURL,
+						"patSecret": tokenSecret,
+						"tokenName": tokenName,
+					},
 				},
 			},
 			wantErr: false,
@@ -254,7 +259,7 @@ func TestTableau_FromChunk(t *testing.T) {
 			}
 
 			ignoreOpts := []cmp.Option{
-				cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "ExtraData"),
+				cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "ExtraData", "AnalysisInfo"),
 				cmpopts.IgnoreUnexported(detectors.Result{}),
 			}
 


### PR DESCRIPTION
### Description:
This PR adds `analysisInfo` in `detector.Result` struct of tableau detector to support tableau analyzer.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
