### PR TITLE
Unify some false positive logic

### DIFF
--- a/pkg/detectors/falsepositives.go
+++ b/pkg/detectors/falsepositives.go
@@ -2,7 +2,6 @@ package detectors
 
 import (
 	_ "embed"
-	"fmt"
 	"math"
 	"strings"
 	"unicode"
@@ -170,32 +169,5 @@ func FilterResultsWithEntropy(ctx context.Context, results []Result, entropy flo
 			filteredResults = append(filteredResults, result)
 		}
 	}
-	return filteredResults
-}
-
-// FilterKnownFalsePositives filters out known false positives from the results.
-func FilterKnownFalsePositives(ctx context.Context, detector Detector, results []Result) []Result {
-	var filteredResults []Result
-
-	isFalsePositive := GetFalsePositiveCheck(detector)
-
-	for _, result := range results {
-		if len(result.Raw) == 0 {
-			ctx.Logger().Error(fmt.Errorf("empty raw"), "Skipping result: invalid")
-			continue
-		}
-
-		if result.Verified {
-			filteredResults = append(filteredResults, result)
-			continue
-		}
-
-		if isFp, reason := isFalsePositive(result); isFp {
-			ctx.Logger().V(4).Info("Skipping result: false positive", "result", string(result.Raw), "reason", reason)
-			continue
-		}
-		filteredResults = append(filteredResults, result)
-	}
-
 	return filteredResults
 }

--- a/pkg/detectors/falsepositives_test.go
+++ b/pkg/detectors/falsepositives_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
 )
 
@@ -74,41 +73,6 @@ func TestGetFalsePositiveCheck_CustomLogic(t *testing.T) {
 		isFalsePositive, _ := GetFalsePositiveCheck(customFalsePositiveChecker{})(Result{Raw: []byte(tt.raw)})
 		assert.Equal(t, tt.isFalsePositive, isFalsePositive, "secret %q had unexpected false positive status", tt.raw)
 	}
-}
-
-func TestFilterKnownFalsePositives_DefaultLogic(t *testing.T) {
-	results := []Result{
-		{Raw: []byte("00000")},  // "default" false positive list
-		{Raw: []byte("number")}, // from wordlist
-		// from uuid list
-		{Raw: []byte("00000000-0000-0000-0000-000000000000")},
-		{Raw: []byte("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx")},
-		// real secrets
-		{Raw: []byte("hga8adshla3434g")},
-		{Raw: []byte("f795f7db-2dfe-4095-96f3-8f8370c735f9")},
-	}
-	expected := []Result{
-		{Raw: []byte("hga8adshla3434g")},
-		{Raw: []byte("f795f7db-2dfe-4095-96f3-8f8370c735f9")},
-	}
-	filtered := FilterKnownFalsePositives(logContext.Background(), fakeDetector{}, results)
-	assert.ElementsMatch(t, expected, filtered)
-}
-
-func TestFilterKnownFalsePositives_CustomLogic(t *testing.T) {
-	results := []Result{
-		{Raw: []byte("a specific magic string")}, // specific target
-		{Raw: []byte("00000")},                   // "default" false positive list
-		{Raw: []byte("number")},                  // from wordlist
-		{Raw: []byte("hga8adshla3434g")},         // real secret
-	}
-	expected := []Result{
-		{Raw: []byte("00000")},
-		{Raw: []byte("number")},
-		{Raw: []byte("hga8adshla3434g")},
-	}
-	filtered := FilterKnownFalsePositives(logContext.Background(), customFalsePositiveChecker{}, results)
-	assert.ElementsMatch(t, expected, filtered)
 }
 
 func TestIsFalsePositive(t *testing.T) {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The (wordlist) false positive check used to happen in two places: Within `filterResults` (a catchall function that dropped findings for various configuration-dependent reasons), and _again_ in `processResult`, which didn't _drop_ findings, but instead annotated them with a boolean flag to indicate false positivity. Both of these two functions are themselves called in two separate places.

This redundancy is confusing and has led to at least one known bug. This PR moves the filtration from `filterResults` to the end of the engine, where results are now dropped based on the false positive flag previously set in `processResult`. The net effect is that false positive filtration is only executed in one place (instead of two) and the actual false positive checking is only executed in two places (instead of four).

There are additional improvements along this line that could be made (e.g. moving entropy filtering as well) but I want to do things very slowly and incrementally.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
