### PR TITLE
Add anypoint oauth2 detector to defaults.go

### DIFF
--- a/pkg/detectors/anypointoauth2/anypointoauth2.go
+++ b/pkg/detectors/anypointoauth2/anypointoauth2.go
@@ -77,7 +77,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				isVerified, verificationErr := verifyMatch(ctx, client, id, secret)
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr)
-
+				if isVerified {
+					s1.AnalysisInfo = map[string]string{
+						"id":     id,
+						"secret": secret,
+					}
+				}
 			}
 
 			results = append(results, s1)
@@ -86,10 +91,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				// Anypoint client IDs and secrets are mapped one-to-one, so if a pair
 				// is verified, we can remove that secret from the uniqueSecrets map.
 				delete(uniqueSecrets, secret)
-				s1.AnalysisInfo = map[string]string{
-					"id":     id,
-					"secret": secret,
-				}
 				break
 			}
 		}

--- a/pkg/detectors/anypointoauth2/anypointoauth2.go
+++ b/pkg/detectors/anypointoauth2/anypointoauth2.go
@@ -86,6 +86,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				// Anypoint client IDs and secrets are mapped one-to-one, so if a pair
 				// is verified, we can remove that secret from the uniqueSecrets map.
 				delete(uniqueSecrets, secret)
+				s1.AnalysisInfo = map[string]string{
+					"id":     id,
+					"secret": secret,
+				}
 				break
 			}
 		}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -30,6 +30,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/amplitudeapikey"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/anthropic"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/anypoint"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/anypointoauth2"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/apacta"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/api2cart"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/apideck"
@@ -891,6 +892,7 @@ func buildDetectorList() []detectors.Detector {
 		&amplitudeapikey.Scanner{},
 		&anthropic.Scanner{},
 		&anypoint.Scanner{},
+		&anypointoauth2.Scanner{},
 		&apacta.Scanner{},
 		&api2cart.Scanner{},
 		&apideck.Scanner{},


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
It turns out we had the Anypoint OAuth2 detector for quite some time, but it was never really used because we didn't add it to `defaults.go`. This PR adds it.

While we're at it, I also added the `AnalysisInfo` for Anypoint OAuth2.

Update: I tested this against the corpora of data (Both the 30GB and the 3GB file) and the detector did not appear in any of the outputs, so we should be good to merge this. Attaching screenshots from the run:
<img width="605" height="786" alt="image" src="https://github.com/user-attachments/assets/033b7d07-0b4b-42c4-a5cb-76082e733016" />
<img width="625" height="552" alt="image" src="https://github.com/user-attachments/assets/f0050926-01dc-461b-8ab0-2ad13165abda" />


### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
