### PR TITLE
Add source entry point to logs

### DIFF
--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -151,7 +151,14 @@ func (c *ConfiguredSource) Init(ctx context.Context, sourceID SourceID, jobID Jo
 		return nil, errors.New("source already initialized")
 	}
 	src := c.source
-	err := src.Init(ctx, c.Name, jobID, sourceID, c.initParams.verify, c.initParams.conn, c.initParams.concurrency)
+	err := src.Init(
+		context.WithValue(ctx, sourceEntryPointLogKey, "Init"),
+		c.Name,
+		jobID,
+		sourceID,
+		c.initParams.verify,
+		c.initParams.conn,
+		c.initParams.concurrency)
 	c.source = nil
 	return src, err
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR adds a log key-value pair to context passed into `Source` methods so that we can quickly distinguish logs emitted by source implementations from logs emitted by source orchestration.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
