### PR TITLE
[INS-307] Added unspecified(0.0.0.0) check to DetectorHttpClientWithNoLocalAddresses

### DIFF
--- a/pkg/detectors/http.go
+++ b/pkg/detectors/http.go
@@ -94,7 +94,7 @@ func NewDetectorTransport(T http.RoundTripper) http.RoundTripper {
 }
 
 func isLocalIP(ip net.IP) bool {
-	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsPrivate() {
+	if ip.IsLoopback() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsPrivate() || ip.IsUnspecified() {
 		return true
 	}
 

--- a/pkg/detectors/http_test.go
+++ b/pkg/detectors/http_test.go
@@ -22,6 +22,18 @@ func TestWithNoLocalIP(t *testing.T) {
 		assert.ErrorIs(t, err, ErrNoLocalIP)
 	})
 
+	t.Run("Prevents dialing wildcard IP", func(t *testing.T) {
+		client := &http.Client{}
+		WithNoLocalIP()(client)
+
+		transport, ok := client.Transport.(*http.Transport)
+		assert.True(t, ok, "Expected transport to be *http.Transport")
+
+		_, err := transport.DialContext(context.Background(), "tcp", "0.0.0.0:8080")
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoLocalIP)
+	})
+
 	t.Run("Allows dialing non-local host", func(t *testing.T) {
 		client := &http.Client{}
 		WithNoLocalIP()(client)
@@ -81,6 +93,8 @@ func TestIsLocalIP(t *testing.T) {
 		{"Loopback IPv6", net.ParseIP("::1"), true},
 		{"Private IPv4", net.ParseIP("192.168.1.1"), true},
 		{"Private IPv6", net.ParseIP("fd00::1"), true},
+		{"Unspecified IPv4", net.ParseIP("0.0.0.0"), true},
+		{"Unspecified IPv6", net.ParseIP("::"), true},
 		{"Public IPv4", net.ParseIP("8.8.8.8"), false},
 		{"Public IPv6", net.ParseIP("2001:4860:4860::8888"), false},
 	}

--- a/pkg/detectors/http_test.go
+++ b/pkg/detectors/http_test.go
@@ -34,6 +34,18 @@ func TestWithNoLocalIP(t *testing.T) {
 		assert.ErrorIs(t, err, ErrNoLocalIP)
 	})
 
+	t.Run("Prevents dialing IPv6 wildcard IP", func(t *testing.T) {
+		client := &http.Client{}
+		WithNoLocalIP()(client)
+
+		transport, ok := client.Transport.(*http.Transport)
+		assert.True(t, ok, "Expected transport to be *http.Transport")
+
+		_, err := transport.DialContext(context.Background(), "tcp", "[::]:8080")
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, ErrNoLocalIP)
+	})
+
 	t.Run("Allows dialing non-local host", func(t *testing.T) {
 		client := &http.Client{}
 		WithNoLocalIP()(client)


### PR DESCRIPTION
### Description:
The current` isLocalIP` check used by `DetectorHttpClientWithNoLocalAddresses` does not account for **unspecified IP addresses (0.0.0.0 / ::)**. This can result in the unspecified/wildcard ip (0.0.0.0) to be resolved into local address which can be used for **SSRF attacks**.

This PR updates the local IP filtering logic to treat unspecified IPs as local, preventing attacker-controlled URLs from forcing HTTP requests to internal services during credential verification.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
