### PR TITLE
Allow logging of caller info

### DIFF
--- a/main.go
+++ b/main.go
@@ -354,6 +354,7 @@ func main() {
 		logFormat = log.WithJSONSink
 	}
 	logger, sync := log.New("trufflehog", logFormat(os.Stderr, log.WithGlobalRedaction()))
+
 	// make it the default logger for contexts
 	context.SetDefaultLogger(logger)
 

--- a/main.go
+++ b/main.go
@@ -354,7 +354,6 @@ func main() {
 		logFormat = log.WithJSONSink
 	}
 	logger, sync := log.New("trufflehog", logFormat(os.Stderr, log.WithGlobalRedaction()))
-
 	// make it the default logger for contexts
 	context.SetDefaultLogger(logger)
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -168,6 +168,9 @@ func AddSink(l logr.Logger, sink logConfig, keysAndValues ...any) (logr.Logger, 
 	return zapr.NewLogger(zapLogger), firstErrorFunc(zapLogger.Sync, sink.cleanup), nil
 }
 
+// SuppressCallerEmission wraps the provided logger's Zap.Core with a new Zap.Core that removes caller information
+// (including any stack traces) from logs before they're written. This change is made at the core level so that this
+// logger's core can be teed together with other logger cores that do not remove caller information.
 func SuppressCallerEmission(l logr.Logger) (logr.Logger, error) {
 	zapLogger, err := getZapLogger(l)
 	if err != nil {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -40,7 +40,7 @@ func New(service string, configs ...logConfig) (logr.Logger, func() error) {
 		}
 	}
 	// create logger
-	zapLogger := zap.New(zapcore.NewTee(cores...))
+	zapLogger := zap.New(zapcore.NewTee(cores...), zap.AddCaller())
 	cleanupFuncs = append(cleanupFuncs, zapLogger.Sync)
 	logger := zapr.NewLogger(zapLogger).WithName(service)
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -22,6 +22,8 @@ type logConfig struct {
 	err     error
 }
 
+type SinkOption func(*sinkConfig)
+
 // New creates a new log object with the provided configurations. If no sinks
 // are provided, a no-op sink will be used. Returns the logger and a cleanup
 // function that should be executed before the program exits.
@@ -93,7 +95,7 @@ type sinkConfig struct {
 }
 
 // WithJSONSink adds a JSON encoded output to the logger.
-func WithJSONSink(sink io.Writer, opts ...func(*sinkConfig)) logConfig {
+func WithJSONSink(sink io.Writer, opts ...SinkOption) logConfig {
 	return newCoreConfig(
 		zapcore.NewJSONEncoder(defaultEncoderConfig()),
 		zapcore.Lock(zapcore.AddSync(sink)),
@@ -103,7 +105,7 @@ func WithJSONSink(sink io.Writer, opts ...func(*sinkConfig)) logConfig {
 }
 
 // WithConsoleSink adds a console-style output to the logger.
-func WithConsoleSink(sink io.Writer, opts ...func(*sinkConfig)) logConfig {
+func WithConsoleSink(sink io.Writer, opts ...SinkOption) logConfig {
 	return newCoreConfig(
 		zapcore.NewConsoleEncoder(defaultEncoderConfig()),
 		zapcore.Lock(zapcore.AddSync(sink)),
@@ -180,7 +182,7 @@ func getZapLogger(l logr.Logger) (*zap.Logger, error) {
 
 // WithLevel sets the sink's level to a static level. This option prevents
 // changing the log level for this sink later on.
-func WithLevel(level int8) func(*sinkConfig) {
+func WithLevel(level int8) SinkOption {
 	return WithLeveler(
 		// Zap's levels get more verbose as the number gets smaller, as explained
 		// by zapr here: https://github.com/go-logr/zapr#increasing-verbosity
@@ -190,22 +192,22 @@ func WithLevel(level int8) func(*sinkConfig) {
 }
 
 // WithLeveler sets the sink's level enabler to leveler.
-func WithLeveler(leveler levelSetter) func(*sinkConfig) {
+func WithLeveler(leveler levelSetter) SinkOption {
 	return func(conf *sinkConfig) {
 		conf.level = leveler
 	}
 }
 
 // WithGlobalRedaction adds values to be redacted from logs.
-func WithGlobalRedaction() func(*sinkConfig) {
+func WithGlobalRedaction() SinkOption {
 	return func(conf *sinkConfig) {
 		conf.redactor = globalRedactor
 	}
 }
 
-// WithSuppressCaller prevents caller information from being logged by the core being configured, irrespective of any
+// WithSuppressCaller prevents the sink being configured from logging any caller information, irrespective of any other
 // logger settings.
-func WithSuppressCaller() func(*sinkConfig) {
+func WithSuppressCaller() SinkOption {
 	return func(conf *sinkConfig) {
 		conf.suppressCaller = true
 	}
@@ -244,7 +246,7 @@ func newCoreConfig(
 	defaultEncoder zapcore.Encoder,
 	defaultSink zapcore.WriteSyncer,
 	defaultLevel levelSetter,
-	opts ...func(*sinkConfig),
+	opts ...SinkOption,
 ) logConfig {
 	conf := sinkConfig{
 		encoder: defaultEncoder,

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -168,6 +168,18 @@ func AddSink(l logr.Logger, sink logConfig, keysAndValues ...any) (logr.Logger, 
 	return zapr.NewLogger(zapLogger), firstErrorFunc(zapLogger.Sync, sink.cleanup), nil
 }
 
+func SuppressCallerEmission(l logr.Logger) (logr.Logger, error) {
+	zapLogger, err := getZapLogger(l)
+	if err != nil {
+		return l, err
+	}
+
+	zapLogger = zapLogger.WithOptions(zap.WrapCore(func(core zapcore.Core) zapcore.Core {
+		return &suppressCallerCore{Core: core}
+	}))
+	return zapr.NewLogger(zapLogger), nil
+}
+
 // getZapLogger is a helper function that gets the underlying zap logger from a
 // logr.Logger interface.
 func getZapLogger(l logr.Logger) (*zap.Logger, error) {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -28,6 +28,13 @@ type SinkOption func(*sinkConfig)
 // are provided, a no-op sink will be used. Returns the logger and a cleanup
 // function that should be executed before the program exits.
 func New(service string, configs ...logConfig) (logr.Logger, func() error) {
+	return NewWithCaller(service, false, configs...)
+}
+
+// NewWithCaller creates a new logger named after the specified service with the provided sink configurations. If
+// addCaller is true, call site information will be attached to each emitted log message. (This behavior can be disabled
+// on a per-sink basis using WithSuppressCaller.)
+func NewWithCaller(service string, addCaller bool, configs ...logConfig) (logr.Logger, func() error) {
 	var cores []zapcore.Core
 	var cleanupFuncs []func() error
 
@@ -42,7 +49,7 @@ func New(service string, configs ...logConfig) (logr.Logger, func() error) {
 		}
 	}
 	// create logger
-	zapLogger := zap.New(zapcore.NewTee(cores...), zap.AddCaller())
+	zapLogger := zap.New(zapcore.NewTee(cores...), zap.WithCaller(addCaller))
 	cleanupFuncs = append(cleanupFuncs, zapLogger.Sync)
 	logger := zapr.NewLogger(zapLogger).WithName(service)
 

--- a/pkg/log/log_cores_test.go
+++ b/pkg/log/log_cores_test.go
@@ -21,7 +21,7 @@ type ignoreEverythingCore struct {
 }
 
 func (t *ignoreEverythingCore) With(fields []zapcore.Field) zapcore.Core {
-	return t.Core.With(fields)
+	return &ignoreEverythingCore{t.Core.With(fields)}
 }
 
 func (t *ignoreEverythingCore) Check(entry zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {

--- a/pkg/log/log_cores_test.go
+++ b/pkg/log/log_cores_test.go
@@ -205,6 +205,29 @@ func (ts *TestSuite) TestSuppressCallerCore_RespectsWrappedCheckLogic() {
 	ts.Assert().Empty(msg)
 }
 
+// This test confirms that our custom caller suppression core suppresses caller information.
+func (ts *TestSuite) TestSuppressCallerCore_SuppressesCaller() {
+	// Arrange: Create a testable log sink
+	var buf bytes.Buffer
+	baseCore := zapcore.NewCore(
+		zapcore.NewJSONEncoder(defaultEncoderConfig()),
+		zapcore.Lock(zapcore.AddSync(&buf)),
+		globalLogLevel)
+
+	// Arrange: Set up a core stack
+	core := &suppressCallerCore{baseCore}
+
+	// Arrange: Create a logger
+	logger := zapr.NewLogger(zap.New(core, zap.AddCaller()))
+
+	// Act
+	logger.Info("message")
+
+	// Assert that caller information was suppressed
+	msg := buf.String()
+	ts.Assert().NotContains(msg, "caller")
+}
+
 func BenchmarkLoggerRedact(b *testing.B) {
 	msg := "this is a message with 'foo' in it"
 	logKvps := []any{"key", "value", "foo", "bar", "bar", "baz", "longval", "84hblnqwp97ewilbgoab8fhqlngahs6dl3i269haa"}

--- a/pkg/log/log_cores_test.go
+++ b/pkg/log/log_cores_test.go
@@ -1,0 +1,142 @@
+package log
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type TestSuite struct {
+	suite.Suite
+
+	oldRedactor *dynamicRedactor
+}
+
+func (ts *TestSuite) SetupTest() {
+	ts.oldRedactor = globalRedactor
+	globalRedactor = &dynamicRedactor{
+		denySet: make(map[string]struct{}),
+	}
+}
+
+func (ts *TestSuite) TearDownTest() {
+	globalRedactor = ts.oldRedactor
+}
+
+func TestCustomCores(t *testing.T) {
+	suite.Run(t, new(TestSuite))
+}
+
+func (ts *TestSuite) TestGlobalRedaction_Console() {
+	var buf bytes.Buffer
+	logger, flush := New("console-redaction-test",
+		WithConsoleSink(&buf, WithGlobalRedaction()),
+	)
+	RedactGlobally("foo")
+	RedactGlobally("bar")
+
+	logger.Info("this foo is :bar",
+		"foo", "bar",
+		"array", []string{"foo", "bar", "baz"},
+		"object", map[string]string{"foo": "bar"})
+	ts.Require().NoError(flush())
+
+	gotParts := strings.Split(buf.String(), "\t")[1:] // The first item is the timestamp
+	wantParts := []string{
+		"info-0",
+		"console-redaction-test",
+		"this ***** is :*****",
+		"{\"foo\": \"*****\", \"array\": [\"foo\", \"bar\", \"baz\"], \"object\": {\"foo\":\"bar\"}}\n",
+	}
+	ts.Assert().Equal(wantParts, gotParts)
+}
+
+func (ts *TestSuite) TestGlobalRedaction_JSON() {
+	var jsonBuffer bytes.Buffer
+	logger, flush := New("json-redaction-test",
+		WithJSONSink(&jsonBuffer, WithGlobalRedaction()),
+	)
+	RedactGlobally("foo")
+	RedactGlobally("bar")
+	
+	logger.Info("this foo is :bar",
+		"foo", "bar",
+		"array", []string{"foo", "bar", "baz"},
+		"object", map[string]string{"foo": "bar"})
+	ts.Require().NoError(flush())
+
+	var parsedJSON map[string]any
+	ts.Require().NoError(json.Unmarshal(jsonBuffer.Bytes(), &parsedJSON))
+	ts.Assert().NotEmpty(parsedJSON["ts"])
+	delete(parsedJSON, "ts")
+	ts.Assert().Equal(
+		map[string]any{
+			"level":  "info-0",
+			"logger": "json-redaction-test",
+			"msg":    "this ***** is :*****",
+			"foo":    "*****",
+			"array":  []any{"foo", "bar", "baz"},
+			"object": map[string]interface{}{"foo": "bar"},
+		},
+		parsedJSON,
+	)
+}
+
+func BenchmarkLoggerRedact(b *testing.B) {
+	msg := "this is a message with 'foo' in it"
+	logKvps := []any{"key", "value", "foo", "bar", "bar", "baz", "longval", "84hblnqwp97ewilbgoab8fhqlngahs6dl3i269haa"}
+	redactor := &dynamicRedactor{denySet: make(map[string]struct{})}
+	redactor.replacer.CompareAndSwap(nil, strings.NewReplacer())
+
+	b.Run("no redaction", func(b *testing.B) {
+		logger, flush := New("redaction-benchmark", WithJSONSink(
+			io.Discard,
+			func(conf *sinkConfig) { conf.redactor = redactor },
+		))
+		for i := 0; i < b.N; i++ {
+			logger.Info(msg, logKvps...)
+		}
+		require.NoError(b, flush())
+	})
+	b.Run("1 redaction", func(b *testing.B) {
+		logger, flush := New("redaction-benchmark", WithJSONSink(
+			io.Discard,
+			func(conf *sinkConfig) { conf.redactor = redactor },
+		))
+		redactor.configureForRedaction("84hblnqwp97ewilbgoab8fhqlngahs6dl3i269haa")
+		for i := 0; i < b.N; i++ {
+			logger.Info(msg, logKvps...)
+		}
+		require.NoError(b, flush())
+	})
+	b.Run("2 redactions", func(b *testing.B) {
+		logger, flush := New("redaction-benchmark", WithJSONSink(
+			io.Discard,
+			func(conf *sinkConfig) { conf.redactor = redactor },
+		))
+		redactor.configureForRedaction("84hblnqwp97ewilbgoab8fhqlngahs6dl3i269haa")
+		redactor.configureForRedaction("foo")
+		for i := 0; i < b.N; i++ {
+			logger.Info(msg, logKvps...)
+		}
+		require.NoError(b, flush())
+	})
+	b.Run("3 redactions", func(b *testing.B) {
+		logger, flush := New("redaction-benchmark", WithJSONSink(
+			io.Discard,
+			func(conf *sinkConfig) { conf.redactor = redactor },
+		))
+		redactor.configureForRedaction("84hblnqwp97ewilbgoab8fhqlngahs6dl3i269haa")
+		redactor.configureForRedaction("foo")
+		redactor.configureForRedaction("bar")
+		for i := 0; i < b.N; i++ {
+			logger.Info(msg, logKvps...)
+		}
+		require.NoError(b, flush())
+	})
+}

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -3,7 +3,6 @@ package log
 import (
 	"bytes"
 	"encoding/json"
-	"io"
 	"strings"
 	"testing"
 	"time"
@@ -247,72 +246,6 @@ func splitLines(s string) []string {
 	return logLines
 }
 
-func TestGlobalRedaction_Console(t *testing.T) {
-	oldState := globalRedactor
-	globalRedactor = &dynamicRedactor{
-		denySet: make(map[string]struct{}),
-	}
-	defer func() { globalRedactor = oldState }()
-
-	var buf bytes.Buffer
-	logger, flush := New("console-redaction-test",
-		WithConsoleSink(&buf, WithGlobalRedaction()),
-	)
-	RedactGlobally("foo")
-	RedactGlobally("bar")
-
-	logger.Info("this foo is :bar",
-		"foo", "bar",
-		"array", []string{"foo", "bar", "baz"},
-		"object", map[string]string{"foo": "bar"})
-	require.NoError(t, flush())
-
-	gotParts := strings.Split(buf.String(), "\t")[1:] // The first item is the timestamp
-	wantParts := []string{
-		"info-0",
-		"console-redaction-test",
-		"this ***** is :*****",
-		"{\"foo\": \"*****\", \"array\": [\"foo\", \"bar\", \"baz\"], \"object\": {\"foo\":\"bar\"}}\n",
-	}
-	assert.Equal(t, wantParts, gotParts)
-}
-
-func TestGlobalRedaction_JSON(t *testing.T) {
-	oldState := globalRedactor
-	globalRedactor = &dynamicRedactor{
-		denySet: make(map[string]struct{}),
-	}
-	defer func() { globalRedactor = oldState }()
-
-	var jsonBuffer bytes.Buffer
-	logger, flush := New("json-redaction-test",
-		WithJSONSink(&jsonBuffer, WithGlobalRedaction()),
-	)
-	RedactGlobally("foo")
-	RedactGlobally("bar")
-	logger.Info("this foo is :bar",
-		"foo", "bar",
-		"array", []string{"foo", "bar", "baz"},
-		"object", map[string]string{"foo": "bar"})
-	require.NoError(t, flush())
-
-	var parsedJSON map[string]any
-	require.NoError(t, json.Unmarshal(jsonBuffer.Bytes(), &parsedJSON))
-	assert.NotEmpty(t, parsedJSON["ts"])
-	delete(parsedJSON, "ts")
-	assert.Equal(t,
-		map[string]any{
-			"level":  "info-0",
-			"logger": "json-redaction-test",
-			"msg":    "this ***** is :*****",
-			"foo":    "*****",
-			"array":  []any{"foo", "bar", "baz"},
-			"object": map[string]interface{}{"foo": "bar"},
-		},
-		parsedJSON,
-	)
-}
-
 func TestToLogger(t *testing.T) {
 	var jsonBuffer bytes.Buffer
 	l, flush := New("service-name",
@@ -357,58 +290,4 @@ func TestToSlogger(t *testing.T) {
 		},
 		parsedJSON,
 	)
-}
-
-func BenchmarkLoggerRedact(b *testing.B) {
-	msg := "this is a message with 'foo' in it"
-	logKvps := []any{"key", "value", "foo", "bar", "bar", "baz", "longval", "84hblnqwp97ewilbgoab8fhqlngahs6dl3i269haa"}
-	redactor := &dynamicRedactor{denySet: make(map[string]struct{})}
-	redactor.replacer.CompareAndSwap(nil, strings.NewReplacer())
-
-	b.Run("no redaction", func(b *testing.B) {
-		logger, flush := New("redaction-benchmark", WithJSONSink(
-			io.Discard,
-			func(conf *sinkConfig) { conf.redactor = redactor },
-		))
-		for i := 0; i < b.N; i++ {
-			logger.Info(msg, logKvps...)
-		}
-		require.NoError(b, flush())
-	})
-	b.Run("1 redaction", func(b *testing.B) {
-		logger, flush := New("redaction-benchmark", WithJSONSink(
-			io.Discard,
-			func(conf *sinkConfig) { conf.redactor = redactor },
-		))
-		redactor.configureForRedaction("84hblnqwp97ewilbgoab8fhqlngahs6dl3i269haa")
-		for i := 0; i < b.N; i++ {
-			logger.Info(msg, logKvps...)
-		}
-		require.NoError(b, flush())
-	})
-	b.Run("2 redactions", func(b *testing.B) {
-		logger, flush := New("redaction-benchmark", WithJSONSink(
-			io.Discard,
-			func(conf *sinkConfig) { conf.redactor = redactor },
-		))
-		redactor.configureForRedaction("84hblnqwp97ewilbgoab8fhqlngahs6dl3i269haa")
-		redactor.configureForRedaction("foo")
-		for i := 0; i < b.N; i++ {
-			logger.Info(msg, logKvps...)
-		}
-		require.NoError(b, flush())
-	})
-	b.Run("3 redactions", func(b *testing.B) {
-		logger, flush := New("redaction-benchmark", WithJSONSink(
-			io.Discard,
-			func(conf *sinkConfig) { conf.redactor = redactor },
-		))
-		redactor.configureForRedaction("84hblnqwp97ewilbgoab8fhqlngahs6dl3i269haa")
-		redactor.configureForRedaction("foo")
-		redactor.configureForRedaction("bar")
-		for i := 0; i < b.N; i++ {
-			logger.Info(msg, logKvps...)
-		}
-		require.NoError(b, flush())
-	})
 }

--- a/pkg/log/redaction_core.go
+++ b/pkg/log/redaction_core.go
@@ -25,7 +25,7 @@ func (c *redactionCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapc
 	}
 
 	if wrapped := c.Core.Check(ent, ce); wrapped != nil {
-		return wrapped.AddCore(ent, c)
+		return ce.AddCore(ent, c)
 	}
 
 	return ce

--- a/pkg/log/redaction_core.go
+++ b/pkg/log/redaction_core.go
@@ -20,9 +20,14 @@ func NewRedactionCore(core zapcore.Core, redactor *dynamicRedactor) zapcore.Core
 // Check overrides the embedded zapcore.Core Check() method to add the
 // redactionCore to the zapcore.CheckedEntry.
 func (c *redactionCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-	if c.Enabled(ent.Level) {
-		return ce.AddCore(ent, c)
+	if !c.Enabled(ent.Level) {
+		return ce
 	}
+
+	if wrapped := c.Core.Check(ent, ce); wrapped != nil {
+		return wrapped.AddCore(ent, c)
+	}
+
 	return ce
 }
 

--- a/pkg/log/suppress_caller_core.go
+++ b/pkg/log/suppress_caller_core.go
@@ -2,11 +2,18 @@ package log
 
 import "go.uber.org/zap/zapcore"
 
+// suppressCallerCore is a zap core that removes caller information from zap entries before writing. It is intended to
+// be used as a wrapper around particular zap cores that you do not want to write caller information to.
+//
+// If you want to exclude caller information from the entire logger, don't use this core - instead, do not enable caller
+// information at the logger level. (That will be much faster than using this core, because zap will refrain from
+// generating caller information in the first place, rather than generating it and then throwing it away.)
 type suppressCallerCore struct {
 	zapcore.Core
 }
 
-// Check overrides the embedded zapcore.Core Check() method to add the suppressCallerCore to the zapcore.CheckedEntry.
+// Check determines whether the supplied Entry should be logged and, if it should, adds the core to the entry. It does
+// not do anything interesting and is only implemented at all because of the way zap works.
 func (c *suppressCallerCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
 	if !c.Enabled(ent.Level) {
 		return ce
@@ -19,10 +26,13 @@ func (c *suppressCallerCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) 
 	return ce
 }
 
+// With adds structured context to the Core. It does not do anything interesting and is only implemented at all because
+// of the way zap works.
 func (c *suppressCallerCore) With(fields []zapcore.Field) zapcore.Core {
 	return &suppressCallerCore{Core: c.Core.With(fields)}
 }
 
+// Write removes caller information from a zap entry and then passes it to the wrapped core for writing.
 func (c *suppressCallerCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
 	ent.Caller = zapcore.EntryCaller{}
 	ent.Stack = ""

--- a/pkg/log/suppress_caller_core.go
+++ b/pkg/log/suppress_caller_core.go
@@ -8,9 +8,14 @@ type suppressCallerCore struct {
 
 // Check overrides the embedded zapcore.Core Check() method to add the suppressCallerCore to the zapcore.CheckedEntry.
 func (c *suppressCallerCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
-	if c.Enabled(ent.Level) {
-		return ce.AddCore(ent, c)
+	if !c.Enabled(ent.Level) {
+		return ce
 	}
+
+	if wrapped := c.Core.Check(ent, ce); wrapped != nil {
+		return wrapped.AddCore(ent, c)
+	}
+
 	return ce
 }
 

--- a/pkg/log/suppress_caller_core.go
+++ b/pkg/log/suppress_caller_core.go
@@ -6,6 +6,18 @@ type suppressCallerCore struct {
 	zapcore.Core
 }
 
+// Check overrides the embedded zapcore.Core Check() method to add the suppressCallerCore to the zapcore.CheckedEntry.
+func (c *suppressCallerCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if c.Enabled(ent.Level) {
+		return ce.AddCore(ent, c)
+	}
+	return ce
+}
+
+func (c *suppressCallerCore) With(fields []zapcore.Field) zapcore.Core {
+	return &suppressCallerCore{Core: c.Core.With(fields)}
+}
+
 func (c *suppressCallerCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
 	ent.Caller = zapcore.EntryCaller{}
 	ent.Stack = ""

--- a/pkg/log/suppress_caller_core.go
+++ b/pkg/log/suppress_caller_core.go
@@ -20,7 +20,10 @@ func (c *suppressCallerCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) 
 	}
 
 	if wrapped := c.Core.Check(ent, ce); wrapped != nil {
-		return wrapped.AddCore(ent, c)
+		// If we add the wrapped core, then that core will generate its own writes - which won't have caller information
+		// suppressed! Instead, we only add this core, which will delegate its (caller-suppressed) writes to the wrapped
+		// core.
+		return ce.AddCore(ent, c)
 	}
 
 	return ce

--- a/pkg/log/suppress_caller_core.go
+++ b/pkg/log/suppress_caller_core.go
@@ -12,8 +12,7 @@ type suppressCallerCore struct {
 	zapcore.Core
 }
 
-// Check determines whether the supplied Entry should be logged and, if it should, adds the core to the entry. It does
-// not do anything interesting and is only implemented at all because of the way zap works.
+// Check determines whether the supplied Entry should be logged and, if it should, adds the core to the entry.
 func (c *suppressCallerCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
 	if !c.Enabled(ent.Level) {
 		return ce

--- a/pkg/log/suppress_caller_core.go
+++ b/pkg/log/suppress_caller_core.go
@@ -1,0 +1,13 @@
+package log
+
+import "go.uber.org/zap/zapcore"
+
+type suppressCallerCore struct {
+	zapcore.Core
+}
+
+func (c *suppressCallerCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	ent.Caller = zapcore.EntryCaller{}
+	ent.Stack = ""
+	return c.Core.Write(ent, fields)
+}

--- a/pkg/log/suppress_caller_core.go
+++ b/pkg/log/suppress_caller_core.go
@@ -19,7 +19,11 @@ func (c *suppressCallerCore) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) 
 		return ce
 	}
 
-	if wrapped := c.Core.Check(ent, ce); wrapped != nil {
+	// Check to see whether the wrapped core would write, and if so, add this core to the CheckedEntry. We do not pass
+	// the CheckedEntry directly to the wrapped core, because if we do, the wrapped core will probably add itself as a
+	// side effect, which would result in the wrapped core executing its own writes, which would be both duplicative and
+	// without caller suppression.
+	if wrapped := c.Core.Check(ent, nil); wrapped != nil {
 		// If we add the wrapped core, then that core will generate its own writes - which won't have caller information
 		// suppressed! Instead, we only add this core, which will delegate its (caller-suppressed) writes to the wrapped
 		// core.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR extends our logging wrapper code to allow the addition of automatically generated caller information to log entries. It also adds a way to selectively suppress this caller information for individual sinks. This PR does not change any of trufflehog's behavior - it just enables future functionality in case we want it to use it later.

This PR also provides an exportable type alias for sink configuration option functions so that callers have more flexibility in how they prepare groups of them.

This PR also adds some new tests for the existing `redactionCore` and fixes an existing bug in it. (The bug hasn't yet caused problems, but it created the potential for future problems.)

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
