### PR TITLE
Refactor log package

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -16,60 +16,33 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-type logConfig struct {
-	core    zapcore.Core
-	cleanup func() error
-	err     error
-}
-
 type SinkOption func(*sinkConfig)
 
 // New creates a new log object with the provided configurations. If no sinks
 // are provided, a no-op sink will be used. Returns the logger and a cleanup
 // function that should be executed before the program exits.
-func New(service string, configs ...logConfig) (logr.Logger, func() error) {
-	return NewWithCaller(service, false, configs...)
+func New(service string, cores ...zapcore.Core) (logr.Logger, func() error) {
+	return NewWithCaller(service, false, cores...)
 }
 
 // NewWithCaller creates a new logger named after the specified service with the provided sink configurations. If
 // addCaller is true, call site information will be attached to each emitted log message. (This behavior can be disabled
 // on a per-sink basis using WithSuppressCaller.)
-func NewWithCaller(service string, addCaller bool, configs ...logConfig) (logr.Logger, func() error) {
-	var cores []zapcore.Core
-	var cleanupFuncs []func() error
-
-	// create cores for the logger
-	for _, config := range configs {
-		if config.err != nil {
-			continue
-		}
-		cores = append(cores, config.core)
-		if config.cleanup != nil {
-			cleanupFuncs = append(cleanupFuncs, config.cleanup)
-		}
-	}
+func NewWithCaller(service string, addCaller bool, cores ...zapcore.Core) (logr.Logger, func() error) {
 	// create logger
 	zapLogger := zap.New(zapcore.NewTee(cores...), zap.WithCaller(addCaller))
-	cleanupFuncs = append(cleanupFuncs, zapLogger.Sync)
 	logger := zapr.NewLogger(zapLogger).WithName(service)
 
-	// report the errors we encountered in the configs
-	for _, config := range configs {
-		if config.err != nil {
-			logger.Error(config.err, "error configuring logger")
-		}
-	}
-
-	return logger, firstErrorFunc(cleanupFuncs...)
+	return logger, zapLogger.Sync
 }
 
 // WithSentry adds sentry integration to the logger. This configuration may
 // fail, in which case, sentry will not be added and execution will continue
 // normally.
-func WithSentry(opts sentry.ClientOptions, tags map[string]string) logConfig {
+func WithSentry(opts sentry.ClientOptions, tags map[string]string) zapcore.Core {
 	client, err := sentry.NewClient(opts)
 	if err != nil {
-		return logConfig{err: err}
+		return nil
 	}
 
 	// create sentry core
@@ -81,16 +54,10 @@ func WithSentry(opts sentry.ClientOptions, tags map[string]string) logConfig {
 	}
 	core, err := zapsentry.NewCore(cfg, zapsentry.NewSentryClientFromClient(client))
 	if err != nil {
-		return logConfig{err: err}
+		return nil
 	}
 
-	return logConfig{
-		core: core,
-		cleanup: func() error {
-			sentry.Flush(5 * time.Second)
-			return nil
-		},
-	}
+	return core
 }
 
 type sinkConfig struct {
@@ -102,7 +69,7 @@ type sinkConfig struct {
 }
 
 // WithJSONSink adds a JSON encoded output to the logger.
-func WithJSONSink(sink io.Writer, opts ...SinkOption) logConfig {
+func WithJSONSink(sink io.Writer, opts ...SinkOption) zapcore.Core {
 	return newCoreConfig(
 		zapcore.NewJSONEncoder(defaultEncoderConfig()),
 		zapcore.Lock(zapcore.AddSync(sink)),
@@ -112,7 +79,7 @@ func WithJSONSink(sink io.Writer, opts ...SinkOption) logConfig {
 }
 
 // WithConsoleSink adds a console-style output to the logger.
-func WithConsoleSink(sink io.Writer, opts ...SinkOption) logConfig {
+func WithConsoleSink(sink io.Writer, opts ...SinkOption) zapcore.Core {
 	return newCoreConfig(
 		zapcore.NewConsoleEncoder(defaultEncoderConfig()),
 		zapcore.Lock(zapcore.AddSync(sink)),
@@ -136,8 +103,8 @@ func defaultEncoderConfig() zapcore.EncoderConfig {
 }
 
 // WithCore adds any user supplied zap core to the logger.
-func WithCore(core zapcore.Core) logConfig {
-	return logConfig{core: core}
+func WithCore(core zapcore.Core) zapcore.Core {
+	return core
 }
 
 // AddSentry initializes a sentry client and extends an existing
@@ -151,16 +118,12 @@ func AddSentry(l logr.Logger, opts sentry.ClientOptions, tags map[string]string)
 //
 // The new sink will not inherit any of the existing logger's key-value pairs. Key-value pairs can be added to the new
 // sink specifically by passing them to this function.
-func AddSink(l logr.Logger, sink logConfig, keysAndValues ...any) (logr.Logger, func() error, error) {
-	if sink.err != nil {
-		return l, nil, sink.err
-	}
-
+func AddSink(l logr.Logger, core zapcore.Core, keysAndValues ...any) (logr.Logger, func() error, error) {
 	// New key-value pairs cannot be ergonomically added directly to cores. logr has code to do it, but that code is not
 	// exported. Rather than replicating it ourselves, we indirectly use it by creating a temporary logger for the new
 	// core, adding the key-value pairs to the temporary logger, and then extracting the temporary logger's modified
 	// core.
-	newSinkLogger := zapr.NewLogger(zap.New(sink.core))
+	newSinkLogger := zapr.NewLogger(zap.New(core))
 	newSinkLogger = newSinkLogger.WithValues(keysAndValues...)
 	newCoreLogger, err := getZapLogger(newSinkLogger)
 	if err != nil {
@@ -186,7 +149,7 @@ func AddSink(l logr.Logger, sink logConfig, keysAndValues ...any) (logr.Logger, 
 
 	zapLogger = zapLogger.WithOptions(newLoggerOptions...)
 	newLogger := zapr.NewLogger(zapLogger)
-	return newLogger, firstErrorFunc(zapLogger.Sync, sink.cleanup), nil
+	return newLogger, zapLogger.Sync, nil
 }
 
 // getZapLogger is a helper function that gets the underlying zap logger from a
@@ -241,23 +204,6 @@ func ToSlogger(l logr.Logger) *slog.Logger {
 	return slog.New(logr.ToSlogHandler(l))
 }
 
-// firstErrorFunc is a helper function that returns a function that executes
-// all provided args and returns the first error, if any.
-func firstErrorFunc(fs ...func() error) func() error {
-	return func() error {
-		var firstErr error = nil
-		for _, f := range fs {
-			if f == nil {
-				continue
-			}
-			if err := f(); err != nil && firstErr == nil {
-				firstErr = err
-			}
-		}
-		return firstErr
-	}
-}
-
 // newCoreConfig is a helper function that creates a default sinkConfig,
 // applies the options, then creates a zapcore.Core.
 func newCoreConfig(
@@ -265,7 +211,7 @@ func newCoreConfig(
 	defaultSink zapcore.WriteSyncer,
 	defaultLevel levelSetter,
 	opts ...SinkOption,
-) logConfig {
+) zapcore.Core {
 	conf := sinkConfig{
 		encoder: defaultEncoder,
 		sink:    defaultSink,
@@ -288,5 +234,5 @@ func newCoreConfig(
 		core = &suppressCallerCore{Core: core}
 	}
 
-	return logConfig{core: core}
+	return core
 }

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -69,7 +69,7 @@ type sinkConfig struct {
 
 // WithJSONSink adds a JSON encoded output to the logger.
 func WithJSONSink(sink io.Writer, opts ...SinkOption) zapcore.Core {
-	return newCoreConfig(
+	return newCore(
 		zapcore.NewJSONEncoder(defaultEncoderConfig()),
 		zapcore.Lock(zapcore.AddSync(sink)),
 		globalLogLevel,
@@ -79,7 +79,7 @@ func WithJSONSink(sink io.Writer, opts ...SinkOption) zapcore.Core {
 
 // WithConsoleSink adds a console-style output to the logger.
 func WithConsoleSink(sink io.Writer, opts ...SinkOption) zapcore.Core {
-	return newCoreConfig(
+	return newCore(
 		zapcore.NewConsoleEncoder(defaultEncoderConfig()),
 		zapcore.Lock(zapcore.AddSync(sink)),
 		globalLogLevel,
@@ -203,9 +203,9 @@ func ToSlogger(l logr.Logger) *slog.Logger {
 	return slog.New(logr.ToSlogHandler(l))
 }
 
-// newCoreConfig is a helper function that creates a default sinkConfig,
+// newCore is a helper function that creates a default sinkConfig,
 // applies the options, then creates a zapcore.Core.
-func newCoreConfig(
+func newCore(
 	defaultEncoder zapcore.Encoder,
 	defaultSink zapcore.WriteSyncer,
 	defaultLevel levelSetter,

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -20,16 +20,17 @@ type SyncFunc func() error
 
 type SinkOption func(*sinkConfig)
 
-// New creates a new log object with the provided configurations. If no sinks
-// are provided, a no-op sink will be used. Returns the logger and a cleanup
+// New creates a new log object with the provided sinks. If no sinks are
+// provided, a no-op sink will be used. Returns the logger and a cleanup
 // function that should be executed before the program exits.
 func New(service string, cores ...zapcore.Core) (logr.Logger, SyncFunc) {
 	return NewWithCaller(service, false, cores...)
 }
 
-// NewWithCaller creates a new logger named after the specified service with the provided sink configurations. If
-// addCaller is true, call site information will be attached to each emitted log message. (This behavior can be disabled
-// on a per-sink basis using WithSuppressCaller.)
+// NewWithCaller creates a new logger named after the specified service with
+// the provided sinks. If addCaller is true, call site information will be
+// attached to each emitted log message. (This behavior can be disabled on a
+// per-sink basis using WithSuppressCaller.)
 func NewWithCaller(service string, addCaller bool, cores ...zapcore.Core) (logr.Logger, SyncFunc) {
 	// create logger
 	zapLogger := zap.New(zapcore.NewTee(cores...), zap.WithCaller(addCaller))

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -101,11 +101,6 @@ func defaultEncoderConfig() zapcore.EncoderConfig {
 	return conf
 }
 
-// WithCore adds any user supplied zap core to the logger.
-func WithCore(core zapcore.Core) zapcore.Core {
-	return core
-}
-
 // AddSentry initializes a sentry client and extends an existing
 // logr.Logger with the hook.
 func AddSentry(l logr.Logger, client *sentry.Client, tags map[string]string) (logr.Logger, SyncFunc, error) {

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -11,7 +11,48 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
+
+// testCore implement zapcore.Core with custom methods.
+type testCore struct {
+	check   func(zapcore.Entry, *zapcore.CheckedEntry) *zapcore.CheckedEntry
+	enabled func(zapcore.Level) bool
+	sync    func() error
+	with    func([]zapcore.Field) zapcore.Core
+	write   func(zapcore.Entry, []zapcore.Field) error
+}
+
+func (t *testCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if t.check != nil {
+		return t.check(e, ce)
+	}
+	return ce
+}
+func (t *testCore) Enabled(l zapcore.Level) bool {
+	if t.enabled != nil {
+		return t.enabled(l)
+	}
+	return true
+}
+func (t *testCore) Sync() error {
+	if t.sync != nil {
+		return t.sync()
+	}
+	return nil
+}
+func (t *testCore) With(fields []zapcore.Field) zapcore.Core {
+	if t.with != nil {
+		return t.with(fields)
+	}
+	return t
+}
+func (t *testCore) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	if t.write != nil {
+		return t.write(ent, fields)
+	}
+	return nil
+}
 
 func TestNew(t *testing.T) {
 	var jsonBuffer, consoleBuffer bytes.Buffer
@@ -290,4 +331,38 @@ func TestToSlogger(t *testing.T) {
 		},
 		parsedJSON,
 	)
+}
+
+func TestSyncFunc(t *testing.T) {
+	var syncCalled bool
+	core := testCore{
+		sync: func() error {
+			syncCalled = true
+			return nil
+		},
+	}
+	_, flush := New("service-name", &core)
+	assert.NoError(t, flush())
+	assert.True(t, syncCalled)
+}
+
+func TestAddSinkStillSyncs(t *testing.T) {
+	var syncCalled [2]bool
+	core := testCore{
+		sync: func() error {
+			syncCalled[0] = true
+			return nil
+		},
+	}
+	l, _ := New("service-name", &core)
+	_, flush, err := AddSink(l, &testCore{
+		sync: func() error {
+			syncCalled[1] = true
+			return nil
+		},
+	})
+	assert.NoError(t, err)
+	assert.NoError(t, flush())
+	assert.True(t, syncCalled[0])
+	assert.True(t, syncCalled[1])
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Refactor some parts of the `log` package to simplify the internals. NB this is a breaking change for `WithSentry` and `AddSentry` functions.

* Replace logConfig with zapcore.Core
* Add SyncFunc type and tests
* Change Sentry functions to accept a *sentry.Client
* Rename newCoreConfig to newCore

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking API refactor of logging/Sentry setup and changes failure handling from graceful degradation to `panic`, which could impact app startup/runtime behavior if misused.
> 
> **Overview**
> Simplifies the `log` package API by removing the internal `logConfig` wrapper and having `New`/`NewWithCaller` and `AddSink` operate directly on `zapcore.Core` sinks, returning a `SyncFunc` that delegates to `zapLogger.Sync`.
> 
> Refactors Sentry integration: `WithSentry`/`AddSentry` now require a pre-built `*sentry.Client` (breaking change) and core creation failures now `panic` instead of being logged/returned; related tests for prior “Sentry init failure” behavior were removed and new tests were added to assert `Sync()` is still invoked for `New` and after `AddSink`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f3eeadf09171e813aca726af78ca2d00240493c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->