### PR TITLE
Implement CodeOwnersLeveler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/googleapis/gax-go/v2 v2.15.0
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/hashicorp/golang-lru/v2 v2.0.7
+	github.com/hmarr/codeowners v1.2.1
 	github.com/jedib0t/go-pretty/v6 v6.6.8
 	github.com/jlaffaye/ftp v0.2.0
 	github.com/joho/godotenv v1.5.1
@@ -109,6 +110,7 @@ require (
 	golang.org/x/sync v0.19.0
 	golang.org/x/text v0.32.0
 	golang.org/x/time v0.14.0
+	golang.org/x/tools v0.39.0
 	google.golang.org/api v0.247.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/h2non/gock.v1 v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -458,6 +458,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
+github.com/hmarr/codeowners v1.2.1 h1:+9yndrwG0UVP1GkLBEQMSbSUNeLpbrbL924SRthA/9k=
+github.com/hmarr/codeowners v1.2.1/go.mod h1:KPlR1p/B4owPjwfNIBueWlOP4CmqlQFX9b6nANG6j40=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20230524184225-eabc099b10ab/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
@@ -1016,6 +1018,8 @@ golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
+golang.org/x/tools v0.39.0 h1:ik4ho21kwuQln40uelmciQPp9SipgNDdrafrYA4TmQQ=
+golang.org/x/tools v0.39.0/go.mod h1:JnefbkDPyD8UU2kI5fuf8ZX4/yUeh9W877ZeBONxUqQ=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/log/codeowners.go
+++ b/pkg/log/codeowners.go
@@ -1,0 +1,81 @@
+package log
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/hmarr/codeowners"
+)
+
+type CodeOwners struct {
+	rules codeowners.Ruleset
+}
+
+func ParseCodeOwners(content string) (*CodeOwners, error) {
+	rules, err := codeowners.ParseFile(strings.NewReader(content))
+	if err != nil {
+		return nil, err
+	}
+	return &CodeOwners{rules}, nil
+}
+
+func (co *CodeOwners) OwnersOf(path string) ([]string, error) {
+	path = goPathToFilePath(path)
+	rule, err := co.rules.Match(path)
+	if err != nil {
+		return nil, err
+	}
+	if rule == nil {
+		return nil, nil
+	}
+	owners := make([]string, len(rule.Owners))
+	for i, owner := range rule.Owners {
+		owners[i] = owner.String()
+	}
+	return owners, nil
+}
+
+func (co *CodeOwners) Owners() []string {
+	ownerSet := make(map[string]struct{})
+	for _, rule := range co.rules {
+		for _, owner := range rule.Owners {
+			ownerSet[owner.String()] = struct{}{}
+		}
+	}
+
+	owners := make([]string, 0, len(ownerSet))
+	for owner := range ownerSet {
+		owners = append(owners, owner)
+	}
+	return owners
+}
+
+func goPathToFilePath(path string) string {
+	// Expected formats:
+	// - host/repo_owner/repo_name/path/to/package.func
+	// - host/repo_owner/repo_name/repo_version/path/to/package.func
+	parts := strings.Split(path, "/")
+	if len(parts) < 3 {
+		return path
+	}
+	parts = parts[3:]
+	if len(parts) > 1 && isVersionString(parts[0]) {
+		parts = parts[1:]
+	}
+	return strings.Join(parts, "/")
+}
+
+func isVersionString(s string) bool {
+	if len(s) <= 1 {
+		return false
+	}
+	if s[0] != 'v' {
+		return false
+	}
+	for _, r := range s[1:] {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/log/codeowners_leveler.go
+++ b/pkg/log/codeowners_leveler.go
@@ -1,0 +1,131 @@
+package log
+
+import (
+	"errors"
+	"runtime"
+	"strings"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// CodeOwnersLeveler is a dynamic leveler based on the codeowners of where the
+// log was emitted.
+type CodeOwnersLeveler struct {
+	codeOwners goCodeOwnerData
+	baseLevel  zap.AtomicLevel
+	levelers   map[string]zap.AtomicLevel
+}
+
+// goCodeOwnerData describes a way to list all the possible code owners and a
+// way to lookup the codeowners associated with a Go function path (see
+// [runtime.Frame.Function]).
+type goCodeOwnerData interface {
+	// Owners is the list of all possible owners.
+	Owners() []string
+	// OwnersOf looks up the list of codeowners according to the Go
+	// function path (see [runtime.Frame.Function]).
+	OwnersOf(goFuncPath string) []string
+}
+
+// NewCodeOwnersLeveler initializes a CodeOwnersLeveler with the provided data
+// source.
+func NewCodeOwnersLeveler(co goCodeOwnerData) *CodeOwnersLeveler {
+	// Write to the map on initialization so all other accesses are
+	// read-only (and therefore thread-safe).
+	levelers := make(map[string]zap.AtomicLevel)
+	for _, owner := range co.Owners() {
+		levelers[owner] = zap.NewAtomicLevel()
+	}
+	return &CodeOwnersLeveler{
+		codeOwners: co,
+		baseLevel:  zap.NewAtomicLevel(),
+		levelers:   levelers,
+	}
+}
+
+// SetLevel sets the minimum level for logs, regardless of code ownership.
+func (c *CodeOwnersLeveler) SetLevel(l zapcore.Level) {
+	c.baseLevel.SetLevel(l)
+}
+
+// Enabled checks that the level is enabled for the codeowner that this method
+// was called from.
+func (c *CodeOwnersLeveler) Enabled(l zapcore.Level) bool {
+	path := callerGoFuncPath(3)
+	return c.anyEnabledForPath(path, l)
+}
+
+// Level gets the zapcore.Level based on the codeowner that this method was
+// called from.
+func (c *CodeOwnersLeveler) Level() zapcore.Level {
+	path := callerGoFuncPath(3)
+	// We return the minimum level because zap's levels get more verbose as
+	// the number gets smaller (see [SetLevelForControl]).
+	//
+	// This is effectively returning the most verbose log level.
+	return c.minLevelForPath(path)
+}
+
+// SetLevelFor sets the log level for the provided codeowner. An error is
+// returned if the codeowner does not exist.
+func (c *CodeOwnersLeveler) SetLevelFor(owner string, level int8) error {
+	l, ok := c.levelers[owner]
+	if !ok {
+		return errors.New("no such owner")
+	}
+	SetLevelForControl(l, level)
+	return nil
+}
+
+// anyEnabledForPath checks if any of the codeowners for the provided path are
+// enabled at the provided level.
+func (c *CodeOwnersLeveler) anyEnabledForPath(path string, level zapcore.Level) bool {
+	owners := c.codeOwners.OwnersOf(path)
+	// If any CODEOWNER is enabled, return true.
+	for _, owner := range owners {
+		leveler, ok := c.levelers[owner]
+		if !ok {
+			continue
+		}
+		if leveler.Enabled(level) {
+			return true
+		}
+	}
+	// Default to baseLevel.
+	return c.baseLevel.Enabled(level)
+}
+
+// minLevelForPath gets the minimum (aka most verbose) level for the provided
+// codeowner path.
+func (c *CodeOwnersLeveler) minLevelForPath(path string) zapcore.Level {
+	owners := c.codeOwners.OwnersOf(path)
+	minLevel := c.baseLevel.Level()
+	for _, owner := range owners {
+		leveler, ok := c.levelers[owner]
+		if !ok {
+			continue
+		}
+		minLevel = min(minLevel, leveler.Level())
+	}
+	return minLevel
+}
+
+// callerGoFuncPath gets the non-logging related caller function path and name
+// (see [runtime.Frame.Function]).
+func callerGoFuncPath(skip int) string {
+	pcs := make([]uintptr, 8)
+	n := runtime.Callers(skip, pcs)
+	frames := runtime.CallersFrames(pcs[:n])
+
+	for {
+		f, more := frames.Next()
+		if !strings.Contains(f.File, "go.uber.org/zap") && !strings.Contains(f.File, "go-logr") {
+			return f.Function
+		}
+		if !more {
+			break
+		}
+	}
+	return ""
+}

--- a/pkg/log/codeowners_leveler_test.go
+++ b/pkg/log/codeowners_leveler_test.go
@@ -1,0 +1,140 @@
+package log
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+// testCodeOwner is a test implementation of the codeOwnerData interface.
+type testCodeOwner struct {
+	owners   []string
+	ownersOf func(string) []string
+}
+
+func (t testCodeOwner) Owners() []string { return t.owners }
+func (t testCodeOwner) OwnersOf(path string) []string {
+	if t.ownersOf != nil {
+		return t.ownersOf(path)
+	}
+	return nil
+}
+
+func TestCodeOwnersLeveler_Logging(t *testing.T) {
+	var buf bytes.Buffer
+	lvl := NewCodeOwnersLeveler(testCodeOwner{
+		owners: []string{"me", "you"},
+		ownersOf: func(path string) []string {
+			base := filepath.Base(path)
+			// Anonymous functions within a function are of the
+			// form: pkg.Function.funcN
+			if strings.Count(base, ".") == 2 {
+				return []string{"you"}
+			}
+			return []string{"me"}
+		},
+	})
+	logger, flush := New(
+		"service-name",
+		WithConsoleSink(&buf, WithLeveler(lvl)),
+	)
+
+	lvl.SetLevelFor("me", 1)
+	lvl.SetLevelFor("you", 2)
+
+	// "me" codeowner (level 1)
+	logger.V(0).Info("line 1")
+	logger.V(1).Info("line 2")
+	logger.V(2).Info("line 3")
+	logger.V(3).Info("line 4")
+	func() {
+		// "you" codeowner (level 2)
+		logger.V(0).Info("line 5")
+		logger.V(1).Info("line 6")
+		logger.V(2).Info("line 7")
+		logger.V(3).Info("line 8")
+
+	}()
+	require.Nil(t, flush())
+
+	// buf should have lines 1, 2 (from "me") and 5, 6, 7 (from "you").
+	require.Contains(t, buf.String(), "line 1")
+	require.Contains(t, buf.String(), "line 2")
+	require.NotContains(t, buf.String(), "line 3")
+	require.NotContains(t, buf.String(), "line 4")
+	require.Contains(t, buf.String(), "line 5")
+	require.Contains(t, buf.String(), "line 6")
+	require.Contains(t, buf.String(), "line 7")
+	require.NotContains(t, buf.String(), "line 8")
+}
+
+func TestCodeOwnersLeveler_MostVerboseLevel(t *testing.T) {
+	lvl := NewCodeOwnersLeveler(testCodeOwner{
+		owners: []string{"me", "you"},
+		ownersOf: func(path string) []string {
+			return []string{"me", "you"}
+		},
+	})
+
+	lvl.SetLevelFor("me", 1)
+	require.Equal(t, zapcore.Level(-1), lvl.Level())
+
+	lvl.SetLevelFor("you", 2)
+	require.Equal(t, zapcore.Level(-2), lvl.Level())
+}
+
+func TestCodeOwnersLeveler_AnyEnabled(t *testing.T) {
+	lvl := NewCodeOwnersLeveler(testCodeOwner{
+		owners: []string{"me", "you"},
+		ownersOf: func(path string) []string {
+			return []string{"me", "you"}
+		},
+	})
+
+	lvl.SetLevelFor("me", 1)
+	require.True(t, lvl.Enabled(zapcore.Level(0)))
+	require.True(t, lvl.Enabled(zapcore.Level(-1)))
+	require.False(t, lvl.Enabled(zapcore.Level(-2)))
+	require.False(t, lvl.Enabled(zapcore.Level(-3)))
+
+	lvl.SetLevelFor("you", 2)
+	require.True(t, lvl.Enabled(zapcore.Level(0)))
+	require.True(t, lvl.Enabled(zapcore.Level(-1)))
+	require.True(t, lvl.Enabled(zapcore.Level(-2)))
+	require.False(t, lvl.Enabled(zapcore.Level(-3)))
+}
+
+func TestCodeOwnersLeveler_BaseLevelEnabled(t *testing.T) {
+	lvl := NewCodeOwnersLeveler(testCodeOwner{})
+
+	require.True(t, lvl.Enabled(zapcore.Level(0)))
+	require.False(t, lvl.Enabled(zapcore.Level(-1)))
+	require.False(t, lvl.Enabled(zapcore.Level(-2)))
+
+	lvl.SetLevel(zapcore.Level(-1))
+	require.True(t, lvl.Enabled(zapcore.Level(0)))
+	require.True(t, lvl.Enabled(zapcore.Level(-1)))
+	require.False(t, lvl.Enabled(zapcore.Level(-2)))
+}
+
+func TestCodeOwnersLeveler_BaseLevelMostVerbose(t *testing.T) {
+	lvl := NewCodeOwnersLeveler(testCodeOwner{
+		owners: []string{"me", "you"},
+		ownersOf: func(path string) []string {
+			return []string{"me", "you"}
+		},
+	})
+	lvl.SetLevelFor("me", 1)
+	lvl.SetLevelFor("you", 2)
+	SetLevelForControl(lvl, 3)
+
+	require.True(t, lvl.Enabled(zapcore.Level(0)))
+	require.True(t, lvl.Enabled(zapcore.Level(-1)))
+	require.True(t, lvl.Enabled(zapcore.Level(-2)))
+	require.True(t, lvl.Enabled(zapcore.Level(-3)))
+	require.False(t, lvl.Enabled(zapcore.Level(-4)))
+}

--- a/pkg/log/codeowners_test.go
+++ b/pkg/log/codeowners_test.go
@@ -1,0 +1,68 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseCodeOwners(t *testing.T) {
+	_, err := ParseCodeOwners(`
+* @trufflesecurity/product-eng
+pkg/sources/ @trufflesecurity/Scanning
+pkg/writers/ @trufflesecurity/Scanning
+	`)
+	require.NoError(t, err)
+}
+
+func TestCodeOwners_OwnersDoNotRepeat(t *testing.T) {
+	co, err := ParseCodeOwners(`
+* @trufflesecurity/product-eng
+pkg/sources/ @trufflesecurity/Scanning
+pkg/writers/ @trufflesecurity/Scanning
+	`)
+	require.NoError(t, err)
+
+	owners := co.Owners()
+	require.Len(t, owners, 2)
+	require.Contains(t, owners, "@trufflesecurity/product-eng")
+	require.Contains(t, owners, "@trufflesecurity/Scanning")
+}
+
+func TestCodeOwners_OwnersOf(t *testing.T) {
+	co, err := ParseCodeOwners(`
+* @trufflesecurity/product-eng
+pkg/sources/ @trufflesecurity/Scanning
+pkg/writers/ @trufflesecurity/Scanning
+	`)
+	require.NoError(t, err)
+
+	{
+		owners, err := co.OwnersOf("github.com/trufflesecurity/trufflehog/v3/pkg/sources/filesystem.Foo")
+		require.NoError(t, err)
+		require.Equal(t, []string{"@trufflesecurity/Scanning"}, owners)
+	}
+	{
+		owners, err := co.OwnersOf("main.main")
+		require.NoError(t, err)
+		require.Equal(t, []string{"@trufflesecurity/product-eng"}, owners)
+	}
+}
+
+func TestCodeOwners_MultipleOwnersOf(t *testing.T) {
+	co, err := ParseCodeOwners("* @foo @bar")
+	require.NoError(t, err)
+
+	owners, err := co.OwnersOf("main.main")
+	require.NoError(t, err)
+	require.Equal(t, []string{"@foo", "@bar"}, owners)
+}
+
+func TestCodeOwners_NoOwnersOf(t *testing.T) {
+	co, err := ParseCodeOwners("pkg/ @foo @bar")
+	require.NoError(t, err)
+
+	owners, err := co.OwnersOf("main.main")
+	require.NoError(t, err)
+	require.Len(t, owners, 0)
+}


### PR DESCRIPTION
CodeOwnersLeveler is a log leveler that can be dynamically controlled by the owners found in CODEOWNERS. Levels can be independently set for each owner, and logs will be checked based on the owner of the function that emitted them.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
