### PR TITLE
added rotation on 403s access_refused, this detector considered them indeterminate failures

### DIFF
--- a/pkg/detectors/rabbitmq/rabbitmq.go
+++ b/pkg/detectors/rabbitmq/rabbitmq.go
@@ -108,7 +108,8 @@ func (s Scanner) verify(url string) (bool, error) {
 	if (strings.Contains(errStr, "403") &&
 		strings.Contains(errStr, "access_refused")) ||
 		strings.Contains(errStr, "username or password not allowed") {
-		return false, err
+		// make secret as rotated
+		return false, nil
 	}
 	return false, err
 }

--- a/pkg/detectors/rabbitmq/rabbitmq.go
+++ b/pkg/detectors/rabbitmq/rabbitmq.go
@@ -99,7 +99,18 @@ func (s Scanner) verify(url string) (bool, error) {
 			_ = conn.Close()
 		}
 	}()
-	return err == nil, err
+	if err == nil {
+		return true, nil
+	}
+	// Check if this is a determinate authentication failure
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "403") ||
+		strings.Contains(errMsg, "username or password not allowed") ||
+		strings.Contains(errMsg, "ACCESS_REFUSED") ||
+		strings.Contains(errMsg, "access_refused") {
+		return false, nil
+	}
+	return false, err
 }
 
 func (s Scanner) Type() detectorspb.DetectorType {

--- a/pkg/detectors/rabbitmq/rabbitmq.go
+++ b/pkg/detectors/rabbitmq/rabbitmq.go
@@ -103,13 +103,12 @@ func (s Scanner) verify(url string) (bool, error) {
 		return true, nil
 	}
 	// Check if this is a determinate authentication failure
-	errMsg := err.Error()
-	has403 := strings.Contains(errMsg, "403")
-	hasAccessRefused := strings.Contains(errMsg, "ACCESS_REFUSED") || strings.Contains(errMsg, "access_refused")
-	hasUsernamePasswordError := strings.Contains(errMsg, "username or password not allowed")
-	
-	if (has403 && hasAccessRefused) || hasUsernamePasswordError {
-		return false, nil
+	errStr := strings.ToLower(err.Error())
+
+	if (strings.Contains(errStr, "403") &&
+		strings.Contains(errStr, "access_refused")) ||
+		strings.Contains(errStr, "username or password not allowed") {
+		return false, err
 	}
 	return false, err
 }

--- a/pkg/detectors/rabbitmq/rabbitmq.go
+++ b/pkg/detectors/rabbitmq/rabbitmq.go
@@ -104,10 +104,11 @@ func (s Scanner) verify(url string) (bool, error) {
 	}
 	// Check if this is a determinate authentication failure
 	errMsg := err.Error()
-	if strings.Contains(errMsg, "403") ||
-		strings.Contains(errMsg, "username or password not allowed") ||
-		strings.Contains(errMsg, "ACCESS_REFUSED") ||
-		strings.Contains(errMsg, "access_refused") {
+	has403 := strings.Contains(errMsg, "403")
+	hasAccessRefused := strings.Contains(errMsg, "ACCESS_REFUSED") || strings.Contains(errMsg, "access_refused")
+	hasUsernamePasswordError := strings.Contains(errMsg, "username or password not allowed")
+	
+	if (has403 && hasAccessRefused) || hasUsernamePasswordError {
 		return false, nil
 	}
 	return false, err


### PR DESCRIPTION
fix(rabbitmq): treat authentication failures as determinate errors

Return false, nil for authentication failures (both "403" and "ACCESS_REFUSED" together or "username or password
not allowed")
instead of false, err to properly distinguish determinate failures from
indeterminate errors.
### Description:
Explain the purpose of the PR.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?
