### PR TITLE
Pre-allocate anthropic analyzer bindings slice capacity with zero length

### DIFF
--- a/pkg/analyzer/analyzers/anthropic/anthropic.go
+++ b/pkg/analyzer/analyzers/anthropic/anthropic.go
@@ -125,7 +125,7 @@ func secretInfoToAnalyzerResult(info *SecretInfo) *analyzers.AnalyzerResult {
 	result := analyzers.AnalyzerResult{
 		AnalyzerType: analyzers.AnalyzerAnthropic,
 		Metadata:     map[string]any{"Valid_Key": info.Valid},
-		Bindings:     make([]analyzers.Binding, len(info.AnthropicResources)),
+		Bindings:     make([]analyzers.Binding, 0, len(info.AnthropicResources)), // pre-allocate with zero length
 	}
 
 	// extract information to create bindings and append to result bindings

--- a/pkg/analyzer/analyzers/anthropic/result_output.json
+++ b/pkg/analyzer/analyzers/anthropic/result_output.json
@@ -1,90 +1,142 @@
 {
-    "AnalyzerType": 2,
-    "Bindings": [
-        {
-            "Resource": {
-                "Name": "Claude 3.5 Sonnet (New)",
-                "FullyQualifiedName": "claude-3-5-sonnet-20241022",
-                "Type": "model",
-                "Metadata": {},
-                "Parent": null
-            },
-            "Permission": {
-                "Value": "full_access",
-                "Parent": null
-            }
+  "AnalyzerType": 2,
+  "Bindings": [
+    {
+      "Resource": {
+        "Name": "Claude Sonnet 4.6",
+        "FullyQualifiedName": "claude-sonnet-4-6",
+        "Type": "model",
+        "Metadata": {},
+        "Parent": null
+      },
+      "Permission": { "Value": "full_access", "Parent": null },
+      "Condition": ""
+    },
+    {
+      "Resource": {
+        "Name": "Claude Opus 4.6",
+        "FullyQualifiedName": "claude-opus-4-6",
+        "Type": "model",
+        "Metadata": {},
+        "Parent": null
+      },
+      "Permission": { "Value": "full_access", "Parent": null },
+      "Condition": ""
+    },
+    {
+      "Resource": {
+        "Name": "Claude Opus 4.5",
+        "FullyQualifiedName": "claude-opus-4-5-20251101",
+        "Type": "model",
+        "Metadata": {},
+        "Parent": null
+      },
+      "Permission": { "Value": "full_access", "Parent": null },
+      "Condition": ""
+    },
+    {
+      "Resource": {
+        "Name": "Claude Haiku 4.5",
+        "FullyQualifiedName": "claude-haiku-4-5-20251001",
+        "Type": "model",
+        "Metadata": {},
+        "Parent": null
+      },
+      "Permission": { "Value": "full_access", "Parent": null },
+      "Condition": ""
+    },
+    {
+      "Resource": {
+        "Name": "Claude Sonnet 4.5",
+        "FullyQualifiedName": "claude-sonnet-4-5-20250929",
+        "Type": "model",
+        "Metadata": {},
+        "Parent": null
+      },
+      "Permission": { "Value": "full_access", "Parent": null },
+      "Condition": ""
+    },
+    {
+      "Resource": {
+        "Name": "Claude Opus 4.1",
+        "FullyQualifiedName": "claude-opus-4-1-20250805",
+        "Type": "model",
+        "Metadata": {},
+        "Parent": null
+      },
+      "Permission": { "Value": "full_access", "Parent": null },
+      "Condition": ""
+    },
+    {
+      "Resource": {
+        "Name": "Claude Opus 4",
+        "FullyQualifiedName": "claude-opus-4-20250514",
+        "Type": "model",
+        "Metadata": {},
+        "Parent": null
+      },
+      "Permission": { "Value": "full_access", "Parent": null },
+      "Condition": ""
+    },
+    {
+      "Resource": {
+        "Name": "Claude Sonnet 4",
+        "FullyQualifiedName": "claude-sonnet-4-20250514",
+        "Type": "model",
+        "Metadata": {},
+        "Parent": null
+      },
+      "Permission": { "Value": "full_access", "Parent": null },
+      "Condition": ""
+    },
+    {
+      "Resource": {
+        "Name": "Claude Sonnet 3.7",
+        "FullyQualifiedName": "claude-3-7-sonnet-20250219",
+        "Type": "model",
+        "Metadata": {},
+        "Parent": null
+      },
+      "Permission": { "Value": "full_access", "Parent": null },
+      "Condition": ""
+    },
+    {
+      "Resource": {
+        "Name": "Claude Haiku 3.5",
+        "FullyQualifiedName": "claude-3-5-haiku-20241022",
+        "Type": "model",
+        "Metadata": {},
+        "Parent": null
+      },
+      "Permission": { "Value": "full_access", "Parent": null },
+      "Condition": ""
+    },
+    {
+      "Resource": {
+        "Name": "Claude Haiku 3",
+        "FullyQualifiedName": "claude-3-haiku-20240307",
+        "Type": "model",
+        "Metadata": {},
+        "Parent": null
+      },
+      "Permission": { "Value": "full_access", "Parent": null },
+      "Condition": ""
+    },
+    {
+      "Resource": {
+        "Name": "",
+        "FullyQualifiedName": "msgbatch_015FDqbx29LDeVvbwwyCe314",
+        "Type": "message_batch",
+        "Metadata": {
+          "expires_at": "2025-02-05T07:36:34.761695+00:00",
+          "results_url": ""
         },
-        {
-            "Resource": {
-                "Name": "Claude 3.5 Haiku",
-                "FullyQualifiedName": "claude-3-5-haiku-20241022",
-                "Type": "model",
-                "Metadata": {},
-                "Parent": null
-            },
-            "Permission": {
-                "Value": "full_access",
-                "Parent": null
-            }
-        },
-        {
-            "Resource": {
-                "Name": "Claude 3.5 Sonnet (Old)",
-                "FullyQualifiedName": "claude-3-5-sonnet-20240620",
-                "Type": "model",
-                "Metadata": {},
-                "Parent": null
-            },
-            "Permission": {
-                "Value": "full_access",
-                "Parent": null
-            }
-        },
-        {
-            "Resource": {
-                "Name": "Claude 3 Haiku",
-                "FullyQualifiedName": "claude-3-haiku-20240307",
-                "Type": "model",
-                "Metadata": {},
-                "Parent": null
-            },
-            "Permission": {
-                "Value": "full_access",
-                "Parent": null
-            }
-        },
-        {
-            "Resource": {
-                "Name": "Claude 3 Opus",
-                "FullyQualifiedName": "claude-3-opus-20240229",
-                "Type": "model",
-                "Metadata": {},
-                "Parent": null
-            },
-            "Permission": {
-                "Value": "full_access",
-                "Parent": null
-            }
-        },
-        {
-            "Resource": {
-                "Name": "",
-                "FullyQualifiedName": "msgbatch_015FDqbx29LDeVvbwwyCe314",
-                "Type": "message_batch",
-                "Metadata": {
-                    "expires_at": "2025-02-05T07:36:34.761695+00:00",
-                    "results_url": "https://api.anthropic.com/v1/messages/batches/msgbatch_015FDqbx29LDeVvbwwyCe314/results"
-                },
-                "Parent": null
-            },
-            "Permission": {
-                "Value": "full_access",
-                "Parent": null
-            }
-        }
-    ],
-    "UnboundedResources": null,
-    "Metadata": {
-        "Valid_Key": true
+        "Parent": null
+      },
+      "Permission": { "Value": "full_access", "Parent": null },
+      "Condition": ""
     }
+  ],
+  "UnboundedResources": null,
+  "Metadata": { "Valid_Key": true }
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
There’s a small bug in how the bindings slice is pre-allocated in anthropic analyzer.
```go
Bindings: make([]analyzers.Binding, len(info.AnthropicResources))
```
This creates a slice with length = n and capacity = n, meaning it already contains n zero-value elements.
We should instead initialize it with length 0 and the same capacity:
```go
Bindings: make([]analyzers.Binding, 0, len(info.AnthropicResources))
```
This creates an empty slice with pre-allocated capacity, allowing append to work correctly without introducing zero-value entries.
This change should resolve the issue.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to result construction that should only affect analyzer output formatting/contents; low risk aside from potential golden/fixture comparisons downstream.
> 
> **Overview**
> Fixes a slice preallocation bug in the Anthropic analyzer by changing `Bindings` initialization to `make([]Binding, 0, n)`, so `append` produces only real bindings instead of leaving pre-filled zero-value entries.
> 
> Updates the stored `result_output.json` fixture to reflect the corrected output shape/content (no extra empty bindings), along with refreshed sample resources.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7189eef8c01a4ba40111c667d5449efaf5b178c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->