### PR TITLE
Fix typo in CODEOWNERS for pkg/analyzer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -33,7 +33,7 @@ proto/ @trufflesecurity/Scanning  @trufflesecurity/Integrations
 pkg/detectors/ @trufflesecurity/OSS
 pkg/common/ @trufflesecurity/OSS
 pkg/custom_detectors/ @trufflesecurity/OSS
-pkg/analzyers/ @trufflesecurity/OSS
+pkg/analyzer/ @trufflesecurity/OSS
 pkg/engine/defaults/defaults.go @trufflesecurity/OSS
 pkg/engine/defaults/defaults_test.go @trufflesecurity/OSS
 


### PR DESCRIPTION
Fixed a small typo in the CODEOWNERS for pkg/analyzer

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/metadata-only change affecting reviewer assignment, with no runtime or build impact.
> 
> **Overview**
> Fixes a typo in `CODEOWNERS` by correcting the path entry from `pkg/analzyers/` to `pkg/analyzer/`, ensuring ownership/approval routing applies to the intended directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e46eb8710ef4454c986633d789de7da2308364d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->