### PR TITLE
fix: add --provenance=false to docker buildx steps

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,6 +32,7 @@ dockers:
     use: buildx
     build_flag_templates:
     - --platform=linux/amd64
+    - --provenance=false
     - --label=org.opencontainers.image.title={{ .ProjectName }}
     - --label=org.opencontainers.image.description={{ .ProjectName }}
     - --label=org.opencontainers.image.url=https://github.com/trufflesecurity/{{ .ProjectName }}
@@ -47,6 +48,7 @@ dockers:
     use: buildx
     build_flag_templates:
     - --platform=linux/arm64/v8
+    - --provenance=false
     - --label=org.opencontainers.image.title={{ .ProjectName }}
     - --label=org.opencontainers.image.description={{ .ProjectName }}
     - --label=org.opencontainers.image.url=https://github.com/trufflesecurity/{{ .ProjectName }}
@@ -61,6 +63,7 @@ dockers:
     use: buildx
     build_flag_templates:
     - --platform=linux/amd64
+    - --provenance=false
     - --label=org.opencontainers.image.title={{ .ProjectName }}
     - --label=org.opencontainers.image.description={{ .ProjectName }}
     - --label=org.opencontainers.image.url=https://github.com/trufflesecurity/{{ .ProjectName }}
@@ -76,6 +79,7 @@ dockers:
     use: buildx
     build_flag_templates:
     - --platform=linux/arm64/v8
+    - --provenance=false
     - --label=org.opencontainers.image.title={{ .ProjectName }}
     - --label=org.opencontainers.image.description={{ .ProjectName }}
     - --label=org.opencontainers.image.url=https://github.com/trufflesecurity/{{ .ProjectName }}


### PR DESCRIPTION
## Summary

Fixes the broken v3.93.4 release (issue #4750).

- Newer versions of `docker buildx` (v0.10+) automatically attach provenance attestations when pushing images, which causes single-arch images to be pushed as OCI manifest lists (indexes) rather than plain image manifests
- When GoReleaser's `docker_manifests` step then tries to assemble a multi-arch manifest from those per-arch tags, `docker manifest create` fails because it cannot include a manifest list as a component — only plain image manifests are valid
- Adding `--provenance=false` to all four `dockers` build entries prevents attestations from being added, ensuring per-arch tags are pushed as simple image manifests that `docker_manifests` can combine correctly

## Test plan

- [ ] Trigger a release and confirm all artifacts (linux/amd64, linux/arm64) are present in the GitHub release
- [ ] Confirm the install script completes successfully: `curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin`
- [ ] Confirm Docker Hub and GHCR multi-arch manifests are created correctly

Closes #4750

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, release-pipeline-only config change limited to Docker image build flags; primary risk is reduced/provenance metadata on published images.
> 
> **Overview**
> Disables provenance attestations for all GoReleaser `buildx` Docker image builds by adding `--provenance=false` to each per-arch image build flag template.
> 
> This ensures the per-architecture tags are pushed as plain image manifests so the subsequent `docker_manifests` step can successfully assemble multi-arch `:{{ .Version }}`/`:latest` manifests for Docker Hub and GHCR.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecd3134ee7e07d077140b340c73c014d8f559bcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->