### PR TITLE
fix(release): Disable docker provenance feature

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,6 +39,7 @@ dockers:
     - --label=org.opencontainers.image.version={{ .Version }}
     - --label=org.opencontainers.image.revision={{ .FullCommit }}
     - --label=org.opencontainers.image.licenses=AGPL-3.0
+    - --provenance=false
   - image_templates: ["trufflesecurity/{{ .ProjectName }}:{{ .Version }}-arm64v8"]
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
@@ -54,6 +55,7 @@ dockers:
     - --label=org.opencontainers.image.version={{ .Version }}
     - --label=org.opencontainers.image.revision={{ .FullCommit }}
     - --label=org.opencontainers.image.licenses=AGPL-3.0
+    - --provenance=false
   - image_templates: ["ghcr.io/trufflesecurity/{{ .ProjectName }}:{{ .Version }}-amd64"]
     dockerfile: Dockerfile.goreleaser
     extra_files:
@@ -68,6 +70,7 @@ dockers:
     - --label=org.opencontainers.image.version={{ .Version }}
     - --label=org.opencontainers.image.revision={{ .FullCommit }}
     - --label=org.opencontainers.image.licenses=AGPL-3.0
+    - --provenance=false
   - image_templates: ["ghcr.io/trufflesecurity/{{ .ProjectName }}:{{ .Version }}-arm64v8"]
     goarch: arm64
     dockerfile: Dockerfile.goreleaser
@@ -83,6 +86,7 @@ dockers:
     - --label=org.opencontainers.image.version={{ .Version }}
     - --label=org.opencontainers.image.revision={{ .FullCommit }}
     - --label=org.opencontainers.image.licenses=AGPL-3.0
+    - --provenance=false
 docker_manifests:
   - name_template: trufflesecurity/{{ .ProjectName }}:{{ .Version }}
     image_templates:


### PR DESCRIPTION
Our underlying "ubuntu-latest" image moved to Docker v29, which defaults to a containerd image store, which can store provenance info and creates even single images with a manifest by default, but goreleaser with our current config isn't expecting that.  This unblocks the release build, but I believe moving to dockers_v2 will fully resolve.

See also: docker/build-push-action#755

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change limited to release image build flags; main risk is reduced supply-chain metadata (provenance) rather than runtime behavior changes.
> 
> **Overview**
> GoReleaser Docker image builds now pass `--provenance=false` for both Docker Hub and GHCR targets across `amd64` and `arm64` (buildx), preventing auto-generated provenance/manifest behavior from interfering with the current release pipeline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c0b0d9cd9e7016e95606db4dd901d736eda435e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->