### PR TITLE
github detector: add crc32/base62 checksum validation for classic tokens

### DIFF
--- a/pkg/detectors/github/v2/github_test.go
+++ b/pkg/detectors/github/v2/github_test.go
@@ -2,6 +2,8 @@ package github
 
 import (
 	"context"
+	"hash/crc32"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -25,8 +27,13 @@ var (
 		"method": "GET",
 		"deprecated": false
 	}]`
-	secret = "ghs_RWGUZ6kS8_Ut7PbtR72k2miJwwYtxkpe8mOpT8feAWYZcwz43PxBVGCNATnycaQV9VUlPJe1uST5Xen7d3uZ5lilVlEVvT9AbxnhURdT3OzPtCvXydIrvE4LrDO"
+	secret            = "ghs_RWGUZ6kS8_Ut7PbtR72k2miJwwYtxkpe8mOpT8feAWYZcwz43PxBVGCNATnycaQV9VUlPJe1uST5Xen7d3uZ5lilVlEVvT9AbxnhURdT3OzPtCvXydIrvE4LrDO"
+	fineGrainedSecret = "github_pat_" + strings.Repeat("A", 82)
 )
+
+func makeClassicToken(prefix, body string) string {
+	return prefix + body + base62EncodePadded(uint64(crc32.ChecksumIEEE([]byte(body))), 6)
+}
 
 func TestGithub_Pattern(t *testing.T) {
 	d := Scanner{}
@@ -41,6 +48,11 @@ func TestGithub_Pattern(t *testing.T) {
 			name:  "valid pattern",
 			input: validPattern,
 			want:  []string{secret},
+		},
+		{
+			name:  "valid github_pat pattern",
+			input: fineGrainedSecret,
+			want:  []string{fineGrainedSecret},
 		},
 	}
 
@@ -64,6 +76,70 @@ func TestGithub_Pattern(t *testing.T) {
 				} else {
 					t.Errorf("expected %d results, only received %d", len(test.want), len(results))
 				}
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.RawV2) > 0 {
+					actual[string(r.RawV2)] = struct{}{}
+				} else {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}
+
+func TestGithub_ClassicTokenChecksum(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+
+	body := "sbUsUmRNn8X74dFU0DJ9Fm1mvdCgtH"
+	validToken := makeClassicToken("ghp_", body)
+	invalidToken := "ghp_" + body + "AAAAAA"
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "valid classic token checksum",
+			input: validToken,
+			want:  []string{validToken},
+		},
+		{
+			name:  "invalid classic token checksum",
+			input: invalidToken,
+			want:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(matchedDetectors) == 0 {
+				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			if err != nil {
+				t.Errorf("error = %v", err)
+				return
+			}
+
+			if len(results) != len(test.want) {
+				t.Errorf("expected %d results, only received %d", len(test.want), len(results))
 				return
 			}
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to GitHub token detection heuristics with added unit tests; primary risk is false negatives if the checksum algorithm/format assumptions are wrong.
> 
> **Overview**
> The GitHub v2 detector now **validates classic token format checksums** (CRC32 over the token body, base62-encoded) and skips reporting `gh[p|o|u|s|r]_...` tokens that fail this checksum, reducing false positives.
> 
> Tests were expanded to cover fine-grained `github_pat_` matching and to assert that classic tokens with invalid checksums are not returned by `FromData`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ae2507e0e6a38d29ca31db37757176fb33956b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->