### PR TITLE
fix(ftp): set read deadline on connection to prevent indefinite hang

### DIFF
--- a/pkg/detectors/ftp/ftp.go
+++ b/pkg/detectors/ftp/ftp.go
@@ -137,7 +137,10 @@ func verifyFTP(timeout time.Duration, u *url.URL) error {
 		if err != nil {
 			return nil, err
 		}
-		conn.SetDeadline(time.Now().Add(timeout))
+		if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+			conn.Close()
+			return nil, err
+		}
 		return conn, nil
 	}))
 	if err != nil {

--- a/pkg/detectors/ftp/ftp.go
+++ b/pkg/detectors/ftp/ftp.go
@@ -3,6 +3,7 @@ package ftp
 import (
 	"context"
 	"errors"
+	"net"
 	"net/textproto"
 	"net/url"
 	"strings"
@@ -128,7 +129,17 @@ func verifyFTP(timeout time.Duration, u *url.URL) error {
 		host = host + ":21"
 	}
 
-	c, err := ftp.Dial(host, ftp.DialWithTimeout(timeout))
+	// Use a custom dial function that sets a deadline on the connection so that
+	// the FTP banner read and login are also bounded by the timeout. Without this,
+	// a server that accepts TCP but never sends a banner will block indefinitely.
+	c, err := ftp.Dial(host, ftp.DialWithDialFunc(func(network, address string) (net.Conn, error) {
+		conn, err := net.DialTimeout(network, address, timeout)
+		if err != nil {
+			return nil, err
+		}
+		conn.SetDeadline(time.Now().Add(timeout))
+		return conn, nil
+	}))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The FTP detector uses ftp.DialWithTimeout to bound the TCP connection, but after the connection is established the banner read and login have no deadline. If a server accepts TCP but never sends a response, the detector blocks indefinitely, stalling the entire scan pipeline.

Switch to DialWithDialFunc and set a deadline on the connection that covers the full handshake (banner + login).

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to FTP verification connection handling; main risk is causing false negatives if the deadline is too aggressive on slow servers.
> 
> **Overview**
> Prevents the FTP detector’s verification step from hanging indefinitely when a server accepts TCP but never sends an FTP banner.
> 
> `verifyFTP` now dials via a custom `DialWithDialFunc` that uses `net.DialTimeout` and sets a connection-wide deadline so the banner read and `Login` are also bounded by the configured timeout (instead of only timing out the initial TCP connect).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a93d3a322eb76220d8155df053daaa108d9c757. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->