### PR TITLE
Fix overlap worker silently dropping non-duplicate secrets

### DIFF
--- a/docs/bugfix-overlap-worker-detector-deletion.md
+++ b/docs/bugfix-overlap-worker-detector-deletion.md
@@ -1,0 +1,84 @@
+# Bug Fix: Overlap Worker Silently Drops Non-Duplicate Secrets
+
+## Summary
+
+The verification overlap worker in `pkg/engine/engine.go` silently drops unique secrets when a chunk contains multiple secrets from the same detector, and one of those secrets overlaps with a different detector's result.
+
+## Root Cause
+
+When a chunk matches multiple detectors (e.g., `GoogleGeminiAPIKey` and `YoutubeApiKey`), the overlap worker runs each detector to check for cross-detector duplicates via `likelyDuplicate()`. If one of a detector's results is flagged as a duplicate, the code deletes the **entire detector** from further processing:
+
+```go
+delete(detectorKeysWithResults, detector.Key)
+```
+
+This means any **other, non-duplicate results** from that same detector on different match spans are silently lost — they never reach `detectChunk` for full processing.
+
+Because detectors are iterated from a Go map (non-deterministic order), which detector gets deleted changes between runs. This causes unique secrets to randomly appear or disappear across scans of the same data.
+
+## How to Reproduce
+
+Create a test file containing multiple secrets that match both `GoogleGeminiAPIKey` (regex: `AIzaSy[A-Za-z0-9_-]{33}`) and `YoutubeApiKey` (requires a `youtube` keyword prefix). The key ingredient is:
+
+1. A secret that matches **both** detectors (the overlap trigger)
+2. A separate secret that matches **only one** of those detectors (the victim)
+
+Example file (`/tmp/overlap-test.txt`):
+
+```
+# Config file for testing
+
+youtube_api_key = AIzaSyFAKE1aaBBccDDeeFFggHHiiJJkkLLmmNNO
+
+other_api_key = AIzaSyFAKE2xxYYzzAAbbCCddEEffGGhhIIjjKKL
+```
+
+Line 3 contains a key prefixed with `youtube`, so it matches both `YoutubeApiKey` and `GoogleGeminiAPIKey`. Line 5 contains a key that only matches `GoogleGeminiAPIKey` (no `youtube` prefix).
+
+Run the scan multiple times and observe the flapping:
+
+```bash
+for i in $(seq 1 10); do
+  RESULTS=$(trufflehog filesystem /tmp/overlap-test.txt --no-verification --json 2>/dev/null)
+  COUNT=$(echo "$RESULTS" | wc -l)
+  UNIQUE=$(echo "$RESULTS" | python3 -c "
+import sys, json
+seen = set()
+for line in sys.stdin:
+    r = json.loads(line.strip())
+    seen.add((r.get('DetectorType'), r.get('Raw')))
+print(len(seen))
+")
+  echo "Run $i: $COUNT results, $UNIQUE unique secrets"
+done
+```
+
+**Before fix:** The unique count flaps — sometimes the second key (`AIzaSyFAKE2...`) is missing because `GoogleGeminiAPIKey` lost the overlap coin flip on the first key and the entire detector was deleted.
+
+**After fix:** The result count and unique count are stable across all runs.
+
+## The Fix
+
+Instead of deleting the entire detector when one of its results is a cross-detector duplicate, we now track the specific duplicate result and pass it through to `detectChunk` via an `overlapSecrets` set on the `detectableChunk` struct.
+
+The overlap worker still emits the duplicate result with `errOverlap` (preserving existing behavior). The detector remains in `detectorKeysWithResults` and flows to `detectChunk` for full processing. In `detectChunk`, results whose raw value matches an entry in `overlapSecrets` are skipped, preventing double-reporting. All other results from that detector are processed normally.
+
+This gives us proper deduplication with no silent data loss:
+- Duplicate results: emitted exactly once (from the overlap worker, with `errOverlap`)
+- Non-duplicate results: emitted exactly once (from `detectChunk`)
+- No results lost
+
+## Impact
+
+Any file containing:
+- Multiple secrets matching the same detector (e.g., multiple Google API keys)
+- At least one of those secrets also matching a different detector (e.g., a key near the word "youtube")
+
+...is affected. The non-overlapping secrets randomly disappear depending on Go map iteration order, making scan results non-deterministic.
+
+## Files Changed
+
+- `pkg/engine/engine.go`:
+  - Added `overlapSecrets` field to `detectableChunk` struct
+  - Replaced `delete(detectorKeysWithResults, detector.Key)` in `verificationOverlapWorker` with per-result tracking via `overlapEmitted` map
+  - Added overlap secret filtering in `detectChunk` result loop


### PR DESCRIPTION
When a chunk matched multiple detectors and one result was flagged as a cross-detector duplicate via likelyDuplicate(), the entire detector was removed from detectorKeysWithResults. This silently dropped any other non-duplicate results from later match spans of that same detector.

Because detector iteration order comes from a Go map (non-deterministic), which detector got deleted changed between runs, causing unique secrets to randomly appear or disappear across scans of the same data.

The fix tracks specific duplicate results in an overlapEmitted map keyed by (DetectorKey, raw secret value). The detector remains in the pipeline for full processing by detectChunk, which skips only the results already emitted by the overlap worker via the new overlapSecrets field on detectableChunk. Detectors that had overlaps are also sent to detectChunk with Verify = false to avoid redundant verification calls and preserve the original performance characteristics. This gives exact-once reporting for both duplicate and non-duplicate results with no silent data loss and no performance regression.

More info in the md

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core scan-engine result/verification behavior in overlap scenarios; low surface area but could affect deduping and verification decisions for chunks with multi-detector matches.
> 
> **Overview**
> Fixes non-deterministic secret loss in the verification overlap pipeline when a chunk matches multiple detectors: instead of removing an entire detector after one cross-detector duplicate, the worker now tracks *which specific raw secrets* were already emitted as overlaps and lets the detector continue through normal processing.
> 
> `detectableChunk` carries an `overlapSecrets` set from `verificationOverlapWorker` to `detectChunk`, which filters out only those already-emitted overlap findings (while also forcing verification off for detectors that had overlaps), ensuring stable, exact-once reporting without dropping other unique results. Adds a markdown doc describing the bug, reproduction, and fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89b1fa75577ef8a0d873823dd105c8d52ddbd911. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->