### PR TITLE
GH_TOKEN needed for gh

### DIFF
--- a/.github/workflows/release-guard.yml
+++ b/.github/workflows/release-guard.yml
@@ -31,3 +31,5 @@ jobs:
 
           echo "Restoring $PREVIOUS_TAG as latest..."
           gh release edit "$PREVIOUS_TAG" --latest
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
GH_TOKEN was missing from release-guard and prevented it from working as expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds the standard `GH_TOKEN` env var so `gh release` commands can authenticate; behavior only changes in CI when managing release metadata.
> 
> **Overview**
> Fixes the `Release Guard` GitHub Actions workflow by exporting `GH_TOKEN` (using `github.token`) for the step that runs `gh release` commands, ensuring the workflow can authenticate when restoring the previous release as `latest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a317edb5674f8e8ef6048b6a330b91b7ca568e70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->