### PR TITLE
Fix GitHub App cross-org member enumeration using per-installation tokens

### DIFF
--- a/pkg/sources/github/connector_app.go
+++ b/pkg/sources/github/connector_app.go
@@ -56,35 +56,26 @@ func NewAppConnector(ctx context.Context, apiEndpoint string, app *credentialspb
 		return nil, fmt.Errorf("could not create installation client: %w", err)
 	}
 
-	apiTransport, err := ghinstallation.New(
-		httpClient.Transport,
-		appID,
-		installationID,
-		[]byte(app.PrivateKey))
-	if err != nil {
-		return nil, fmt.Errorf("could not create API client transport: %w", err)
-	}
-	apiTransport.BaseURL = apiEndpoint
-
-	httpClient.Transport = apiTransport
-	apiClient, err := github.NewClient(httpClient).WithEnterpriseURLs(apiEndpoint, apiEndpoint)
-	if err != nil {
-		return nil, fmt.Errorf("could not create API client: %w", err)
-	}
-
-	graphqlClient, err := createGraphqlClient(ctx, httpClient, apiEndpoint)
-	if err != nil {
-		return nil, fmt.Errorf("error creating GraphQL client: %w", err)
-	}
-
-	return &appConnector{
-		apiClient:          apiClient,
-		graphqlClient:      graphqlClient,
+	connector := &appConnector{
 		installationClient: installationClient,
 		installationID:     installationID,
 		appsTransport:      installationTransport,
 		apiEndpoint:        apiEndpoint,
-	}, nil
+	}
+
+	apiClient, err := connector.APIClientForInstallation(installationID)
+	if err != nil {
+		return nil, fmt.Errorf("could not create API client for configured installation: %w", err)
+	}
+	connector.apiClient = apiClient
+
+	graphqlClient, err := createGraphqlClient(ctx, apiClient.Client(), apiEndpoint)
+	if err != nil {
+		return nil, fmt.Errorf("error creating GraphQL client: %w", err)
+	}
+	connector.graphqlClient = graphqlClient
+
+	return connector, nil
 }
 
 func (c *appConnector) APIClient() *github.Client {

--- a/pkg/sources/github/connector_app_test.go
+++ b/pkg/sources/github/connector_app_test.go
@@ -1,0 +1,152 @@
+package github
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/bradleyfalzon/ghinstallation/v2"
+	"github.com/google/go-github/v67/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	trContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
+)
+
+func generateTestPrivateKey(t *testing.T) []byte {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+}
+
+func TestAPIClientForInstallation(t *testing.T) {
+	privKey := generateTestPrivateKey(t)
+
+	var mu sync.Mutex
+	var tokenRequestPaths []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == "POST" && strings.Contains(r.URL.Path, "access_tokens") {
+			mu.Lock()
+			tokenRequestPaths = append(tokenRequestPaths, r.URL.Path)
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"token":      "test-token",
+				"expires_at": "2099-01-01T00:00:00Z",
+			})
+			return
+		}
+
+		// Default: return empty JSON array for any list endpoint.
+		_ = json.NewEncoder(w).Encode([]interface{}{})
+	}))
+	defer server.Close()
+
+	appsTransport, err := ghinstallation.NewAppsTransport(
+		http.DefaultTransport,
+		12345,
+		privKey,
+	)
+	require.NoError(t, err)
+	appsTransport.BaseURL = server.URL
+
+	connector := &appConnector{
+		appsTransport: appsTransport,
+		apiEndpoint:   server.URL,
+	}
+
+	t.Run("creates distinct clients for different installations", func(t *testing.T) {
+		client1, err := connector.APIClientForInstallation(111)
+		require.NoError(t, err)
+		assert.NotNil(t, client1)
+
+		client2, err := connector.APIClientForInstallation(222)
+		require.NoError(t, err)
+		assert.NotNil(t, client2)
+
+		assert.NotSame(t, client1, client2, "should be different client instances")
+	})
+
+	t.Run("returned client uses the correct installation ID", func(t *testing.T) {
+		mu.Lock()
+		tokenRequestPaths = nil
+		mu.Unlock()
+
+		client, err := connector.APIClientForInstallation(42)
+		require.NoError(t, err)
+
+		ctx := trContext.Background()
+		_, _, _ = client.Organizations.ListMembers(ctx, "test-org", nil)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, tokenRequestPaths, 1)
+		assert.Contains(t, tokenRequestPaths[0], "/app/installations/42/access_tokens")
+	})
+
+	t.Run("different installations use different tokens", func(t *testing.T) {
+		mu.Lock()
+		tokenRequestPaths = nil
+		mu.Unlock()
+
+		ctx := trContext.Background()
+
+		client1, err := connector.APIClientForInstallation(100)
+		require.NoError(t, err)
+		_, _, _ = client1.Organizations.ListMembers(ctx, "org-a", nil)
+
+		client2, err := connector.APIClientForInstallation(200)
+		require.NoError(t, err)
+		_, _, _ = client2.Organizations.ListMembers(ctx, "org-b", nil)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, tokenRequestPaths, 2)
+		assert.Contains(t, tokenRequestPaths[0], "/installations/100/")
+		assert.Contains(t, tokenRequestPaths[1], "/installations/200/")
+	})
+}
+
+func TestAddMembersByOrgWithClient(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	memberPage := []*github.User{
+		{Login: strPtr("alice")},
+		{Login: strPtr("bob")},
+		{Login: strPtr("charlie")},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(memberPage)
+	}))
+	defer server.Close()
+
+	client, err := github.NewClient(nil).WithEnterpriseURLs(server.URL, server.URL)
+	require.NoError(t, err)
+
+	s := &Source{
+		memberCache: make(map[string]struct{}),
+	}
+
+	ctx := trContext.Background()
+	err = s.addMembersByOrgWithClient(ctx, client, "test-org", nil)
+	require.NoError(t, err)
+
+	assert.Len(t, s.memberCache, 3)
+	assert.Contains(t, s.memberCache, "alice")
+	assert.Contains(t, s.memberCache, "bob")
+	assert.Contains(t, s.memberCache, "charlie")
+}

--- a/pkg/sources/github/connector_app_test.go
+++ b/pkg/sources/github/connector_app_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	trContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/credentialspb"
 )
 
 func generateTestPrivateKey(t *testing.T) []byte {
@@ -118,6 +119,46 @@ func TestAPIClientForInstallation(t *testing.T) {
 		assert.Contains(t, tokenRequestPaths[0], "/installations/100/")
 		assert.Contains(t, tokenRequestPaths[1], "/installations/200/")
 	})
+}
+
+func TestNewAppConnectorDefaultAPIClientUsesConfiguredInstallation(t *testing.T) {
+	privKey := generateTestPrivateKey(t)
+
+	var mu sync.Mutex
+	var tokenRequestPaths []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.Method == "POST" && strings.Contains(r.URL.Path, "access_tokens") {
+			mu.Lock()
+			tokenRequestPaths = append(tokenRequestPaths, r.URL.Path)
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"token":      "configured-installation-token",
+				"expires_at": "2099-01-01T00:00:00Z",
+			})
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode([]map[string]string{{"login": "alice"}})
+	}))
+	defer server.Close()
+
+	connector, err := NewAppConnector(trContext.Background(), server.URL, &credentialspb.GitHubApp{
+		PrivateKey:     string(privKey),
+		InstallationId: "4242",
+		AppId:          "12345",
+	})
+	require.NoError(t, err)
+
+	_, _, err = connector.APIClient().Organizations.ListMembers(trContext.Background(), "test-org", nil)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, tokenRequestPaths, 1)
+	assert.Contains(t, tokenRequestPaths[0], "/app/installations/4242/access_tokens")
 }
 
 func TestAddMembersByOrgWithClient(t *testing.T) {

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -421,7 +421,7 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 	// this felt like a compromise that allowed me to isolate connection logic without rewriting the entire source.
 	switch c := s.connector.(type) {
 	case *appConnector:
-		if err := s.enumerateWithApp(ctx, c.InstallationClient(), dedupeReporter); err != nil {
+		if err := s.enumerateWithApp(ctx, c, dedupeReporter); err != nil {
 			return err
 		}
 	case *basicAuthConnector:
@@ -631,7 +631,7 @@ func (s *Source) enumerateWithToken(ctx context.Context, isGithubEnterprise bool
 	return nil
 }
 
-func (s *Source) enumerateWithApp(ctx context.Context, installationClient *github.Client, reporter sources.UnitReporter) error {
+func (s *Source) enumerateWithApp(ctx context.Context, connector *appConnector, reporter sources.UnitReporter) error {
 	// If no repos were provided, enumerate them.
 	if len(s.repos) == 0 {
 		if err := s.getReposByApp(ctx, reporter); err != nil {
@@ -640,7 +640,7 @@ func (s *Source) enumerateWithApp(ctx context.Context, installationClient *githu
 
 		// Check if we need to find user repos.
 		if s.conn.ScanUsers {
-			err := s.addMembersByApp(ctx, installationClient, reporter)
+			err := s.addMembersByApp(ctx, connector, reporter)
 			if err != nil {
 				return err
 			}
@@ -938,7 +938,8 @@ func (s *Source) addUserGistsToCache(ctx context.Context, user string, reporter 
 	return nil
 }
 
-func (s *Source) addMembersByApp(ctx context.Context, installationClient *github.Client, reporter sources.UnitReporter) error {
+func (s *Source) addMembersByApp(ctx context.Context, connector *appConnector, reporter sources.UnitReporter) error {
+	installationClient := connector.InstallationClient()
 	opts := &github.ListOptions{
 		PerPage: membersAppPagination,
 	}
@@ -949,12 +950,25 @@ func (s *Source) addMembersByApp(ctx context.Context, installationClient *github
 		return fmt.Errorf("could not enumerate installed orgs: %w", err)
 	}
 
-	for _, org := range installs {
-		if org.Account.GetType() != "Organization" {
+	for _, install := range installs {
+		if install.Account.GetType() != "Organization" {
 			continue
 		}
-		if err := s.addMembersByOrg(ctx, *org.Account.Login, reporter); err != nil {
-			return err
+		org := install.Account.GetLogin()
+		logger := ctx.Logger().WithValues("org", org, "installation_id", install.GetID())
+
+		// Create a per-installation API client so that the token is scoped to
+		// this org. GitHub App installation tokens only bypass IP allowlists for
+		// their own org; using a cross-org token causes 403s.
+		client, err := connector.APIClientForInstallation(install.GetID())
+		if err != nil {
+			logger.Error(err, "could not create API client for installation")
+			continue
+		}
+
+		if err := s.addMembersByOrgWithClient(ctx, client, org, reporter); err != nil {
+			logger.Error(err, "Unable to add members for org")
+			continue
 		}
 	}
 
@@ -1036,6 +1050,10 @@ func (s *Source) addOrgsByUser(ctx context.Context, user string, reporter source
 }
 
 func (s *Source) addMembersByOrg(ctx context.Context, org string, reporter sources.UnitReporter) error {
+	return s.addMembersByOrgWithClient(ctx, s.connector.APIClient(), org, reporter)
+}
+
+func (s *Source) addMembersByOrgWithClient(ctx context.Context, client *github.Client, org string, reporter sources.UnitReporter) error {
 	opts := &github.ListMembersOptions{
 		PublicOnly: false,
 		ListOptions: github.ListOptions{
@@ -1045,7 +1063,7 @@ func (s *Source) addMembersByOrg(ctx context.Context, org string, reporter sourc
 
 	logger := ctx.Logger().WithValues("org", org)
 	for {
-		members, res, err := s.connector.APIClient().Organizations.ListMembers(ctx, org, opts)
+		members, res, err := client.Organizations.ListMembers(ctx, org, opts)
 		if s.handleRateLimitWithUnitReporter(ctx, reporter, err) {
 			continue
 		}

--- a/pkg/sources/github/github_integration_test.go
+++ b/pkg/sources/github/github_integration_test.go
@@ -65,7 +65,7 @@ func TestSource_Token(t *testing.T) {
 	s.Init(ctx, "github integration test source", 0, 0, false, conn, 1)
 	s.filteredRepoCache = s.newFilteredRepoCache(ctx, simple.NewCache[string](), nil, nil)
 
-	err = s.enumerateWithApp(ctx, s.connector.(*appConnector).InstallationClient(), noopReporter())
+	err = s.enumerateWithApp(ctx, s.connector.(*appConnector), noopReporter())
 	assert.NoError(t, err)
 
 	_, _, err = s.cloneRepo(ctx, "https://github.com/truffle-test-integration-org/another-test-repo.git")

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -302,7 +302,7 @@ func TestAddMembersByApp(t *testing.T) {
 		Get("/app/installations").
 		Reply(200).
 		JSON([]map[string]any{
-			{"account": map[string]string{"login": "super-secret-org", "type": "Organization"}},
+			{"id": 1337, "account": map[string]string{"login": "super-secret-org", "type": "Organization"}},
 		})
 	gock.New("https://api.github.com").
 		Post("/app/installations/1337/access_tokens").
@@ -326,7 +326,7 @@ func TestAddMembersByApp(t *testing.T) {
 				AppId:          "4141",
 			},
 		}})
-	err := s.addMembersByApp(context.Background(), s.connector.(*appConnector).InstallationClient(), noopReporter())
+	err := s.addMembersByApp(context.Background(), s.connector.(*appConnector), noopReporter())
 	assert.Nil(t, err)
 	assert.Equal(t, 3, len(s.memberCache))
 	_, ok := s.memberCache["ssm1"]
@@ -884,7 +884,7 @@ func TestEnumerateWithApp(t *testing.T) {
 			},
 		},
 	})
-	err := s.enumerateWithApp(context.Background(), s.connector.(*appConnector).InstallationClient(), noopReporter())
+	err := s.enumerateWithApp(context.Background(), s.connector.(*appConnector), noopReporter())
 	assert.Nil(t, err)
 	assert.Equal(t, 0, len(s.repos))
 	assert.False(t, gock.HasUnmatchedRequest())


### PR DESCRIPTION
## Summary

- When a GitHub App is installed across multiple orgs, `addMembersByApp` discovers all installations via JWT but uses a single installation's token for `ListMembers` calls across all orgs
- GitHub App installation tokens only bypass IP allowlists for their own org, so cross-org calls get 403s
- Adds `APIClientForInstallation` to `appConnector` which creates per-installation API clients using `ghinstallation.NewFromAppsTransport`
- Extracts `addMembersByOrgWithClient` from `addMembersByOrg` so the app auth path can provide an explicit per-installation client

## Test plan

- [x] New unit tests for `APIClientForInstallation` (3 subtests verifying distinct clients, correct installation ID, different tokens)
- [x] New unit test for `addMembersByOrgWithClient`
- [x] Existing `TestAddMembersByApp` and `TestEnumerateWithApp` updated and passing
- [x] `go build` passes
- [x] Manual verification with a multi-org GitHub App installation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GitHub App authentication and org member enumeration; mis-scoped tokens could still miss members, but behavior is narrowed with tests and per-org error isolation.
> 
> **Overview**
> Fixes **GitHub App** member enumeration when the app is installed on **multiple orgs** by using an **installation-scoped API client** for each org instead of one token for every `ListMembers` call (which caused **403s** when IP allowlists apply per installation).
> 
> **`appConnector`** now keeps the shared `AppsTransport` and adds **`APIClientForInstallation`**, built with `ghinstallation.NewFromAppsTransport`; the default API client from `NewAppConnector` still targets the configured installation ID. **`addMembersByApp`** walks app installations, builds a client per installation ID, and calls **`addMembersByOrgWithClient`**; failures for a single org are logged and skipped rather than aborting the whole run. **`addMembersByOrg`** delegates to the same helper with the connector’s default client.
> 
> New unit tests cover per-installation clients and the refactored member listing; existing app enumeration tests were updated for installation IDs in mocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3fe806a69147ff3b078cc5aa4e6eb550bcb7c66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->