### PR TITLE
Add AnalysisError type and wrap all analyzer error paths

### DIFF
--- a/pkg/analyzer/analyzers/airbrake/airbrake.go
+++ b/pkg/analyzer/analyzers/airbrake/airbrake.go
@@ -25,7 +25,9 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeAir
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	info, err := AnalyzePermissions(a.Cfg, credInfo["key"])
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Airbrake", "analyze_permissions", "API", "", err,
+		)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/airbrake/airbrake.go
+++ b/pkg/analyzer/analyzers/airbrake/airbrake.go
@@ -25,8 +25,7 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeAir
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	info, err := AnalyzePermissions(a.Cfg, credInfo["key"])
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Airbrake", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/airtable/airtableoauth/airtable.go
+++ b/pkg/analyzer/analyzers/airtable/airtableoauth/airtable.go
@@ -22,12 +22,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeAir
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	token, ok := credInfo["token"]
 	if !ok {
-		return nil, errors.New("token not found in credInfo")
+		return nil, analyzers.NewAnalysisError("AirtableOAuth", "validate_credentials", "config", "", errors.New("token not found in credInfo"))
 	}
 
 	userInfo, err := common.FetchAirtableUserInfo(token)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("AirtableOAuth", "analyze_permissions", "API", "", err)
 	}
 
 	var basesInfo *common.AirtableBases

--- a/pkg/analyzer/analyzers/airtable/airtableoauth/airtable.go
+++ b/pkg/analyzer/analyzers/airtable/airtableoauth/airtable.go
@@ -22,12 +22,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeAir
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	token, ok := credInfo["token"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("AirtableOAuth", "validate_credentials", "config", "", errors.New("token not found in credInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("token not found in credInfo"))
 	}
 
 	userInfo, err := common.FetchAirtableUserInfo(token)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("AirtableOAuth", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 
 	var basesInfo *common.AirtableBases

--- a/pkg/analyzer/analyzers/airtable/airtablepat/airtable.go
+++ b/pkg/analyzer/analyzers/airtable/airtablepat/airtable.go
@@ -36,12 +36,12 @@ func getScopeEndpoint(scope string) (common.Endpoint, bool) {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	token, ok := credInfo["token"]
 	if !ok {
-		return nil, errors.New("token not found in credInfo")
+		return nil, analyzers.NewAnalysisError("AirtablePat", "validate_credentials", "config", "", errors.New("token not found in credInfo"))
 	}
 
 	userInfo, err := common.FetchAirtableUserInfo(token)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("AirtablePat", "analyze_permissions", "API", "", err)
 	}
 
 	scopeStatusMap[common.PermissionStrings[common.UserEmailRead]] = userInfo.Email != nil
@@ -49,17 +49,17 @@ func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analy
 	var basesInfo *common.AirtableBases
 	granted, err := determineScope(token, common.SchemaBasesRead, nil)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("AirtablePat", "analyze_permissions", "API", "", err)
 	}
 	if granted {
 		basesInfo, err = common.FetchAirtableBases(token)
 		if err != nil {
-			return nil, err
+			return nil, analyzers.NewAnalysisError("AirtablePat", "analyze_permissions", "API", "", err)
 		}
 		// If bases are fetched, determine the token scopes
 		err := determineScopes(token, basesInfo)
 		if err != nil {
-			return nil, err
+			return nil, analyzers.NewAnalysisError("AirtablePat", "analyze_permissions", "API", "", err)
 		}
 	}
 

--- a/pkg/analyzer/analyzers/airtable/airtablepat/airtable.go
+++ b/pkg/analyzer/analyzers/airtable/airtablepat/airtable.go
@@ -36,12 +36,12 @@ func getScopeEndpoint(scope string) (common.Endpoint, bool) {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	token, ok := credInfo["token"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("AirtablePat", "validate_credentials", "config", "", errors.New("token not found in credInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("token not found in credInfo"))
 	}
 
 	userInfo, err := common.FetchAirtableUserInfo(token)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("AirtablePat", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 
 	scopeStatusMap[common.PermissionStrings[common.UserEmailRead]] = userInfo.Email != nil
@@ -49,17 +49,17 @@ func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analy
 	var basesInfo *common.AirtableBases
 	granted, err := determineScope(token, common.SchemaBasesRead, nil)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("AirtablePat", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 	if granted {
 		basesInfo, err = common.FetchAirtableBases(token)
 		if err != nil {
-			return nil, analyzers.NewAnalysisError("AirtablePat", "analyze_permissions", "API", "", err)
+			return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 		}
 		// If bases are fetched, determine the token scopes
 		err := determineScopes(token, basesInfo)
 		if err != nil {
-			return nil, analyzers.NewAnalysisError("AirtablePat", "analyze_permissions", "API", "", err)
+			return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 		}
 	}
 

--- a/pkg/analyzer/analyzers/anthropic/anthropic.go
+++ b/pkg/analyzer/analyzers/anthropic/anthropic.go
@@ -51,12 +51,16 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, errors.New("key not found in credentials info")
+		return nil, analyzers.NewAnalysisError(
+			"Anthropic", "validate_credentials", "config", "", errors.New("key not found in credentials info"),
+		)
 	}
 
 	secretInfo, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Anthropic", "analyze_permissions", "API", "", err,
+		)
 	}
 
 	return secretInfoToAnalyzerResult(secretInfo), nil

--- a/pkg/analyzer/analyzers/anthropic/anthropic.go
+++ b/pkg/analyzer/analyzers/anthropic/anthropic.go
@@ -51,15 +51,13 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError(
-			"Anthropic", "validate_credentials", "config", "", errors.New("key not found in credentials info"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentials info"),
 		)
 	}
 
 	secretInfo, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Anthropic", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 

--- a/pkg/analyzer/analyzers/asana/asana.go
+++ b/pkg/analyzer/analyzers/asana/asana.go
@@ -28,12 +28,16 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeAsa
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, errors.New("key not found in credInfo")
+		return nil, analyzers.NewAnalysisError(
+			"Asana", "validate_credentials", "config", "", errors.New("key not found in credInfo"),
+		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Asana", "analyze_permissions", "API", "", err,
+		)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/asana/asana.go
+++ b/pkg/analyzer/analyzers/asana/asana.go
@@ -28,15 +28,13 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeAsa
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError(
-			"Asana", "validate_credentials", "config", "", errors.New("key not found in credInfo"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credInfo"),
 		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Asana", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 

--- a/pkg/analyzer/analyzers/bitbucket/bitbucket.go
+++ b/pkg/analyzer/analyzers/bitbucket/bitbucket.go
@@ -63,11 +63,11 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeBit
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, errors.New("key not found in credentialInfo")
+		return nil, analyzers.NewAnalysisError("Bitbucket", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("Bitbucket", "analyze_permissions", "API", "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/bitbucket/bitbucket.go
+++ b/pkg/analyzer/analyzers/bitbucket/bitbucket.go
@@ -63,11 +63,11 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeBit
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("Bitbucket", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentialInfo"))
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Bitbucket", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/databricks/databricks.go
+++ b/pkg/analyzer/analyzers/databricks/databricks.go
@@ -26,17 +26,17 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(ctx context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	token, exist := credInfo["token"]
 	if !exist {
-		return nil, fmt.Errorf("key not found in credential info")
+		return nil, analyzers.NewAnalysisError("DataBricks", "validate_credentials", "config", "", fmt.Errorf("key not found in credential info"))
 	}
 
 	domain, exist := credInfo["domain"]
 	if !exist {
-		return nil, fmt.Errorf("domain not found in credential info")
+		return nil, analyzers.NewAnalysisError("DataBricks", "validate_credentials", "config", "", fmt.Errorf("domain not found in credential info"))
 	}
 
 	info, err := AnalyzePermissions(ctx, a.Cfg, domain, token)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("DataBricks", "analyze_permissions", "API", "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/databricks/databricks.go
+++ b/pkg/analyzer/analyzers/databricks/databricks.go
@@ -26,17 +26,17 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(ctx context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	token, exist := credInfo["token"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError("DataBricks", "validate_credentials", "config", "", fmt.Errorf("key not found in credential info"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", fmt.Errorf("key not found in credential info"))
 	}
 
 	domain, exist := credInfo["domain"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError("DataBricks", "validate_credentials", "config", "", fmt.Errorf("domain not found in credential info"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", fmt.Errorf("domain not found in credential info"))
 	}
 
 	info, err := AnalyzePermissions(ctx, a.Cfg, domain, token)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("DataBricks", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/datadog/datadog.go
+++ b/pkg/analyzer/analyzers/datadog/datadog.go
@@ -33,7 +33,7 @@ func (a Analyzer) Analyze(ctx context.Context, credInfo map[string]string) (*ana
 
 	info, err := AnalyzePermissions(a.Cfg, apiKey, appKey, endpoint)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Datadog", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/datadog/datadog.go
+++ b/pkg/analyzer/analyzers/datadog/datadog.go
@@ -33,7 +33,7 @@ func (a Analyzer) Analyze(ctx context.Context, credInfo map[string]string) (*ana
 
 	info, err := AnalyzePermissions(a.Cfg, apiKey, appKey, endpoint)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("Datadog", "analyze_permissions", "API", "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/digitalocean/digitalocean.go
+++ b/pkg/analyzer/analyzers/digitalocean/digitalocean.go
@@ -34,11 +34,15 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeDig
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, errors.New("missing key in credInfo")
+		return nil, analyzers.NewAnalysisError(
+			"DigitalOcean", "validate_credentials", "config", "", errors.New("missing key in credInfo"),
+		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"DigitalOcean", "analyze_permissions", "API", "", err,
+		)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/digitalocean/digitalocean.go
+++ b/pkg/analyzer/analyzers/digitalocean/digitalocean.go
@@ -34,14 +34,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeDig
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError(
-			"DigitalOcean", "validate_credentials", "config", "", errors.New("missing key in credInfo"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("missing key in credInfo"),
 		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"DigitalOcean", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/dockerhub/dockerhub.go
+++ b/pkg/analyzer/analyzers/dockerhub/dockerhub.go
@@ -54,17 +54,23 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	username, exist := credInfo["username"]
 	if !exist {
-		return nil, errors.New("username not found in the credentials info")
+		return nil, analyzers.NewAnalysisError(
+			"DockerHub", "validate_credentials", "config", "", errors.New("username not found in the credentials info"),
+		)
 	}
 
 	pat, exist := credInfo["pat"]
 	if !exist {
-		return nil, errors.New("personal access token(PAT) not found in the credentials info")
+		return nil, analyzers.NewAnalysisError(
+			"DockerHub", "validate_credentials", "config", "", errors.New("personal access token(PAT) not found in the credentials info"),
+		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, username, pat)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"DockerHub", "analyze_permissions", "API", "", err,
+		)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/dockerhub/dockerhub.go
+++ b/pkg/analyzer/analyzers/dockerhub/dockerhub.go
@@ -54,22 +54,19 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	username, exist := credInfo["username"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError(
-			"DockerHub", "validate_credentials", "config", "", errors.New("username not found in the credentials info"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("username not found in the credentials info"),
 		)
 	}
 
 	pat, exist := credInfo["pat"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError(
-			"DockerHub", "validate_credentials", "config", "", errors.New("personal access token(PAT) not found in the credentials info"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("personal access token(PAT) not found in the credentials info"),
 		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, username, pat)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"DockerHub", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 

--- a/pkg/analyzer/analyzers/dropbox/dropbox.go
+++ b/pkg/analyzer/analyzers/dropbox/dropbox.go
@@ -43,12 +43,12 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	token, exist := credInfo["token"]
 	if !exist {
-		return nil, errors.New("token not found in credentials info")
+		return nil, analyzers.NewAnalysisError("Dropbox", "validate_credentials", "config", "", errors.New("token not found in credentials info"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, token)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("Dropbox", "analyze_permissions", "API", "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/dropbox/dropbox.go
+++ b/pkg/analyzer/analyzers/dropbox/dropbox.go
@@ -43,12 +43,12 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	token, exist := credInfo["token"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError("Dropbox", "validate_credentials", "config", "", errors.New("token not found in credentials info"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("token not found in credentials info"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, token)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Dropbox", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/elevenlabs/elevenlabs.go
+++ b/pkg/analyzer/analyzers/elevenlabs/elevenlabs.go
@@ -86,12 +86,16 @@ func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analy
 	// check if the `key` exist in the credentials info
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, errors.New("key not found in credentials info")
+		return nil, analyzers.NewAnalysisError(
+			"ElevenLabs", "validate_credentials", "config", "", errors.New("key not found in credentials info"),
+		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"ElevenLabs", "analyze_permissions", "API", "", err,
+		)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/elevenlabs/elevenlabs.go
+++ b/pkg/analyzer/analyzers/elevenlabs/elevenlabs.go
@@ -86,15 +86,13 @@ func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analy
 	// check if the `key` exist in the credentials info
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError(
-			"ElevenLabs", "validate_credentials", "config", "", errors.New("key not found in credentials info"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentials info"),
 		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"ElevenLabs", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 

--- a/pkg/analyzer/analyzers/errors.go
+++ b/pkg/analyzer/analyzers/errors.go
@@ -1,0 +1,50 @@
+package analyzers
+
+import "fmt"
+
+// AnalysisErrorInfo is implemented by errors that provide structured context
+// about analysis failures. This allows downstream consumers (e.g., the scanner)
+// to extract metadata for structured error storage without depending on
+// concrete error types.
+type AnalysisErrorInfo interface {
+	error
+	AnalyzerType() string
+	Operation() string // "validate_credentials", "authenticate", "analyze_permissions", "connect", "ping"
+	Service() string   // "config", "API", "OAuth", "Database"
+	Resource() string  // account ID, endpoint URL, or other identifier
+}
+
+// AnalysisError represents a structured error from an analyzer.
+type AnalysisError struct {
+	analyzerType string
+	operation    string
+	service      string
+	resource     string
+	err          error
+}
+
+// NewAnalysisError creates a new AnalysisError.
+func NewAnalysisError(analyzerType, operation, service, resource string, err error) *AnalysisError {
+	return &AnalysisError{
+		analyzerType: analyzerType,
+		operation:    operation,
+		service:      service,
+		resource:     resource,
+		err:          err,
+	}
+}
+
+func (e *AnalysisError) Error() string {
+	if e.err != nil {
+		return fmt.Sprintf("%s analysis failed: %s on %s (resource: %s): %v",
+			e.analyzerType, e.operation, e.service, e.resource, e.err)
+	}
+	return fmt.Sprintf("%s analysis failed: %s on %s (resource: %s)",
+		e.analyzerType, e.operation, e.service, e.resource)
+}
+
+func (e *AnalysisError) Unwrap() error    { return e.err }
+func (e *AnalysisError) AnalyzerType() string { return e.analyzerType }
+func (e *AnalysisError) Operation() string    { return e.operation }
+func (e *AnalysisError) Service() string      { return e.service }
+func (e *AnalysisError) Resource() string     { return e.resource }

--- a/pkg/analyzer/analyzers/errors.go
+++ b/pkg/analyzer/analyzers/errors.go
@@ -2,6 +2,21 @@ package analyzers
 
 import "fmt"
 
+// Operation constants for AnalysisError.
+const (
+	OperationValidateCredentials = "validate_credentials"
+	OperationAnalyzePermissions  = "analyze_permissions"
+)
+
+// Service constants for AnalysisError.
+const (
+	ServiceAPI      = "API"
+	ServiceConfig   = "config"
+	ServiceDatabase = "Database"
+	ServiceOAuth    = "OAuth"
+	ServiceCrypto   = "crypto"
+)
+
 // AnalysisErrorInfo is implemented by errors that provide structured context
 // about analysis failures. This allows downstream consumers (e.g., the scanner)
 // to extract metadata for structured error storage without depending on

--- a/pkg/analyzer/analyzers/errors.go
+++ b/pkg/analyzer/analyzers/errors.go
@@ -50,12 +50,16 @@ func NewAnalysisError(analyzerType, operation, service, resource string, err err
 }
 
 func (e *AnalysisError) Error() string {
-	if e.err != nil {
-		return fmt.Sprintf("%s analysis failed: %s on %s (resource: %s): %v",
-			e.analyzerType, e.operation, e.service, e.resource, e.err)
+	var resource string
+	if e.resource != "" {
+		resource = fmt.Sprintf(" (resource: %s)", e.resource)
 	}
-	return fmt.Sprintf("%s analysis failed: %s on %s (resource: %s)",
-		e.analyzerType, e.operation, e.service, e.resource)
+	if e.err != nil {
+		return fmt.Sprintf("%s analysis failed: %s on %s%s: %v",
+			e.analyzerType, e.operation, e.service, resource, e.err)
+	}
+	return fmt.Sprintf("%s analysis failed: %s on %s%s",
+		e.analyzerType, e.operation, e.service, resource)
 }
 
 func (e *AnalysisError) Unwrap() error    { return e.err }

--- a/pkg/analyzer/analyzers/errors_test.go
+++ b/pkg/analyzer/analyzers/errors_test.go
@@ -1,0 +1,76 @@
+package analyzers
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestAnalysisErrorImplementsInterface(t *testing.T) {
+	var _ AnalysisErrorInfo = (*AnalysisError)(nil)
+}
+
+func TestAnalysisErrorFields(t *testing.T) {
+	orig := fmt.Errorf("connection refused")
+	e := NewAnalysisError("Postgres", "connect", "Database", "localhost:5432", orig)
+
+	if e.AnalyzerType() != "Postgres" {
+		t.Errorf("AnalyzerType() = %q, want %q", e.AnalyzerType(), "Postgres")
+	}
+	if e.Operation() != "connect" {
+		t.Errorf("Operation() = %q, want %q", e.Operation(), "connect")
+	}
+	if e.Service() != "Database" {
+		t.Errorf("Service() = %q, want %q", e.Service(), "Database")
+	}
+	if e.Resource() != "localhost:5432" {
+		t.Errorf("Resource() = %q, want %q", e.Resource(), "localhost:5432")
+	}
+}
+
+func TestAnalysisErrorUnwrap(t *testing.T) {
+	orig := fmt.Errorf("timeout")
+	e := NewAnalysisError("GitHub", "authenticate", "API", "", orig)
+
+	if !errors.Is(e, orig) {
+		t.Error("errors.Is should find the original error")
+	}
+}
+
+func TestAnalysisErrorAs(t *testing.T) {
+	orig := fmt.Errorf("bad key")
+	e := NewAnalysisError("Airbrake", "validate_credentials", "config", "", orig)
+
+	// Wrap it further
+	wrapped := fmt.Errorf("analyze failed: %w", e)
+
+	var ae AnalysisErrorInfo
+	if !errors.As(wrapped, &ae) {
+		t.Fatal("errors.As should find AnalysisErrorInfo in wrapped error")
+	}
+	if ae.AnalyzerType() != "Airbrake" {
+		t.Errorf("AnalyzerType() = %q, want %q", ae.AnalyzerType(), "Airbrake")
+	}
+	if ae.Operation() != "validate_credentials" {
+		t.Errorf("Operation() = %q, want %q", ae.Operation(), "validate_credentials")
+	}
+}
+
+func TestAnalysisErrorMessage(t *testing.T) {
+	orig := fmt.Errorf("401 unauthorized")
+	e := NewAnalysisError("Slack", "authenticate", "API", "workspace-123", orig)
+
+	expected := "Slack analysis failed: authenticate on API (resource: workspace-123): 401 unauthorized"
+	if e.Error() != expected {
+		t.Errorf("Error() = %q, want %q", e.Error(), expected)
+	}
+}
+
+func TestAnalysisErrorMessageNilError(t *testing.T) {
+	e := NewAnalysisError("MySQL", "connect", "Database", "db.example.com", nil)
+
+	expected := "MySQL analysis failed: connect on Database (resource: db.example.com)"
+	if e.Error() != expected {
+		t.Errorf("Error() = %q, want %q", e.Error(), expected)
+	}
+}

--- a/pkg/analyzer/analyzers/errors_test.go
+++ b/pkg/analyzer/analyzers/errors_test.go
@@ -74,3 +74,13 @@ func TestAnalysisErrorMessageNilError(t *testing.T) {
 		t.Errorf("Error() = %q, want %q", e.Error(), expected)
 	}
 }
+
+func TestAnalysisErrorMessageEmptyResource(t *testing.T) {
+	orig := fmt.Errorf("invalid token")
+	e := NewAnalysisError("OpenAI", "analyze_permissions", "API", "", orig)
+
+	expected := "OpenAI analysis failed: analyze_permissions on API: invalid token"
+	if e.Error() != expected {
+		t.Errorf("Error() = %q, want %q", e.Error(), expected)
+	}
+}

--- a/pkg/analyzer/analyzers/fastly/fastly.go
+++ b/pkg/analyzer/analyzers/fastly/fastly.go
@@ -25,16 +25,18 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, fmt.Errorf("key not found in credential info")
+		return nil, analyzers.NewAnalysisError(
+			"Fastly", "validate_credentials", "config", "", fmt.Errorf("key not found in credential info"),
+		)
 	}
 
-	// analyze permissions
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Fastly", "analyze_permissions", "API", "", err,
+		)
 	}
 
-	// secret info to analyzer
 	return secretInfoToAnalyzerResult(info), nil
 }
 

--- a/pkg/analyzer/analyzers/fastly/fastly.go
+++ b/pkg/analyzer/analyzers/fastly/fastly.go
@@ -25,15 +25,13 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError(
-			"Fastly", "validate_credentials", "config", "", fmt.Errorf("key not found in credential info"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", fmt.Errorf("key not found in credential info"),
 		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Fastly", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 

--- a/pkg/analyzer/analyzers/figma/figma.go
+++ b/pkg/analyzer/analyzers/figma/figma.go
@@ -41,11 +41,11 @@ const (
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	token, ok := credInfo["token"]
 	if !ok {
-		return nil, errors.New("token not found in credInfo")
+		return nil, analyzers.NewAnalysisError("Figma", "validate_credentials", "config", "", errors.New("token not found in credInfo"))
 	}
 	info, err := AnalyzePermissions(a.Cfg, token)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("Figma", "analyze_permissions", "API", "", err)
 	}
 	return MapToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/figma/figma.go
+++ b/pkg/analyzer/analyzers/figma/figma.go
@@ -41,11 +41,11 @@ const (
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	token, ok := credInfo["token"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("Figma", "validate_credentials", "config", "", errors.New("token not found in credInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("token not found in credInfo"))
 	}
 	info, err := AnalyzePermissions(a.Cfg, token)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Figma", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 	return MapToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/github/github.go
+++ b/pkg/analyzer/analyzers/github/github.go
@@ -35,7 +35,7 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeGit
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	info, err := AnalyzePermissions(a.Cfg, credInfo["key"])
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("GitHub", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 	if info == nil {
 		return nil, fmt.Errorf("GitHub analyzer returned no data for token")

--- a/pkg/analyzer/analyzers/github/github.go
+++ b/pkg/analyzer/analyzers/github/github.go
@@ -35,7 +35,7 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeGit
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	info, err := AnalyzePermissions(a.Cfg, credInfo["key"])
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("GitHub", "analyze_permissions", "API", "", err)
 	}
 	if info == nil {
 		return nil, fmt.Errorf("GitHub analyzer returned no data for token")

--- a/pkg/analyzer/analyzers/github/github.go
+++ b/pkg/analyzer/analyzers/github/github.go
@@ -38,7 +38,7 @@ func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analy
 		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 	if info == nil {
-		return nil, fmt.Errorf("GitHub analyzer returned no data for token")
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", fmt.Errorf("GitHub analyzer returned no data for token"))
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/gitlab/gitlab.go
+++ b/pkg/analyzer/analyzers/gitlab/gitlab.go
@@ -34,7 +34,7 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeGit
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, errors.New("key not found in credentialInfo")
+		return nil, analyzers.NewAnalysisError("GitLab", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
 	}
 	host, ok := credInfo["host"]
 	if !ok {
@@ -43,7 +43,7 @@ func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analy
 
 	info, err := AnalyzePermissions(a.Cfg, key, host)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("GitLab", "analyze_permissions", "API", "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/gitlab/gitlab.go
+++ b/pkg/analyzer/analyzers/gitlab/gitlab.go
@@ -34,7 +34,7 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeGit
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("GitLab", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentialInfo"))
 	}
 	host, ok := credInfo["host"]
 	if !ok {
@@ -43,7 +43,7 @@ func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analy
 
 	info, err := AnalyzePermissions(a.Cfg, key, host)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("GitLab", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/groq/groq.go
+++ b/pkg/analyzer/analyzers/groq/groq.go
@@ -58,12 +58,16 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, errors.New("key not found in credentials info")
+		return nil, analyzers.NewAnalysisError(
+			"Groq", "validate_credentials", "config", "", errors.New("key not found in credentials info"),
+		)
 	}
 
 	secretInfo, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Groq", "analyze_permissions", "API", "", err,
+		)
 	}
 
 	return secretInfoToAnalyzerResult(secretInfo), nil

--- a/pkg/analyzer/analyzers/groq/groq.go
+++ b/pkg/analyzer/analyzers/groq/groq.go
@@ -58,15 +58,13 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError(
-			"Groq", "validate_credentials", "config", "", errors.New("key not found in credentials info"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentials info"),
 		)
 	}
 
 	secretInfo, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Groq", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 

--- a/pkg/analyzer/analyzers/huggingface/huggingface.go
+++ b/pkg/analyzer/analyzers/huggingface/huggingface.go
@@ -33,12 +33,16 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeHug
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok || key == "" {
-		return nil, fmt.Errorf("key not found in credentialInfo")
+		return nil, analyzers.NewAnalysisError(
+			"HuggingFace", "validate_credentials", "config", "", fmt.Errorf("key not found in credentialInfo"),
+		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"HuggingFace", "analyze_permissions", "API", "", err,
+		)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/huggingface/huggingface.go
+++ b/pkg/analyzer/analyzers/huggingface/huggingface.go
@@ -33,15 +33,13 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeHug
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok || key == "" {
-		return nil, analyzers.NewAnalysisError(
-			"HuggingFace", "validate_credentials", "config", "", fmt.Errorf("key not found in credentialInfo"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", fmt.Errorf("key not found in credentialInfo"),
 		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"HuggingFace", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/jira/jira.go
+++ b/pkg/analyzer/analyzers/jira/jira.go
@@ -28,20 +28,20 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	token, exist := credInfo["token"]
 	if !exist {
-		return nil, fmt.Errorf("token not found in credential info")
+		return nil, analyzers.NewAnalysisError("Jira", "validate_credentials", "config", "", fmt.Errorf("token not found in credential info"))
 	}
 	domain, exist := credInfo["domain"]
 	if !exist {
-		return nil, fmt.Errorf("domain not found in credential info")
+		return nil, analyzers.NewAnalysisError("Jira", "validate_credentials", "config", "", fmt.Errorf("domain not found in credential info"))
 	}
 	email, exist := credInfo["email"]
 	if !exist {
-		return nil, fmt.Errorf("email not found in credential info")
+		return nil, analyzers.NewAnalysisError("Jira", "validate_credentials", "config", "", fmt.Errorf("email not found in credential info"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, token, domain, email)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("Jira", "analyze_permissions", "API", "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/jira/jira.go
+++ b/pkg/analyzer/analyzers/jira/jira.go
@@ -28,20 +28,20 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	token, exist := credInfo["token"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError("Jira", "validate_credentials", "config", "", fmt.Errorf("token not found in credential info"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", fmt.Errorf("token not found in credential info"))
 	}
 	domain, exist := credInfo["domain"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError("Jira", "validate_credentials", "config", "", fmt.Errorf("domain not found in credential info"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", fmt.Errorf("domain not found in credential info"))
 	}
 	email, exist := credInfo["email"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError("Jira", "validate_credentials", "config", "", fmt.Errorf("email not found in credential info"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", fmt.Errorf("email not found in credential info"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, token, domain, email)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Jira", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/launchdarkly/launchdarkly.go
+++ b/pkg/analyzer/analyzers/launchdarkly/launchdarkly.go
@@ -29,16 +29,16 @@ func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analy
 	// check if the `key` exist in the credentials info
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, errors.New("key not found in credentials info")
+		return nil, analyzers.NewAnalysisError("LaunchDarkly", "validate_credentials", "config", "", errors.New("key not found in credentials info"))
 	}
 
 	if isSDKKey(key) {
-		return nil, errors.New("sdk keys cannot be analyzed")
+		return nil, analyzers.NewAnalysisError("LaunchDarkly", "validate_credentials", "config", "", errors.New("sdk keys cannot be analyzed"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("LaunchDarkly", "analyze_permissions", "API", "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/launchdarkly/launchdarkly.go
+++ b/pkg/analyzer/analyzers/launchdarkly/launchdarkly.go
@@ -29,16 +29,16 @@ func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analy
 	// check if the `key` exist in the credentials info
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError("LaunchDarkly", "validate_credentials", "config", "", errors.New("key not found in credentials info"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentials info"))
 	}
 
 	if isSDKKey(key) {
-		return nil, analyzers.NewAnalysisError("LaunchDarkly", "validate_credentials", "config", "", errors.New("sdk keys cannot be analyzed"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("sdk keys cannot be analyzed"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("LaunchDarkly", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/mailchimp/mailchimp.go
+++ b/pkg/analyzer/analyzers/mailchimp/mailchimp.go
@@ -29,12 +29,16 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeMai
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, errors.New("key not found in credentialInfo")
+		return nil, analyzers.NewAnalysisError(
+			"Mailchimp", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"),
+		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Mailchimp", "analyze_permissions", "API", "", err,
+		)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/mailchimp/mailchimp.go
+++ b/pkg/analyzer/analyzers/mailchimp/mailchimp.go
@@ -29,15 +29,13 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeMai
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError(
-			"Mailchimp", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentialInfo"),
 		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Mailchimp", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/mailgun/mailgun.go
+++ b/pkg/analyzer/analyzers/mailgun/mailgun.go
@@ -33,12 +33,16 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeMai
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, errors.New("key not found in credentialInfo")
+		return nil, analyzers.NewAnalysisError(
+			"Mailgun", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"),
+		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Mailgun", "analyze_permissions", "API", "", err,
+		)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/mailgun/mailgun.go
+++ b/pkg/analyzer/analyzers/mailgun/mailgun.go
@@ -33,15 +33,13 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeMai
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError(
-			"Mailgun", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentialInfo"),
 		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Mailgun", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 

--- a/pkg/analyzer/analyzers/monday/monday.go
+++ b/pkg/analyzer/analyzers/monday/monday.go
@@ -44,12 +44,12 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, errors.New("key not found in credentials info")
+		return nil, analyzers.NewAnalysisError("Monday", "validate_credentials", "config", "", errors.New("key not found in credentials info"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("Monday", "analyze_permissions", "API", "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/monday/monday.go
+++ b/pkg/analyzer/analyzers/monday/monday.go
@@ -44,12 +44,12 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError("Monday", "validate_credentials", "config", "", errors.New("key not found in credentials info"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentials info"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Monday", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/mux/mux.go
+++ b/pkg/analyzer/analyzers/mux/mux.go
@@ -41,16 +41,22 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, errors.New("key not found in credentials info")
+		return nil, analyzers.NewAnalysisError(
+			"Mux", "validate_credentials", "config", "", errors.New("key not found in credentials info"),
+		)
 	}
 	secret, exist := credInfo["secret"]
 	if !exist {
-		return nil, errors.New("secret not found in credentials info")
+		return nil, analyzers.NewAnalysisError(
+			"Mux", "validate_credentials", "config", "", errors.New("secret not found in credentials info"),
+		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key, secret)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Mux", "analyze_permissions", "API", "", err,
+		)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/mux/mux.go
+++ b/pkg/analyzer/analyzers/mux/mux.go
@@ -41,21 +41,18 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError(
-			"Mux", "validate_credentials", "config", "", errors.New("key not found in credentials info"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentials info"),
 		)
 	}
 	secret, exist := credInfo["secret"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError(
-			"Mux", "validate_credentials", "config", "", errors.New("secret not found in credentials info"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("secret not found in credentials info"),
 		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key, secret)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Mux", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 

--- a/pkg/analyzer/analyzers/mysql/mysql.go
+++ b/pkg/analyzer/analyzers/mysql/mysql.go
@@ -33,11 +33,11 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeMyS
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	uri, ok := credInfo["connection_string"]
 	if !ok {
-		return nil, fmt.Errorf("missing connection string")
+		return nil, analyzers.NewAnalysisError("MySQL", "validate_credentials", "config", "", fmt.Errorf("missing connection string"))
 	}
 	info, err := AnalyzePermissions(a.Cfg, uri)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("MySQL", "analyze_permissions", "Database", "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/mysql/mysql.go
+++ b/pkg/analyzer/analyzers/mysql/mysql.go
@@ -33,11 +33,11 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeMyS
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	uri, ok := credInfo["connection_string"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("MySQL", "validate_credentials", "config", "", fmt.Errorf("missing connection string"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", fmt.Errorf("missing connection string"))
 	}
 	info, err := AnalyzePermissions(a.Cfg, uri)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("MySQL", "analyze_permissions", "Database", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceDatabase, "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/netlify/netlify.go
+++ b/pkg/analyzer/analyzers/netlify/netlify.go
@@ -25,12 +25,16 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, fmt.Errorf("key not found in credential info")
+		return nil, analyzers.NewAnalysisError(
+			"Netlify", "validate_credentials", "config", "", fmt.Errorf("key not found in credential info"),
+		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Netlify", "analyze_permissions", "API", "", err,
+		)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/netlify/netlify.go
+++ b/pkg/analyzer/analyzers/netlify/netlify.go
@@ -25,15 +25,13 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError(
-			"Netlify", "validate_credentials", "config", "", fmt.Errorf("key not found in credential info"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", fmt.Errorf("key not found in credential info"),
 		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Netlify", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 

--- a/pkg/analyzer/analyzers/ngrok/ngrok.go
+++ b/pkg/analyzer/analyzers/ngrok/ngrok.go
@@ -36,12 +36,16 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, errors.New("key not found in credentials info")
+		return nil, analyzers.NewAnalysisError(
+			"Ngrok", "validate_credentials", "config", "", errors.New("key not found in credentials info"),
+		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Ngrok", "analyze_permissions", "API", "", err,
+		)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/ngrok/ngrok.go
+++ b/pkg/analyzer/analyzers/ngrok/ngrok.go
@@ -36,15 +36,13 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, exist := credInfo["key"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError(
-			"Ngrok", "validate_credentials", "config", "", errors.New("key not found in credentials info"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentials info"),
 		)
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Ngrok", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 

--- a/pkg/analyzer/analyzers/notion/notion.go
+++ b/pkg/analyzer/analyzers/notion/notion.go
@@ -30,11 +30,15 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeNot
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, errors.New("missing key in credInfo")
+		return nil, analyzers.NewAnalysisError(
+			"Notion", "validate_credentials", "config", "", errors.New("missing key in credInfo"),
+		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Notion", "analyze_permissions", "API", "", err,
+		)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/notion/notion.go
+++ b/pkg/analyzer/analyzers/notion/notion.go
@@ -30,14 +30,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeNot
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError(
-			"Notion", "validate_credentials", "config", "", errors.New("missing key in credInfo"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("missing key in credInfo"),
 		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Notion", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/openai/openai.go
+++ b/pkg/analyzer/analyzers/openai/openai.go
@@ -31,7 +31,9 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeOpe
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	info, err := AnalyzePermissions(a.Cfg, credInfo["key"])
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"OpenAI", "analyze_permissions", "API", "", err,
+		)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/openai/openai.go
+++ b/pkg/analyzer/analyzers/openai/openai.go
@@ -31,8 +31,7 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeOpe
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	info, err := AnalyzePermissions(a.Cfg, credInfo["key"])
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"OpenAI", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/opsgenie/opsgenie.go
+++ b/pkg/analyzer/analyzers/opsgenie/opsgenie.go
@@ -30,11 +30,15 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeOps
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, errors.New("missing key in credInfo")
+		return nil, analyzers.NewAnalysisError(
+			"Opsgenie", "validate_credentials", "config", "", errors.New("missing key in credInfo"),
+		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Opsgenie", "analyze_permissions", "API", "", err,
+		)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/opsgenie/opsgenie.go
+++ b/pkg/analyzer/analyzers/opsgenie/opsgenie.go
@@ -30,14 +30,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeOps
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError(
-			"Opsgenie", "validate_credentials", "config", "", errors.New("missing key in credInfo"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("missing key in credInfo"),
 		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Opsgenie", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/plaid/plaid.go
+++ b/pkg/analyzer/analyzers/plaid/plaid.go
@@ -31,20 +31,20 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	secret, exist := credInfo["secret"]
 	if !exist {
-		return nil, errors.New("secret not found in credentials info")
+		return nil, analyzers.NewAnalysisError("Plaid", "validate_credentials", "config", "", errors.New("secret not found in credentials info"))
 	}
 	clientID, exist := credInfo["id"]
 	if !exist {
-		return nil, errors.New("id not found in credentials info")
+		return nil, analyzers.NewAnalysisError("Plaid", "validate_credentials", "config", "", errors.New("id not found in credentials info"))
 	}
 	accessToken, exist := credInfo["token"]
 	if !exist {
-		return nil, errors.New("token not found in credentials info")
+		return nil, analyzers.NewAnalysisError("Plaid", "validate_credentials", "config", "", errors.New("token not found in credentials info"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, secret, clientID, accessToken)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("Plaid", "analyze_permissions", "API", "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/plaid/plaid.go
+++ b/pkg/analyzer/analyzers/plaid/plaid.go
@@ -31,20 +31,20 @@ func (a Analyzer) Type() analyzers.AnalyzerType {
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	secret, exist := credInfo["secret"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError("Plaid", "validate_credentials", "config", "", errors.New("secret not found in credentials info"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("secret not found in credentials info"))
 	}
 	clientID, exist := credInfo["id"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError("Plaid", "validate_credentials", "config", "", errors.New("id not found in credentials info"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("id not found in credentials info"))
 	}
 	accessToken, exist := credInfo["token"]
 	if !exist {
-		return nil, analyzers.NewAnalysisError("Plaid", "validate_credentials", "config", "", errors.New("token not found in credentials info"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("token not found in credentials info"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, secret, clientID, accessToken)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Plaid", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/planetscale/planetscale.go
+++ b/pkg/analyzer/analyzers/planetscale/planetscale.go
@@ -31,15 +31,15 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypePla
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	id, ok := credInfo["id"]
 	if !ok {
-		return nil, errors.New("missing id in credInfo")
+		return nil, analyzers.NewAnalysisError("PlanetScale", "validate_credentials", "config", "", errors.New("missing id in credInfo"))
 	}
 	key, ok := credInfo["token"]
 	if !ok {
-		return nil, errors.New("missing key in credInfo")
+		return nil, analyzers.NewAnalysisError("PlanetScale", "validate_credentials", "config", "", errors.New("missing key in credInfo"))
 	}
 	info, err := AnalyzePermissions(a.Cfg, id, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("PlanetScale", "analyze_permissions", "API", "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/planetscale/planetscale.go
+++ b/pkg/analyzer/analyzers/planetscale/planetscale.go
@@ -31,15 +31,15 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypePla
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	id, ok := credInfo["id"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("PlanetScale", "validate_credentials", "config", "", errors.New("missing id in credInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("missing id in credInfo"))
 	}
 	key, ok := credInfo["token"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("PlanetScale", "validate_credentials", "config", "", errors.New("missing key in credInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("missing key in credInfo"))
 	}
 	info, err := AnalyzePermissions(a.Cfg, id, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("PlanetScale", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/postgres/postgres.go
+++ b/pkg/analyzer/analyzers/postgres/postgres.go
@@ -30,12 +30,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypePos
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	uri, ok := credInfo["connection_string"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("Postgres", "validate_credentials", "config", "", errors.New("connection string not found in credInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("connection string not found in credInfo"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, uri)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Postgres", "analyze_permissions", "Database", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceDatabase, "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/posthog/posthog.go
+++ b/pkg/analyzer/analyzers/posthog/posthog.go
@@ -37,11 +37,15 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypePos
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, errors.New("missing key in credInfo")
+		return nil, analyzers.NewAnalysisError(
+			"Posthog", "validate_credentials", "config", "", errors.New("missing key in credInfo"),
+		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Posthog", "analyze_permissions", "API", "", err,
+		)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/posthog/posthog.go
+++ b/pkg/analyzer/analyzers/posthog/posthog.go
@@ -37,14 +37,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypePos
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError(
-			"Posthog", "validate_credentials", "config", "", errors.New("missing key in credInfo"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("missing key in credInfo"),
 		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Posthog", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/postman/postman.go
+++ b/pkg/analyzer/analyzers/postman/postman.go
@@ -26,11 +26,15 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypePos
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, fmt.Errorf("missing key in credInfo")
+		return nil, analyzers.NewAnalysisError(
+			"Postman", "validate_credentials", "config", "", fmt.Errorf("missing key in credInfo"),
+		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Postman", "analyze_permissions", "API", "", err,
+		)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/postman/postman.go
+++ b/pkg/analyzer/analyzers/postman/postman.go
@@ -26,14 +26,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypePos
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError(
-			"Postman", "validate_credentials", "config", "", fmt.Errorf("missing key in credInfo"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", fmt.Errorf("missing key in credInfo"),
 		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Postman", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/privatekey/privatekey.go
+++ b/pkg/analyzer/analyzers/privatekey/privatekey.go
@@ -32,12 +32,12 @@ func (a Analyzer) Analyze(ctx context.Context, credInfo map[string]string) (*ana
 	// token will be already normalized by the time it reaches here
 	token, ok := credInfo["token"]
 	if !ok {
-		return nil, errors.New("token not found in credInfo")
+		return nil, analyzers.NewAnalysisError("PrivateKey", "validate_credentials", "config", "", errors.New("token not found in credInfo"))
 	}
 
 	info, err := AnalyzePermissions(ctx, a.Cfg, token)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("PrivateKey", "analyze_permissions", "crypto", "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/privatekey/privatekey.go
+++ b/pkg/analyzer/analyzers/privatekey/privatekey.go
@@ -32,12 +32,12 @@ func (a Analyzer) Analyze(ctx context.Context, credInfo map[string]string) (*ana
 	// token will be already normalized by the time it reaches here
 	token, ok := credInfo["token"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("PrivateKey", "validate_credentials", "config", "", errors.New("token not found in credInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("token not found in credInfo"))
 	}
 
 	info, err := AnalyzePermissions(ctx, a.Cfg, token)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("PrivateKey", "analyze_permissions", "crypto", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceCrypto, "", err)
 	}
 
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/sendgrid/sendgrid.go
+++ b/pkg/analyzer/analyzers/sendgrid/sendgrid.go
@@ -47,11 +47,15 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeSen
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, fmt.Errorf("missing key in credInfo")
+		return nil, analyzers.NewAnalysisError(
+			"Sendgrid", "validate_credentials", "config", "", fmt.Errorf("missing key in credInfo"),
+		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Sendgrid", "analyze_permissions", "API", "", err,
+		)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/sendgrid/sendgrid.go
+++ b/pkg/analyzer/analyzers/sendgrid/sendgrid.go
@@ -47,14 +47,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeSen
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError(
-			"Sendgrid", "validate_credentials", "config", "", fmt.Errorf("missing key in credInfo"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", fmt.Errorf("missing key in credInfo"),
 		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Sendgrid", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/shopify/shopify.go
+++ b/pkg/analyzer/analyzers/shopify/shopify.go
@@ -34,17 +34,17 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeSho
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, errors.New("key not found in credentialInfo")
+		return nil, analyzers.NewAnalysisError("Shopify", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
 	}
 
 	storeUrl, ok := credInfo["store_url"]
 	if !ok {
-		return nil, errors.New("store_url not found in credentialInfo")
+		return nil, analyzers.NewAnalysisError("Shopify", "validate_credentials", "config", "", errors.New("store_url not found in credentialInfo"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key, storeUrl)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("Shopify", "analyze_permissions", "API", "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/shopify/shopify.go
+++ b/pkg/analyzer/analyzers/shopify/shopify.go
@@ -34,17 +34,17 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeSho
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("Shopify", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentialInfo"))
 	}
 
 	storeUrl, ok := credInfo["store_url"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("Shopify", "validate_credentials", "config", "", errors.New("store_url not found in credentialInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("store_url not found in credentialInfo"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key, storeUrl)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Shopify", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/slack/slack.go
+++ b/pkg/analyzer/analyzers/slack/slack.go
@@ -29,12 +29,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeSla
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, errors.New("key not found in credentialInfo")
+		return nil, analyzers.NewAnalysisError("Slack", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("Slack", "analyze_permissions", "API", "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/slack/slack.go
+++ b/pkg/analyzer/analyzers/slack/slack.go
@@ -29,12 +29,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeSla
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("Slack", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentialInfo"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Slack", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/sourcegraph/sourcegraph.go
+++ b/pkg/analyzer/analyzers/sourcegraph/sourcegraph.go
@@ -26,11 +26,15 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeSou
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, fmt.Errorf("missing key in credInfo")
+		return nil, analyzers.NewAnalysisError(
+			"Sourcegraph", "validate_credentials", "config", "", fmt.Errorf("missing key in credInfo"),
+		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError(
+			"Sourcegraph", "analyze_permissions", "API", "", err,
+		)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/sourcegraph/sourcegraph.go
+++ b/pkg/analyzer/analyzers/sourcegraph/sourcegraph.go
@@ -26,14 +26,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeSou
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError(
-			"Sourcegraph", "validate_credentials", "config", "", fmt.Errorf("missing key in credInfo"),
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", fmt.Errorf("missing key in credInfo"),
 		)
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError(
-			"Sourcegraph", "analyze_permissions", "API", "", err,
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err,
 		)
 	}
 	return secretInfoToAnalyzerResult(info), nil

--- a/pkg/analyzer/analyzers/square/square.go
+++ b/pkg/analyzer/analyzers/square/square.go
@@ -28,11 +28,11 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeSqu
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, errors.New("key not found in credentialInfo")
+		return nil, analyzers.NewAnalysisError("Square", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("Square", "analyze_permissions", "API", "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/square/square.go
+++ b/pkg/analyzer/analyzers/square/square.go
@@ -28,11 +28,11 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeSqu
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("Square", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentialInfo"))
 	}
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Square", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/stripe/stripe.go
+++ b/pkg/analyzer/analyzers/stripe/stripe.go
@@ -33,12 +33,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeStr
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, errors.New("key not found in credentialInfo")
+		return nil, analyzers.NewAnalysisError("Stripe", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("Stripe", "analyze_permissions", "API", "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/stripe/stripe.go
+++ b/pkg/analyzer/analyzers/stripe/stripe.go
@@ -33,12 +33,12 @@ func (Analyzer) Type() analyzers.AnalyzerType { return analyzers.AnalyzerTypeStr
 func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("Stripe", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentialInfo"))
 	}
 
 	info, err := AnalyzePermissions(a.Cfg, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Stripe", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 	return secretInfoToAnalyzerResult(info), nil
 }

--- a/pkg/analyzer/analyzers/twilio/twilio.go
+++ b/pkg/analyzer/analyzers/twilio/twilio.go
@@ -25,12 +25,12 @@ func (a *Analyzer) Type() analyzers.AnalyzerType {
 func (a *Analyzer) Analyze(ctx context.Context, credentialInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credentialInfo["key"]
 	if !ok {
-		return nil, errors.New("key not found in credentialInfo")
+		return nil, analyzers.NewAnalysisError("Twilio", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
 	}
 
 	sid, ok := credentialInfo["sid"]
 	if !ok {
-		return nil, errors.New("sid not found in credentialInfo")
+		return nil, analyzers.NewAnalysisError("Twilio", "validate_credentials", "config", "", errors.New("sid not found in credentialInfo"))
 	}
 
 	if a.Cfg == nil {
@@ -39,13 +39,13 @@ func (a *Analyzer) Analyze(ctx context.Context, credentialInfo map[string]string
 
 	info, err := AnalyzePermissions(a.Cfg, sid, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("Twilio", "analyze_permissions", "API", "", err)
 	}
 
 	// List parent and subaccounts
 	accounts, err := listTwilioAccounts(a.Cfg, sid, key)
 	if err != nil {
-		return nil, err
+		return nil, analyzers.NewAnalysisError("Twilio", "analyze_permissions", "API", "", err)
 	}
 
 	var permissions []Permission

--- a/pkg/analyzer/analyzers/twilio/twilio.go
+++ b/pkg/analyzer/analyzers/twilio/twilio.go
@@ -25,12 +25,12 @@ func (a *Analyzer) Type() analyzers.AnalyzerType {
 func (a *Analyzer) Analyze(ctx context.Context, credentialInfo map[string]string) (*analyzers.AnalyzerResult, error) {
 	key, ok := credentialInfo["key"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("Twilio", "validate_credentials", "config", "", errors.New("key not found in credentialInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("key not found in credentialInfo"))
 	}
 
 	sid, ok := credentialInfo["sid"]
 	if !ok {
-		return nil, analyzers.NewAnalysisError("Twilio", "validate_credentials", "config", "", errors.New("sid not found in credentialInfo"))
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationValidateCredentials, analyzers.ServiceConfig, "", errors.New("sid not found in credentialInfo"))
 	}
 
 	if a.Cfg == nil {
@@ -39,13 +39,13 @@ func (a *Analyzer) Analyze(ctx context.Context, credentialInfo map[string]string
 
 	info, err := AnalyzePermissions(a.Cfg, sid, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Twilio", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 
 	// List parent and subaccounts
 	accounts, err := listTwilioAccounts(a.Cfg, sid, key)
 	if err != nil {
-		return nil, analyzers.NewAnalysisError("Twilio", "analyze_permissions", "API", "", err)
+		return nil, analyzers.NewAnalysisError(a.Type().String(), analyzers.OperationAnalyzePermissions, analyzers.ServiceAPI, "", err)
 	}
 
 	var permissions []Permission


### PR DESCRIPTION
## What this does

Adds a shared error type so analyzer failures carry structured metadata (analyzer type, operation, service). Currently only GCP errors have this; the other 44 analyzers return bare `errors.New` that get stored as "unknown" in the database.

## How to review

**Read one file, skip the other 44.** There are only 2 things to look at:

### 1. The new error type (entire abstraction)

`pkg/analyzer/analyzers/errors.go` -- new file:

```go
// Constants for structured error metadata
const (
    OperationValidateCredentials = "validate_credentials"
    OperationAnalyzePermissions  = "analyze_permissions"
)
const (
    ServiceAPI      = "API"
    ServiceConfig   = "config"
    ServiceDatabase = "Database"
    ServiceOAuth    = "OAuth"
    ServiceCrypto   = "crypto"
)

type AnalysisErrorInfo interface {
    error
    AnalyzerType() string
    Operation() string
    Service() string
    Resource() string
}

type AnalysisError struct {
    analyzerType, operation, service, resource string
    err error
}

func NewAnalysisError(analyzerType, operation, service, resource string, err error) *AnalysisError
```

### 2. The pattern every analyzer follows

Every analyzer diff looks like this (Airbrake shown):

```go
// Before:
return nil, err

// After:
return nil, analyzers.NewAnalysisError(
    a.Type().String(),                      // dynamic from analyzer's own type
    analyzers.OperationAnalyzePermissions,  // constant
    analyzers.ServiceAPI,                   // constant
    "",
    err,
)
```

The original error is wrapped, not replaced (`Unwrap()` preserves the chain). Analyzer type is derived dynamically via `a.Type().String()`. Two operation constants are used: `OperationValidateCredentials` for bad input, `OperationAnalyzePermissions` for API/DB failures.

**All 44 analyzer files are this same 1-3 line change.** You can spot-check a few and skip the rest.

## Part of a cross-repo change

| Order | Repo | PR | What |
|-------|------|----|------|
| **1** | **trufflehog** | **this PR** | Define error type + constants, wrap 44 analyzers |
| 2 | integrations | [#118](https://github.com/trufflesecurity/integrations/pull/118) | Wrap 10 integrations analyzers |
| 3 | thog | [#5724](https://github.com/trufflesecurity/thog/pull/5724) | Scanner consumes the metadata via `errors.As()` |

## Test plan

- [ ] `go test ./pkg/analyzer/analyzers/...` (includes `errors_test.go`)
- [ ] `go build ./pkg/analyzer/analyzers/...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches error-return paths across many analyzers; behavior should be equivalent but changes the concrete error type/message, which could affect downstream error handling or assertions.
> 
> **Overview**
> Introduces a new structured `AnalysisError` (with `AnalysisErrorInfo` interface) plus shared `Operation*` and `Service*` constants so analyzer failures can carry consistent metadata and still `Unwrap()` to the original error.
> 
> Updates many analyzers to wrap both **missing credential** validation errors and **permission/API/DB analysis** failures with `analyzers.NewAnalysisError(...)` instead of returning raw errors, standardizing how failures are reported and stored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dbe8232d9c577f5bee2460275e2129774524e2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->