### PR TITLE
[INS-389] Fixed Squareup detector not detecting secret and verifying it a wrong endpoint

### DIFF
--- a/pkg/detectors/squareup/squareup.go
+++ b/pkg/detectors/squareup/squareup.go
@@ -3,9 +3,11 @@ package squareup
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
+	"io"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -20,14 +22,14 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	client = common.SaneHttpClient()
 
-	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(`\b(sq0idp-[0-9A-Za-z]{22})\b`)
+	// This detector detects Squareup Production Access Tokens, which are 64-character strings that start with "EAAA".
+	keyPat = regexp.MustCompile(`\b(EAAA[0-9A-Za-z-_]{60})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"sq0idp-"}
+	return []string{"EAAA"}
 }
 
 // FromData will find and optionally verify Squareup secrets in a given set of bytes.
@@ -45,25 +47,59 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-
-			req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://connect.squareup.com/oauth2/authorize?client_id=%s&scope=CUSTOMERS_WRITE+CUSTOMERS_READ&session=False&state=82201dd8d83d23cc8a48caf52b", resMatch), nil)
-			if err != nil {
-				continue
-			}
-			req.Header.Add("Content-Type", "application/json")
-			res, err := client.Do(req)
-			if err == nil {
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					s1.Verified = true
-				}
-			}
+			isVerified, verificationErr := verifySquareToken(ctx, client, resMatch)
+			s1.Verified = isVerified
+			s1.SetVerificationError(verificationErr, resMatch)
 		}
 
 		results = append(results, s1)
 	}
 
 	return results, nil
+}
+
+func verifySquareToken(
+	ctx context.Context,
+	client *http.Client,
+	token string,
+) (bool, error) {
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		"https://connect.squareup.com/v2/locations",
+		http.NoBody,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+
+	case http.StatusOK:
+		return true, nil
+
+	case http.StatusUnauthorized:
+		return false, nil
+
+	default:
+		return false, fmt.Errorf(
+			"unexpected HTTP response status %d",
+			res.StatusCode,
+		)
+	}
 }
 
 func (s Scanner) Type() detectorspb.DetectorType {

--- a/pkg/detectors/squareup/squareup_integration_test.go
+++ b/pkg/detectors/squareup/squareup_integration_test.go
@@ -19,12 +19,12 @@ import (
 func TestSquareup_FromChunk(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors2")
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors6")
 	if err != nil {
 		t.Fatalf("could not get test secrets from GCP: %s", err)
 	}
-	secret := testSecrets.MustGetField("SQUAREUP")
-	inactiveSecret := testSecrets.MustGetField("SQUAREUP_INACTIVE")
+	secret := testSecrets.MustGetField("SQUAREUP_ACCESS_TOKEN")
+	inactiveSecret := "EAAAl-CIlelDAba0mIksYXPGwUzydawadapwdpalwffkjewfinweifnwiefnweif"
 
 	type args struct {
 		ctx    context.Context

--- a/pkg/detectors/squareup/squareup_test.go
+++ b/pkg/detectors/squareup/squareup_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 var (
-	validPattern   = "sq0idp-CIlelDA4a0mIksYXPGwUzy"
-	invalidPattern = "sq0idp-CIlelDA?a0mIksYXPGwUzy"
-	keyword        = "squareup"
+	validPattern   = "EAAAl-CIlelDA4a0mIksYXPGwUzyakldwao-wadljadkmnjkdgndxvnmervw--c3"
+	invalidPattern = "EAAAl-CIlelDA@a0mIksYXPGwUzydaw.dapwdpalwffkjewfinweifnwiefnweif"
+	keyword        = "EAAA"
 )
 
 func TestSquareup_Pattern(t *testing.T) {


### PR DESCRIPTION
### Description:
This PR fixes the existing squareup detector, which was previously detecting a `client_id` and attempting to verify it using an incorrect endpoint.

The detector has been updated to correctly detect Square production access tokens using the following regex:

`\b(EAAA[0-9A-Za-z-_]{60})\b`

Verification has also been updated to use the correct Square API endpoint:

https://connect.squareup.com/v2/locations

If the token is valid, this endpoint returns a 200 OK response.

### Notes
- This detector currently detects Square production access tokens only.

- It does not detect OAuth client credentials (such as client_id and client_secret) because they cannot be reliably verified.

- Square's OAuth flow requires user authorization via the authorization code flow, and the platform does not support a client_credentials grant type for machine-to-machine token generation.

- Because of this limitation, OAuth secrets cannot be safely verified without human interaction.

### Corpora Test
The detector does not appear in the list.  
<img width="407" height="759" alt="image" src="https://github.com/user-attachments/assets/2b77c7a0-b074-4a3c-ae6a-c7c186496681" />


### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes detection and verification logic for Square secrets and the outbound verification HTTP request/endpoint, which may impact false positive/negative rates and runtime verification behavior.
> 
> **Overview**
> Fixes the Squareup detector to **detect production access tokens** (64-char tokens starting with `EAAA`) instead of matching `sq0idp-` client IDs, updating both the regex and keyword prefilter.
> 
> Reworks verification to call `GET https://connect.squareup.com/v2/locations` with a Bearer token (with proper response-body draining/close and clearer status handling), and updates unit/integration tests and test-secret wiring to reflect the new token format and verification behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84ac20b9ce4c925209ea4da2b5b3fe4db399a3e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->