### PR TITLE
Use trContext instead of context throughout Filesystem source

### DIFF
--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	trContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/feature"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/handlers"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
@@ -63,7 +63,7 @@ func (s *Source) JobID() sources.JobID {
 }
 
 // Init returns an initialized Filesystem source.
-func (s *Source) Init(aCtx context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
+func (s *Source) Init(aCtx trContext.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
 	s.log = aCtx.Logger()
 
 	s.concurrency = concurrency
@@ -109,7 +109,7 @@ func (s *Source) canFollowSymlinks() bool {
 }
 
 // Chunks emits chunks of bytes over a channel.
-func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ ...sources.ChunkingTarget) error {
+func (s *Source) Chunks(ctx trContext.Context, chunksChan chan *sources.Chunk, _ ...sources.ChunkingTarget) error {
 	for i, path := range s.paths {
 		logger := ctx.Logger().WithValues("path", path)
 		if common.IsDone(ctx) {
@@ -166,7 +166,7 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 }
 
 func (s *Source) scanSymlink(
-	ctx context.Context,
+	ctx trContext.Context,
 	path string,
 	chunksChan chan *sources.Chunk,
 	workerPool *errgroup.Group,
@@ -239,7 +239,7 @@ func (s *Source) scanSymlink(
 }
 
 func (s *Source) scanDir(
-	ctx context.Context,
+	ctx trContext.Context,
 	path string,
 	chunksChan chan *sources.Chunk,
 	workerPool *errgroup.Group,
@@ -356,8 +356,8 @@ func (s *Source) scanDir(
 
 var skipSymlinkErr = errors.New("skipping symlink")
 
-func (s *Source) scanFile(ctx context.Context, path string, chunksChan chan *sources.Chunk) error {
-	fileCtx := context.WithValues(ctx, "path", path)
+func (s *Source) scanFile(ctx trContext.Context, path string, chunksChan chan *sources.Chunk) error {
+	fileCtx := trContext.WithValues(ctx, "path", path)
 	fileStat, err := os.Lstat(path)
 	if err != nil {
 		return fmt.Errorf("unable to stat file: %w", err)
@@ -401,7 +401,7 @@ func (s *Source) scanFile(ctx context.Context, path string, chunksChan chan *sou
 // Enumerate implements SourceUnitEnumerator interface. This implementation simply
 // passes the configured paths as the source unit, whether it be a single
 // filepath or a directory.
-func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) error {
+func (s *Source) Enumerate(ctx trContext.Context, reporter sources.UnitReporter) error {
 	for _, path := range s.paths {
 		_, err := os.Lstat(filepath.Clean(path))
 		if err != nil {
@@ -419,7 +419,7 @@ func (s *Source) Enumerate(ctx context.Context, reporter sources.UnitReporter) e
 }
 
 // ChunkUnit implements SourceUnitChunker interface.
-func (s *Source) ChunkUnit(ctx context.Context, unit sources.SourceUnit, reporter sources.ChunkReporter) error {
+func (s *Source) ChunkUnit(ctx trContext.Context, unit sources.SourceUnit, reporter sources.ChunkReporter) error {
 	path, _ := unit.SourceUnitID()
 	logger := ctx.Logger().WithValues("path", path)
 

--- a/pkg/sources/filesystem/filesystem_symlink_test.go
+++ b/pkg/sources/filesystem/filesystem_symlink_test.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	trContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sourcestest"
@@ -26,7 +26,7 @@ func probeSymlinkSupport(t *testing.T, baseDir string) {
 }
 
 func TestScanDir_VisitedPath_PreventInfiniteRecursion(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), time.Second*3)
 	defer cancel()
 	baseDir, cleanup, err := createTempDir("")
 	if err != nil {
@@ -78,7 +78,7 @@ func TestScanDir_VisitedPath_PreventInfiniteRecursion(t *testing.T) {
 }
 
 func TestChunks_DirectorySymlinkLoop(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), time.Second*3)
 	defer cancel()
 	baseDir, cleanup, err := createTempDir("")
 	if err != nil {
@@ -122,7 +122,7 @@ func TestChunks_DirectorySymlinkLoop(t *testing.T) {
 }
 
 func TestChunkUnit_DirectorySymlinkLoop(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), time.Second*3)
 	defer cancel()
 	baseDir, cleanup, err := createTempDir("")
 	if err != nil {
@@ -164,7 +164,7 @@ func TestChunkUnit_DirectorySymlinkLoop(t *testing.T) {
 }
 
 func TestChunks_FileSymlinkLoop(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), time.Second*3)
 	defer cancel()
 	baseDir, cleanup, err := createTempDir("")
 	if err != nil {
@@ -210,7 +210,7 @@ func TestChunks_FileSymlinkLoop(t *testing.T) {
 }
 
 func TestChunkUnit_FileSymlinkLoop(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), 3*time.Second)
 	defer cancel()
 
 	baseDir, cleanup, err := createTempDir("")
@@ -253,7 +253,7 @@ func TestChunkUnit_FileSymlinkLoop(t *testing.T) {
 }
 
 func TestChunks_ValidDirectorySymlink(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), 3*time.Second)
 	defer cancel()
 
 	// Create a temporary base directory
@@ -314,7 +314,7 @@ func TestChunks_ValidDirectorySymlink(t *testing.T) {
 }
 
 func TestChunkUnit_ValidDirectorySymlink(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), 3*time.Second)
 	defer cancel()
 
 	// Create a temporary base directory
@@ -362,7 +362,7 @@ func TestChunkUnit_ValidDirectorySymlink(t *testing.T) {
 }
 
 func TestChunks_ValidFileSymlink(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), 3*time.Second)
 	defer cancel()
 
 	// Create a temporary base directory
@@ -427,7 +427,7 @@ func TestChunks_ValidFileSymlink(t *testing.T) {
 }
 
 func TestChunkUnit_ValidFileSymlink(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), 3*time.Second)
 	defer cancel()
 
 	// Create a temporary base directory
@@ -471,7 +471,7 @@ func TestChunkUnit_ValidFileSymlink(t *testing.T) {
 }
 
 func TestScanSymlink_NoError(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), time.Second*3)
 	defer cancel()
 	baseDir, cleanup, err := createTempDir("")
 	if err != nil {
@@ -521,7 +521,7 @@ func TestScanSymlink_NoError(t *testing.T) {
 }
 
 func TestScanSymlink_MaxDepthExceeded(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), time.Second*3)
 	defer cancel()
 	baseDir, cleanup, err := createTempDir("")
 	if err != nil {
@@ -573,7 +573,7 @@ func TestScanSymlink_MaxDepthExceeded(t *testing.T) {
 }
 
 func TestScanSymlink_FileTarget(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), 3*time.Second)
 	defer cancel()
 
 	baseDir, cleanup, err := createTempDir("")
@@ -621,7 +621,7 @@ func TestScanSymlink_FileTarget(t *testing.T) {
 }
 
 func TestScanSymlink_SelfLoop(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), 3*time.Second)
 	defer cancel()
 
 	baseDir, cleanup, err := createTempDir("")
@@ -657,7 +657,7 @@ func TestScanSymlink_SelfLoop(t *testing.T) {
 }
 
 func TestScanSymlink_BrokenSymlink(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), 3*time.Second)
 	defer cancel()
 
 	baseDir, cleanup, err := createTempDir("")
@@ -693,7 +693,7 @@ func TestScanSymlink_BrokenSymlink(t *testing.T) {
 }
 
 func TestScanSymlink_TwoFileLoop(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), 3*time.Second)
 	defer cancel()
 
 	baseDir, cleanup, err := createTempDir("")

--- a/pkg/sources/filesystem/filesystem_test.go
+++ b/pkg/sources/filesystem/filesystem_test.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/anypb"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	trContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/source_metadatapb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/sourcespb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
@@ -25,7 +25,7 @@ import (
 )
 
 func TestSource_Scan(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), time.Second*3)
 	defer cancel()
 
 	type init struct {
@@ -113,7 +113,7 @@ func TestScanFile(t *testing.T) {
 	source := &Source{}
 	chunksChan := make(chan *sources.Chunk, 2)
 
-	ctx := context.WithLogger(context.Background(), logr.Discard())
+	ctx := trContext.WithLogger(trContext.Background(), logr.Discard())
 	go func() {
 		defer close(chunksChan)
 		err = source.scanFile(ctx, tmpfile.Name(), chunksChan)
@@ -144,7 +144,7 @@ func TestScanBinaryFile(t *testing.T) {
 	chunksChan := make(chan *sources.Chunk, 2)
 	errChan := make(chan error, 1)
 
-	ctx := context.WithLogger(context.Background(), logr.Discard())
+	ctx := trContext.WithLogger(trContext.Background(), logr.Discard())
 
 	go func() {
 		defer close(chunksChan)
@@ -166,7 +166,7 @@ func TestScanBinaryFile(t *testing.T) {
 func TestEnumerate(t *testing.T) {
 	// TODO: refactor to allow a virtual filesystem.
 	t.Parallel()
-	ctx := context.Background()
+	ctx := trContext.Background()
 
 	// Setup the connection to test enumeration.
 	dir, err := os.MkdirTemp("", "trufflehog-test-enumerate")
@@ -222,7 +222,7 @@ func TestEnumerate(t *testing.T) {
 
 func TestChunkUnit(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := trContext.Background()
 
 	// Setup test file to chunk.
 	fileContents := "TestChunkUnit"
@@ -275,7 +275,7 @@ func TestChunkUnit(t *testing.T) {
 
 func TestEnumerateReporterErr(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := trContext.Background()
 
 	// Setup the connection to test enumeration.
 	units := []string{
@@ -302,7 +302,7 @@ func TestEnumerateReporterErr(t *testing.T) {
 
 func TestChunkUnitReporterErr(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := trContext.Background()
 
 	// Setup test file to chunk.
 	tmpfile, err := os.CreateTemp("", "example.txt")
@@ -342,7 +342,7 @@ func TestChunkUnitReporterErr(t *testing.T) {
 
 func TestSkipDir(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := trContext.Background()
 
 	// create a temp directory with files
 	ignoreDir, cleanupDir, err := createTempDir("", "ignore1", "ignore2", "ignore3")
@@ -377,7 +377,7 @@ func TestSkipDir(t *testing.T) {
 
 func TestScanSubDirFile(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+	ctx := trContext.Background()
 
 	// Use a fixed directory for the test
 	testDir := filepath.Join(os.TempDir(), "trufflehog-test")
@@ -442,7 +442,7 @@ func TestSkipBinaries(t *testing.T) {
 	}
 
 	chunks := make(chan *sources.Chunk, 10)
-	ctx := context.Background()
+	ctx := trContext.Background()
 
 	// Run the scan
 	go func() {
@@ -468,7 +468,7 @@ func TestSkipBinaries(t *testing.T) {
 }
 
 func TestResumptionInfoDoesNotGrowWithSubdirectories(t *testing.T) {
-	ctx := context.AddLogger(t.Context())
+	ctx := trContext.AddLogger(t.Context())
 
 	// Create a deeply nested directory structure with files at each level.
 	// Structure: root/dir0/dir1/dir2/.../dir9, each containing a file.
@@ -572,7 +572,7 @@ polling:
 }
 
 func TestResumptionSkipsAlreadyScannedFiles(t *testing.T) {
-	ctx := context.Background()
+	ctx := trContext.Background()
 
 	// Create a directory with files that have predictable alphabetical order.
 	rootDir, err := os.MkdirTemp("", "trufflehog-resumption-test")
@@ -622,7 +622,7 @@ func TestResumptionSkipsAlreadyScannedFiles(t *testing.T) {
 }
 
 func TestResumptionWithNestedDirectories(t *testing.T) {
-	ctx := context.Background()
+	ctx := trContext.Background()
 
 	// Create a nested directory structure:
 	// root/
@@ -680,7 +680,7 @@ func TestResumptionWithNestedDirectories(t *testing.T) {
 }
 
 func TestResumptionWithOutOfSubtreeResumePoint(t *testing.T) {
-	ctx := context.Background()
+	ctx := trContext.Background()
 
 	// Create a directory structure:
 	// root/


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
In order to avoid confusion, we use `trContext` to refer to Truffle's home-grown context instead of Go's context from the stdlib. This PR does that in the Filesystem source.
