### PR TITLE
Add test cases for escaped unicode

### DIFF
--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1742,10 +1742,22 @@ func TestEngine_VerificationOverlapWorker_DetectableChunkHasCorrectVerifyFlag(t 
 func TestEngine_IterativeDecoding(t *testing.T) {
 	t.Parallel()
 
-	// base64(base64("my-secret-key-test-value"))
 	const (
+		// base64(base64("my-secret-key-test-value"))
 		doubleEncoded   = "YlhrdGMyVmpjbVYwTFd0bGVTMTBaWE4wTFhaaGJIVmw="
 		detectorKeyword = "my-secret"
+
+		// escapedUnicode("my-secret-key-test-value")
+		escapedUnicode = `\u006d\u0079\u002d\u0073\u0065\u0063\u0072\u0065\u0074\u002d\u006b\u0065\u0079\u002d\u0074\u0065\u0073\u0074\u002d\u0076\u0061\u006c\u0075\u0065`
+
+		// escapedUnicode(escapedUnicode("my-secret-key-test-value"))
+		doubleEscapedUnicode = `\u005c\u0075\u0030\u0030\u0036\u0064\u005c\u0075\u0030\u0030\u0037\u0039\u005c\u0075\u0030\u0030\u0032\u0064\u005c\u0075\u0030\u0030\u0037\u0033\u005c\u0075\u0030\u0030\u0036\u0035\u005c\u0075\u0030\u0030\u0036\u0033\u005c\u0075\u0030\u0030\u0037\u0032\u005c\u0075\u0030\u0030\u0036\u0035\u005c\u0075\u0030\u0030\u0037\u0034\u005c\u0075\u0030\u0030\u0032\u0064\u005c\u0075\u0030\u0030\u0036\u0062\u005c\u0075\u0030\u0030\u0036\u0035\u005c\u0075\u0030\u0030\u0037\u0039\u005c\u0075\u0030\u0030\u0032\u0064\u005c\u0075\u0030\u0030\u0037\u0034\u005c\u0075\u0030\u0030\u0036\u0035\u005c\u0075\u0030\u0030\u0037\u0033\u005c\u0075\u0030\u0030\u0037\u0034\u005c\u0075\u0030\u0030\u0032\u0064\u005c\u0075\u0030\u0030\u0037\u0036\u005c\u0075\u0030\u0030\u0036\u0031\u005c\u0075\u0030\u0030\u0036\u0063\u005c\u0075\u0030\u0030\u0037\u0035\u005c\u0075\u0030\u0030\u0036\u0035`
+
+		// base64(escapedUnicode("my-secret-key-test-value"))
+		b64EscapedUnicode = "XHUwMDZkXHUwMDc5XHUwMDJkXHUwMDczXHUwMDY1XHUwMDYzXHUwMDcyXHUwMDY1XHUwMDc0XHUwMDJkXHUwMDZiXHUwMDY1XHUwMDc5XHUwMDJkXHUwMDc0XHUwMDY1XHUwMDczXHUwMDc0XHUwMDJkXHUwMDc2XHUwMDYxXHUwMDZjXHUwMDc1XHUwMDY1"
+
+		// escapedUnicode(base64("my-secret-key-test-value"))
+		escapedUnicodeB64 = `\u0062\u0058\u006b\u0074\u0063\u0032\u0056\u006a\u0063\u006d\u0056\u0030\u004c\u0057\u0074\u006c\u0065\u0053\u0031\u0030\u005a\u0058\u004e\u0030\u004c\u0058\u005a\u0068\u0062\u0048\u0056\u006c`
 	)
 
 	// "token: bXktc2VjcmV0LWtleS10ZXN0LXZhbHVl end" as UTF-16LE
@@ -1785,6 +1797,48 @@ func TestEngine_IterativeDecoding(t *testing.T) {
 		{
 			name:        "utf16+base64, depth=2, found",
 			input:       utf16ContainingBase64,
+			depth:       2,
+			wantKeyword: true,
+		},
+		{
+			name:        "escaped unicode, depth=1, found",
+			input:       []byte("token: " + escapedUnicode),
+			depth:       1,
+			wantKeyword: true,
+		},
+		{
+			name:        "double escaped unicode, depth=1, miss",
+			input:       []byte("token: " + doubleEscapedUnicode),
+			depth:       1,
+			wantKeyword: false,
+		},
+		{
+			name:        "double escaped unicode, depth=2, found",
+			input:       []byte("token: " + doubleEscapedUnicode),
+			depth:       2,
+			wantKeyword: true,
+		},
+		{
+			name:        "base64+escaped unicode, depth=1, miss",
+			input:       []byte("token: " + b64EscapedUnicode),
+			depth:       1,
+			wantKeyword: false,
+		},
+		{
+			name:        "base64+escaped unicode, depth=2, found",
+			input:       []byte("token: " + b64EscapedUnicode),
+			depth:       2,
+			wantKeyword: true,
+		},
+		{
+			name:        "escaped unicode+base64, depth=1, miss",
+			input:       []byte("token: " + escapedUnicodeB64),
+			depth:       1,
+			wantKeyword: false,
+		},
+		{
+			name:        "escaped unicode+base64, depth=2, found",
+			input:       []byte("token: " + escapedUnicodeB64),
 			depth:       2,
 			wantKeyword: true,
 		},


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The purpose of this PR is to add escaped unicode test cases for the engine tests. 

### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that expands coverage for decoding edge cases; no production logic or APIs are modified.
> 
> **Overview**
> Expands `TestEngine_IterativeDecoding` to cover `\uXXXX` escaped-unicode inputs and nested/combined encodings.
> 
> Adds new fixtures and table-driven cases to assert when the engine should (or should not) detect the `my-secret` keyword at different decode depths for single-escaped, double-escaped, `base64(escapedUnicode(...))`, and `escapedUnicode(base64(...))` payloads.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4a5f25e4f3ead28efb10b46e0d9643716ac2119. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->