### PR TITLE
use struct-based SourceMetadataFunc signature across git sources

### DIFF
--- a/hack/snifftest/main.go
+++ b/hack/snifftest/main.go
@@ -197,7 +197,7 @@ func main() {
 					SkipBinaries: true,
 					SkipArchives: false,
 					Concurrency:  runtime.NumCPU(),
-					SourceMetadataFunc: func(info *git.SourceMetadataInfo) *source_metadatapb.MetaData {
+					SourceMetadataFunc: func(info git.SourceMetadataInfo) *source_metadatapb.MetaData {
 						return &source_metadatapb.MetaData{
 							Data: &source_metadatapb.MetaData_Git{
 								Git: &source_metadatapb.Git{

--- a/hack/snifftest/main.go
+++ b/hack/snifftest/main.go
@@ -197,15 +197,15 @@ func main() {
 					SkipBinaries: true,
 					SkipArchives: false,
 					Concurrency:  runtime.NumCPU(),
-					SourceMetadataFunc: func(file, email, commit, timestamp, repository, repositoryLocalPath string, line int64) *source_metadatapb.MetaData {
+					SourceMetadataFunc: func(info *git.SourceMetadataInfo) *source_metadatapb.MetaData {
 						return &source_metadatapb.MetaData{
 							Data: &source_metadatapb.MetaData_Git{
 								Git: &source_metadatapb.Git{
-									Commit:     commit,
-									File:       file,
-									Email:      email,
-									Repository: repository,
-									Timestamp:  timestamp,
+									Commit:     info.Commit,
+									File:       info.File,
+									Email:      info.Email,
+									Repository: info.Repository,
+									Timestamp:  info.Timestamp,
 								},
 							},
 						}

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -70,18 +70,7 @@ type SourceMetadataInfo struct {
 }
 
 // SourceMetadataFunc is a function that maps git source metadata to a protobuf MetaData message.
-type SourceMetadataFunc func(info *SourceMetadataInfo) *source_metadatapb.MetaData
-
-// LegacySourceMetadataFunc wraps an old-style 7-parameter function into the new
-// SourceMetadataFunc signature.
-//
-// Deprecated: Use SourceMetadataFunc directly. This exists for backwards compatibility
-// during migration and should be removed once all consumers are updated.
-func LegacySourceMetadataFunc(fn func(file, email, commit, timestamp, repository, repositoryLocalPath string, line int64) *source_metadatapb.MetaData) SourceMetadataFunc {
-	return func(info *SourceMetadataInfo) *source_metadatapb.MetaData {
-		return fn(info.File, info.Email, info.Commit, info.Timestamp, info.Repository, info.RepositoryLocalPath, info.Line)
-	}
-}
+type SourceMetadataFunc func(info SourceMetadataInfo) *source_metadatapb.MetaData
 
 type Git struct {
 	sourceType         sourcespb.SourceType
@@ -238,7 +227,7 @@ func (s *Source) Init(aCtx context.Context, name string, jobId sources.JobID, so
 		SkipBinaries: conn.GetSkipBinaries(),
 		SkipArchives: conn.GetSkipArchives(),
 		Concurrency:  concurrency,
-		SourceMetadataFunc: func(info *SourceMetadataInfo) *source_metadatapb.MetaData {
+		SourceMetadataFunc: func(info SourceMetadataInfo) *source_metadatapb.MetaData {
 			return &source_metadatapb.MetaData{
 				Data: &source_metadatapb.MetaData_Git{
 					Git: &source_metadatapb.Git{
@@ -773,7 +762,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 			// Scan the commit metadata.
 			// See https://github.com/trufflesecurity/trufflehog/issues/2683
 			var (
-				metadata = s.sourceMetadataFunc(&SourceMetadataInfo{
+				metadata = s.sourceMetadataFunc(SourceMetadataInfo{
 					Email:               email,
 					Commit:              fullHash,
 					Timestamp:           when,
@@ -821,7 +810,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 				continue
 			}
 
-			metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+			metadata := s.sourceMetadataFunc(SourceMetadataInfo{
 				File:                fileName,
 				Email:               email,
 				Commit:              fullHash,
@@ -855,7 +844,7 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 		}
 
 		chunkData := func(d *gitparse.Diff) error {
-			metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+			metadata := s.sourceMetadataFunc(SourceMetadataInfo{
 				File:                fileName,
 				Email:               email,
 				Commit:              fullHash,
@@ -922,7 +911,7 @@ func (s *Git) gitChunk(ctx context.Context, diff *gitparse.Diff, fileName, email
 			// Add oversize chunk info
 			if newChunkBuffer.Len() > 0 {
 				// Send the existing fragment.
-				metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+				metadata := s.sourceMetadataFunc(SourceMetadataInfo{
 					File:       fileName,
 					Email:      email,
 					Commit:     hash,
@@ -949,7 +938,7 @@ func (s *Git) gitChunk(ctx context.Context, diff *gitparse.Diff, fileName, email
 			}
 			if len(line) > sources.DefaultChunkSize {
 				// Send the oversize line.
-				metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+				metadata := s.sourceMetadataFunc(SourceMetadataInfo{
 					File:       fileName,
 					Email:      email,
 					Commit:     hash,
@@ -980,7 +969,7 @@ func (s *Git) gitChunk(ctx context.Context, diff *gitparse.Diff, fileName, email
 	}
 	// Send anything still in the new chunk buffer
 	if newChunkBuffer.Len() > 0 {
-		metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+		metadata := s.sourceMetadataFunc(SourceMetadataInfo{
 			File:       fileName,
 			Email:      email,
 			Commit:     hash,
@@ -1088,7 +1077,7 @@ func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string,
 				continue
 			}
 
-			metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+			metadata := s.sourceMetadataFunc(SourceMetadataInfo{
 				File:                fileName,
 				Email:               email,
 				Commit:              "Staged",
@@ -1111,7 +1100,7 @@ func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string,
 		}
 
 		chunkData := func(d *gitparse.Diff) error {
-			metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+			metadata := s.sourceMetadataFunc(SourceMetadataInfo{
 				File:                fileName,
 				Email:               email,
 				Commit:              "Staged",

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -57,12 +57,38 @@ type Source struct {
 // WithCustomContentWriter sets the useCustomContentWriter flag on the source.
 func (s *Source) WithCustomContentWriter() { s.useCustomContentWriter = true }
 
+// SourceMetadataInfo contains the metadata fields passed to SourceMetadataFunc.
+// Using a struct allows adding new fields without breaking existing consumers.
+type SourceMetadataInfo struct {
+	File                string
+	Email               string
+	Commit              string
+	Timestamp           string
+	Repository          string
+	RepositoryLocalPath string
+	Line                int64
+}
+
+// SourceMetadataFunc is a function that maps git source metadata to a protobuf MetaData message.
+type SourceMetadataFunc func(info *SourceMetadataInfo) *source_metadatapb.MetaData
+
+// LegacySourceMetadataFunc wraps an old-style 7-parameter function into the new
+// SourceMetadataFunc signature.
+//
+// Deprecated: Use SourceMetadataFunc directly. This exists for backwards compatibility
+// during migration and should be removed once all consumers are updated.
+func LegacySourceMetadataFunc(fn func(file, email, commit, timestamp, repository, repositoryLocalPath string, line int64) *source_metadatapb.MetaData) SourceMetadataFunc {
+	return func(info *SourceMetadataInfo) *source_metadatapb.MetaData {
+		return fn(info.File, info.Email, info.Commit, info.Timestamp, info.Repository, info.RepositoryLocalPath, info.Line)
+	}
+}
+
 type Git struct {
 	sourceType         sourcespb.SourceType
 	sourceName         string
 	sourceID           sources.SourceID
 	jobID              sources.JobID
-	sourceMetadataFunc func(file, email, commit, timestamp, repository, repositoryLocalPath string, line int64) *source_metadatapb.MetaData
+	sourceMetadataFunc SourceMetadataFunc
 	verify             bool
 	metrics            metricsCollector
 	concurrency        *semaphore.Weighted
@@ -76,7 +102,7 @@ type Git struct {
 // Config for a Git source.
 type Config struct {
 	Concurrency        int
-	SourceMetadataFunc func(file, email, commit, timestamp, repository, repositoryLocalPath string, line int64) *source_metadatapb.MetaData
+	SourceMetadataFunc SourceMetadataFunc
 
 	SourceName   string
 	JobID        sources.JobID
@@ -212,17 +238,17 @@ func (s *Source) Init(aCtx context.Context, name string, jobId sources.JobID, so
 		SkipBinaries: conn.GetSkipBinaries(),
 		SkipArchives: conn.GetSkipArchives(),
 		Concurrency:  concurrency,
-		SourceMetadataFunc: func(file, email, commit, timestamp, repository, repositoryLocalPath string, line int64) *source_metadatapb.MetaData {
+		SourceMetadataFunc: func(info *SourceMetadataInfo) *source_metadatapb.MetaData {
 			return &source_metadatapb.MetaData{
 				Data: &source_metadatapb.MetaData_Git{
 					Git: &source_metadatapb.Git{
-						Commit:              sanitizer.UTF8(commit),
-						File:                sanitizer.UTF8(file),
-						Email:               sanitizer.UTF8(email),
-						Repository:          sanitizer.UTF8(repository),
-						Timestamp:           sanitizer.UTF8(timestamp),
-						Line:                line,
-						RepositoryLocalPath: sanitizer.UTF8(repositoryLocalPath),
+						Commit:              sanitizer.UTF8(info.Commit),
+						File:                sanitizer.UTF8(info.File),
+						Email:               sanitizer.UTF8(info.Email),
+						Repository:          sanitizer.UTF8(info.Repository),
+						Timestamp:           sanitizer.UTF8(info.Timestamp),
+						Line:                info.Line,
+						RepositoryLocalPath: sanitizer.UTF8(info.RepositoryLocalPath),
 					},
 				},
 			}
@@ -747,8 +773,14 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 			// Scan the commit metadata.
 			// See https://github.com/trufflesecurity/trufflehog/issues/2683
 			var (
-				metadata = s.sourceMetadataFunc("", email, fullHash, when, remoteURL, path, 0)
-				sb       strings.Builder
+				metadata = s.sourceMetadataFunc(&SourceMetadataInfo{
+					Email:               email,
+					Commit:              fullHash,
+					Timestamp:           when,
+					Repository:          remoteURL,
+					RepositoryLocalPath: path,
+				})
+				sb strings.Builder
 			)
 			sb.WriteString(email)
 			sb.WriteString("\n")
@@ -789,7 +821,14 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 				continue
 			}
 
-			metadata := s.sourceMetadataFunc(fileName, email, fullHash, when, remoteURL, path, 0)
+			metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+				File:                fileName,
+				Email:               email,
+				Commit:              fullHash,
+				Timestamp:           when,
+				Repository:          remoteURL,
+				RepositoryLocalPath: path,
+			})
 			chunkSkel := &sources.Chunk{
 				SourceName:     s.sourceName,
 				SourceID:       s.sourceID,
@@ -816,7 +855,15 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 		}
 
 		chunkData := func(d *gitparse.Diff) error {
-			metadata := s.sourceMetadataFunc(fileName, email, fullHash, when, remoteURL, path, int64(diff.LineStart))
+			metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+				File:                fileName,
+				Email:               email,
+				Commit:              fullHash,
+				Timestamp:           when,
+				Repository:          remoteURL,
+				RepositoryLocalPath: path,
+				Line:                int64(diff.LineStart),
+			})
 
 			reader, err := d.ReadCloser()
 			if err != nil {
@@ -875,7 +922,14 @@ func (s *Git) gitChunk(ctx context.Context, diff *gitparse.Diff, fileName, email
 			// Add oversize chunk info
 			if newChunkBuffer.Len() > 0 {
 				// Send the existing fragment.
-				metadata := s.sourceMetadataFunc(fileName, email, hash, when, urlMetadata, "", int64(diff.LineStart+lastOffset))
+				metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+					File:       fileName,
+					Email:      email,
+					Commit:     hash,
+					Timestamp:  when,
+					Repository: urlMetadata,
+					Line:       int64(diff.LineStart + lastOffset),
+				})
 				chunk := sources.Chunk{
 					SourceName:     s.sourceName,
 					SourceID:       s.sourceID,
@@ -895,7 +949,14 @@ func (s *Git) gitChunk(ctx context.Context, diff *gitparse.Diff, fileName, email
 			}
 			if len(line) > sources.DefaultChunkSize {
 				// Send the oversize line.
-				metadata := s.sourceMetadataFunc(fileName, email, hash, when, urlMetadata, "", int64(diff.LineStart+offset))
+				metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+					File:       fileName,
+					Email:      email,
+					Commit:     hash,
+					Timestamp:  when,
+					Repository: urlMetadata,
+					Line:       int64(diff.LineStart + offset),
+				})
 				chunk := sources.Chunk{
 					SourceName:     s.sourceName,
 					SourceID:       s.sourceID,
@@ -919,7 +980,14 @@ func (s *Git) gitChunk(ctx context.Context, diff *gitparse.Diff, fileName, email
 	}
 	// Send anything still in the new chunk buffer
 	if newChunkBuffer.Len() > 0 {
-		metadata := s.sourceMetadataFunc(fileName, email, hash, when, urlMetadata, "", int64(diff.LineStart+lastOffset))
+		metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+			File:       fileName,
+			Email:      email,
+			Commit:     hash,
+			Timestamp:  when,
+			Repository: urlMetadata,
+			Line:       int64(diff.LineStart + lastOffset),
+		})
 		chunk := sources.Chunk{
 			SourceName:     s.sourceName,
 			SourceID:       s.sourceID,
@@ -1020,7 +1088,14 @@ func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string,
 				continue
 			}
 
-			metadata := s.sourceMetadataFunc(fileName, email, "Staged", when, urlMetadata, path, 0)
+			metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+				File:                fileName,
+				Email:               email,
+				Commit:              "Staged",
+				Timestamp:           when,
+				Repository:          urlMetadata,
+				RepositoryLocalPath: path,
+			})
 			chunkSkel := &sources.Chunk{
 				SourceName:     s.sourceName,
 				SourceID:       s.sourceID,
@@ -1036,7 +1111,15 @@ func (s *Git) ScanStaged(ctx context.Context, repo *git.Repository, path string,
 		}
 
 		chunkData := func(d *gitparse.Diff) error {
-			metadata := s.sourceMetadataFunc(fileName, email, "Staged", when, urlMetadata, path, int64(diff.LineStart))
+			metadata := s.sourceMetadataFunc(&SourceMetadataInfo{
+				File:                fileName,
+				Email:               email,
+				Commit:              "Staged",
+				Timestamp:           when,
+				Repository:          urlMetadata,
+				RepositoryLocalPath: path,
+				Line:                int64(diff.LineStart),
+			})
 
 			reader, err := d.ReadCloser()
 			if err != nil {

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -288,19 +288,19 @@ func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, so
 		SkipBinaries: conn.GetSkipBinaries(),
 		SkipArchives: conn.GetSkipArchives(),
 		Concurrency:  concurrency,
-		SourceMetadataFunc: func(file, email, commit, timestamp, repository, repositoryLocalPath string, line int64) *source_metadatapb.MetaData {
+		SourceMetadataFunc: func(info *git.SourceMetadataInfo) *source_metadatapb.MetaData {
 			return &source_metadatapb.MetaData{
 				Data: &source_metadatapb.MetaData_Github{
 					Github: &source_metadatapb.Github{
-						Commit:              sanitizer.UTF8(commit),
-						File:                sanitizer.UTF8(file),
-						Email:               sanitizer.UTF8(email),
-						Repository:          sanitizer.UTF8(repository),
-						Link:                giturl.GenerateLink(repository, commit, file, line),
-						Timestamp:           sanitizer.UTF8(timestamp),
-						Line:                line,
-						Visibility:          s.visibilityOf(aCtx, repository),
-						RepositoryLocalPath: sanitizer.UTF8(repositoryLocalPath),
+						Commit:              sanitizer.UTF8(info.Commit),
+						File:                sanitizer.UTF8(info.File),
+						Email:               sanitizer.UTF8(info.Email),
+						Repository:          sanitizer.UTF8(info.Repository),
+						Link:                giturl.GenerateLink(info.Repository, info.Commit, info.File, info.Line),
+						Timestamp:           sanitizer.UTF8(info.Timestamp),
+						Line:                info.Line,
+						Visibility:          s.visibilityOf(aCtx, info.Repository),
+						RepositoryLocalPath: sanitizer.UTF8(info.RepositoryLocalPath),
 					},
 				},
 			}

--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -288,7 +288,7 @@ func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, so
 		SkipBinaries: conn.GetSkipBinaries(),
 		SkipArchives: conn.GetSkipArchives(),
 		Concurrency:  concurrency,
-		SourceMetadataFunc: func(info *git.SourceMetadataInfo) *source_metadatapb.MetaData {
+		SourceMetadataFunc: func(info git.SourceMetadataInfo) *source_metadatapb.MetaData {
 			return &source_metadatapb.MetaData{
 				Data: &source_metadatapb.MetaData_Github{
 					Github: &source_metadatapb.Github{

--- a/pkg/sources/github_experimental/github_experimental.go
+++ b/pkg/sources/github_experimental/github_experimental.go
@@ -128,7 +128,7 @@ func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, so
 		SkipBinaries: false,
 		SkipArchives: false,
 		Concurrency:  concurrency,
-		SourceMetadataFunc: func(info *git.SourceMetadataInfo) *source_metadatapb.MetaData {
+		SourceMetadataFunc: func(info git.SourceMetadataInfo) *source_metadatapb.MetaData {
 			return &source_metadatapb.MetaData{
 				Data: &source_metadatapb.MetaData_Github{
 					Github: &source_metadatapb.Github{

--- a/pkg/sources/github_experimental/github_experimental.go
+++ b/pkg/sources/github_experimental/github_experimental.go
@@ -128,18 +128,18 @@ func (s *Source) Init(aCtx context.Context, name string, jobID sources.JobID, so
 		SkipBinaries: false,
 		SkipArchives: false,
 		Concurrency:  concurrency,
-		SourceMetadataFunc: func(file, email, commit, timestamp, repository, repositoryLocalPath string, line int64) *source_metadatapb.MetaData {
+		SourceMetadataFunc: func(info *git.SourceMetadataInfo) *source_metadatapb.MetaData {
 			return &source_metadatapb.MetaData{
 				Data: &source_metadatapb.MetaData_Github{
 					Github: &source_metadatapb.Github{
-						Commit:     sanitizer.UTF8(commit),
-						File:       sanitizer.UTF8(file),
-						Email:      sanitizer.UTF8(email),
-						Repository: sanitizer.UTF8(repository),
-						Link:       giturl.GenerateLink(repository, commit, file, line),
-						Timestamp:  sanitizer.UTF8(timestamp),
-						Line:       line,
-						Visibility: s.visibilityOf(aCtx, repository),
+						Commit:     sanitizer.UTF8(info.Commit),
+						File:       sanitizer.UTF8(info.File),
+						Email:      sanitizer.UTF8(info.Email),
+						Repository: sanitizer.UTF8(info.Repository),
+						Link:       giturl.GenerateLink(info.Repository, info.Commit, info.File, info.Line),
+						Timestamp:  sanitizer.UTF8(info.Timestamp),
+						Line:       info.Line,
+						Visibility: s.visibilityOf(aCtx, info.Repository),
 					},
 				},
 			}

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -231,18 +231,18 @@ func (s *Source) Init(ctx context.Context, name string, jobId sources.JobID, sou
 		SkipBinaries: conn.GetSkipBinaries(),
 		SkipArchives: conn.GetSkipArchives(),
 		Concurrency:  concurrency,
-		SourceMetadataFunc: func(file, email, commit, timestamp, repository, repositoryLocalPath string, line int64) *source_metadatapb.MetaData {
+		SourceMetadataFunc: func(info *git.SourceMetadataInfo) *source_metadatapb.MetaData {
 			gitlabMetadata := &source_metadatapb.Gitlab{
-				Commit:              sanitizer.UTF8(commit),
-				File:                sanitizer.UTF8(file),
-				Email:               sanitizer.UTF8(email),
-				Repository:          sanitizer.UTF8(repository),
-				RepositoryLocalPath: sanitizer.UTF8(repositoryLocalPath),
-				Link:                giturl.GenerateLink(repository, commit, file, line),
-				Timestamp:           sanitizer.UTF8(timestamp),
-				Line:                line,
+				Commit:              sanitizer.UTF8(info.Commit),
+				File:                sanitizer.UTF8(info.File),
+				Email:               sanitizer.UTF8(info.Email),
+				Repository:          sanitizer.UTF8(info.Repository),
+				RepositoryLocalPath: sanitizer.UTF8(info.RepositoryLocalPath),
+				Link:                giturl.GenerateLink(info.Repository, info.Commit, info.File, info.Line),
+				Timestamp:           sanitizer.UTF8(info.Timestamp),
+				Line:                info.Line,
 			}
-			proj, ok := s.repoToProjCache.get(repository)
+			proj, ok := s.repoToProjCache.get(info.Repository)
 			if ok {
 				gitlabMetadata.ProjectId = int64(proj.id)
 				gitlabMetadata.ProjectName = proj.name

--- a/pkg/sources/gitlab/gitlab.go
+++ b/pkg/sources/gitlab/gitlab.go
@@ -231,7 +231,7 @@ func (s *Source) Init(ctx context.Context, name string, jobId sources.JobID, sou
 		SkipBinaries: conn.GetSkipBinaries(),
 		SkipArchives: conn.GetSkipArchives(),
 		Concurrency:  concurrency,
-		SourceMetadataFunc: func(info *git.SourceMetadataInfo) *source_metadatapb.MetaData {
+		SourceMetadataFunc: func(info git.SourceMetadataInfo) *source_metadatapb.MetaData {
 			gitlabMetadata := &source_metadatapb.Gitlab{
 				Commit:              sanitizer.UTF8(info.Commit),
 				File:                sanitizer.UTF8(info.File),

--- a/pkg/sources/huggingface/huggingface.go
+++ b/pkg/sources/huggingface/huggingface.go
@@ -235,19 +235,19 @@ func (s *Source) Init(ctx context.Context, name string, jobID sources.JobID, sou
 		SourceType:  s.Type(),
 		Verify:      s.verify,
 		Concurrency: concurrency,
-		SourceMetadataFunc: func(file, email, commit, timestamp, repository, repositoryLocalPath string, line int64) *source_metadatapb.MetaData {
+		SourceMetadataFunc: func(info *git.SourceMetadataInfo) *source_metadatapb.MetaData {
 			return &source_metadatapb.MetaData{
 				Data: &source_metadatapb.MetaData_Huggingface{
 					Huggingface: &source_metadatapb.Huggingface{
-						Commit:       sanitizer.UTF8(commit),
-						File:         sanitizer.UTF8(file),
-						Email:        sanitizer.UTF8(email),
-						Repository:   sanitizer.UTF8(repository),
-						Link:         giturl.GenerateLink(repository, commit, file, line),
-						Timestamp:    sanitizer.UTF8(timestamp),
-						Line:         line,
-						Visibility:   s.visibilityOf(ctx, repository),
-						ResourceType: s.getResourceType(ctx, repository),
+						Commit:       sanitizer.UTF8(info.Commit),
+						File:         sanitizer.UTF8(info.File),
+						Email:        sanitizer.UTF8(info.Email),
+						Repository:   sanitizer.UTF8(info.Repository),
+						Link:         giturl.GenerateLink(info.Repository, info.Commit, info.File, info.Line),
+						Timestamp:    sanitizer.UTF8(info.Timestamp),
+						Line:         info.Line,
+						Visibility:   s.visibilityOf(ctx, info.Repository),
+						ResourceType: s.getResourceType(ctx, info.Repository),
 					},
 				},
 			}

--- a/pkg/sources/huggingface/huggingface.go
+++ b/pkg/sources/huggingface/huggingface.go
@@ -235,7 +235,7 @@ func (s *Source) Init(ctx context.Context, name string, jobID sources.JobID, sou
 		SourceType:  s.Type(),
 		Verify:      s.verify,
 		Concurrency: concurrency,
-		SourceMetadataFunc: func(info *git.SourceMetadataInfo) *source_metadatapb.MetaData {
+		SourceMetadataFunc: func(info git.SourceMetadataInfo) *source_metadatapb.MetaData {
 			return &source_metadatapb.MetaData{
 				Data: &source_metadatapb.MetaData_Huggingface{
 					Huggingface: &source_metadatapb.Huggingface{


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
- Refactor `SourceMetadataFunc` from a 7-parameter function to a struct-based `SourceMetadataInfo` approach
- Add `LegacySourceMetadataFunc` wrapper for backward compatibility with EE consumers
- Update all OSS git-based source implementations (GitHub, GitLab, HuggingFace, GitHub Experimental, snifftest)

## Benefits
- **Future extensibility**: Adding new metadata fields (e.g. `Branch`) no longer requires changing the function signature across all consumers
- **Backward compatibility**: `LegacySourceMetadataFunc` allows gradual EE migration

## Testing
- Existing tests pass unchanged — refactoring is type-level only with no behavioral modifications

### Checklist:
* [X] Tests passing (`make test-community`)?
* [X] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk type-level refactor, but it touches core git scanning paths; any missed field mapping could degrade metadata (links/line numbers) across sources.
> 
> **Overview**
> **Refactors git metadata callback plumbing** by replacing the 7-parameter `SourceMetadataFunc` with a struct-based `SourceMetadataInfo`, making the callback signature extensible without widespread breaking changes.
> 
> Updates git chunk/commit/staged scanning code to construct and pass `SourceMetadataInfo` (including `RepositoryLocalPath`/`Line` where relevant), and migrates OSS consumers (`github`, `gitlab`, `huggingface`, `github_experimental`, and `hack/snifftest`) to the new callback shape while preserving existing metadata fields/links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b160a793079887a0346efd2a90d3e6fa40dbce21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->