### PR TITLE
[INS-402] Support custom endpoint configuration in Jira detectors

### DIFF
--- a/pkg/detectors/jiratoken/v1/jiratoken.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken.go
@@ -20,14 +20,21 @@ import (
 
 type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
+	detectors.EndpointSetter
 	client *http.Client
 }
 
-// Ensure the Scanner satisfies the interface at compile time.
+// Ensure the Scanner satisfies the interfaces at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 var _ detectors.Versioner = (*Scanner)(nil)
+var _ detectors.EndpointCustomizer = (*Scanner)(nil)
+var _ detectors.CloudProvider = (*Scanner)(nil)
 
 func (Scanner) Version() int { return 1 }
+
+// reason: https://community.atlassian.com/forums/Jira-Product-Discovery-questions/Authorization-issues-with-GRAPHQL/qaq-p/2640943
+// In case we don't find any domain matches we can use this as the graphql API works with this domain if our authentication is valid
+func (Scanner) CloudEndpoint() string { return "api.atlassian.com" }
 
 var (
 	defaultClient = detectors.DetectorHttpClientWithLocalAddresses
@@ -70,23 +77,25 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	dataStr := string(data)
 
 	var uniqueTokens, uniqueDomains, uniqueEmails = make(map[string]struct{}), make(map[string]struct{}), make(map[string]struct{})
+	var foundEndpoints = make([]string, 0)
 
 	for _, token := range tokenPat.FindAllStringSubmatch(dataStr, -1) {
 		uniqueTokens[token[1]] = struct{}{}
 	}
 
 	for _, domain := range domainPat.FindAllStringSubmatch(dataStr, -1) {
-		uniqueDomains[domain[1]] = struct{}{}
+		foundEndpoints = append(foundEndpoints, domain[1])
 	}
 
 	for _, email := range emailPat.FindAllStringSubmatch(dataStr, -1) {
 		uniqueEmails[strings.ToLower(email[1])] = struct{}{}
 	}
 
-	if len(uniqueDomains) == 0 {
-		// reason: https://community.atlassian.com/forums/Jira-Product-Discovery-questions/Authorization-issues-with-GRAPHQL/qaq-p/2640943
-		// In case we don't find any domain matches we can use this as the graphql API works with this domain if our authentication is valid
-		uniqueDomains["api.atlassian.com"] = struct{}{}
+	// add found + configured endpoints to the list
+	for _, endpoint := range s.Endpoints(foundEndpoints...) {
+		endpoint = strings.TrimPrefix(endpoint, "https://")
+		endpoint = strings.TrimSuffix(endpoint, "/")
+		uniqueDomains[endpoint] = struct{}{}
 	}
 
 	for email := range uniqueEmails {

--- a/pkg/detectors/jiratoken/v1/jiratoken_integration_test.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken_integration_test.go
@@ -141,6 +141,7 @@ func TestJiraToken_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt.s.UseFoundEndpoints(true)
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("JiraToken.FromData() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/detectors/jiratoken/v1/jiratoken_test.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken_test.go
@@ -96,7 +96,7 @@ func TestJiraToken_Pattern(t *testing.T) {
 			d.UseFoundEndpoints(test.useFoundEndpoints)
 			d.UseCloudEndpoint(test.useCloudEndpoint)
 			d.SetCloudEndpoint(d.CloudEndpoint())
-			d.SetConfiguredEndpoints(test.configuredEndpoints...)
+			_ = d.SetConfiguredEndpoints(test.configuredEndpoints...)
 			results, err := d.FromData(context.Background(), false, []byte(test.input))
 			if err != nil {
 				t.Errorf("error = %v", err)

--- a/pkg/detectors/jiratoken/v1/jiratoken_test.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken_test.go
@@ -24,8 +24,6 @@ var (
 )
 
 func TestJiraToken_Pattern(t *testing.T) {
-	d := Scanner{}
-	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {
 		name                string
 		input               string
@@ -88,6 +86,8 @@ func TestJiraToken_Pattern(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			d := Scanner{}
+			ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
 			if len(matchedDetectors) == 0 {
 				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)

--- a/pkg/detectors/jiratoken/v1/jiratoken_test.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken_test.go
@@ -19,20 +19,60 @@ var (
 	validEmailPattern    = "xfkf_bz7@grum.com"
 	invalidEmailPattern  = "xfKF_BZq7/grum.com"
 	keyword              = "jira"
+	cloudEndpoint        = "api.atlassian.com"
+	configuredEndpoint   = "example.atlassian.net"
 )
 
 func TestJiraToken_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {
-		name  string
-		input string
-		want  []string
+		name                string
+		input               string
+		want                []string
+		useFoundEndpoints   bool
+		useCloudEndpoint    bool
+		configuredEndpoints []string
 	}{
 		{
-			name:  "valid pattern - with keyword jira",
-			input: fmt.Sprintf("%s %s          \n%s %s\n%s %s", keyword, validTokenPattern, keyword, validDomainPattern, keyword, validEmailPattern),
-			want:  []string{validEmailPattern + ":" + validTokenPattern + ":" + validDomainPattern},
+			name:              "valid pattern - use found endpoint",
+			input:             fmt.Sprintf("%s %s          \n%s %s\n%s %s", keyword, validTokenPattern, keyword, validDomainPattern, keyword, validEmailPattern),
+			useFoundEndpoints: true,
+			want:              []string{validEmailPattern + ":" + validTokenPattern + ":" + validDomainPattern},
+		},
+		{
+			name:             "valid pattern - use cloud endpoint",
+			input:            fmt.Sprintf("%s %s          \n%s\n%s %s", keyword, validTokenPattern, keyword, keyword, validEmailPattern),
+			useCloudEndpoint: true,
+			want:             []string{validEmailPattern + ":" + validTokenPattern + ":" + cloudEndpoint},
+		},
+		{
+			name:                "valid pattern - use configured endpoint",
+			input:               fmt.Sprintf("%s %s          \n%s\n%s %s", keyword, validTokenPattern, keyword, keyword, validEmailPattern),
+			configuredEndpoints: []string{validDomainPattern},
+			want:                []string{validEmailPattern + ":" + validTokenPattern + ":" + validDomainPattern},
+		},
+		{
+			name:                "valid pattern - use found + configured endpoint",
+			input:               fmt.Sprintf("%s %s          \n%s %s\n%s %s", keyword, validTokenPattern, keyword, validDomainPattern, keyword, validEmailPattern),
+			useFoundEndpoints:   true,
+			configuredEndpoints: []string{configuredEndpoint},
+			want: []string{
+				validEmailPattern + ":" + validTokenPattern + ":" + validDomainPattern,
+				validEmailPattern + ":" + validTokenPattern + ":" + configuredEndpoint,
+			},
+		},
+		{
+			name:                "valid pattern - use found + configured + cloud endpoint",
+			input:               fmt.Sprintf("%s %s          \n%s %s\n%s %s", keyword, validTokenPattern, keyword, validDomainPattern, keyword, validEmailPattern),
+			useFoundEndpoints:   true,
+			useCloudEndpoint:    true,
+			configuredEndpoints: []string{configuredEndpoint},
+			want: []string{
+				validEmailPattern + ":" + validTokenPattern + ":" + validDomainPattern,
+				validEmailPattern + ":" + validTokenPattern + ":" + configuredEndpoint,
+				validEmailPattern + ":" + validTokenPattern + ":" + cloudEndpoint,
+			},
 		},
 		{
 			name:  "valid pattern - key out of prefix range",
@@ -53,7 +93,10 @@ func TestJiraToken_Pattern(t *testing.T) {
 				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
 				return
 			}
-
+			d.UseFoundEndpoints(test.useFoundEndpoints)
+			d.UseCloudEndpoint(test.useCloudEndpoint)
+			d.SetCloudEndpoint(d.CloudEndpoint())
+			d.SetConfiguredEndpoints(test.configuredEndpoints...)
 			results, err := d.FromData(context.Background(), false, []byte(test.input))
 			if err != nil {
 				t.Errorf("error = %v", err)

--- a/pkg/detectors/jiratoken/v2/jiratoken_v2.go
+++ b/pkg/detectors/jiratoken/v2/jiratoken_v2.go
@@ -17,13 +17,20 @@ import (
 type Scanner struct {
 	client *http.Client
 	detectors.DefaultMultiPartCredentialProvider
+	detectors.EndpointSetter
 }
 
-// Ensure the Scanner satisfies the interface at compile time.
+// Ensure the Scanner satisfies the interfaces at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 var _ detectors.Versioner = (*Scanner)(nil)
+var _ detectors.EndpointCustomizer = (*Scanner)(nil)
+var _ detectors.CloudProvider = (*Scanner)(nil)
 
 func (Scanner) Version() int { return 2 }
+
+// reason: https://community.atlassian.com/forums/Jira-Product-Discovery-questions/Authorization-issues-with-GRAPHQL/qaq-p/2640943
+// In case we don't find any domain matches we can use this as the graphql API works with this domain if our authentication is valid
+func (Scanner) CloudEndpoint() string { return "api.atlassian.com" }
 
 var (
 	defaultClient = detectors.DetectorHttpClientWithLocalAddresses
@@ -53,23 +60,25 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	dataStr := string(data)
 
 	var uniqueTokens, uniqueDomains, uniqueEmails = make(map[string]struct{}), make(map[string]struct{}), make(map[string]struct{})
+	var foundEndpoints = make([]string, 0)
 
 	for _, token := range tokenPat.FindAllStringSubmatch(dataStr, -1) {
 		uniqueTokens[token[1]] = struct{}{}
 	}
 
 	for _, domain := range domainPat.FindAllStringSubmatch(dataStr, -1) {
-		uniqueDomains[domain[1]] = struct{}{}
+		foundEndpoints = append(foundEndpoints, domain[1])
 	}
 
 	for _, email := range emailPat.FindAllStringSubmatch(dataStr, -1) {
 		uniqueEmails[strings.ToLower(email[1])] = struct{}{}
 	}
 
-	if len(uniqueDomains) == 0 {
-		// reason: https://community.atlassian.com/forums/Jira-Product-Discovery-questions/Authorization-issues-with-GRAPHQL/qaq-p/2640943
-		// In case we don't find any domain matches we can use this as the graphql API works with this domain if our authentication is valid
-		uniqueDomains["api.atlassian.com"] = struct{}{}
+	// add found + configured endpoints to the list
+	for _, endpoint := range s.Endpoints(foundEndpoints...) {
+		endpoint = strings.TrimPrefix(endpoint, "https://")
+		endpoint = strings.TrimSuffix(endpoint, "/")
+		uniqueDomains[endpoint] = struct{}{}
 	}
 
 	for email := range uniqueEmails {

--- a/pkg/detectors/jiratoken/v2/jiratoken_v2_integration_test.go
+++ b/pkg/detectors/jiratoken/v2/jiratoken_v2_integration_test.go
@@ -141,6 +141,7 @@ func TestJiraToken_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt.s.UseFoundEndpoints(true)
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("JiraToken.FromData() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/detectors/jiratoken/v2/jiratoken_v2_test.go
+++ b/pkg/detectors/jiratoken/v2/jiratoken_v2_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestJiraToken_Pattern(t *testing.T) {
-	d := Scanner{}
-	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {
 		name                string
 		input               string
@@ -311,6 +309,8 @@ func TestJiraToken_Pattern(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			d := Scanner{}
+			ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
 			if len(matchedDetectors) == 0 {
 				// if intentionally no keywords are passed

--- a/pkg/detectors/jiratoken/v2/jiratoken_v2_test.go
+++ b/pkg/detectors/jiratoken/v2/jiratoken_v2_test.go
@@ -324,7 +324,7 @@ func TestJiraToken_Pattern(t *testing.T) {
 			d.UseFoundEndpoints(test.useFoundEndpoints)
 			d.UseCloudEndpoint(test.useCloudEndpoint)
 			d.SetCloudEndpoint(d.CloudEndpoint())
-			d.SetConfiguredEndpoints(test.configuredEndpoints...)
+			_ = d.SetConfiguredEndpoints(test.configuredEndpoints...)
 			results, err := d.FromData(context.Background(), false, []byte(test.input))
 			if err != nil {
 				t.Errorf("error = %v", err)

--- a/pkg/detectors/jiratoken/v2/jiratoken_v2_test.go
+++ b/pkg/detectors/jiratoken/v2/jiratoken_v2_test.go
@@ -14,10 +14,13 @@ func TestJiraToken_Pattern(t *testing.T) {
 	d := Scanner{}
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {
-		name       string
-		input      string
-		want       []string
-		noKeywords bool
+		name                string
+		input               string
+		want                []string
+		noKeywords          bool
+		configuredEndpoints []string
+		useFoundEndpoints   bool
+		useCloudEndpoint    bool
 	}{
 		{
 			name: "valid pattern",
@@ -48,10 +51,11 @@ func TestJiraToken_Pattern(t *testing.T) {
 							},
 						}
 					]}`,
-			want: []string{"trufflesecurity@example.com" + ":" + "ATATThktLkSzzcXi1xt19IlU6gAchV1TS83w11YOqAXqFUeA2=Yx3ssoNC" + ":" + "example.atlassian.net"},
+			useFoundEndpoints: true,
+			want:              []string{"trufflesecurity@example.com" + ":" + "ATATThktLkSzzcXi1xt19IlU6gAchV1TS83w11YOqAXqFUeA2=Yx3ssoNC" + ":" + "example.atlassian.net"},
 		},
 		{
-			name: "valid pattern - without domain",
+			name: "valid pattern - without domain (use cloud)",
 			input: `
 					{
 					"expand": "schema,names",
@@ -77,7 +81,112 @@ func TestJiraToken_Pattern(t *testing.T) {
 							},
 						}
 					]}`,
-			want: []string{"trufflesecurity@example.com" + ":" + "ATATThktLkSzzcXi1xt19IlU6gAchV1TS83w11YOqAXqFUeA2=Yx3ssoNC" + ":" + "api.atlassian.com"},
+			useCloudEndpoint: true,
+			want:             []string{"trufflesecurity@example.com" + ":" + "ATATThktLkSzzcXi1xt19IlU6gAchV1TS83w11YOqAXqFUeA2=Yx3ssoNC" + ":" + "api.atlassian.com"},
+		},
+		{
+			name: "valid pattern - without domain (use configured)",
+			input: `
+					{
+					"expand": "schema,names",
+					"startAt": 0,
+					"maxResults": 50,
+					"total": 1,
+					"issues": [
+						{
+							"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+							"id": "fake454",
+							"key": "ESI-5555",
+							"fields": {
+								"statuscategorychangedate": "2016-06-01T01:25:35.807-0700",
+								"issuetype": {
+								"id": "09090",
+								"description": "This is an example ticket. Here's the token to test JIRA APIs: ATATThktLkSzzcXi1xt19IlU6gAchV1TS83w11YOqAXqFUeA2=Yx3ssoNC",
+								"name": "Example Pattern test 2",
+								"subtask": false,
+								"avatarId": 1298,
+								"entityId": "93a51c1d-fake-4673-a71d-0889fake1238",
+								"hierarchyLevel": 0,
+								"emailAddress": "trufflesecurity@example.com",
+							},
+						}
+					]}`,
+			configuredEndpoints: []string{"https://example.atlassian.net"},
+			want:                []string{"trufflesecurity@example.com" + ":" + "ATATThktLkSzzcXi1xt19IlU6gAchV1TS83w11YOqAXqFUeA2=Yx3ssoNC" + ":" + "example.atlassian.net"},
+		},
+		{
+			name: "valid pattern - with domain (use found + configured)",
+			input: `
+					{
+					"expand": "schema,names",
+					"startAt": 0,
+					"maxResults": 50,
+					"total": 1,
+					"issues": [
+						{
+							"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+							"id": "fake454",
+							"self": "https://example.atlassian.net/rest/api/2/issue/fake454",
+							"key": "ESI-5555",
+							"fields": {
+								"statuscategorychangedate": "2016-06-01T01:25:35.807-0700",
+								"issuetype": {
+								"self": "https://example.atlassian.net/rest/api/2/issuetype/09090",
+								"id": "09090",
+								"description": "This is an example ticket. Here's the token to test JIRA APIs: ATATThktLkSzzcXi1xt19IlU6gAchV1TS83w11YOqAXqFUeA2=Yx3ssoNC",
+								"name": "Example Pattern test",
+								"subtask": false,
+								"avatarId": 1298,
+								"entityId": "93a51c1d-fake-4673-a71d-0889fake1238",
+								"hierarchyLevel": 0,
+								"emailAddress": "trufflesecurity@example.com",
+							},
+						}
+					]}`,
+			useFoundEndpoints:   true,
+			configuredEndpoints: []string{"https://test.atlassian.net"},
+			want: []string{
+				"trufflesecurity@example.com" + ":" + "ATATThktLkSzzcXi1xt19IlU6gAchV1TS83w11YOqAXqFUeA2=Yx3ssoNC" + ":" + "example.atlassian.net",
+				"trufflesecurity@example.com" + ":" + "ATATThktLkSzzcXi1xt19IlU6gAchV1TS83w11YOqAXqFUeA2=Yx3ssoNC" + ":" + "test.atlassian.net",
+			},
+		},
+		{
+			name: "valid pattern - with domain (use found + configured + cloud)",
+			input: `
+					{
+					"expand": "schema,names",
+					"startAt": 0,
+					"maxResults": 50,
+					"total": 1,
+					"issues": [
+						{
+							"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+							"id": "fake454",
+							"self": "https://example.atlassian.net/rest/api/2/issue/fake454",
+							"key": "ESI-5555",
+							"fields": {
+								"statuscategorychangedate": "2016-06-01T01:25:35.807-0700",
+								"issuetype": {
+								"self": "https://example.atlassian.net/rest/api/2/issuetype/09090",
+								"id": "09090",
+								"description": "This is an example ticket. Here's the token to test JIRA APIs: ATATThktLkSzzcXi1xt19IlU6gAchV1TS83w11YOqAXqFUeA2=Yx3ssoNC",
+								"name": "Example Pattern test",
+								"subtask": false,
+								"avatarId": 1298,
+								"entityId": "93a51c1d-fake-4673-a71d-0889fake1238",
+								"hierarchyLevel": 0,
+								"emailAddress": "trufflesecurity@example.com",
+							},
+						}
+					]}`,
+			useFoundEndpoints:   true,
+			useCloudEndpoint:    true,
+			configuredEndpoints: []string{"https://test.atlassian.net"},
+			want: []string{
+				"trufflesecurity@example.com" + ":" + "ATATThktLkSzzcXi1xt19IlU6gAchV1TS83w11YOqAXqFUeA2=Yx3ssoNC" + ":" + "example.atlassian.net",
+				"trufflesecurity@example.com" + ":" + "ATATThktLkSzzcXi1xt19IlU6gAchV1TS83w11YOqAXqFUeA2=Yx3ssoNC" + ":" + "test.atlassian.net",
+				"trufflesecurity@example.com" + ":" + "ATATThktLkSzzcXi1xt19IlU6gAchV1TS83w11YOqAXqFUeA2=Yx3ssoNC" + ":" + "api.atlassian.com",
+			},
 		},
 		{
 			name: "valid pattern - without token",
@@ -212,7 +321,10 @@ func TestJiraToken_Pattern(t *testing.T) {
 				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
 				return
 			}
-
+			d.UseFoundEndpoints(test.useFoundEndpoints)
+			d.UseCloudEndpoint(test.useCloudEndpoint)
+			d.SetCloudEndpoint(d.CloudEndpoint())
+			d.SetConfiguredEndpoints(test.configuredEndpoints...)
 			results, err := d.FromData(context.Background(), false, []byte(test.input))
 			if err != nil {
 				t.Errorf("error = %v", err)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
This PR adds support for custom endpoint configuration in the Jira V1 and V2 detectors by implementing the `detectors.EndpointCustomizer` and `detectors.CloudProvider` interfaces.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Jira detectors choose domains for `RawV2`/verification by introducing configurable/cloud/found endpoint selection, which can alter detection/verification behavior and result counts. Risk is limited to Jira token scanning logic and is covered by expanded tests.
> 
> **Overview**
> Jira token detectors (v1 and v2) now support **endpoint customization** by embedding `EndpointSetter` and implementing `EndpointCustomizer`/`CloudProvider`, including a default `CloudEndpoint()` of `api.atlassian.com`.
> 
> `FromData` no longer unconditionally falls back to `api.atlassian.com` when no domain is found; instead it builds the candidate domain set from **found domains plus any configured endpoints and optional cloud endpoint**, normalizing entries by stripping `https://` and trailing `/`.
> 
> Tests were updated/expanded to exercise `UseFoundEndpoints`, `UseCloudEndpoint`, and configured endpoint combinations for both v1 and v2 (including integration tests enabling found endpoints).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6947b2a44194157c35e529ed9c94fa3f21532bc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->