### PR TITLE
feat(git,github): add --since date filter to git and github scans

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,6 +102,7 @@ var (
 	gitScanBranch          = gitScan.Flag("branch", "Branch to scan.").String()
 	gitScanMaxDepth        = gitScan.Flag("max-depth", "Maximum depth of commits to scan.").Int()
 	gitScanBare            = gitScan.Flag("bare", "Scan bare repository (e.g. useful while using in pre-receive hooks)").Bool()
+	gitScanSinceDate       = gitScan.Flag("since", "Scan commits more recent than a specific date (e.g. 2024-01-01).").String()
 	gitClonePath           = gitScan.Flag("clone-path", "Custom path where the repository should be cloned (default: temp dir).").String()
 	gitNoCleanup           = gitScan.Flag("no-cleanup", "Do not delete cloned repositories after scanning (can only be used with --clone-path).").Bool()
 	gitTrustLocalGitConfig = gitScan.Flag("trust-local-git-config", "Trust local git config.").Bool()
@@ -129,6 +130,8 @@ var (
 	githubClonePath             = githubScan.Flag("clone-path", "Custom path where the repository should be cloned (default: temp dir).").String()
 	githubNoCleanup             = githubScan.Flag("no-cleanup", "Do not delete cloned repositories after scanning (can only be used with --clone-path).").Bool()
 	githubIgnoreGists           = githubScan.Flag("ignore-gists", "Ignore all gists in scan.").Bool()
+	githubScanMaxDepth          = githubScan.Flag("max-depth", "Maximum depth of commits to scan.").Int()
+	githubScanSinceDate         = githubScan.Flag("since", "Scan commits more recent than a specific date (e.g. 2024-01-01).").String()
 
 	// GitHub Cross Fork Object Reference Experimental Feature
 	githubExperimentalScan = cli.Command("github-experimental", "Run an experimental GitHub scan. Must specify at least one experimental sub-module to run: object-discovery.")
@@ -781,6 +784,7 @@ func runSingleScan(ctx context.Context, cmd string, cfg engine.Config) (metrics,
 			NoCleanup:           *gitNoCleanup,
 			PrintLegacyJSON:     *jsonLegacy,
 			TrustLocalGitConfig: *gitTrustLocalGitConfig,
+			SinceDate:           *gitScanSinceDate,
 		}
 
 		// detect if trufflehog is running git source as a pre-commit hook
@@ -843,6 +847,8 @@ func runSingleScan(ctx context.Context, cmd string, cfg engine.Config) (metrics,
 			NoCleanup:                  *githubNoCleanup,
 			IgnoreGists:                *githubIgnoreGists,
 			PrintLegacyJSON:            *jsonLegacy,
+			MaxDepth:                   *githubScanMaxDepth,
+			SinceDate:                  *githubScanSinceDate,
 		}
 
 		if ref, err := eng.ScanGitHub(ctx, cfg); err != nil {

--- a/main.go
+++ b/main.go
@@ -130,7 +130,6 @@ var (
 	githubClonePath             = githubScan.Flag("clone-path", "Custom path where the repository should be cloned (default: temp dir).").String()
 	githubNoCleanup             = githubScan.Flag("no-cleanup", "Do not delete cloned repositories after scanning (can only be used with --clone-path).").Bool()
 	githubIgnoreGists           = githubScan.Flag("ignore-gists", "Ignore all gists in scan.").Bool()
-	githubScanMaxDepth          = githubScan.Flag("max-depth", "Maximum depth of commits to scan.").Int()
 	githubScanSinceDate         = githubScan.Flag("since", "Scan commits more recent than a specific date (e.g. 2024-01-01).").String()
 
 	// GitHub Cross Fork Object Reference Experimental Feature
@@ -847,7 +846,6 @@ func runSingleScan(ctx context.Context, cmd string, cfg engine.Config) (metrics,
 			NoCleanup:                  *githubNoCleanup,
 			IgnoreGists:                *githubIgnoreGists,
 			PrintLegacyJSON:            *jsonLegacy,
-			MaxDepth:                   *githubScanMaxDepth,
 			SinceDate:                  *githubScanSinceDate,
 		}
 

--- a/main.go
+++ b/main.go
@@ -9,11 +9,13 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/fatih/color"
@@ -102,7 +104,7 @@ var (
 	gitScanBranch          = gitScan.Flag("branch", "Branch to scan.").String()
 	gitScanMaxDepth        = gitScan.Flag("max-depth", "Maximum depth of commits to scan.").Int()
 	gitScanBare            = gitScan.Flag("bare", "Scan bare repository (e.g. useful while using in pre-receive hooks)").Bool()
-	gitScanSinceDate       = gitScan.Flag("since", "Scan commits more recent than a specific date (e.g. 2024-01-01).").String()
+	gitScanSinceDate       = gitScan.Flag("since", "Scan commits more recent than a specific date. Accepts YYYY-MM-DD, RFC 3339, or a git-style relative date (e.g. 2024-01-01 or \"2 weeks ago\").").String()
 	gitClonePath           = gitScan.Flag("clone-path", "Custom path where the repository should be cloned (default: temp dir).").String()
 	gitNoCleanup           = gitScan.Flag("no-cleanup", "Do not delete cloned repositories after scanning (can only be used with --clone-path).").Bool()
 	gitTrustLocalGitConfig = gitScan.Flag("trust-local-git-config", "Trust local git config.").Bool()
@@ -130,7 +132,7 @@ var (
 	githubClonePath             = githubScan.Flag("clone-path", "Custom path where the repository should be cloned (default: temp dir).").String()
 	githubNoCleanup             = githubScan.Flag("no-cleanup", "Do not delete cloned repositories after scanning (can only be used with --clone-path).").Bool()
 	githubIgnoreGists           = githubScan.Flag("ignore-gists", "Ignore all gists in scan.").Bool()
-	githubScanSinceDate         = githubScan.Flag("since", "Scan commits more recent than a specific date (e.g. 2024-01-01).").String()
+	githubScanSinceDate         = githubScan.Flag("since", "Scan commits more recent than a specific date. Accepts YYYY-MM-DD, RFC 3339, or a git-style relative date (e.g. 2024-01-01 or \"2 weeks ago\").").String()
 
 	// GitHub Cross Fork Object Reference Experimental Feature
 	githubExperimentalScan = cli.Command("github-experimental", "Run an experimental GitHub scan. Must specify at least one experimental sub-module to run: object-discovery.")
@@ -797,6 +799,10 @@ func runSingleScan(ctx context.Context, cmd string, cfg engine.Config) (metrics,
 			return scanMetrics, err
 		}
 
+		if err := validateSinceDate(*gitScanSinceDate); err != nil {
+			return scanMetrics, err
+		}
+
 		gitCfg := sources.GitConfig{
 			URI:                 *gitScanURI,
 			IncludePathsFile:    *gitScanIncludePaths,
@@ -849,6 +855,10 @@ func runSingleScan(ctx context.Context, cmd string, cfg engine.Config) (metrics,
 		}
 
 		if err := validateClonePath(*githubClonePath, *githubNoCleanup); err != nil {
+			return scanMetrics, err
+		}
+
+		if err := validateSinceDate(*githubScanSinceDate); err != nil {
 			return scanMetrics, err
 		}
 
@@ -1283,6 +1293,41 @@ func validateClonePath(clonePath string, noCleanup bool) error {
 	}
 
 	return nil
+}
+
+// sinceDateRelativePattern matches the subset of git's approxidate-style
+// relative inputs we want to allow through validation (e.g. "yesterday",
+// "2 weeks ago"). Anything that does not match this and does not parse as
+// one of the fixed layouts is treated as a likely typo.
+var sinceDateRelativePattern = regexp.MustCompile(`(?i)^(now|today|yesterday|noon|midnight|tea|breakfast|lunch|\d+\s+(seconds?|minutes?|hours?|days?|weeks?|months?|years?)\s+ago)$`)
+
+// validateSinceDate ensures that --since, if provided, is a date string
+// git log will accept. We reject obvious typos up front so they cannot be
+// silently interpreted by git's permissive date parser as "the beginning
+// of time" — which would scan the full history instead of the intended slice.
+func validateSinceDate(sinceDate string) error {
+	if sinceDate == "" {
+		return nil
+	}
+
+	layouts := []string{
+		"2006-01-02",
+		"2006-01-02T15:04:05",
+		"2006-01-02 15:04:05",
+		time.RFC3339,
+		time.RFC3339Nano,
+	}
+	for _, layout := range layouts {
+		if _, err := time.Parse(layout, sinceDate); err == nil {
+			return nil
+		}
+	}
+
+	if sinceDateRelativePattern.MatchString(strings.TrimSpace(sinceDate)) {
+		return nil
+	}
+
+	return fmt.Errorf("invalid --since value %q: expected YYYY-MM-DD, RFC 3339, or a git-style relative date (e.g. \"2 weeks ago\")", sinceDate)
 }
 
 // isPreCommitHook detects if trufflehog is running as a pre-commit hook

--- a/pkg/engine/git.go
+++ b/pkg/engine/git.go
@@ -44,5 +44,9 @@ func (e *Engine) ScanGit(ctx context.Context, c sources.GitConfig) (sources.JobP
 		return sources.JobProgressRef{}, err
 	}
 
+	if c.SinceDate != "" {
+		gitSource.ApplyScanOption(git.ScanOptionSinceDate(c.SinceDate))
+	}
+
 	return e.sourceManager.EnumerateAndScan(ctx, sourceName, gitSource)
 }

--- a/pkg/engine/github.go
+++ b/pkg/engine/github.go
@@ -56,10 +56,6 @@ func (e *Engine) ScanGitHub(ctx context.Context, c sources.GithubConfig) (source
 		git.ScanOptionLogOptions(logOptions),
 	}
 
-	if c.MaxDepth != 0 {
-		opts = append(opts, git.ScanOptionMaxDepth(int64(c.MaxDepth)))
-	}
-
 	if c.SinceDate != "" {
 		opts = append(opts, git.ScanOptionSinceDate(c.SinceDate))
 	}

--- a/pkg/engine/github.go
+++ b/pkg/engine/github.go
@@ -55,6 +55,15 @@ func (e *Engine) ScanGitHub(ctx context.Context, c sources.GithubConfig) (source
 		git.ScanOptionFilter(c.Filter),
 		git.ScanOptionLogOptions(logOptions),
 	}
+
+	if c.MaxDepth != 0 {
+		opts = append(opts, git.ScanOptionMaxDepth(int64(c.MaxDepth)))
+	}
+
+	if c.SinceDate != "" {
+		opts = append(opts, git.ScanOptionSinceDate(c.SinceDate))
+	}
+
 	scanOptions := git.NewScanOptions(opts...)
 
 	sourceName := "trufflehog - github"

--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -326,17 +326,32 @@ func (c *Parser) executeCommand(ctx context.Context, cmd *exec.Cmd, isStaged boo
 		return diffChan, err
 	}
 
+	// Capture stderr in parallel: stream at V(2) for live debug output, and
+	// retain the full text so we can surface it at Error level if the command
+	// exits non-zero. Without this, mistakes like an unparseable `--after`
+	// date are swallowed and the scan looks like a clean (but empty) success.
+	var stderrBuf strings.Builder
+	stderrDone := make(chan struct{})
 	go func() {
+		defer close(stderrDone)
 		scanner := bufio.NewScanner(stdErr)
 		for scanner.Scan() {
-			ctx.Logger().V(2).Info(scanner.Text())
+			line := scanner.Text()
+			ctx.Logger().V(2).Info(line)
+			stderrBuf.WriteString(line)
+			stderrBuf.WriteByte('\n')
 		}
 	}()
 
 	go func() {
 		defer func() {
+			<-stderrDone
 			if err := cmd.Wait(); err != nil {
-				ctx.Logger().V(2).Info("Error waiting for git command to complete.", "error", err)
+				if ctx.Err() != nil {
+					ctx.Logger().V(2).Info("git command interrupted", "error", err)
+					return
+				}
+				ctx.Logger().Error(err, "git command failed", "stderr", strings.TrimSpace(stderrBuf.String()))
 			}
 		}()
 		c.FromReader(ctx, stdOut, diffChan, isStaged)

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -145,6 +145,15 @@ func (s *Source) withScanOptions(scanOptions *ScanOptions) {
 	s.scanOptions = scanOptions
 }
 
+// ApplyScanOption applies an additional scan option on top of the source's existing scan options.
+// This can be used after Init to augment options without replacing the full set.
+func (s *Source) ApplyScanOption(opt ScanOption) {
+	if s.scanOptions == nil {
+		s.scanOptions = NewScanOptions()
+	}
+	opt(s.scanOptions)
+}
+
 // Init returns an initialized Git source.
 func (s *Source) Init(aCtx context.Context, name string, jobId sources.JobID, sourceId sources.SourceID, verify bool, connection *anypb.Any, concurrency int) error {
 	s.name = name
@@ -704,7 +713,13 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 		logValues = append(logValues, "max_depth", scanOptions.MaxDepth)
 	}
 
-	diffChan, err := s.parser.RepoPath(repoCtx, path, scanOptions.HeadHash, scanOptions.BaseHash == "", scanOptions.ExcludeGlobs, isRepoBare(path))
+	var additionalArgs []string
+	if scanOptions.SinceDate != "" {
+		additionalArgs = append(additionalArgs, fmt.Sprintf("--after=%s", scanOptions.SinceDate))
+		repoCtx.Logger().V(2).Info("limiting git log by date", "since", scanOptions.SinceDate)
+	}
+
+	diffChan, err := s.parser.RepoPath(repoCtx, path, scanOptions.HeadHash, scanOptions.BaseHash == "", scanOptions.ExcludeGlobs, isRepoBare(path), additionalArgs...)
 	if err != nil {
 		return err
 	}

--- a/pkg/sources/git/scan_options.go
+++ b/pkg/sources/git/scan_options.go
@@ -13,6 +13,7 @@ type ScanOptions struct {
 	Bare         bool
 	ExcludeGlobs []string
 	LogOptions   *git.LogOptions
+	SinceDate    string
 }
 
 type ScanOption func(*ScanOptions)
@@ -56,6 +57,12 @@ func ScanOptionLogOptions(logOptions *git.LogOptions) ScanOption {
 func ScanOptionBare(bare bool) ScanOption {
 	return func(scanOptions *ScanOptions) {
 		scanOptions.Bare = bare
+	}
+}
+
+func ScanOptionSinceDate(sinceDate string) ScanOption {
+	return func(scanOptions *ScanOptions) {
+		scanOptions.SinceDate = sinceDate
 	}
 }
 

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -291,6 +291,8 @@ type GitConfig struct {
 	PrintLegacyJSON bool
 	// TrustLocalGitConfig allows to trust the local git config.
 	TrustLocalGitConfig bool
+	// SinceDate limits scanning to commits more recent than the specified date.
+	SinceDate string
 }
 
 // GithubConfig defines the optional configuration for a github source.
@@ -336,6 +338,10 @@ type GithubConfig struct {
 	IgnoreGists bool
 	// PrintLegacyJSON indicates whether to print legacy JSON output format for this source.
 	PrintLegacyJSON bool
+	// MaxDepth is the maximum depth of commits to scan.
+	MaxDepth int
+	// SinceDate limits scanning to commits more recent than the specified date.
+	SinceDate string
 }
 
 // GitHubExperimentalConfig defines the optional configuration for an experimental GitHub source.

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -338,8 +338,6 @@ type GithubConfig struct {
 	IgnoreGists bool
 	// PrintLegacyJSON indicates whether to print legacy JSON output format for this source.
 	PrintLegacyJSON bool
-	// MaxDepth is the maximum depth of commits to scan.
-	MaxDepth int
 	// SinceDate limits scanning to commits more recent than the specified date.
 	SinceDate string
 }


### PR DESCRIPTION
### Description:

Add a `--since <date>` flag to the `git` and `github` subcommands to limit scanning to commits more recent than the specified date (e.g. `2024-01-01`).

Internally, the date is passed as `--after=<date>` to `git log` via the existing variadic `additionalArgs` in `gitparse.RepoPath`. This allows incremental scans where only recent history needs to be checked, avoiding re-scanning the full commit history on each run.

#### Files changed

| File | Change |
|---|---|
| `pkg/sources/git/scan_options.go` | Add `SinceDate` field and `ScanOptionSinceDate` option func |
| `pkg/sources/git/git.go` | Pass `SinceDate` as `--after` arg to `RepoPath`; expose `ApplyScanOption` for post-`Init` augmentation |
| `pkg/sources/sources.go` | Add `SinceDate` to `GitConfig` and `GithubConfig` |
| `pkg/engine/git.go` | Apply `SinceDate` scan option after source `Init` |
| `pkg/engine/github.go` | Apply `SinceDate` scan option |
| `main.go` | Wire `--since` flag for `git` and `github` subcommands |

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how git history is enumerated (adds `git log --after` filtering) and introduces new date parsing/validation that could cause unexpectedly empty or expanded scans if misparsed.
> 
> **Overview**
> Adds a new `--since` flag to the `git` and `github` CLI subcommands and threads it through `GitConfig`/`GithubConfig` into git scan options, limiting history enumeration to commits newer than the provided date.
> 
> Implements `SinceDate` as a `git log --after=<date>` argument during git parsing, adds upfront `--since` validation to prevent typos from silently scanning full history, and improves `gitparse` error surfacing by capturing/logging `git` stderr on non-zero exits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce6f662b94ca50e7290404e4829e9a22cf616920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->