### PR TITLE
Expand tilde manually in TUI

### DIFF
--- a/main.go
+++ b/main.go
@@ -280,6 +280,28 @@ var (
 	usingTUI   = false
 )
 
+// expandTilde replaces a leading ~ in each argument with the user's home
+// directory. This compensates for bypassing the shell (which would normally
+// perform this expansion) while still avoiding shell metacharacter injection.
+func expandTilde(args []string) []string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return args
+	}
+	out := make([]string, len(args))
+	for i, arg := range args {
+		switch {
+		case arg == "~":
+			out[i] = home
+		case strings.HasPrefix(arg, "~/"):
+			out[i] = home + arg[1:]
+		default:
+			out[i] = arg
+		}
+	}
+	return out
+}
+
 func init() {
 	_, _ = maxprocs.Set()
 
@@ -307,6 +329,11 @@ func init() {
 		if len(args) == 0 {
 			os.Exit(0)
 		}
+
+		// The TUI passes user input as literal strings. Since we no longer
+		// invoke a shell, we must expand ~ ourselves so paths like ~/foo
+		// resolve correctly.
+		args = expandTilde(args)
 
 		binary, err := exec.LookPath(os.Args[0])
 		if err == nil {


### PR DESCRIPTION

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the TUI restarts the program by removing the `sh -c` indirection and manually expanding `~`, which could affect argument parsing/quoting and path handling. Scope is limited to the TUI launch path but impacts process execution behavior.
> 
> **Overview**
> When launched via the TUI, the app now re-execs the current binary directly instead of building a command string and running it through `sh -c`, reducing shell injection risk and preserving literal arguments.
> 
> Adds `expandTilde` to manually expand leading `~`/`~/` in TUI-provided arguments so common home-directory paths continue to work without shell expansion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ba6947c03b6ace3e721815a9764a86c501c55dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->