### PR TITLE
todoist: replace deprecated verification endpoint

### DIFF
--- a/pkg/detectors/todoist/todoist.go
+++ b/pkg/detectors/todoist/todoist.go
@@ -46,7 +46,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.todoist.com/rest/v2/projects", nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.todoist.com/api/v1/projects", nil)
 			if err != nil {
 				continue
 			}

--- a/pkg/detectors/todoist/todoist_test.go
+++ b/pkg/detectors/todoist/todoist_test.go
@@ -3,6 +3,9 @@ package todoist
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,6 +13,12 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 var (
 	validPattern   = "qpgv7z8amkp4ln55znaacezm9jy35wcayy6bya2r"
@@ -87,5 +96,48 @@ func TestTodoist_Pattern(t *testing.T) {
 				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
 			}
 		})
+	}
+}
+
+func TestTodoist_VerificationEndpoint(t *testing.T) {
+	d := Scanner{}
+	input := fmt.Sprintf("%s token = '%s'", keyword, validPattern)
+
+	prevClient := client
+	t.Cleanup(func() {
+		client = prevClient
+	})
+
+	called := false
+	client = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			called = true
+			if req.URL.String() != "https://api.todoist.com/api/v1/projects" {
+				t.Fatalf("unexpected verification URL: %s", req.URL.String())
+			}
+			if req.Header.Get("Authorization") == "" {
+				t.Fatal("missing Authorization header")
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	results, err := d.FromData(context.Background(), true, []byte(input))
+	if err != nil {
+		t.Fatalf("FromData returned error: %v", err)
+	}
+	if !called {
+		t.Fatal("verification HTTP request was not made")
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if !results[0].Verified {
+		t.Fatal("expected result to be verified")
 	}
 }


### PR DESCRIPTION
## Summary
- replace Todoist verification endpoint from deprecated /rest/v2/projects to /api/v1/projects
- add regression test to verify detector uses /api/v1/projects
- keep change scoped to Todoist detector only

## Validation
- go test ./pkg/detectors/todoist

Closes #4816

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single URL change in the Todoist detector plus an isolated HTTP-transport-mocked regression test; behavior impact is limited to verification calls.
> 
> **Overview**
> Updates the Todoist detector’s verification request to use the non-deprecated `https://api.todoist.com/api/v1/projects` endpoint instead of `/rest/v2/projects`.
> 
> Adds a regression test that stubs the HTTP client transport to assert the verification URL and `Authorization` header are used, and that a 200 response marks the result as verified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff3da2f9cb56748bd55f68fcc5750c09564ebd08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->