### PR TITLE
feat: add WaveApps payment token detector

### DIFF
--- a/pkg/detectors/waveapps/waveapps.go
+++ b/pkg/detectors/waveapps/waveapps.go
@@ -1,0 +1,106 @@
+package waveapps
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detectorspb"
+)
+
+type Scanner struct {
+	client *http.Client
+}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	defaultClient = common.SaneHttpClient()
+
+	// Wave payment tokens have prefixes wave_sn_prod_ or wave_ci_prod_ followed by 30+ alphanumeric/dash/underscore chars.
+	keyPat = regexp.MustCompile(`\b(wave_(?:sn|ci)_prod_[A-Za-z0-9_\-]{30,})\b`)
+)
+
+// Keywords are used for efficiently pre-filtering chunks.
+// Use identifiers in the secret preferably, or the provider name.
+func (s Scanner) Keywords() []string {
+	return []string{"wave_sn_prod_", "wave_ci_prod_"}
+}
+
+// FromData will find and optionally verify WaveApps secrets in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	uniqueKeys := make(map[string]struct{})
+
+	for _, matches := range keyPat.FindAllStringSubmatch(dataStr, -1) {
+		key := strings.TrimSpace(matches[1])
+		uniqueKeys[key] = struct{}{}
+	}
+
+	for key := range uniqueKeys {
+		s1 := detectors.Result{
+			DetectorType: detectorspb.DetectorType_WaveApps,
+			Raw:          []byte(key),
+		}
+
+		if verify {
+			client := s.client
+			if client == nil {
+				client = defaultClient
+			}
+
+			isVerified, verificationErr := verifyWaveAppsKey(ctx, client, key)
+			s1.Verified = isVerified
+			s1.SetVerificationError(verificationErr)
+		}
+
+		results = append(results, s1)
+	}
+
+	return results, nil
+}
+
+func verifyWaveAppsKey(ctx context.Context, client *http.Client, key string) (bool, error) {
+	payload := strings.NewReader(`{"query": "{ user { id } }"}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://gql.waveapps.com/graphql/public", payload)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+}
+
+func (s Scanner) Type() detectorspb.DetectorType {
+	return detectorspb.DetectorType_WaveApps
+}
+
+func (s Scanner) Description() string {
+	return "WaveApps is a financial software platform for small businesses. Payment tokens can be used to access the Wave GraphQL API for invoicing, accounting, and payment data."
+}

--- a/pkg/detectors/waveapps/waveapps_test.go
+++ b/pkg/detectors/waveapps/waveapps_test.go
@@ -1,0 +1,98 @@
+package waveapps
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+)
+
+func TestWaveApps_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "valid pattern - sn token in env var",
+			input: `WAVE_SN_PAYMENT_TOKEN=wave_sn_prod_aBcDeFgHiJkLmNoPqRsTuVwXyZ012345`,
+			want:  []string{"wave_sn_prod_aBcDeFgHiJkLmNoPqRsTuVwXyZ012345"},
+		},
+		{
+			name:  "valid pattern - ci token in env var",
+			input: `WAVE_CI_PAYMENT_TOKEN=wave_ci_prod_aBcDeFgHiJkLmNoPqRsTuVwXyZ012345`,
+			want:  []string{"wave_ci_prod_aBcDeFgHiJkLmNoPqRsTuVwXyZ012345"},
+		},
+		{
+			name:  "valid pattern - sn token in config",
+			input: `wave_token: "wave_sn_prod_xYz123AbC456dEf789GhI012JkL345mNo"`,
+			want:  []string{"wave_sn_prod_xYz123AbC456dEf789GhI012JkL345mNo"},
+		},
+		{
+			name:  "valid pattern - ci token with dashes",
+			input: `export WAVE_KEY=wave_ci_prod_abc-def-ghi-jkl-mno-pqr-stu-vwx`,
+			want:  []string{"wave_ci_prod_abc-def-ghi-jkl-mno-pqr-stu-vwx"},
+		},
+		{
+			name:  "invalid pattern - wrong prefix",
+			input: `WAVE_TOKEN=wave_xx_prod_aBcDeFgHiJkLmNoPqRsTuVwXyZ012345`,
+			want:  nil,
+		},
+		{
+			name:  "invalid pattern - too short",
+			input: `WAVE_TOKEN=wave_sn_prod_tooshort`,
+			want:  nil,
+		},
+		{
+			name:  "invalid pattern - not prod",
+			input: `WAVE_TOKEN=wave_sn_test_aBcDeFgHiJkLmNoPqRsTuVwXyZ012345`,
+			want:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(matchedDetectors) == 0 {
+				if len(test.want) == 0 {
+					return
+				}
+				t.Errorf("keywords %v not matched by: %s", d.Keywords(), test.input)
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			require.NoError(t, err)
+
+			if len(results) != len(test.want) {
+				t.Errorf("expected %d results, got %d", len(test.want), len(results))
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.RawV2) > 0 {
+					actual[string(r.RawV2)] = struct{}{}
+				} else {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -819,6 +819,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/vultrapikey"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/vyte"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/walkscore"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/waveapps"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/weatherbit"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/weatherstack"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/web3storage"
@@ -1708,6 +1709,7 @@ func buildDetectorList() []detectors.Detector {
 		&vultrapikey.Scanner{},
 		&vyte.Scanner{},
 		&walkscore.Scanner{},
+		&waveapps.Scanner{},
 		&weatherbit.Scanner{},
 		&weatherstack.Scanner{},
 		&web3storage.Scanner{},

--- a/pkg/pb/detectorspb/detectors.pb.go
+++ b/pkg/pb/detectorspb/detectors.pb.go
@@ -1150,6 +1150,7 @@ const (
 	DetectorType_GoogleGeminiAPIKey                      DetectorType = 1041
 	DetectorType_ArtifactoryReferenceToken               DetectorType = 1042
 	DetectorType_DatadogApikey                           DetectorType = 1043
+	DetectorType_WaveApps                                DetectorType = 1044
 )
 
 // Enum value maps for DetectorType.
@@ -2195,6 +2196,7 @@ var (
 		1041: "GoogleGeminiAPIKey",
 		1042: "ArtifactoryReferenceToken",
 		1043: "DatadogApikey",
+		1044: "WaveApps",
 	}
 	DetectorType_value = map[string]int32{
 		"Alibaba":                               0,
@@ -3237,6 +3239,7 @@ var (
 		"GoogleGeminiAPIKey":                1041,
 		"ArtifactoryReferenceToken":         1042,
 		"DatadogApikey":                     1043,
+		"WaveApps":                          1044,
 	}
 )
 

--- a/proto/detectors.proto
+++ b/proto/detectors.proto
@@ -1053,6 +1053,7 @@ enum DetectorType {
   GoogleGeminiAPIKey = 1041;
   ArtifactoryReferenceToken = 1042;
   DatadogApikey = 1043;
+  WaveApps = 1044;
 }
 
 message Result {


### PR DESCRIPTION
Closes #4618

## Summary
- New detector for WaveApps payment tokens with prefixes `wave_sn_prod_` and `wave_ci_prod_`
- Verification via GraphQL query to `https://gql.waveapps.com/graphql/public`
- Registered as detector ID 1044

## Changes
- `pkg/detectors/waveapps/waveapps.go`: Scanner implementation
- `pkg/detectors/waveapps/waveapps_test.go`: 7 pattern tests (4 valid, 3 invalid)
- `proto/detectors.proto`: Added enum entry
- `pkg/pb/detectorspb/detectors.pb.go`: Generated enum constants
- `pkg/engine/defaults/defaults.go`: Scanner registration

## Test plan
- [x] All 7 detector tests pass
- [x] Both token prefixes matched correctly
- [x] Invalid patterns rejected (wrong prefix, too short, non-prod)
- [x] Build succeeds with no errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds a new detector with optional live verification calls to an external WaveApps GraphQL endpoint and wires it into the default detector set; incorrect patterns or verification behavior could cause false positives/negatives or unexpected network activity.
> 
> **Overview**
> Adds a new `waveapps.Scanner` that detects `wave_sn_prod_`/`wave_ci_prod_` payment tokens via regex and can *optionally verify* them by calling WaveApps’ public GraphQL endpoint with a bearer token.
> 
> Registers the new detector in `defaults.go` and introduces `DetectorType_WaveApps = 1044` in `proto/detectors.proto` (with regenerated `detectors.pb.go`), plus pattern-matching unit tests covering valid and invalid token formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d8542c138d086097e0fc7fc8c87da65be63194bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->