### PR TITLE
Skip TestAPKHandler

### DIFF
--- a/pkg/handlers/apk_test.go
+++ b/pkg/handlers/apk_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAPKHandler(t *testing.T) {
+	t.Skip("[INS-421] - Skipping this test because the apk file being used in this test is unavailable")
 	tests := map[string]struct {
 		archiveURL      string
 		expectedChunks  int


### PR DESCRIPTION
The [TestAPKHandler](https://github.com/trufflesecurity/trufflehog/blob/586f66d7886cd0b037c7c245d4a6e34ef357ab10/pkg/handlers/apk_test.go#L15) is failing in the [test-community](https://github.com/trufflesecurity/trufflehog/actions/runs/23603450396/job/68739583054?pr=4821), so we are temporarily disabling the test to ensure the checks pass, but we need to address the issue and enable the test ASAP.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only disables a failing integration-style test and does not change production APK handling logic. The main risk is reduced coverage for APK processing until the test fixture is restored.
> 
> **Overview**
> Temporarily skips `TestAPKHandler` in `apk_test.go` because the external APK fixture URL is unavailable, unblocking CI while the underlying test dependency issue is addressed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99cc975d8c470713d1584c4b9cdd8393ea03beee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->