### PR TITLE
Fixed failing apk handler test

### DIFF
--- a/pkg/handlers/apk_test.go
+++ b/pkg/handlers/apk_test.go
@@ -20,7 +20,7 @@ func TestAPKHandler(t *testing.T) {
 		matchString     string
 	}{
 		"apk_with_3_leaked_keys": {
-			archiveURL:     "https://github.com/joeleonjr/leakyAPK/raw/refs/heads/main/aws_leak.apk",
+			archiveURL:     "https://raw.githubusercontent.com/MuneebUllahKhan222/asset-hosting/refs/heads/main/aws_leak.apk",
 			expectedChunks: 942,
 			// Note: the secret count is 4 instead of 3 b/c we're not actually running the secret detection engine,
 			// we're just looking for a string match. There is one extra string match in the APK (but only 3 detected secrets).


### PR DESCRIPTION
### Description:
This PR fixes the failing APK handler test due to the deletion of an artifact that it uses.
To fix this I have re-uploaded the artifact to my public repo and used that in test.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a test fixture download URL, with no production code changes; remaining risk is continued dependence on an external GitHub-hosted asset for test stability.
> 
> **Overview**
> Fixes a failing `TestAPKHandler` by updating the APK fixture download URL to a new GitHub-hosted location after the previous artifact was removed.
> 
> No runtime behavior changes; this only affects test setup and reliability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 547cf57b7494c5a1f19e3b31ab7a562ce0cdc211. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->