### PR TITLE
[INS-421] Re-enabled TestAPKHandler test and updated artifact url

### DIFF
--- a/pkg/handlers/apk_test.go
+++ b/pkg/handlers/apk_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestAPKHandler(t *testing.T) {
-	t.Skip("[INS-421] - Skipping this test because the apk file being used in this test is unavailable")
 	tests := map[string]struct {
 		archiveURL      string
 		expectedChunks  int
@@ -21,7 +20,7 @@ func TestAPKHandler(t *testing.T) {
 		matchString     string
 	}{
 		"apk_with_3_leaked_keys": {
-			archiveURL:     "https://github.com/joeleonjr/leakyAPK/raw/refs/heads/main/aws_leak.apk",
+			archiveURL:     "https://raw.githubusercontent.com/trufflesecurity/leakyAPK/main/aws_leak.apk",
 			expectedChunks: 942,
 			// Note: the secret count is 4 instead of 3 b/c we're not actually running the secret detection engine,
 			// we're just looking for a string match. There is one extra string match in the APK (but only 3 detected secrets).


### PR DESCRIPTION
### Description:
This PR re-enables a previously skipped test that was failing due to an unavailable APK file. It also updates the test to use a newly hosted URL for the APK.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change limited to tests, but it reintroduces a network dependency on an externally hosted APK which could make CI flaky if the URL becomes unavailable.
> 
> **Overview**
> Re-enables `TestAPKHandler` by removing the skip and updates the APK fixture download URL to a TruffleSecurity-hosted `leakyAPK` artifact.
> 
> The test now runs again in CI and validates the handler against the hosted APK using the same expected chunk/secret assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 522075117d9c57cef6158bd795cfdaf53f96f99c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->