### PR TITLE
Add nil check and error context to GitHub analyzer

### DIFF
--- a/pkg/analyzer/analyzers/github/classic/classictoken.go
+++ b/pkg/analyzer/analyzers/github/classic/classictoken.go
@@ -91,13 +91,13 @@ func AnalyzeClassicToken(client *gh.Client, meta *common.TokenMetadata) (*common
 		var err error
 		repos, err = common.GetAllReposForUser(client)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("enumerating repos for classic PAT: %w", err)
 		}
 	}
 
 	gists, err := common.GetAllGistsForUser(client)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("enumerating gists for classic PAT: %w", err)
 	}
 
 	return &common.SecretInfo{

--- a/pkg/analyzer/analyzers/github/github.go
+++ b/pkg/analyzer/analyzers/github/github.go
@@ -37,6 +37,9 @@ func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analy
 	if err != nil {
 		return nil, err
 	}
+	if info == nil {
+		return nil, fmt.Errorf("GitHub analyzer returned no data for token")
+	}
 	return secretInfoToAnalyzerResult(info), nil
 }
 


### PR DESCRIPTION
## Summary
- Return explicit error when `AnalyzePermissions` yields nil info instead of passing nil through to `secretInfoToAnalyzerResult`
- Wrap classic PAT repo/gist enumeration errors with context (`enumerating repos for classic PAT`, `enumerating gists for classic PAT`)

Related to enterprise CSM-1216 (GitHub classic PAT analysis showing perpetual "pending").

## Test plan
- [x] `go vet` clean
- [ ] Existing analyzer tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds defensive nil handling and improves error context without changing token permission analysis logic.
> 
> **Overview**
> Prevents the GitHub analyzer from silently returning a nil result by emitting an explicit error when `AnalyzePermissions` yields no `SecretInfo`.
> 
> Improves debuggability for classic PAT analysis by wrapping repo and gist enumeration failures with contextual errors (`enumerating repos/gists for classic PAT`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23de99f247e342a72c2eb08a30ce170856039ced. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->