### PR TITLE
Update CI and make command to be golangci-lint v2.0+ compatible

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version: "1.24"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: latest

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ check:
 	go vet $(shell go list ./... | grep -v /vendor/)
 
 lint:
-	golangci-lint run --enable bodyclose --enable copyloopvar --enable misspell --out-format=colored-line-number --timeout 10m
+	golangci-lint run --enable bodyclose --enable copyloopvar --enable misspell --output.text.colors --timeout 10m
 
 test-failing:
 	CGO_ENABLED=0 go test -timeout=5m $(shell go list ./... | grep -v /vendor/) | grep FAIL


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Changes between golangci-lint v1 and v2 caused the `--out-format` flag to not be used anymore. As of this PR, version 9 of golangci-lint is the latest major version.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI/build tooling change; main impact is potential lint output/behavior differences under newer `golangci-lint` and the updated flag syntax.
> 
> **Overview**
> Updates the lint workflow to use `golangci/golangci-lint-action@v9` (tracking `golangci-lint` `latest`) to align CI with newer major versions.
> 
> Adjusts `make lint` to replace the deprecated `--out-format=colored-line-number` with the v2+ compatible `--output.text.colors`, keeping the same enabled linters and timeout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b145251e631d75c9ea90566ccdadfcea8116d57b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->