### PR TITLE
Add AnalysisInfo to verified results

### DIFF
--- a/pkg/detectors/airbrakeprojectkey/airbrakeprojectkey.go
+++ b/pkg/detectors/airbrakeprojectkey/airbrakeprojectkey.go
@@ -70,7 +70,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				isVerified, verificationErr := verifyAirbrakeProjectKey(ctx, client, key, id)
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr)
-				s1.AnalysisInfo = map[string]string{"key": key}
+				if isVerified {
+					s1.AnalysisInfo = map[string]string{"key": key}
+				}
 			}
 
 			results = append(results, s1)

--- a/pkg/detectors/airbrakeprojectkey/airbrakeprojectkey.go
+++ b/pkg/detectors/airbrakeprojectkey/airbrakeprojectkey.go
@@ -70,6 +70,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				isVerified, verificationErr := verifyAirbrakeProjectKey(ctx, client, key, id)
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr)
+				s1.AnalysisInfo = map[string]string{"key": key}
 			}
 
 			results = append(results, s1)

--- a/pkg/detectors/airbrakeuserkey/airbrakeuserkey.go
+++ b/pkg/detectors/airbrakeuserkey/airbrakeuserkey.go
@@ -61,7 +61,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, verificationErr := verifyAirbrakeUserKey(ctx, client, key)
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr)
-			s1.AnalysisInfo = map[string]string{"key": key}
+			if isVerified {
+				s1.AnalysisInfo = map[string]string{"key": key}
+			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/airbrakeuserkey/airbrakeuserkey.go
+++ b/pkg/detectors/airbrakeuserkey/airbrakeuserkey.go
@@ -61,6 +61,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, verificationErr := verifyAirbrakeUserKey(ctx, client, key)
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr)
+			s1.AnalysisInfo = map[string]string{"key": key}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/asanapersonalaccesstoken/asanapersonalaccesstoken.go
+++ b/pkg/detectors/asanapersonalaccesstoken/asanapersonalaccesstoken.go
@@ -52,7 +52,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, err := verifyMatch(ctx, client, resMatch)
 			s1.Verified = isVerified
 			s1.SetVerificationError(err, resMatch)
-			s1.AnalysisInfo = map[string]string{"key": resMatch}
+			if isVerified {
+				s1.AnalysisInfo = map[string]string{"key": resMatch}
+			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/asanapersonalaccesstoken/asanapersonalaccesstoken.go
+++ b/pkg/detectors/asanapersonalaccesstoken/asanapersonalaccesstoken.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, err := verifyMatch(ctx, client, resMatch)
 			s1.Verified = isVerified
 			s1.SetVerificationError(err, resMatch)
+			s1.AnalysisInfo = map[string]string{"key": resMatch}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/coinbase/coinbase.go
+++ b/pkg/detectors/coinbase/coinbase.go
@@ -112,10 +112,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				isVerified, verificationErr := s.verifyMatch(ctx, client, resKeyName, resPrivateKey)
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr, resPrivateKey)
-				s1.AnalysisInfo = map[string]string{
-					"keyName": resKeyName,
-					"key":     resPrivateKey,
-				}
 			}
 			results = append(results, s1)
 

--- a/pkg/detectors/coinbase/coinbase.go
+++ b/pkg/detectors/coinbase/coinbase.go
@@ -112,6 +112,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				isVerified, verificationErr := s.verifyMatch(ctx, client, resKeyName, resPrivateKey)
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr, resPrivateKey)
+				s1.AnalysisInfo = map[string]string{
+					"keyName": resKeyName,
+					"key":     resPrivateKey,
+				}
 			}
 			results = append(results, s1)
 

--- a/pkg/detectors/jiratoken/v1/jiratoken.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken.go
@@ -118,10 +118,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 						s1.SetVerificationError(verificationErr, token)
 					}
-					s1.AnalysisInfo = map[string]string{
-						"token":  token,
-						"domain": domain,
-						"email":  email,
+					if isVerified {
+						s1.AnalysisInfo = map[string]string{
+							"token":  token,
+							"domain": domain,
+							"email":  email,
+						}
 					}
 				}
 

--- a/pkg/detectors/jiratoken/v1/jiratoken.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken.go
@@ -118,6 +118,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 						s1.SetVerificationError(verificationErr, token)
 					}
+					s1.AnalysisInfo = map[string]string{
+						"token":  token,
+						"domain": domain,
+						"email":  email,
+					}
 				}
 
 				results = append(results, s1)

--- a/pkg/detectors/jiratoken/v2/jiratoken_v2.go
+++ b/pkg/detectors/jiratoken/v2/jiratoken_v2.go
@@ -90,6 +90,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					isVerified, verificationErr := v1.VerifyJiraToken(ctx, client, email, domain, token)
 					s1.Verified = isVerified
 					s1.SetVerificationError(verificationErr, token)
+					s1.AnalysisInfo = map[string]string{
+						"token":  token,
+						"domain": domain,
+						"email":  email,
+					}
 				}
 
 				results = append(results, s1)

--- a/pkg/detectors/jiratoken/v2/jiratoken_v2.go
+++ b/pkg/detectors/jiratoken/v2/jiratoken_v2.go
@@ -90,10 +90,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					isVerified, verificationErr := v1.VerifyJiraToken(ctx, client, email, domain, token)
 					s1.Verified = isVerified
 					s1.SetVerificationError(verificationErr, token)
-					s1.AnalysisInfo = map[string]string{
-						"token":  token,
-						"domain": domain,
-						"email":  email,
+					if isVerified {
+						s1.AnalysisInfo = map[string]string{
+							"token":  token,
+							"domain": domain,
+							"email":  email,
+						}
 					}
 				}
 


### PR DESCRIPTION
### Description:

These detectors have associated analyzers but aren't passing the key info along

- [Airbrake analyzer](https://github.com/trufflesecurity/trufflehog/blob/main/pkg/analyzer/analyzers/airbrake/airbrake.go)
- [Asana analyzer](https://github.com/trufflesecurity/trufflehog/blob/main/pkg/analyzer/analyzers/asana/asana.go)
- [Jira analyzer](https://github.com/trufflesecurity/trufflehog/blob/main/pkg/analyzer/analyzers/jira/jira.go)

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds `AnalysisInfo` metadata containing the verified credential values, which changes what secret material is propagated to analyzers and downstream outputs. Low code complexity, but reviewers should confirm this extra data is handled/redacted appropriately wherever results are logged or exported.
> 
> **Overview**
> When a finding is **successfully verified**, the Airbrake project/user key, Asana personal access token, and Jira token detectors now populate `Result.AnalysisInfo` with the credential fields needed by their analyzers (e.g., `key` for Airbrake/Asana and `token`/`domain`/`email` for Jira v1/v2).
> 
> This enables analyzers to run with the necessary inputs without re-parsing `Raw`/`RawV2`, but also means verified results carry additional secret values in `AnalysisInfo`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cbcc935895bd30e0fc5063861a0d7a0a7ebbeadd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->