### PR TITLE
Add support to Gitlab v1 for older self hosted versions

### DIFF
--- a/pkg/detectors/gitlab/v1/gitlab.go
+++ b/pkg/detectors/gitlab/v1/gitlab.go
@@ -34,7 +34,11 @@ func (Scanner) CloudEndpoint() string { return "https://gitlab.com" }
 
 var (
 	defaultClient = common.SaneHttpClient()
-	keyPat        = regexp.MustCompile(detectors.PrefixRegex([]string{"gitlab"}) + `\b([a-zA-Z0-9][a-zA-Z0-9\-=_]{19,21})\b`)
+	// Legacy short tokens (20-22 chars).
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"gitlab"}) + `\b([a-zA-Z0-9][a-zA-Z0-9\-=_]{19,21})\b`)
+	// Dotted format tokens without glpat- prefix (from older self-hosted GitLab instances
+	// that adopted the new token structure before adding the glpat- prefix).
+	keyPatDotted = regexp.MustCompile(detectors.PrefixRegex([]string{"gitlab"}) + `\b([a-zA-Z0-9][a-zA-Z0-9\-=_]{26,299}\.[0-9a-z]{2}\.[a-z0-9]{9})\b`)
 
 	BlockedUserMessage = "403 Forbidden - Your account has been blocked"
 )
@@ -65,15 +69,25 @@ func (s Scanner) Description() string {
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
 	dataStr := string(data)
 
-	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
-	for _, match := range matches {
-		resMatch := strings.TrimSpace(match[1])
-
-		// ignore v2 detectors which have a prefix of `glpat-`
-		if strings.Contains(match[0], "glpat-") {
-			continue
+	// Collect unique matches from both patterns.
+	uniqueMatches := make(map[string]struct{})
+	var allMatches []string
+	for _, pat := range []*regexp.Regexp{keyPat, keyPatDotted} {
+		for _, match := range pat.FindAllStringSubmatch(dataStr, -1) {
+			// ignore v2/v3 detectors which have a prefix of `glpat-`
+			if strings.Contains(match[0], "glpat-") {
+				continue
+			}
+			resMatch := strings.TrimSpace(match[1])
+			if _, seen := uniqueMatches[resMatch]; seen {
+				continue
+			}
+			uniqueMatches[resMatch] = struct{}{}
+			allMatches = append(allMatches, resMatch)
 		}
+	}
 
+	for _, resMatch := range allMatches {
 		// to avoid false positives
 		if detectors.StringShannonEntropy(resMatch) < 3.6 {
 			continue

--- a/pkg/detectors/gitlab/v1/gitlab_v1_test.go
+++ b/pkg/detectors/gitlab/v1/gitlab_v1_test.go
@@ -45,6 +45,16 @@ func TestGitLab_Pattern(t *testing.T) {
 			input: "GITLAB_TOKEN=ABc123456789dEFghIJK",
 			want:  []string{"ABc123456789dEFghIJKhttps://gitlab.com"},
 		},
+		{
+			name:  "dotted format without glpat- prefix",
+			input: `gitlab_token ="ThisIsNotAValidTokenAtAllNoWayXx.01.a1b2c3d4e"`,
+			want:  []string{"ThisIsNotAValidTokenAtAllNoWayXx.01.a1b2c3d4ehttps://gitlab.com"},
+		},
+		{
+			name:  "dotted format with glpat- prefix should be ignored",
+			input: `gitlab_token ="glpat-ThisIsNotAValidTokenAtAllNoWayXx.01.a1b2c3d4e"`,
+			want:  nil,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### Description:

Fixes the GitLab v1 detector not matching personal access tokens that use the dotted format (`{base}.{version}.{checksum}`) without a `glpat-` prefix. This format is generated by older self-hosted GitLab instances that adopted the new token structure before adding the prefix.

**Problem:** The three GitLab detectors have a gap:
- v1 only matches 20-22 character tokens
- v2/v3 require the `glpat-` prefix

Tokens in the dotted format without `glpat-` fall through all three.

**Fix:** Added a second regex pattern (`keyPatDotted`) to the v1 detector that matches the dotted token format without requiring `glpat-`. The existing `glpat-` skip logic ensures no overlap with v2/v3. Matches from both patterns are deduplicated before processing.

**Tests:** Added two test cases to `TestGitLab_Pattern`:
- Dotted format without `glpat-` prefix is matched
- Dotted format with `glpat-` prefix is still ignored (handled by v2/v3)

Closes #4880

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands GitLab token detection via a new regex and match-deduping, which could slightly increase false positives/scan volume if the dotted pattern is overly permissive.
> 
> **Overview**
> Extends the GitLab v1 detector to also match *dotted-format* PATs (`{base}.{version}.{checksum}`) that lack the `glpat-` prefix (seen in older self-hosted GitLab), while continuing to ignore `glpat-` tokens handled by v2/v3.
> 
> Updates `FromData` to aggregate matches from both the legacy short-token regex and the new dotted regex, deduplicating tokens before entropy checking and result generation, and adds test coverage for both dotted-token scenarios (match without `glpat-`, ignore with `glpat-`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8a70ce2bcaa2fe8a67bd0cbe488906ae25a453c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->