### PR TITLE
[INS-444] Fix verification logic in Mesibo detector

### DIFF
--- a/pkg/detectors/mesibo/mesibo.go
+++ b/pkg/detectors/mesibo/mesibo.go
@@ -28,6 +28,8 @@ type apiResponse struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
+	defaultClient = common.SaneHttpClient()
+
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"mesibo"}) + `\b([0-9A-Za-z]{64})\b`)
 )
@@ -36,7 +38,7 @@ func (s Scanner) getClient() *http.Client {
 	if s.client != nil {
 		return s.client
 	}
-	return common.SaneHttpClient()
+	return defaultClient
 }
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/mesibo/mesibo.go
+++ b/pkg/detectors/mesibo/mesibo.go
@@ -112,9 +112,15 @@ func (s Scanner) verify(ctx context.Context, token string) (bool, error) {
 	}
 	// The `code` field contains an RFC 9110 compliant HTTP status
 	// code indicating the outcome of the operation.
-	// code 400 means valid token (bad request due to missing params, but auth passed)
-	// any other code means invalid/unauthorized
-	return result.Code == http.StatusBadRequest, nil
+	switch result.Code {
+	case http.StatusBadRequest:
+		// code 400 means valid token (bad request due to missing params, but auth passed)
+		return true, nil
+	case http.StatusUnauthorized:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected code field: %d", result.Code)
+	}
 }
 
 func (s Scanner) Type() detector_typepb.DetectorType {

--- a/pkg/detectors/mesibo/mesibo.go
+++ b/pkg/detectors/mesibo/mesibo.go
@@ -1,28 +1,43 @@
 package mesibo
 
 import (
+	"bytes"
 	"context"
-	regexp "github.com/wasilibs/go-re2"
+	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
 )
 
-type Scanner struct{}
+type Scanner struct {
+	client *http.Client
+}
+
+type apiResponse struct {
+	Code int `json:"code"`
+}
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClient()
-
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"mesibo"}) + `\b([0-9A-Za-z]{64})\b`)
 )
+
+func (s Scanner) getClient() *http.Client {
+	if s.client != nil {
+		return s.client
+	}
+	return common.SaneHttpClient()
+}
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
@@ -45,22 +60,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.mesibo.com/api.php?op=useradd&token="+resMatch, nil)
+			s1.Verified, err = s.verify(ctx, resMatch)
 			if err != nil {
-				continue
-			}
-			res, err := client.Do(req)
-			if err == nil {
-				defer res.Body.Close()
-				bodyBytes, err := io.ReadAll(res.Body)
-				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-
-				if !strings.Contains(body, "AUTHFAIL") {
-					s1.Verified = true
-				}
+				s1.SetVerificationError(err, resMatch)
 			}
 		}
 
@@ -68,6 +70,49 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	return results, nil
+}
+
+// verify checks the validity of a Mesibo app token against the backend API.
+// https://docs.mesibo.com/api/backend-api/
+func (s Scanner) verify(ctx context.Context, token string) (bool, error) {
+
+	// We use the `useradd` operation as a probe: a valid token will yield
+	// code 400 (bad request due to missing required user parameters, but
+	// authentication succeeded), whereas an invalid or unauthorized
+	// token will yield a different code such as 403.
+	payload, err := json.Marshal(map[string]string{"op": "useradd", "token": token})
+	if err != nil {
+		return false, fmt.Errorf("failed to marshal request payload: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.mesibo.com/backend", bytes.NewBuffer(payload))
+	if err != nil {
+		return false, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	res, err := s.getClient().Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer res.Body.Close()
+
+	// The backend API always returns HTTP 200, with the actual result encoded in the
+	// JSON response body.
+	if res.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+	bodyBytes, err := io.ReadAll(res.Body)
+	if err != nil {
+		return false, fmt.Errorf("failed to read response body: %w", err)
+	}
+	var result apiResponse
+	if err := json.Unmarshal(bodyBytes, &result); err != nil {
+		return false, fmt.Errorf("failed to unmarshal response body: %w", err)
+	}
+	// The `code` field contains an RFC 9110 compliant HTTP status
+	// code indicating the outcome of the operation.
+	// code 400 means valid token (bad request due to missing params, but auth passed)
+	// any other code means invalid/unauthorized
+	return result.Code == http.StatusBadRequest, nil
 }
 
 func (s Scanner) Type() detector_typepb.DetectorType {

--- a/pkg/detectors/mesibo/mesibo.go
+++ b/pkg/detectors/mesibo/mesibo.go
@@ -81,7 +81,7 @@ func (s Scanner) verify(ctx context.Context, token string) (bool, error) {
 	// We use the `useradd` operation as a probe: a valid token will yield
 	// code 400 (bad request due to missing required user parameters, but
 	// authentication succeeded), whereas an invalid or unauthorized
-	// token will yield a different code such as 403.
+	// token will yield a different code such as 401.
 	payload, err := json.Marshal(map[string]string{"op": "useradd", "token": token})
 	if err != nil {
 		return false, fmt.Errorf("failed to marshal request payload: %w", err)

--- a/pkg/detectors/mesibo/mesibo_integration_test.go
+++ b/pkg/detectors/mesibo/mesibo_integration_test.go
@@ -9,7 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kylelemons/godebug/pretty"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
@@ -32,11 +33,12 @@ func TestMesibo_FromChunk(t *testing.T) {
 		verify bool
 	}
 	tests := []struct {
-		name    string
-		s       Scanner
-		args    args
-		want    []detectors.Result
-		wantErr bool
+		name                string
+		s                   Scanner
+		args                args
+		want                []detectors.Result
+		wantErr             bool
+		wantVerificationErr bool
 	}{
 		{
 			name: "found, verified",
@@ -81,11 +83,27 @@ func TestMesibo_FromChunk(t *testing.T) {
 			want:    nil,
 			wantErr: false,
 		},
+		{
+			name: "found, verification error on 502",
+			s:    Scanner{client: common.ConstantResponseHttpClient(502, "")},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a mesibo secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_Mesibo,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := Scanner{}
-			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Mesibo.FromData() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -95,9 +113,12 @@ func TestMesibo_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Fatalf("wantVerificationErr=%v, got verificationError=%v", tt.wantVerificationErr, got[i].VerificationError())
+				}
 			}
-			if diff := pretty.Compare(got, tt.want); diff != "" {
-				t.Errorf("Mesibo.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			if diff := cmp.Diff(tt.want, got, cmpopts.IgnoreUnexported(detectors.Result{})); diff != "" {
+				t.Errorf("Mesibo.FromData() %s diff: (-want +got)\n%s", tt.name, diff)
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Problem

The Mesibo detector was incorrectly marking unverified secrets as verified. The original implementation sent a `GET` request to `https://api.mesibo.com/api.php?op=useradd&token=<token>` and checked whether the response body contained the string `"AUTHFAIL"`. This endpoint no longer works correctly — it now returns 502 on all requests, meaning the `"AUTHFAIL"` string is never present and every candidate token is marked as verified regardless of its validity. Even setting aside the broken endpoint, checking for a specific error string in the body is an unreliable verification strategy compared to inspecting a structured response field.

### Fix

Switched to the current Mesibo backend API (`POST https://api.mesibo.com/backend`) as documented at https://docs.mesibo.com/api/backend-api/.

The backend API always returns HTTP 200. The actual outcome is encoded in the JSON response body via a `code` field, which contains an RFC 9110 compliant HTTP status code. We probe using the `useradd` operation:

- A **valid token** passes authentication but fails the operation due to missing required user parameters, yielding `code: 400`.
- An **invalid or unauthorized token** yields a different code (e.g. `401`).

The verification logic was refactored into a dedicated `verify()` method that:

1. POSTs a JSON payload with `op=useradd` and the candidate token.
2. Checks that the HTTP status is 200, returning a verification error otherwise.
3. Parses the JSON response into a typed `apiResponse` struct.
4. Returns `true` only if `code == 400`.

All errors are wrapped with context using `fmt.Errorf(..., %w)` and surfaced via `SetVerificationError`.

### Tests

Added a test case `"found, verification error on 502"` to the integration test suite using `common.ConstantResponseHttpClient(502, "")` to simulate an unexpected HTTP status from the API, asserting that the result is unverified and a verification error is set.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live secret verification behavior and external API interaction; incorrect interpretation of Mesibo response codes could flip verified/unverified results, but the scope is limited to this detector and is covered by tests.
> 
> **Overview**
> Mesibo secret verification is rewritten to use the documented backend API (`POST https://api.mesibo.com/backend`) and to decide validity via the JSON `code` field (treating `400` as *auth succeeded* and `401` as unverified) instead of string-matching `AUTHFAIL` from the deprecated `api.php` endpoint.
> 
> The detector now encapsulates verification in a dedicated `verify()` method, supports injecting an HTTP client on `Scanner`, and surfaces unexpected HTTP/response conditions via `SetVerificationError`. Integration tests are updated to use `go-cmp` and add coverage for a verification-error scenario (simulated `502`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52cedea4e7d88650a1a2947cc9348d7d7f0683bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->