### PR TITLE
Ensure that custom endpoint verification works in artifactory detectors.

### DIFF
--- a/pkg/detectors/artifactory/artifactory_integration_test.go
+++ b/pkg/detectors/artifactory/artifactory_integration_test.go
@@ -96,6 +96,57 @@ func TestArtifactory_FromChunk(t *testing.T) {
 	}
 }
 
+func TestArtifactory_FromChunk_FoundUnverified(t *testing.T) {
+	// NOTE: Using mock secrets because JFrog deprecated AKCp API keys.
+	mockSecret := "AKCp5bueTFpfypEqQbGJPp7eHFi28fBivfWczrjbPb9erDff9LbXZbj6UsRExVXA8asWGc9fM"
+	appURL := "trufflehog.jfrog.io"
+
+	s := Scanner{}
+	s.UseFoundEndpoints(true)
+	s.SetConfiguredEndpoints(appURL)
+
+	data := []byte(fmt.Sprintf(
+		"You can find a artifactory secret %s",
+		mockSecret,
+	))
+
+	got, err := s.FromData(context.Background(), false, data) // verify = false
+	if err != nil {
+		t.Fatalf("FromData() unexpected error: %v", err)
+	}
+
+	if len(got) == 0 {
+		t.Fatalf("expected at least one result, got none")
+	}
+
+	// Validate results
+	for i := range got {
+		if len(got[i].Raw) == 0 {
+			t.Fatalf("no raw secret present: \n %+v", got[i])
+		}
+
+		if got[i].VerificationError() != nil {
+			t.Fatalf("unexpected verification error: %v", got[i].VerificationError())
+		}
+	}
+
+	want := []detectors.Result{
+		{
+			DetectorType: detector_typepb.DetectorType_ArtifactoryAccessToken,
+			Verified:     false,
+		},
+	}
+
+	ignoreOpts := cmpopts.IgnoreFields(
+		detectors.Result{},
+		"Raw", "RawV2", "verificationError", "primarySecret",
+	)
+
+	if diff := cmp.Diff(got, want, ignoreOpts); diff != "" {
+		t.Errorf("FromData() diff (-got +want):\n%s", diff)
+	}
+}
+
 func BenchmarkFromData(benchmark *testing.B) {
 	ctx := context.Background()
 	s := Scanner{}

--- a/pkg/detectors/artifactory/artifactory_integration_test.go
+++ b/pkg/detectors/artifactory/artifactory_integration_test.go
@@ -96,7 +96,7 @@ func TestArtifactory_FromChunk(t *testing.T) {
 	}
 }
 
-func TestArtifactory_FromChunk_FoundUnverified(t *testing.T) {
+func TestArtifactory_FromChunk_FoundUnverified_With_Confiured_Ep(t *testing.T) {
 	// NOTE: Using mock secrets because JFrog deprecated AKCp API keys.
 	mockSecret := "AKCp5bueTFpfypEqQbGJPp7eHFi28fBivfWczrjbPb9erDff9LbXZbj6UsRExVXA8asWGc9fM"
 	appURL := "trufflehog.jfrog.io"

--- a/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken_integration_test.go
+++ b/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken_integration_test.go
@@ -28,6 +28,7 @@ func TestArtifactoryreferencetoken_FromChunk(t *testing.T) {
 	instanceURL := testSecrets.MustGetField("ARTIFACTORY_URL")
 	secret := testSecrets.MustGetField("ARTIFACTORYREFERENCETOKEN")
 	inactiveSecret := testSecrets.MustGetField("ARTIFACTORYREFERENCETOKEN_INACTIVE")
+	fmt.Println(instanceURL, secret, inactiveSecret)
 
 	type args struct {
 		ctx    context.Context
@@ -145,6 +146,60 @@ func TestArtifactoryreferencetoken_FromChunk(t *testing.T) {
 				t.Errorf("Artifactoryreferencetoken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
 		})
+	}
+}
+func TestArtifactoryreferencetoken_FromChunk_with_configured_ep(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors6")
+	if err != nil {
+		t.Fatalf("could not get test secrets from GCP: %s", err)
+	}
+
+	instanceURL := testSecrets.MustGetField("ARTIFACTORY_URL")
+	secret := testSecrets.MustGetField("ARTIFACTORYREFERENCETOKEN")
+
+	s := Scanner{}
+	s.UseFoundEndpoints(true)
+	s.SetConfiguredEndpoints(instanceURL)
+
+	data := []byte(fmt.Sprintf("You can find a artifactoryreferencetoken secret %s", secret))
+
+	got, err := s.FromData(context.Background(), true, data)
+	if err != nil {
+		t.Fatalf("FromData() unexpected error: %v", err)
+	}
+
+	if len(got) == 0 {
+		t.Fatalf("expected at least one result, got none")
+	}
+
+	// Validate each result
+	for i := range got {
+		if len(got[i].Raw) == 0 {
+			t.Fatalf("no raw secret present: \n %+v", got[i])
+		}
+
+		if got[i].VerificationError() != nil {
+			t.Fatalf("unexpected verification error: %v", got[i].VerificationError())
+		}
+	}
+
+	want := []detectors.Result{
+		{
+			DetectorType: detector_typepb.DetectorType_ArtifactoryReferenceToken,
+			Verified:     true,
+		},
+	}
+
+	ignoreOpts := cmpopts.IgnoreFields(
+		detectors.Result{},
+		"Raw", "RawV2", "verificationError", "primarySecret", "AnalysisInfo",
+	)
+
+	if diff := cmp.Diff(got, want, ignoreOpts); diff != "" {
+		t.Errorf("FromData() diff (-got +want):\n%s", diff)
 	}
 }
 

--- a/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken_integration_test.go
+++ b/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken_integration_test.go
@@ -28,7 +28,6 @@ func TestArtifactoryreferencetoken_FromChunk(t *testing.T) {
 	instanceURL := testSecrets.MustGetField("ARTIFACTORY_URL")
 	secret := testSecrets.MustGetField("ARTIFACTORYREFERENCETOKEN")
 	inactiveSecret := testSecrets.MustGetField("ARTIFACTORYREFERENCETOKEN_INACTIVE")
-	fmt.Println(instanceURL, secret, inactiveSecret)
 
 	type args struct {
 		ctx    context.Context


### PR DESCRIPTION
### Description:
This PR adds new tests for each Artifactory detector to verify that custom endpoint configuration works correctly.

The tests pass the endpoint URL to the `SetConfiguredEndpoints` function instead of embedding it directly in the test input string. This ensures that endpoint-based configuration is properly respected during detection and verification.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add coverage for `SetConfiguredEndpoints` behavior in Artifactory detectors; no production logic changes.
> 
> **Overview**
> Adds new integration tests for the Artifactory access-token and reference-token detectors to ensure verification can use a user-configured endpoint via `SetConfiguredEndpoints`, rather than relying on the endpoint being present in the scanned input.
> 
> The new tests assert expected `Verified` status and no `VerificationError` when `UseFoundEndpoints(true)` is enabled and a custom endpoint is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c8c10ebdbdd8e88f00823aa5437ba89ee7ffa02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->