### PR TITLE
Moved s3 object checker to run before handlefile, to improve active scans UI

### DIFF
--- a/pkg/sources/s3/s3.go
+++ b/pkg/sources/s3/s3.go
@@ -598,13 +598,12 @@ func (s *Source) pageChunker(
 				},
 				SourceVerify: s.verify,
 			}
-
+			atomic.AddUint64(state.objectCount, 1)
 			if err := handlers.HandleFile(ctx, res.Body, chunkSkel, reporter); err != nil {
 				ctx.Logger().Error(err, "error handling file")
 				s.metricsCollector.RecordObjectError(metadata.bucket)
 				return nil
 			}
-			atomic.AddUint64(state.objectCount, 1)
 			ctx.Logger().V(5).Info("S3 object scanned.", "object_count", state.objectCount)
 			nErr, ok = state.errorCount.Load(prefix)
 			if !ok {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
moved the atomic.AddUint64(state.objectCount, 1) call to fire before handlers.HandleFile, so objects are counted as "scanned" as soon as GetObject succeeds and they reach the handler -- regardless of whether HandleFile returns an error afterward.

In Enterprise UI, s3 Buckets are returning a message of "Completed Scanning Source: 0 Objects scanned", when there are scanned results present. This will mean that a partial error while not stop scanned objects from being counted.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change that only shifts when the scanned-object counter increments; no auth, data mutation, or API contract changes.
> 
> **Overview**
> Adjusts S3 scanning progress accounting so an object is counted as “scanned” immediately after a successful `GetObject`, before `handlers.HandleFile` runs.
> 
> This prevents the UI/reporting from showing `0 objects scanned` when `HandleFile` errors occur after retrieval, while keeping existing error logging/metrics behavior unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09d6f239f93c3d5648c6676275ec2ad2a3c9f90f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->