### PR TITLE
detectors: emit unverified results instead of dropping them on verify…

### DIFF
--- a/pkg/detectors/algoliaadminkey/algoliaadminkey.go
+++ b/pkg/detectors/algoliaadminkey/algoliaadminkey.go
@@ -68,12 +68,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	// Test matches.
 	for key := range keyMatches {
 		for id := range idMatches {
-			if invalidHosts.Exists(id) {
-				logger.V(3).Info("Skipping application id: no such host", "host", id)
-				delete(idMatches, id)
-				continue
-			}
-
 			r := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_AlgoliaAdminKey,
 				Raw:          []byte(key),
@@ -81,17 +75,20 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				// Verify if the key is a valid Algolia Admin Key.
-				isVerified, extraData, verificationErr := verifyMatch(ctx, id, key)
-				r.Verified = isVerified
-				r.ExtraData = extraData
-				if verificationErr != nil {
-					if errors.Is(verificationErr, errNoHost) {
-						invalidHosts.Set(id, struct{}{})
-						continue
+				if invalidHosts.Exists(id) {
+					logger.V(3).Info("Skipping verification: cached no such host", "host", id)
+					r.SetVerificationError(errNoHost, key)
+				} else {
+					// Verify if the key is a valid Algolia Admin Key.
+					isVerified, extraData, verificationErr := verifyMatch(ctx, id, key)
+					r.Verified = isVerified
+					r.ExtraData = extraData
+					if verificationErr != nil {
+						if errors.Is(verificationErr, errNoHost) {
+							invalidHosts.Set(id, struct{}{})
+						}
+						r.SetVerificationError(verificationErr, key)
 					}
-
-					r.SetVerificationError(verificationErr, key)
 				}
 			}
 

--- a/pkg/detectors/artifactory/artifactory.go
+++ b/pkg/detectors/artifactory/artifactory.go
@@ -77,11 +77,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for token := range uniqueTokens {
 		for url := range uniqueUrls {
-			if invalidHosts.Exists(url) {
-				delete(uniqueUrls, url)
-				continue
-			}
-
 			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_ArtifactoryAccessToken,
 				Raw:          []byte(token),
@@ -89,16 +84,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				isVerified, verificationErr := verifyArtifactory(ctx, s.getClient(), url, token)
-				s1.Verified = isVerified
-				if verificationErr != nil {
-					if errors.Is(verificationErr, errNoHost) {
-						invalidHosts.Set(url, struct{}{})
-						continue
+				if invalidHosts.Exists(url) {
+					s1.SetVerificationError(errNoHost, token)
+				} else {
+					isVerified, verificationErr := verifyArtifactory(ctx, s.getClient(), url, token)
+					s1.Verified = isVerified
+					if verificationErr != nil {
+						if errors.Is(verificationErr, errNoHost) {
+							invalidHosts.Set(url, struct{}{})
+						}
+						s1.SetVerificationError(verificationErr, token)
 					}
-
-					s1.SetVerificationError(verificationErr, token)
-
 					if isVerified {
 						s1.AnalysisInfo = map[string]string{
 							"domain": url,

--- a/pkg/detectors/azure_cosmosdb/azure_cosmosdb.go
+++ b/pkg/detectors/azure_cosmosdb/azure_cosmosdb.go
@@ -74,11 +74,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for key := range uniqueKeyMatches {
 		for accountUrl := range uniqueAccountMatches {
-			if invalidHosts.Exists(accountUrl) {
-				delete(uniqueAccountMatches, accountUrl)
-				continue
-			}
-
 			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_AzureCosmosDBKeyIdentifiable,
 				Raw:          []byte(key),
@@ -87,29 +82,31 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				var verified bool
-				var verificationErr error
+				if invalidHosts.Exists(accountUrl) {
+					s1.SetVerificationError(errNoHost)
+				} else {
+					var verified bool
+					var verificationErr error
 
-				client := s.getClient()
+					client := s.getClient()
 
-				// perform verification based on db type
-				if strings.Contains(accountUrl, ".documents.azure.com") {
-					verified, verificationErr = verifyCosmosDocumentDB(client, accountUrl, key)
-					s1.ExtraData["DB Type"] = "Document"
+					// perform verification based on db type
+					if strings.Contains(accountUrl, ".documents.azure.com") {
+						verified, verificationErr = verifyCosmosDocumentDB(client, accountUrl, key)
+						s1.ExtraData["DB Type"] = "Document"
 
-				} else if strings.Contains(accountUrl, ".table.cosmos.azure.com") {
-					verified, verificationErr = verifyCosmosTableDB(client, accountUrl, key)
-					s1.ExtraData["DB Type"] = "Table"
-				}
-
-				s1.Verified = verified
-				if verificationErr != nil {
-					if errors.Is(verificationErr, errNoHost) {
-						invalidHosts.Set(accountUrl, struct{}{})
-						continue
+					} else if strings.Contains(accountUrl, ".table.cosmos.azure.com") {
+						verified, verificationErr = verifyCosmosTableDB(client, accountUrl, key)
+						s1.ExtraData["DB Type"] = "Table"
 					}
 
-					s1.SetVerificationError(verificationErr)
+					s1.Verified = verified
+					if verificationErr != nil {
+						if errors.Is(verificationErr, errNoHost) {
+							invalidHosts.Set(accountUrl, struct{}{})
+						}
+						s1.SetVerificationError(verificationErr)
+					}
 				}
 			}
 

--- a/pkg/detectors/azureapimanagement/repositorykey/repositorykey.go
+++ b/pkg/detectors/azureapimanagement/repositorykey/repositorykey.go
@@ -59,7 +59,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		uniquePasswordMatches[strings.TrimSpace(matches[1])] = struct{}{}
 	}
 
-EndpointLoop:
 	for urlMatch := range uniqueUrlsMatches {
 		for passwordMatch := range uniquePasswordMatches {
 			s1 := detectors.Result{
@@ -70,18 +69,17 @@ EndpointLoop:
 
 			if verify {
 				if invalidHosts.Exists(urlMatch) {
-					logger.V(3).Info("Skipping invalid registry", "url", urlMatch)
-					continue EndpointLoop
-				}
-
-				isVerified, err := verifyUrlPassword(ctx, urlMatch, azureGitUsername, passwordMatch)
-				s1.Verified = isVerified
-				if err != nil {
-					if errors.Is(err, noSuchHostErr) {
-						invalidHosts.Set(urlMatch, struct{}{})
-						continue EndpointLoop
+					logger.V(3).Info("Skipping verification: cached no such host", "url", urlMatch)
+					s1.SetVerificationError(noSuchHostErr, urlMatch)
+				} else {
+					isVerified, err := verifyUrlPassword(ctx, urlMatch, azureGitUsername, passwordMatch)
+					s1.Verified = isVerified
+					if err != nil {
+						if errors.Is(err, noSuchHostErr) {
+							invalidHosts.Set(urlMatch, struct{}{})
+						}
+						s1.SetVerificationError(err, urlMatch)
 					}
-					s1.SetVerificationError(err, urlMatch)
 				}
 			}
 			results = append(results, s1)

--- a/pkg/detectors/azureapimanagementsubscriptionkey/azureapimanagementsubscriptionkey.go
+++ b/pkg/detectors/azureapimanagementsubscriptionkey/azureapimanagementsubscriptionkey.go
@@ -54,7 +54,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		keyMatchesUnique[strings.TrimSpace(keyMatch[1])] = struct{}{}
 	}
 
-EndpointLoop:
 	for baseUrl := range urlMatchesUnique {
 		for key := range keyMatchesUnique {
 			s1 := detectors.Result{
@@ -65,23 +64,22 @@ EndpointLoop:
 
 			if verify {
 				if invalidHosts.Exists(baseUrl) {
-					logger.V(3).Info("Skipping invalid registry", "baseUrl", baseUrl)
-					continue EndpointLoop
-				}
-
-				client := s.client
-				if client == nil {
-					client = defaultClient
-				}
-
-				isVerified, verificationErr := s.verifyMatch(ctx, client, baseUrl, key)
-				s1.Verified = isVerified
-				if verificationErr != nil {
-					if errors.Is(verificationErr, noSuchHostErr) {
-						invalidHosts.Set(baseUrl, struct{}{})
-						continue EndpointLoop
+					logger.V(3).Info("Skipping verification: cached no such host", "baseUrl", baseUrl)
+					s1.SetVerificationError(noSuchHostErr, baseUrl)
+				} else {
+					client := s.client
+					if client == nil {
+						client = defaultClient
 					}
-					s1.SetVerificationError(verificationErr, baseUrl)
+
+					isVerified, verificationErr := s.verifyMatch(ctx, client, baseUrl, key)
+					s1.Verified = isVerified
+					if verificationErr != nil {
+						if errors.Is(verificationErr, noSuchHostErr) {
+							invalidHosts.Set(baseUrl, struct{}{})
+						}
+						s1.SetVerificationError(verificationErr, baseUrl)
+					}
 				}
 			}
 

--- a/pkg/detectors/azurecontainerregistry/azurecontainerregistry.go
+++ b/pkg/detectors/azurecontainerregistry/azurecontainerregistry.go
@@ -73,7 +73,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		passwordMatches[p] = struct{}{}
 	}
 
-EndpointLoop:
 	for username := range registryMatches {
 		for password := range passwordMatches {
 			r := detectors.Result{
@@ -85,26 +84,25 @@ EndpointLoop:
 
 			if verify {
 				if invalidHosts.Exists(username) {
-					logger.V(3).Info("Skipping invalid registry", "username", username)
-					continue EndpointLoop
-				}
-
-				client := s.client
-				if client == nil {
-					client = defaultClient
-				}
-
-				isVerified, verificationErr := verifyMatch(ctx, client, username, password)
-				if isVerified {
-					delete(passwordMatches, password)
-					r.Verified = true
-				}
-				if verificationErr != nil {
-					if errors.Is(verificationErr, noSuchHostErr) {
-						invalidHosts.Set(username, struct{}{})
-						continue EndpointLoop
+					logger.V(3).Info("Skipping verification: cached no such host", "username", username)
+					r.SetVerificationError(noSuchHostErr, password)
+				} else {
+					client := s.client
+					if client == nil {
+						client = defaultClient
 					}
-					r.SetVerificationError(verificationErr, password)
+
+					isVerified, verificationErr := verifyMatch(ctx, client, username, password)
+					if isVerified {
+						delete(passwordMatches, password)
+						r.Verified = true
+					}
+					if verificationErr != nil {
+						if errors.Is(verificationErr, noSuchHostErr) {
+							invalidHosts.Set(username, struct{}{})
+						}
+						r.SetVerificationError(verificationErr, password)
+					}
 				}
 			}
 

--- a/pkg/detectors/azuredirectmanagementkey/azuredirectmanagementkey.go
+++ b/pkg/detectors/azuredirectmanagementkey/azuredirectmanagementkey.go
@@ -60,7 +60,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		keyMatchesUnique[strings.TrimSpace(keyMatch[1])] = struct{}{}
 	}
 
-EndpointLoop:
 	for baseUrl, serviceName := range urlMatchesUnique {
 		for key := range keyMatchesUnique {
 			s1 := detectors.Result{
@@ -71,23 +70,22 @@ EndpointLoop:
 
 			if verify {
 				if invalidHosts.Exists(baseUrl) {
-					logger.V(3).Info("Skipping invalid registry", "baseUrl", baseUrl)
-					continue EndpointLoop
-				}
-
-				client := s.client
-				if client == nil {
-					client = defaultClient
-				}
-
-				isVerified, verificationErr := s.verifyMatch(ctx, client, baseUrl, serviceName, key)
-				s1.Verified = isVerified
-				if verificationErr != nil {
-					if errors.Is(verificationErr, noSuchHostErr) {
-						invalidHosts.Set(baseUrl, struct{}{})
-						continue EndpointLoop
+					logger.V(3).Info("Skipping verification: cached no such host", "baseUrl", baseUrl)
+					s1.SetVerificationError(noSuchHostErr, baseUrl)
+				} else {
+					client := s.client
+					if client == nil {
+						client = defaultClient
 					}
-					s1.SetVerificationError(verificationErr, baseUrl)
+
+					isVerified, verificationErr := s.verifyMatch(ctx, client, baseUrl, serviceName, key)
+					s1.Verified = isVerified
+					if verificationErr != nil {
+						if errors.Is(verificationErr, noSuchHostErr) {
+							invalidHosts.Set(baseUrl, struct{}{})
+						}
+						s1.SetVerificationError(verificationErr, baseUrl)
+					}
 				}
 			}
 

--- a/pkg/detectors/azuresastoken/azuresastoken.go
+++ b/pkg/detectors/azuresastoken/azuresastoken.go
@@ -73,7 +73,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	// Check results.
-UrlLoop:
 	for url, storageAccount := range urlMatchesUnique {
 		for key := range keyMatchesUnique {
 			s1 := detectors.Result{
@@ -84,24 +83,23 @@ UrlLoop:
 
 			if verify {
 				if invalidStorageAccounts.Exists(storageAccount) {
-					logger.V(3).Info("Skipping invalid storage account", "storage account", storageAccount)
-					break
-				}
-
-				client := s.client
-				if client == nil {
-					client = defaultClient
-				}
-
-				isVerified, verificationErr := verifyMatch(ctx, client, url, key, true)
-				s1.Verified = isVerified
-
-				if verificationErr != nil {
-					if errors.Is(verificationErr, noSuchHostErr) {
-						invalidStorageAccounts.Set(storageAccount, struct{}{})
-						continue UrlLoop
+					logger.V(3).Info("Skipping verification: cached invalid storage account", "storage account", storageAccount)
+					s1.SetVerificationError(noSuchHostErr, key)
+				} else {
+					client := s.client
+					if client == nil {
+						client = defaultClient
 					}
-					s1.SetVerificationError(verificationErr, key)
+
+					isVerified, verificationErr := verifyMatch(ctx, client, url, key, true)
+					s1.Verified = isVerified
+
+					if verificationErr != nil {
+						if errors.Is(verificationErr, noSuchHostErr) {
+							invalidStorageAccounts.Set(storageAccount, struct{}{})
+						}
+						s1.SetVerificationError(verificationErr, key)
+					}
 				}
 			}
 

--- a/pkg/detectors/billomat/billomat.go
+++ b/pkg/detectors/billomat/billomat.go
@@ -60,6 +60,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		uniqueAPIKeys[match[1]] = struct{}{}
 	}
 
+	invalidIDs := make(map[string]struct{})
 	for apiKey := range uniqueAPIKeys {
 		for id := range uniqueIDs {
 			s1 := detectors.Result{
@@ -69,16 +70,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				isVerified, verificationErr := verifyBillomat(ctx, client, id, apiKey)
-				s1.Verified = isVerified
-				if verificationErr != nil {
-					// remove the account ID if not found to prevent reuse during other API key checks.
-					if errors.Is(verificationErr, errAccountIDNotFound) {
-						delete(uniqueIDs, id)
-						continue
+				if _, skip := invalidIDs[id]; skip {
+					s1.SetVerificationError(errAccountIDNotFound, apiKey)
+				} else {
+					isVerified, verificationErr := verifyBillomat(ctx, client, id, apiKey)
+					s1.Verified = isVerified
+					if verificationErr != nil {
+						if errors.Is(verificationErr, errAccountIDNotFound) {
+							invalidIDs[id] = struct{}{}
+						}
+						s1.SetVerificationError(verificationErr, apiKey)
 					}
-
-					s1.SetVerificationError(verificationErr, apiKey)
 				}
 			}
 

--- a/pkg/detectors/cexio/cexio.go
+++ b/pkg/detectors/cexio/cexio.go
@@ -87,18 +87,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 						body, err := io.ReadAll(res.Body)
 						if err != nil {
-							continue
-						}
-						bodyString := string(body)
-						validResponse := strings.Contains(bodyString, `timestamp`)
+							s1.SetVerificationError(err, resSecretMatch)
+						} else {
+							bodyString := string(body)
+							validResponse := strings.Contains(bodyString, `timestamp`)
 
-						var responseObject Response
-						if err := json.Unmarshal(body, &responseObject); err != nil {
-							continue
-						}
-
-						if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
-							s1.Verified = true
+							var responseObject Response
+							if err := json.Unmarshal(body, &responseObject); err != nil {
+								s1.SetVerificationError(err, resSecretMatch)
+							} else if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
+								s1.Verified = true
+							}
 						}
 					}
 				}

--- a/pkg/detectors/clientary/clientary.go
+++ b/pkg/detectors/clientary/clientary.go
@@ -64,6 +64,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		uniqueAPIKeys[match[1]] = struct{}{}
 	}
 
+	invalidIDs := make(map[string]struct{})
 	for apiKey := range uniqueAPIKeys {
 		for id := range uniqueIDs {
 			// since regex matches can overlap, continue only if both apiKey and id are the same.
@@ -79,21 +80,22 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				isVerified, verificationErr := verifyClientaryAPIKey(ctx, client, id, apiKey)
-				s1.Verified = isVerified
-				if verificationErr != nil {
-					// remove the account ID if not found to prevent reuse during other API key checks.
-					if errors.Is(verificationErr, errAccountNotFound) {
-						delete(uniqueIDs, id)
-						continue
+				if _, skip := invalidIDs[id]; skip {
+					s1.SetVerificationError(errAccountNotFound, apiKey)
+				} else {
+					isVerified, verificationErr := verifyClientaryAPIKey(ctx, client, id, apiKey)
+					s1.Verified = isVerified
+					if verificationErr != nil {
+						if errors.Is(verificationErr, errAccountNotFound) {
+							invalidIDs[id] = struct{}{}
+						}
+						s1.SetVerificationError(verificationErr, apiKey)
 					}
 
-					s1.SetVerificationError(verificationErr, apiKey)
-				}
-
-				// If a verified result is found, attach rebranding documentation to inform the user about the RoninApp rebranding to Clientary.
-				if s1.Verified {
-					s1.ExtraData["Rebrading Docs"] = "https://www.clientary.com/articles/a-new-brand/"
+					// If a verified result is found, attach rebranding documentation to inform the user about the RoninApp rebranding to Clientary.
+					if s1.Verified {
+						s1.ExtraData["Rebrading Docs"] = "https://www.clientary.com/articles/a-new-brand/"
+					}
 				}
 			}
 

--- a/pkg/detectors/commodities/commodities.go
+++ b/pkg/detectors/commodities/commodities.go
@@ -56,16 +56,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err == nil {
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				bodyString := string(bodyBytes)
-				validResponse := strings.Contains(bodyString, `"success":true`)
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					if validResponse {
-						s1.Verified = true
-					} else {
-						s1.Verified = false
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					bodyString := string(bodyBytes)
+					validResponse := strings.Contains(bodyString, `"success":true`)
+					defer res.Body.Close()
+					if res.StatusCode >= 200 && res.StatusCode < 300 {
+						if validResponse {
+							s1.Verified = true
+						} else {
+							s1.Verified = false
+						}
 					}
 				}
 			}

--- a/pkg/detectors/convier/convier.go
+++ b/pkg/detectors/convier/convier.go
@@ -59,16 +59,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err == nil {
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				bodyString := string(bodyBytes)
-				validResponse := strings.Contains(bodyString, `"error":false`)
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					if validResponse {
-						s1.Verified = true
-					} else {
-						s1.Verified = false
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					bodyString := string(bodyBytes)
+					validResponse := strings.Contains(bodyString, `"error":false`)
+					defer res.Body.Close()
+					if res.StatusCode >= 200 && res.StatusCode < 300 {
+						if validResponse {
+							s1.Verified = true
+						} else {
+							s1.Verified = false
+						}
 					}
 				}
 			}

--- a/pkg/detectors/cryptocompare/cryptocompare.go
+++ b/pkg/detectors/cryptocompare/cryptocompare.go
@@ -54,16 +54,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err == nil {
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				bodyString := string(bodyBytes)
-				errCode := strings.Contains(bodyString, `"Response":"Success"`)
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					if errCode {
-						s1.Verified = true
-					} else {
-						s1.Verified = false
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					bodyString := string(bodyBytes)
+					errCode := strings.Contains(bodyString, `"Response":"Success"`)
+					defer res.Body.Close()
+					if res.StatusCode >= 200 && res.StatusCode < 300 {
+						if errCode {
+							s1.Verified = true
+						} else {
+							s1.Verified = false
+						}
 					}
 				}
 			}

--- a/pkg/detectors/dareboost/dareboost.go
+++ b/pkg/detectors/dareboost/dareboost.go
@@ -57,18 +57,18 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err == nil {
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					bodyString := string(bodyBytes)
+					validResponse := strings.Contains(bodyString, `"status":200`)
 
-				bodyString := string(bodyBytes)
-				validResponse := strings.Contains(bodyString, `"status":200`)
-
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					if validResponse {
-						s1.Verified = true
-					} else {
-						s1.Verified = false
+					defer res.Body.Close()
+					if res.StatusCode >= 200 && res.StatusCode < 300 {
+						if validResponse {
+							s1.Verified = true
+						} else {
+							s1.Verified = false
+						}
 					}
 				}
 			}

--- a/pkg/detectors/dyspatch/dyspatch.go
+++ b/pkg/detectors/dyspatch/dyspatch.go
@@ -58,13 +58,14 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-				validResponse := strings.Contains(body, "limited_usage") || strings.Contains(body, "data")
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					validResponse := strings.Contains(body, "limited_usage") || strings.Contains(body, "data")
 
-				if validResponse {
-					s1.Verified = true
+					if validResponse {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/etherscan/etherscan.go
+++ b/pkg/detectors/etherscan/etherscan.go
@@ -55,12 +55,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
 
-				if strings.Contains(body, `"OK"`) {
-					s1.Verified = true
+					if strings.Contains(body, `"OK"`) {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/fixerio/fixerio.go
+++ b/pkg/detectors/fixerio/fixerio.go
@@ -56,21 +56,21 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+
+					// if client_id and client_secret is valid -> 403 {"error":"invalid_grant","error_description":"Invalid authorization code"}
+					// if invalid -> 401 {"error":"access_denied","error_description":"Unauthorized"}
+					// ingenious!
+
+					validResponse := strings.Contains(body, `"success": true`) || strings.Contains(body, `"info":"Access Restricted - Your current Subscription Plan does not support HTTPS Encryption."`)
+					defer res.Body.Close()
+
+					if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
+						s1.Verified = true
+					}
 				}
-				body := string(bodyBytes)
-
-				// if client_id and client_secret is valid -> 403 {"error":"invalid_grant","error_description":"Invalid authorization code"}
-				// if invalid -> 401 {"error":"access_denied","error_description":"Unauthorized"}
-				// ingenious!
-
-				validResponse := strings.Contains(body, `"success": true`) || strings.Contains(body, `"info":"Access Restricted - Your current Subscription Plan does not support HTTPS Encryption."`)
-				defer res.Body.Close()
-
-				if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
-					s1.Verified = true
-				}
-
 			}
 		}
 

--- a/pkg/detectors/flickr/flickr.go
+++ b/pkg/detectors/flickr/flickr.go
@@ -57,11 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-				if (res.StatusCode >= 200 && res.StatusCode < 300) && strings.Contains(body, "owner=") {
-					s1.Verified = true
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					if (res.StatusCode >= 200 && res.StatusCode < 300) && strings.Contains(body, "owner=") {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/flightstats/flightstats.go
+++ b/pkg/detectors/flightstats/flightstats.go
@@ -64,12 +64,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					defer res.Body.Close()
 					bodyBytes, err := io.ReadAll(res.Body)
 					if err != nil {
-						continue
-					}
-					body := string(bodyBytes)
-					validResponse := (res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, "id")) || (res.StatusCode == 403 && strings.Contains(body, "application is not active"))
-					if validResponse {
-						s1.Verified = true
+						s1.SetVerificationError(err, resMatch)
+					} else {
+						body := string(bodyBytes)
+						validResponse := (res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, "id")) || (res.StatusCode == 403 && strings.Contains(body, "application is not active"))
+						if validResponse {
+							s1.Verified = true
+						}
 					}
 				}
 			}

--- a/pkg/detectors/flowflu/flowflu.go
+++ b/pkg/detectors/flowflu/flowflu.go
@@ -63,18 +63,18 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err == nil {
 					bodyBytes, err := io.ReadAll(res.Body)
 					if err != nil {
-						continue
-					}
+						s1.SetVerificationError(err, resMatch)
+					} else {
+						bodyString := string(bodyBytes)
+						validResponse := strings.Contains(bodyString, `total_result`)
 
-					bodyString := string(bodyBytes)
-					validResponse := strings.Contains(bodyString, `total_result`)
-
-					defer res.Body.Close()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						if validResponse {
-							s1.Verified = true
-						} else {
-							s1.Verified = false
+						defer res.Body.Close()
+						if res.StatusCode >= 200 && res.StatusCode < 300 {
+							if validResponse {
+								s1.Verified = true
+							} else {
+								s1.Verified = false
+							}
 						}
 					}
 				}

--- a/pkg/detectors/freshbooks/freshbooks.go
+++ b/pkg/detectors/freshbooks/freshbooks.go
@@ -61,11 +61,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					defer res.Body.Close()
 					bodyBytes, err := io.ReadAll(res.Body)
 					if err != nil {
-						continue
-					}
-					body := string(bodyBytes)
-					if res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, "Log In to FreshBooks") {
-						s1.Verified = true
+						s1.SetVerificationError(err, resMatch)
+					} else {
+						body := string(bodyBytes)
+						if res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, "Log In to FreshBooks") {
+							s1.Verified = true
+						}
 					}
 				}
 			}

--- a/pkg/detectors/gemini/gemini.go
+++ b/pkg/detectors/gemini/gemini.go
@@ -68,14 +68,16 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if verify {
 				req, err := constructRequest(ctx, resSecretMatch, resMatch)
 				if err != nil {
-					continue
-				}
-
-				res, err := client.Do(req)
-				if err == nil {
-					defer res.Body.Close()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						s1.Verified = true
+					s1.SetVerificationError(err, resSecretMatch)
+				} else {
+					res, err := client.Do(req)
+					if err != nil {
+						s1.SetVerificationError(err, resSecretMatch)
+					} else {
+						defer res.Body.Close()
+						if res.StatusCode >= 200 && res.StatusCode < 300 {
+							s1.Verified = true
+						}
 					}
 				}
 			}

--- a/pkg/detectors/getemail/getemail.go
+++ b/pkg/detectors/getemail/getemail.go
@@ -56,16 +56,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err == nil {
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				bodyString := string(bodyBytes)
-				errCode := strings.Contains(bodyString, `"code":"USER_NOT_EXIST"`)
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					if errCode {
-						s1.Verified = false
-					} else {
-						s1.Verified = true
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					bodyString := string(bodyBytes)
+					errCode := strings.Contains(bodyString, `"code":"USER_NOT_EXIST"`)
+					defer res.Body.Close()
+					if res.StatusCode >= 200 && res.StatusCode < 300 {
+						if errCode {
+							s1.Verified = false
+						} else {
+							s1.Verified = true
+						}
 					}
 				}
 			}

--- a/pkg/detectors/holistic/holistic.go
+++ b/pkg/detectors/holistic/holistic.go
@@ -55,15 +55,15 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err == nil {
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					bodyString := string(bodyBytes)
+					errorResponse := strings.Contains(bodyString, `"data":[]`)
 
-				bodyString := string(bodyBytes)
-				errorResponse := strings.Contains(bodyString, `"data":[]`)
-
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 && !errorResponse {
-					s1.Verified = true
+					defer res.Body.Close()
+					if res.StatusCode >= 200 && res.StatusCode < 300 && !errorResponse {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/humanity/humanity.go
+++ b/pkg/detectors/humanity/humanity.go
@@ -55,14 +55,15 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
 
-				validResponse := strings.Contains(body, "name")
+					validResponse := strings.Contains(body, "name")
 
-				if validResponse {
-					s1.Verified = true
+					if validResponse {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/infura/infura.go
+++ b/pkg/detectors/infura/infura.go
@@ -56,11 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-				if strings.Contains(body, `"result"`) {
-					s1.Verified = true
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					if strings.Contains(body, `"result"`) {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/instamojo/instamojo.go
+++ b/pkg/detectors/instamojo/instamojo.go
@@ -72,14 +72,15 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					defer res.Body.Close()
 					bodyBytes, err := io.ReadAll(res.Body)
 					if err != nil {
-						continue
-					}
-					body := string(bodyBytes)
-					if (res.StatusCode >= 200 && res.StatusCode < 300) && strings.Contains(body, "access_token") {
-						s1.Verified = true
-					} else {
-						err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
 						s1.SetVerificationError(err, resSecret)
+					} else {
+						body := string(bodyBytes)
+						if (res.StatusCode >= 200 && res.StatusCode < 300) && strings.Contains(body, "access_token") {
+							s1.Verified = true
+						} else {
+							err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+							s1.SetVerificationError(err, resSecret)
+						}
 					}
 				} else {
 					s1.SetVerificationError(err, resSecret)

--- a/pkg/detectors/ipstack/ipstack.go
+++ b/pkg/detectors/ipstack/ipstack.go
@@ -53,13 +53,14 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-				validResponse := strings.Contains(body, "continent_code") || strings.Contains(body, `"info":"Access Restricted - Your current Subscription Plan does not support HTTPS Encryption."`)
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					validResponse := strings.Contains(body, "continent_code") || strings.Contains(body, `"info":"Access Restricted - Your current Subscription Plan does not support HTTPS Encryption."`)
 
-				if validResponse {
-					s1.Verified = true
+					if validResponse {
+						s1.Verified = true
+					}
 				}
 			}
 

--- a/pkg/detectors/jdbc/jdbc.go
+++ b/pkg/detectors/jdbc/jdbc.go
@@ -88,24 +88,24 @@ matchLoop:
 		if verify {
 			j, err := NewJDBC(logCtx, jdbcConn)
 			if err != nil {
-				continue
-			}
-
-			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
-			defer cancel()
-			pingRes := j.ping(ctx)
-			result.Verified = pingRes.err == nil
-			// If there's a ping error that is marked as "determinate" we throw it away. We do this because this was the
-			// behavior before tri-state verification was introduced and preserving it allows us to gradually migrate
-			// detectors to use tri-state verification.
-			if pingRes.err != nil && !pingRes.determinate {
-				err = pingRes.err
 				result.SetVerificationError(err, jdbcConn)
+			} else {
+				ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
+				pingRes := j.ping(ctx)
+				result.Verified = pingRes.err == nil
+				// If there's a ping error that is marked as "determinate" we throw it away. We do this because this was the
+				// behavior before tri-state verification was introduced and preserving it allows us to gradually migrate
+				// detectors to use tri-state verification.
+				if pingRes.err != nil && !pingRes.determinate {
+					err = pingRes.err
+					result.SetVerificationError(err, jdbcConn)
+				}
+				result.AnalysisInfo = map[string]string{
+					"connection_string": jdbcConn,
+				}
+				// TODO: specialized redaction
 			}
-			result.AnalysisInfo = map[string]string{
-				"connection_string": jdbcConn,
-			}
-			// TODO: specialized redaction
 		}
 
 		results = append(results, result)

--- a/pkg/detectors/linearapi/linearapi.go
+++ b/pkg/detectors/linearapi/linearapi.go
@@ -58,11 +58,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-				if res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, `"data":`) {
-					s1.Verified = true
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					if res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, `"data":`) {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/mailboxlayer/mailboxlayer.go
+++ b/pkg/detectors/mailboxlayer/mailboxlayer.go
@@ -55,19 +55,19 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					validResponse := strings.Contains(body, `email`) || strings.Contains(body, `"info":"Access Restricted - Your current Subscription Plan does not support HTTPS Encryption."`)
+
+					// if client_id and client_secret is valid -> 403 {"error":"invalid_grant","error_description":"Invalid authorization code"}
+					// if invalid -> 401 {"error":"access_denied","error_description":"Unauthorized"}
+					// ingenious!
+
+					if validResponse {
+						s1.Verified = true
+					}
 				}
-				body := string(bodyBytes)
-				validResponse := strings.Contains(body, `email`) || strings.Contains(body, `"info":"Access Restricted - Your current Subscription Plan does not support HTTPS Encryption."`)
-
-				// if client_id and client_secret is valid -> 403 {"error":"invalid_grant","error_description":"Invalid authorization code"}
-				// if invalid -> 401 {"error":"access_denied","error_description":"Unauthorized"}
-				// ingenious!
-
-				if validResponse {
-					s1.Verified = true
-				}
-
 			}
 		}
 

--- a/pkg/detectors/mesibo/mesibo.go
+++ b/pkg/detectors/mesibo/mesibo.go
@@ -54,12 +54,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
 
-				if !strings.Contains(body, "AUTHFAIL") {
-					s1.Verified = true
+					if !strings.Contains(body, "AUTHFAIL") {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/metabase/metabase.go
+++ b/pkg/detectors/metabase/metabase.go
@@ -72,9 +72,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					defer res.Body.Close()
 					body, err := io.ReadAll(res.Body)
 					if err != nil {
-						continue
-					}
-					if res.StatusCode == http.StatusOK && json.Valid(body) {
+						s1.SetVerificationError(err, resMatch)
+					} else if res.StatusCode == http.StatusOK && json.Valid(body) {
 						s1.Verified = true
 					}
 				}

--- a/pkg/detectors/mongodb/mongodb.go
+++ b/pkg/detectors/mongodb/mongodb.go
@@ -18,6 +18,7 @@ import (
 	"go.mongodb.org/mongo-driver/x/mongo/driver/auth"
 )
 
+
 type Scanner struct {
 	timeout time.Duration // Zero value means "default timeout"
 }
@@ -98,9 +99,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			isVerified, vErr := verifyUri(ctx, connStr, timeout)
 			r.Verified = isVerified
-			if isErrDeterminate(vErr) {
-				continue
-			}
 			r.SetVerificationError(vErr, password)
 
 			if isVerified {
@@ -123,11 +121,6 @@ func (s Scanner) Description() string {
 	return "MongoDB is a NoSQL database that uses a document-oriented data model. MongoDB credentials can be used to access and manipulate the database."
 }
 
-func isErrDeterminate(err error) bool {
-	var authErr *auth.Error
-	return errors.As(err, &authErr)
-}
-
 func verifyUri(ctx context.Context, connStr string, timeout time.Duration) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -144,8 +137,15 @@ func verifyUri(ctx context.Context, connStr string, timeout time.Duration) (bool
 	defer func() {
 		_ = client.Disconnect(ctx)
 	}()
-	err = client.Ping(ctx, readpref.Primary())
-	return err == nil, err
+	if err := client.Ping(ctx, readpref.Primary()); err != nil {
+		var authErr *auth.Error
+		if errors.As(err, &authErr) {
+			// Determinate: bad credentials. Secret is invalid, not a verification failure.
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (s Scanner) Type() detector_typepb.DetectorType {

--- a/pkg/detectors/moosend/moosend.go
+++ b/pkg/detectors/moosend/moosend.go
@@ -54,11 +54,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-				if strings.Contains(body, "CreatedOn") {
-					s1.Verified = true
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					if strings.Contains(body, "CreatedOn") {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/mrticktock/mrticktock.go
+++ b/pkg/detectors/mrticktock/mrticktock.go
@@ -67,11 +67,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					defer res.Body.Close()
 					bodyBytes, err := io.ReadAll(res.Body)
 					if err != nil {
-						continue
-					}
-					body := string(bodyBytes)
-					if res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, `"errors":[]`) {
-						s1.Verified = true
+						s1.SetVerificationError(err, resPassword)
+					} else {
+						body := string(bodyBytes)
+						if res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, `"errors":[]`) {
+							s1.Verified = true
+						}
 					}
 				}
 			}

--- a/pkg/detectors/onedesk/onedesk.go
+++ b/pkg/detectors/onedesk/onedesk.go
@@ -67,11 +67,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					defer res.Body.Close()
 					bodyBytes, err := io.ReadAll(res.Body)
 					if err != nil {
-						continue
-					}
-					body := string(bodyBytes)
-					if res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, `"code":"SUCCESS"`) {
-						s1.Verified = true
+						s1.SetVerificationError(err, resPword)
+					} else {
+						body := string(bodyBytes)
+						if res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, `"code":"SUCCESS"`) {
+							s1.Verified = true
+						}
 					}
 				}
 			}

--- a/pkg/detectors/paralleldots/paralleldots.go
+++ b/pkg/detectors/paralleldots/paralleldots.go
@@ -76,11 +76,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-				if (res.StatusCode >= 200 && res.StatusCode < 300) && strings.Contains(body, "intent") {
-					s1.Verified = true
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					if (res.StatusCode >= 200 && res.StatusCode < 300) && strings.Contains(body, "intent") {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/planyo/planyo.go
+++ b/pkg/detectors/planyo/planyo.go
@@ -57,12 +57,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-				validResponse := strings.Contains(body, "data") || strings.Contains(body, "Your Planyo site has expired")
-				if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
-					s1.Verified = true
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					validResponse := strings.Contains(body, "data") || strings.Contains(body, "Your Planyo site has expired")
+					if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/raven/raven.go
+++ b/pkg/detectors/raven/raven.go
@@ -55,14 +55,15 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err == nil {
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					if json.Valid(bodyBytes) {
-						s1.Verified = true
-					} else {
-						s1.Verified = false
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					defer res.Body.Close()
+					if res.StatusCode >= 200 && res.StatusCode < 300 {
+						if json.Valid(bodyBytes) {
+							s1.Verified = true
+						} else {
+							s1.Verified = false
+						}
 					}
 				}
 			}

--- a/pkg/detectors/razorpay/razorpay.go
+++ b/pkg/detectors/razorpay/razorpay.go
@@ -62,12 +62,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if err == nil {
 					bodyBytes, err := io.ReadAll(res.Body)
 					if err != nil {
-						continue
-					}
-					defer res.Body.Close()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						if json.Valid(bodyBytes) {
-							s1.Verified = true
+						s1.SetVerificationError(err, secret)
+					} else {
+						defer res.Body.Close()
+						if res.StatusCode >= 200 && res.StatusCode < 300 {
+							if json.Valid(bodyBytes) {
+								s1.Verified = true
+							}
 						}
 					}
 				}

--- a/pkg/detectors/reallysimplesystems/reallysimplesystems.go
+++ b/pkg/detectors/reallysimplesystems/reallysimplesystems.go
@@ -57,14 +57,15 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err == nil {
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					if json.Valid(bodyBytes) {
-						s1.Verified = true
-					} else {
-						s1.Verified = false
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					defer res.Body.Close()
+					if res.StatusCode >= 200 && res.StatusCode < 300 {
+						if json.Valid(bodyBytes) {
+							s1.Verified = true
+						} else {
+							s1.Verified = false
+						}
 					}
 				}
 			}

--- a/pkg/detectors/salesforceoauth2/salesforceoauth2.go
+++ b/pkg/detectors/salesforceoauth2/salesforceoauth2.go
@@ -80,12 +80,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		return nil, nil
 	}
 
-domainLoop:
 	for domain := range uniqueInstanceMatches {
-		if invalidHosts.Exists(domain) {
-			continue domainLoop
-		}
-
 		for key := range uniqueKeyMatches {
 			for secret := range uniqueSecretMatches {
 				s1 := detectors.Result{
@@ -95,24 +90,25 @@ domainLoop:
 				}
 
 				if verify {
-					isVerified, verificationErr := s.verifyMatch(ctx, s.getClient(), domain, key, secret)
-					s1.Verified = isVerified
-					if verificationErr != nil {
-						if errors.Is(verificationErr, errNoHost) {
-							invalidHosts.Set(domain, struct{}{})
-							continue domainLoop
+					if invalidHosts.Exists(domain) {
+						s1.SetVerificationError(errNoHost, secret)
+					} else {
+						isVerified, verificationErr := s.verifyMatch(ctx, s.getClient(), domain, key, secret)
+						s1.Verified = isVerified
+						if verificationErr != nil {
+							if errors.Is(verificationErr, errNoHost) {
+								invalidHosts.Set(domain, struct{}{})
+							}
+							s1.SetVerificationError(verificationErr, secret)
 						}
 
-						s1.SetVerificationError(verificationErr, secret)
-					}
-
-					if isVerified {
-						s1.AnalysisInfo = map[string]string{
-							"domain":        domain,
-							"client_id":     key,
-							"client_secret": secret,
+						if isVerified {
+							s1.AnalysisInfo = map[string]string{
+								"domain":        domain,
+								"client_id":     key,
+								"client_secret": secret,
+							}
 						}
-
 					}
 				}
 

--- a/pkg/detectors/semaphore/semaphore.go
+++ b/pkg/detectors/semaphore/semaphore.go
@@ -60,11 +60,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-				if res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, "account_id") {
-					s1.Verified = true
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					if res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, "account_id") {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/simfin/simfin.go
+++ b/pkg/detectors/simfin/simfin.go
@@ -56,13 +56,14 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err == nil {
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				bodyString := string(bodyBytes)
-				validResponse := !strings.Contains(bodyString, `"error"`)
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
-					s1.Verified = true
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					bodyString := string(bodyBytes)
+					validResponse := !strings.Contains(bodyString, `"error"`)
+					defer res.Body.Close()
+					if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/slackwebhook/slackwebhook.go
+++ b/pkg/detectors/slackwebhook/slackwebhook.go
@@ -75,24 +75,24 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					defer res.Body.Close()
 					bodyBytes, err := io.ReadAll(res.Body)
 					if err != nil {
-						continue
-					}
-
-					defer res.Body.Close()
-
-					switch {
-					case res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusMultipleChoices:
-						// Hopefully this never happens - it means we actually sent something to a channel somewhere. But
-						// we at least know the secret is verified.
-						s1.Verified = true
-					case res.StatusCode == http.StatusBadRequest && bytes.Equal(bodyBytes, []byte("invalid_payload")):
-						s1.Verified = true
-					case res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusForbidden:
-						// Not a real webhook or the owning app's OAuth token has been revoked or the app has been deleted
-						// You might want to handle this case or log it.
-					default:
-						err = fmt.Errorf("unexpected HTTP response status %d: %s", res.StatusCode, bodyBytes)
 						s1.SetVerificationError(err, resMatch)
+					} else {
+						defer res.Body.Close()
+
+						switch {
+						case res.StatusCode >= http.StatusOK && res.StatusCode < http.StatusMultipleChoices:
+							// Hopefully this never happens - it means we actually sent something to a channel somewhere. But
+							// we at least know the secret is verified.
+							s1.Verified = true
+						case res.StatusCode == http.StatusBadRequest && bytes.Equal(bodyBytes, []byte("invalid_payload")):
+							s1.Verified = true
+						case res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusForbidden:
+							// Not a real webhook or the owning app's OAuth token has been revoked or the app has been deleted
+							// You might want to handle this case or log it.
+						default:
+							err = fmt.Errorf("unexpected HTTP response status %d: %s", res.StatusCode, bodyBytes)
+							s1.SetVerificationError(err, resMatch)
+						}
 					}
 				} else {
 					s1.SetVerificationError(err, resMatch)

--- a/pkg/detectors/tefter/tefter.go
+++ b/pkg/detectors/tefter/tefter.go
@@ -56,13 +56,14 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err == nil {
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				validResponse := json.Valid(bodyBytes)
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					validResponse := json.Valid(bodyBytes)
 
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
-					s1.Verified = true
+					defer res.Body.Close()
+					if res.StatusCode >= 200 && res.StatusCode < 300 && validResponse {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/teletype/teletype.go
+++ b/pkg/detectors/teletype/teletype.go
@@ -55,18 +55,18 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err == nil {
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					bodyString := string(bodyBytes)
+					validResponse := strings.Contains(bodyString, `"code":401`)
 
-				bodyString := string(bodyBytes)
-				validResponse := strings.Contains(bodyString, `"code":401`)
-
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					if validResponse {
-						s1.Verified = false
-					} else {
-						s1.Verified = true
+					defer res.Body.Close()
+					if res.StatusCode >= 200 && res.StatusCode < 300 {
+						if validResponse {
+							s1.Verified = false
+						} else {
+							s1.Verified = true
+						}
 					}
 				}
 			}

--- a/pkg/detectors/thinkific/thinkific.go
+++ b/pkg/detectors/thinkific/thinkific.go
@@ -64,12 +64,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					defer res.Body.Close()
 					bodyBytes, err := io.ReadAll(res.Body)
 					if err != nil {
-						continue
-					}
-					body := string(bodyBytes)
+						s1.SetVerificationError(err, resMatch)
+					} else {
+						body := string(bodyBytes)
 
-					if strings.Contains(body, "API Access is not available") {
-						s1.Verified = true
+						if strings.Contains(body, "API Access is not available") {
+							s1.Verified = true
+						}
 					}
 				}
 			}

--- a/pkg/detectors/twelvedata/twelvedata.go
+++ b/pkg/detectors/twelvedata/twelvedata.go
@@ -55,18 +55,18 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+
+					// if client_id and client_secret is valid -> 403 {"error":"invalid_grant","error_description":"Invalid authorization code"}
+					// if invalid -> 401 {"error":"access_denied","error_description":"Unauthorized"}
+					// ingenious!
+
+					if !strings.Contains(body, "401") {
+						s1.Verified = true
+					}
 				}
-				body := string(bodyBytes)
-
-				// if client_id and client_secret is valid -> 403 {"error":"invalid_grant","error_description":"Invalid authorization code"}
-				// if invalid -> 401 {"error":"access_denied","error_description":"Unauthorized"}
-				// ingenious!
-
-				if !strings.Contains(body, "401") {
-					s1.Verified = true
-				}
-
 			}
 		}
 

--- a/pkg/detectors/unifyid/unifyid.go
+++ b/pkg/detectors/unifyid/unifyid.go
@@ -57,11 +57,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-				if (res.StatusCode >= 200 && res.StatusCode < 300) || (res.StatusCode == 400 && strings.Contains(body, "invalid token")) {
-					s1.Verified = true
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					if (res.StatusCode >= 200 && res.StatusCode < 300) || (res.StatusCode == 400 && strings.Contains(body, "invalid token")) {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/uptimerobot/uptimerobot.go
+++ b/pkg/detectors/uptimerobot/uptimerobot.go
@@ -54,16 +54,17 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if err == nil {
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				bodyString := string(bodyBytes)
-				validResponse := strings.Contains(bodyString, `"ok"`)
-				defer res.Body.Close()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					if validResponse {
-						s1.Verified = true
-					} else {
-						s1.Verified = false
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					bodyString := string(bodyBytes)
+					validResponse := strings.Contains(bodyString, `"ok"`)
+					defer res.Body.Close()
+					if res.StatusCode >= 200 && res.StatusCode < 300 {
+						if validResponse {
+							s1.Verified = true
+						} else {
+							s1.Verified = false
+						}
 					}
 				}
 			}

--- a/pkg/detectors/uri/uri.go
+++ b/pkg/detectors/uri/uri.go
@@ -36,6 +36,8 @@ var (
 	defaultClient = detectors.DetectorHttpClientWithNoLocalAddresses
 
 	hostNotFoundCache = simple.NewCache[struct{}]()
+
+	errNoHost = errors.New("no such host")
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -107,21 +109,21 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		if verify {
 			hostname := parsedURL.Hostname()
 			if hostNotFoundCache.Exists(hostname) {
-				logger.V(3).Info("Skipping uri: no such host", "host", hostname)
-				continue
-			}
-
-			if s.client == nil {
-				s.client = defaultClient
-			}
-			isVerified, vErr := verifyURL(ctx, s.client, parsedURL)
-			r.Verified = isVerified
-			if vErr != nil {
-				var dnsErr *net.DNSError
-				if errors.As(vErr, &dnsErr) && dnsErr.IsNotFound {
-					hostNotFoundCache.Set(hostname, struct{}{})
+				logger.V(3).Info("Skipping uri verification: cached no such host", "host", hostname)
+				r.SetVerificationError(errNoHost, password)
+			} else {
+				if s.client == nil {
+					s.client = defaultClient
 				}
-				r.SetVerificationError(vErr, password)
+				isVerified, vErr := verifyURL(ctx, s.client, parsedURL)
+				r.Verified = isVerified
+				if vErr != nil {
+					var dnsErr *net.DNSError
+					if errors.As(vErr, &dnsErr) && dnsErr.IsNotFound {
+						hostNotFoundCache.Set(hostname, struct{}{})
+					}
+					r.SetVerificationError(vErr, password)
+				}
 			}
 		}
 

--- a/pkg/detectors/walkscore/walkscore.go
+++ b/pkg/detectors/walkscore/walkscore.go
@@ -56,11 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-				if (res.StatusCode >= 200 && res.StatusCode < 300) && strings.Contains(body, `distance`) {
-					s1.Verified = true
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					if (res.StatusCode >= 200 && res.StatusCode < 300) && strings.Contains(body, `distance`) {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/weatherstack/weatherstack.go
+++ b/pkg/detectors/weatherstack/weatherstack.go
@@ -56,12 +56,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-				validResponse := strings.Contains(body, `location`) || strings.Contains(body, `"info":"Access Restricted - Your current Subscription Plan does not support HTTPS Encryption."`)
-				if (res.StatusCode >= 200 && res.StatusCode < 300) && validResponse {
-					s1.Verified = true
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					validResponse := strings.Contains(body, `location`) || strings.Contains(body, `"info":"Access Restricted - Your current Subscription Plan does not support HTTPS Encryption."`)
+					if (res.StatusCode >= 200 && res.StatusCode < 300) && validResponse {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/webscraping/webscraping.go
+++ b/pkg/detectors/webscraping/webscraping.go
@@ -54,12 +54,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
 
-				if strings.Contains(body, "key `url` required.") {
-					s1.Verified = true
+					if strings.Contains(body, "key `url` required.") {
+						s1.Verified = true
+					}
 				}
 			}
 		}

--- a/pkg/detectors/websitepulse/websitepulse.go
+++ b/pkg/detectors/websitepulse/websitepulse.go
@@ -60,12 +60,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					defer res.Body.Close()
 					bodyBytes, err := io.ReadAll(res.Body)
 					if err != nil {
-						continue
-					}
-					body := string(bodyBytes)
+						s1.SetVerificationError(err, resMatch)
+					} else {
+						body := string(bodyBytes)
 
-					if strings.Contains(body, "Active") {
-						s1.Verified = true
+						if strings.Contains(body, "Active") {
+							s1.Verified = true
+						}
 					}
 				}
 			}

--- a/pkg/detectors/whoxy/whoxy.go
+++ b/pkg/detectors/whoxy/whoxy.go
@@ -56,11 +56,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				bodyBytes, err := io.ReadAll(res.Body)
 				if err != nil {
-					continue
-				}
-				body := string(bodyBytes)
-				if res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, `"status": 1`) {
-					s1.Verified = true
+					s1.SetVerificationError(err, resMatch)
+				} else {
+					body := string(bodyBytes)
+					if res.StatusCode >= 200 && res.StatusCode < 300 && strings.Contains(body, `"status": 1`) {
+						s1.Verified = true
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Many detectors silently dropped results (via `continue`) when verification hit an indeterminate error: no host in cache, body-read failure, request construction failure, etc. This broke the contract that unverified results must still be emitted so downstream consumers can track last-seen state.
Replace those drops with SetVerificationError so the result is still returned with the error attached.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches verification paths across many detectors, changing control flow to always return findings with `VerificationError` instead of dropping them; broad surface area could affect result volume and downstream expectations.
> 
> **Overview**
> Ensures detectors **always emit a `Result` even when verification can’t be completed**, replacing many `continue`/early-exit paths with `Result.SetVerificationError(...)` (including cached `no such host`, request/response body read failures, and other indeterminate errors).
> 
> Standardizes host/ID “no such host” caching behavior to **skip verification but still return an unverified finding with an attached error** across multiple detectors (e.g., Algolia, Artifactory, Azure variants, Salesforce, URI).
> 
> Improves MongoDB verification to treat authentication failures as *determinate invalid credentials* (returns `false, nil`) rather than surfacing them as verification errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc3f4661601485633e5e82211d353042fadf57aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->