### PR TITLE
Fix shallow file scans when merge base objects are missing

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -1217,6 +1217,12 @@ func normalizeConfig(scanOptions *ScanOptions, repo *git.Repository) error {
 	// If baseCommit is an ancestor of headCommit, update c.BaseRef to be the common ancestor.
 	mergeBase, err := headCommit.MergeBase(baseCommit)
 	if err != nil {
+		// Shallow local clones can omit the common ancestor object even when git can still
+		// enumerate the head-side commits to scan. In that case, keep the resolved base ref
+		// instead of aborting the scan entirely.
+		if errors.Is(err, plumbing.ErrObjectNotFound) {
+			return nil
+		}
 		return fmt.Errorf("unable to resolve merge base: %w", err)
 	}
 	if len(mergeBase) == 0 {

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -721,6 +721,67 @@ func TestGitConfigSanitization(t *testing.T) {
 	}
 }
 
+func TestScanRepo_ShallowLocalCloneWithBranchBaseRef(t *testing.T) {
+	ctx := context.Background()
+
+	sourceRepoPath := setupTestRepo(t, "source-repo")
+	assert.NoError(t, exec.Command("git", "-C", sourceRepoPath, "branch", "-M", "main").Run())
+	addTestFileAndCommit(t, sourceRepoPath, "base.txt", "base one")
+	addTestFileAndCommit(t, sourceRepoPath, "base.txt", "base two")
+
+	assert.NoError(t, exec.Command("git", "-C", sourceRepoPath, "checkout", "-b", "feature").Run())
+	addTestFileAndCommit(t, sourceRepoPath, "feature.txt", "feature secret\nsecret: AKIA1234567890123456\n")
+	assert.NoError(t, exec.Command("git", "-C", sourceRepoPath, "checkout", "main").Run())
+	addTestFileAndCommit(t, sourceRepoPath, "main.txt", "main only")
+
+	originRepoPath := filepath.Join(t.TempDir(), "origin.git")
+	assert.NoError(t, exec.Command("git", "clone", "--bare", sourceRepoPath, originRepoPath).Run())
+
+	ciRepoPath := filepath.Join(t.TempDir(), "ci-repo")
+	assert.NoError(t, exec.Command("git", "clone", "--depth=1", "--branch", "feature", "file://"+originRepoPath, ciRepoPath).Run())
+	assert.NoError(t, exec.Command("git", "-C", ciRepoPath, "fetch", "--depth=1", "origin", "main:main").Run())
+
+	preparedRepoPath, _, err := prepareRepoSinceCommit(ctx, "file://"+ciRepoPath, "", "main", false, false)
+	assert.NoError(t, err)
+	t.Cleanup(func() {
+		if preparedRepoPath != "" && preparedRepoPath != ciRepoPath {
+			_ = os.RemoveAll(preparedRepoPath)
+		}
+	})
+
+	repo, err := RepoFromPath(preparedRepoPath)
+	assert.NoError(t, err)
+
+	scanner := NewGit(&Config{
+		Concurrency: 1,
+		SourceMetadataFunc: func(SourceMetadataInfo) *source_metadatapb.MetaData {
+			return nil
+		},
+	})
+	reporter := &sourcestest.TestReporter{}
+	scanOptions := NewScanOptions(
+		ScanOptionBaseHash("main"),
+		ScanOptionHeadCommit("feature"),
+	)
+
+	err = scanner.ScanRepo(ctx, repo, preparedRepoPath, scanOptions, reporter)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, reporter.Chunks)
+	assert.Empty(t, reporter.ChunkErrs)
+
+	var (
+		foundFeatureContent bool
+		foundMainOnly       bool
+	)
+	for _, chunk := range reporter.Chunks {
+		data := string(chunk.Data)
+		foundFeatureContent = foundFeatureContent || strings.Contains(data, "feature secret")
+		foundMainOnly = foundMainOnly || strings.Contains(data, "main only")
+	}
+	assert.True(t, foundFeatureContent)
+	assert.False(t, foundMainOnly)
+}
+
 func TestGitConfigSanitizationWithBareRepo(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Description:
Fixes #4895.

When `trufflehog git file://... --since-commit <base> --branch <head>` runs against a shallow local clone, `normalizeConfig` can fail while resolving the merge base because the common ancestor object is not present locally.

In that case, Git can still enumerate the head-side commits to scan, so this change keeps the resolved base ref instead of aborting the scan when `MergeBase` returns `plumbing.ErrObjectNotFound`.

The new regression test covers the shallow `file://` path end to end and asserts that the scan still reports the feature-side change without pulling in the `main`-only commit.

### Checklist:
* [x] Tests passing (`go test ./pkg/sources/git -run TestScanRepo_ShallowLocalCloneWithBranchBaseRef -count=1`, `go test ./pkg/sources/git -run 'Test(GitConfigSanitization|ScanRepo_ShallowLocalCloneWithBranchBaseRef|GitConfigSanitizationWithBareRepo|GitConfigSecurityIsolation|GitConfigSanitizationWithStagedChanges|PrepareRepoErrorPaths|NormalizeFileURI|PrepareRepoWithNormalization|PrepareRepoWithNormalizationBare)$' -count=1`, `go test ./pkg/sources/git -run 'TestSource_Chunks_Integration/remote repo, main ahead of branch' -count=1`)
* [x] Lint passing (`./scripts/lint.sh`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes commit-range normalization for `--since-commit` scans: shallow clones that can’t load merge-base objects will now continue with the resolved base ref, which could subtly affect which commits are included/excluded. Covered by a new end-to-end regression test for shallow `file://` clones.
> 
> **Overview**
> Fixes shallow local `file://` scans where `normalizeConfig` previously aborted if `MergeBase` failed with `plumbing.ErrObjectNotFound`; it now treats this as non-fatal and proceeds using the resolved base ref.
> 
> Adds `TestScanRepo_ShallowLocalCloneWithBranchBaseRef` to reproduce the CI-style shallow clone scenario and assert the scan still reports feature-branch content without pulling in `main`-only commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c91e5affc73c8c5a67484a3ab86f4b5e9670530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->