### PR TITLE
docs: add table of contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,33 @@ We take the revenue from the enterprise product to fund more awesome open source
 
 </div>
 
+# Table of Contents
+
+- [What is TruffleHog](#what-is-trufflehog-)
+  - [Discovery](#discovery-)
+  - [Classification](#classification-)
+  - [Validation](#validation-)
+  - [Analysis](#analysis-)
+- [Join Our Community](#loudspeaker-join-our-community)
+- [Demo](#tv-demo)
+- [Installation](#floppy_disk-installation)
+- [Verifying the artifacts](#closed_lock_with_key-verifying-the-artifacts)
+- [Quick Start](#rocket-quick-start)
+- [FAQ](#question-faq)
+- [What's new in v3?](#newspaper-whats-new-in-v3)
+- [Usage](#memo-usage)
+  - [S3](#s3)
+  - [TruffleHog GitHub Action](#octocat-trufflehog-github-action)
+  - [TruffleHog GitLab CI](#trufflehog-gitlab-ci)
+  - [Pre-commit Hook](#pre-commit-hook)
+  - [Custom Regex Detector (alpha)](#custom-regex-detector-alpha)
+  - [Generic JWT Detection](#generic-jwt-detection)
+  - [Analyze](#mag-analyze)
+- [Contributors](#heart-contributors)
+- [Contributing](#computer-contributing)
+- [Use as a library](#use-as-a-library)
+- [License Change](#license-change)
+
 # What is TruffleHog 🐽
 
 TruffleHog is the most powerful secrets **Discovery, Classification, Validation,** and **Analysis** tool. In this context, secret refers to a credential a machine uses to authenticate itself to another machine. This includes API keys, database passwords, private encryption keys, and more.


### PR DESCRIPTION
## Summary

Adds a table of contents to the README for easier navigation of the extensive documentation.

## Changes

- Added a `## Table of Contents` section after the badges and before "What is TruffleHog"
- Linked all major sections and their subsections using standard Markdown anchor links
- No content changes, purely navigational addition

Closes #2983

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code or behavior is modified.
> 
> **Overview**
> Adds a **Table of Contents** section near the top of `README.md`, linking to the main documentation headings and key subsections for easier navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e7337605668aa77caf774f37a93fdd25f4f431d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->