### PR TITLE
Renamed AnypointOAuth2 detector's AnalysisInfo keys to make it consistent with its Analyzer

### DIFF
--- a/pkg/detectors/anypointoauth2/anypointoauth2.go
+++ b/pkg/detectors/anypointoauth2/anypointoauth2.go
@@ -79,8 +79,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.SetVerificationError(verificationErr)
 				if isVerified {
 					s1.AnalysisInfo = map[string]string{
-						"id":     id,
-						"secret": secret,
+						"client_id":     id,
+						"client_secret": secret,
 					}
 				}
 			}

--- a/pkg/detectors/coinbase/coinbase.go
+++ b/pkg/detectors/coinbase/coinbase.go
@@ -68,7 +68,7 @@ func isValidECPrivateKey(pemKey []byte) bool {
 
 	// Check the key type
 	_, ok := key.Public().(*ecdsa.PublicKey)
-        return ok
+	return ok
 }
 
 func (s Scanner) getClient() *http.Client {
@@ -112,6 +112,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				isVerified, verificationErr := s.verifyMatch(ctx, client, resKeyName, resPrivateKey)
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr, resPrivateKey)
+				if isVerified {
+					s1.AnalysisInfo = map[string]string{
+						"key_name": resKeyName,
+						"key":      resPrivateKey,
+					}
+				}
 			}
 			results = append(results, s1)
 


### PR DESCRIPTION
### Description:
This PR fixes a mismatch between the AnypointOAuth2 detector and its corresponding analyzer.

Previously, the detector populated credential fields as id and secret, while the analyzer expects them to be provided as client_id and client_secret. This inconsistency caused the analyzer to fail when processing detected credentials.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to detector result metadata; no changes to matching/verification behavior beyond adding extra output fields.
> 
> **Overview**
> Fixes verified-result metadata emitted by the `AnypointOAuth2` detector by renaming `AnalysisInfo` keys from `id`/`secret` to `client_id`/`client_secret` so downstream analyzers receive the expected fields.
> 
> Also updates the `Coinbase` detector to (a) populate `AnalysisInfo` with `key_name` and `key` on successful verification and (b) includes a minor formatting fix in `isValidECPrivateKey`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dd0f293e4737e00178197246efb02164c4b4dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->