### PR TITLE
Rename AnalysisInfo field to SecretParts on detectors.Result

### DIFF
--- a/pkg/detectors/airbrakeprojectkey/airbrakeprojectkey.go
+++ b/pkg/detectors/airbrakeprojectkey/airbrakeprojectkey.go
@@ -71,7 +71,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr)
 				if isVerified {
-					s1.AnalysisInfo = map[string]string{"key": key}
+					s1.SecretParts = map[string]string{"key": key}
 				}
 			}
 

--- a/pkg/detectors/airbrakeuserkey/airbrakeuserkey.go
+++ b/pkg/detectors/airbrakeuserkey/airbrakeuserkey.go
@@ -62,7 +62,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr)
 			if isVerified {
-				s1.AnalysisInfo = map[string]string{"key": key}
+				s1.SecretParts = map[string]string{"key": key}
 			}
 		}
 

--- a/pkg/detectors/airtableoauth/airtableoauth.go
+++ b/pkg/detectors/airtableoauth/airtableoauth.go
@@ -61,7 +61,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.SetVerificationError(verificationErr, match)
 
 			if s1.Verified {
-				s1.AnalysisInfo = map[string]string{"token": match}
+				s1.SecretParts = map[string]string{"token": match}
 			}
 		}
 

--- a/pkg/detectors/airtablepersonalaccesstoken/airtablepersonalaccesstoken.go
+++ b/pkg/detectors/airtablepersonalaccesstoken/airtablepersonalaccesstoken.go
@@ -56,7 +56,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.SetVerificationError(verificationErr, match)
 
 			if s1.Verified {
-				s1.AnalysisInfo = map[string]string{"token": match}
+				s1.SecretParts = map[string]string{"token": match}
 			}
 		}
 

--- a/pkg/detectors/anthropic/anthropic.go
+++ b/pkg/detectors/anthropic/anthropic.go
@@ -76,7 +76,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.SetVerificationError(err, keyMatch)
 
 			if s1.Verified {
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": keyMatch,
 				}
 			}

--- a/pkg/detectors/anthropic/anthropic_integration_test.go
+++ b/pkg/detectors/anthropic/anthropic_integration_test.go
@@ -121,7 +121,7 @@ func TestAnthropic_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Anthropic.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/anypointoauth2/anypointoauth2.go
+++ b/pkg/detectors/anypointoauth2/anypointoauth2.go
@@ -78,7 +78,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr)
 				if isVerified {
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"client_id":     id,
 						"client_secret": secret,
 					}

--- a/pkg/detectors/artifactory/artifactory.go
+++ b/pkg/detectors/artifactory/artifactory.go
@@ -100,7 +100,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					s1.SetVerificationError(verificationErr, token)
 
 					if isVerified {
-						s1.AnalysisInfo = map[string]string{
+						s1.SecretParts = map[string]string{
 							"domain": url,
 							"token":  token,
 						}

--- a/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken.go
+++ b/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken.go
@@ -99,7 +99,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 
 				if isVerified {
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"domain": url,
 						"token":  token,
 					}

--- a/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken_integration_test.go
+++ b/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken_integration_test.go
@@ -142,7 +142,7 @@ func TestArtifactoryreferencetoken_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Artifactoryreferencetoken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
@@ -188,7 +188,7 @@ func TestArtifactoryreferencetoken_FromChunk_WithCustomEndpoint(t *testing.T) {
 		}
 	}
 
-	ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret", "AnalysisInfo")
+	ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret", "SecretParts")
 	if diff := cmp.Diff(got, want, ignoreOpts); diff != "" {
 		t.Errorf("Artifactoryreferencetoken.FromData() diff: (-got +want)\n%s", diff)
 	}

--- a/pkg/detectors/asanaoauth/asanaoauth.go
+++ b/pkg/detectors/asanaoauth/asanaoauth.go
@@ -50,7 +50,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, err := verifyMatch(ctx, client, resMatch)
 			s1.Verified = isVerified
 			s1.SetVerificationError(err, resMatch)
-			s1.AnalysisInfo = map[string]string{"key": resMatch}
+			s1.SecretParts = map[string]string{"key": resMatch}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/asanaoauth/asanaoauth_integration_test.go
+++ b/pkg/detectors/asanaoauth/asanaoauth_integration_test.go
@@ -95,7 +95,7 @@ func TestAsanaOauth_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("AsanaOauth.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/asanapersonalaccesstoken/asanapersonalaccesstoken.go
+++ b/pkg/detectors/asanapersonalaccesstoken/asanapersonalaccesstoken.go
@@ -53,7 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = isVerified
 			s1.SetVerificationError(err, resMatch)
 			if isVerified {
-				s1.AnalysisInfo = map[string]string{"key": resMatch}
+				s1.SecretParts = map[string]string{"key": resMatch}
 			}
 		}
 

--- a/pkg/detectors/atlassian/v1/atlassian.go
+++ b/pkg/detectors/atlassian/v1/atlassian.go
@@ -82,7 +82,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.SetVerificationError(verificationErr, match)
 
 			if isVerified {
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": match,
 				}
 			}

--- a/pkg/detectors/atlassian/v2/atlassian.go
+++ b/pkg/detectors/atlassian/v2/atlassian.go
@@ -67,7 +67,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		uniqueOrgIdMatches[match[1]] = struct{}{}
 	}
 	if len(uniqueOrgIdMatches) == 0 {
-		// we only need an org ID to pass into AnalysisInfo
+		// we only need an org ID to pass into SecretParts
 		// if we don't find one, we can still verify the key
 		// we can add a dummy entry here just to make sure a result is returned
 		uniqueOrgIdMatches[""] = struct{}{}
@@ -97,11 +97,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 				s1.SetVerificationError(verificationErr, match)
 				if s1.Verified {
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"key": match,
 					}
 					if orgId != "" {
-						s1.AnalysisInfo["organization_id"] = orgId
+						s1.SecretParts["organization_id"] = orgId
 					}
 				}
 			}

--- a/pkg/detectors/atlassian/v2/atlassian_integration_test.go
+++ b/pkg/detectors/atlassian/v2/atlassian_integration_test.go
@@ -136,7 +136,7 @@ func TestAtlassian_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "ExtraData", "primarySecret", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "ExtraData", "primarySecret", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Atlassian.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/atlassian/v2/atlassian_test.go
+++ b/pkg/detectors/atlassian/v2/atlassian_test.go
@@ -85,9 +85,9 @@ func TestAtlassian_Pattern(t *testing.T) {
 	}
 }
 
-// TestAtlassian_AnalysisInfo_KeyAndOrgId tests if both the key and organization id are populated into AnalysisInfo
+// TestAtlassian_SecretParts_KeyAndOrgId tests if both the key and organization id are populated into SecretParts
 // given that they are present in the input data chunk
-func TestAtlassian_AnalysisInfo_KeyAndOrgId(t *testing.T) {
+func TestAtlassian_SecretParts_KeyAndOrgId(t *testing.T) {
 	client := common.SaneHttpClient()
 	d := Scanner{client: client}
 
@@ -118,16 +118,16 @@ func TestAtlassian_AnalysisInfo_KeyAndOrgId(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, results, 1, "mismatch in result count: expected %d, got %d", 1, len(results))
 		result := results[0]
-		require.NotNil(t, result.AnalysisInfo, "AnalysisInfo is nil")
+		require.NotNil(t, result.SecretParts, "SecretParts is nil")
 
-		assert.Equal(t, key, result.AnalysisInfo["key"], "mismatch in key")
-		assert.Equal(t, orgId, result.AnalysisInfo["organization_id"], "mismatch in organization_id")
+		assert.Equal(t, key, result.SecretParts["key"], "mismatch in key")
+		assert.Equal(t, orgId, result.SecretParts["organization_id"], "mismatch in organization_id")
 	})
 }
 
-// TestAtlassian_AnalysisInfo_KeyOnly tests if only key is populated into AnalysisInfo
+// TestAtlassian_SecretParts_KeyOnly tests if only key is populated into SecretParts
 // given that only the key and no organization_id is present in the input data chunk
-func TestAtlassian_AnalysisInfo_KeyOnly(t *testing.T) {
+func TestAtlassian_SecretParts_KeyOnly(t *testing.T) {
 	client := common.SaneHttpClient()
 	d := Scanner{client: client}
 
@@ -156,8 +156,8 @@ func TestAtlassian_AnalysisInfo_KeyOnly(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, results, 1, "mismatch in result count: expected %d, got %d", 1, len(results))
 		result := results[0]
-		require.NotNil(t, result.AnalysisInfo, "AnalysisInfo is nil")
+		require.NotNil(t, result.SecretParts, "SecretParts is nil")
 
-		assert.Equal(t, key, result.AnalysisInfo["key"], "mismatch in key")
+		assert.Equal(t, key, result.SecretParts["key"], "mismatch in key")
 	})
 }

--- a/pkg/detectors/aws/access_keys/accesskey.go
+++ b/pkg/detectors/aws/access_keys/accesskey.go
@@ -154,7 +154,7 @@ func (s scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				ExtraData: map[string]string{
 					"resource_type": aws.ResourceTypes[idMatch[:4]],
 				},
-				AnalysisInfo: map[string]string{
+				SecretParts: map[string]string{
 					"access_key_id":     idMatch,
 					"secret_access_key": secretMatch,
 				},

--- a/pkg/detectors/azureapimanagement/repositorykey/repositorykey_integration_test.go
+++ b/pkg/detectors/azureapimanagement/repositorykey/repositorykey_integration_test.go
@@ -110,7 +110,7 @@ func TestAxonaut_FromChunk(t *testing.T) {
 				}
 			}
 
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "ExtraData", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "ExtraData", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("AzureApiManagementRepositoryKey.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/buildkite/v1/buildkite.go
+++ b/pkg/detectors/buildkite/v1/buildkite.go
@@ -62,7 +62,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.ExtraData = extraData
 
 			if isVerified {
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": resMatch,
 				}
 			}

--- a/pkg/detectors/buildkite/v2/buildkite.go
+++ b/pkg/detectors/buildkite/v2/buildkite.go
@@ -54,7 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.ExtraData = extraData
 
 			if isVerified {
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": resMatch,
 				}
 			}

--- a/pkg/detectors/coinbase/coinbase.go
+++ b/pkg/detectors/coinbase/coinbase.go
@@ -113,7 +113,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr, resPrivateKey)
 				if isVerified {
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"key_name": resKeyName,
 						"key":      resPrivateKey,
 					}

--- a/pkg/detectors/databrickstoken/databrickstoken.go
+++ b/pkg/detectors/databrickstoken/databrickstoken.go
@@ -67,7 +67,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.SetVerificationError(verificationErr)
 
 				if s1.Verified {
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"token":  token,
 						"domain": domain,
 					}

--- a/pkg/detectors/databrickstoken/databrickstoken_integration_test.go
+++ b/pkg/detectors/databrickstoken/databrickstoken_integration_test.go
@@ -138,7 +138,7 @@ func TestDatabricksToken_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("DatabricksToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/datadogapikey/datadogapikey.go
+++ b/pkg/detectors/datadogapikey/datadogapikey.go
@@ -74,7 +74,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				isVerified, verificationErr := verifyMatch(ctx, client, resApiMatch, baseURL)
 				if isVerified {
 					s1.Verified = isVerified
-					s1.AnalysisInfo = map[string]string{"api_key": resApiMatch, "endpoint": baseURL}
+					s1.SecretParts = map[string]string{"api_key": resApiMatch, "endpoint": baseURL}
 					// break the loop once we've successfully validated the token against a baseURL
 					break
 				}

--- a/pkg/detectors/datadogapikey/datadogapikey_integration_test.go
+++ b/pkg/detectors/datadogapikey/datadogapikey_integration_test.go
@@ -50,7 +50,7 @@ func TestDataDogApiKey_FromChunk(t *testing.T) {
 				{
 					DetectorType: detector_typepb.DetectorType_DatadogApikey,
 					Verified:     true,
-					AnalysisInfo: map[string]string{
+					SecretParts: map[string]string{
 						"api_key":  apiKey,
 						"endpoint": datdogEndpoint,
 					},

--- a/pkg/detectors/datadogtoken/datadogtoken.go
+++ b/pkg/detectors/datadogtoken/datadogtoken.go
@@ -142,7 +142,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						defer res.Body.Close()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
-							s1.AnalysisInfo = map[string]string{"api_key": resApiMatch, "app_key": resAppMatch, "endpoint": baseURL}
+							s1.SecretParts = map[string]string{"api_key": resApiMatch, "app_key": resAppMatch, "endpoint": baseURL}
 							var serviceResponse userServiceResponse
 							if err := json.NewDecoder(res.Body).Decode(&serviceResponse); err == nil {
 								// setup emails

--- a/pkg/detectors/datadogtoken/datadogtoken_integration_test.go
+++ b/pkg/detectors/datadogtoken/datadogtoken_integration_test.go
@@ -55,7 +55,7 @@ func TestDatadogToken_FromChunk(t *testing.T) {
 					ExtraData: map[string]string{
 						"Type": "Application+APIKey",
 					},
-					AnalysisInfo: map[string]string{
+					SecretParts: map[string]string{
 						"api_key":  apiKey,
 						"app_key":  appKey,
 						"endpoint": endpoint,

--- a/pkg/detectors/deepseek/deepseek_integration_test.go
+++ b/pkg/detectors/deepseek/deepseek_integration_test.go
@@ -126,7 +126,7 @@ func TestDeepseek_FromChunk(t *testing.T) {
 					}
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Deepseek.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -119,10 +119,11 @@ type Result struct {
 	// information about the verification status of the candidate secret, such as if the verification request timed out.
 	verificationError error
 
-	// AnalysisInfo should be set with information required for credential
-	// analysis to run. The keys of the map are analyzer specific and
-	// should match what is expected in the corresponding analyzer.
-	AnalysisInfo map[string]string
+	// SecretParts holds the individual components of a (potentially multi-part)
+	// credential, keyed by a component name. It is used by analyzers where
+	// the keys are analyzer specific and should match what the
+	// corresponding analyzer expects.
+	SecretParts map[string]string
 
 	// primarySecret is used when a detector has multiple secret patterns.
 	// This secret is designated to determine the line number.

--- a/pkg/detectors/digitaloceantoken/digitaloceantoken.go
+++ b/pkg/detectors/digitaloceantoken/digitaloceantoken.go
@@ -54,7 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr)
 			if s1.Verified {
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": token,
 				}
 			}

--- a/pkg/detectors/digitaloceantoken/digitaloceantoken_integration_test.go
+++ b/pkg/detectors/digitaloceantoken/digitaloceantoken_integration_test.go
@@ -119,7 +119,7 @@ func TestDigitalOceanToken_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("DigitalOceanToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/digitaloceanv2/digitaloceanv2.go
+++ b/pkg/detectors/digitaloceanv2/digitaloceanv2.go
@@ -64,7 +64,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.SetVerificationError(verificationErr)
 				s1.Verified = verified
 				if s1.Verified {
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"key": newAccessToken,
 					}
 				}
@@ -73,7 +73,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.Verified = verified
 				s1.SetVerificationError(verificationErr)
 				if s1.Verified {
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"key": token,
 					}
 				}

--- a/pkg/detectors/digitaloceanv2/digitaloceanv2_integration_test.go
+++ b/pkg/detectors/digitaloceanv2/digitaloceanv2_integration_test.go
@@ -116,7 +116,7 @@ func TestDigitalOceanV2_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("DigitalOceanV2.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/dockerhub/v1/dockerhub.go
+++ b/pkg/detectors/dockerhub/v1/dockerhub.go
@@ -82,7 +82,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.ExtraData = extraData
 				s1.SetVerificationError(verificationErr)
 				if s1.Verified {
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"username": username,
 						"pat":      token,
 					}

--- a/pkg/detectors/dockerhub/v2/dockerhub.go
+++ b/pkg/detectors/dockerhub/v2/dockerhub.go
@@ -82,7 +82,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.ExtraData = extraData
 				s1.SetVerificationError(verificationErr)
 				if s1.Verified {
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"username": username,
 						"pat":      token,
 					}

--- a/pkg/detectors/dockerhub/v2/dockerhub_integration_test.go
+++ b/pkg/detectors/dockerhub/v2/dockerhub_integration_test.go
@@ -54,7 +54,7 @@ func TestDockerhub_FromChunk(t *testing.T) {
 				{
 					DetectorType: detector_typepb.DetectorType_Dockerhub,
 					Verified:     true,
-					AnalysisInfo: map[string]string{
+					SecretParts: map[string]string{
 						"username": username,
 						"pat":      pat,
 					},
@@ -74,7 +74,7 @@ func TestDockerhub_FromChunk(t *testing.T) {
 				{
 					DetectorType: detector_typepb.DetectorType_Dockerhub,
 					Verified:     true,
-					AnalysisInfo: map[string]string{
+					SecretParts: map[string]string{
 						"username": strings.Split(email, "-")[0],
 						"pat":      pat,
 					},

--- a/pkg/detectors/dropbox/dropbox.go
+++ b/pkg/detectors/dropbox/dropbox.go
@@ -58,7 +58,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr)
 			if s1.Verified {
-				s1.AnalysisInfo = map[string]string{"token": key}
+				s1.SecretParts = map[string]string{"token": key}
 			}
 		}
 

--- a/pkg/detectors/elevenlabs/v1/elevenlabs.go
+++ b/pkg/detectors/elevenlabs/v1/elevenlabs.go
@@ -76,7 +76,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.SetVerificationError(verificationErr, match)
 
 			if s1.Verified {
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": match,
 				}
 			}

--- a/pkg/detectors/elevenlabs/v2/elevenlabs.go
+++ b/pkg/detectors/elevenlabs/v2/elevenlabs.go
@@ -73,7 +73,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.SetVerificationError(verificationErr, match)
 
 			if s1.Verified {
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": match,
 				}
 			}

--- a/pkg/detectors/elevenlabs/v2/elevenlabs_integration_test.go
+++ b/pkg/detectors/elevenlabs/v2/elevenlabs_integration_test.go
@@ -150,7 +150,7 @@ func TestElevenlabs_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Elevenlabs.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/fastlypersonaltoken/fastlypersonaltoken.go
+++ b/pkg/detectors/fastlypersonaltoken/fastlypersonaltoken.go
@@ -61,7 +61,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.SetVerificationError(verificationErr, match)
 
 			if s1.Verified {
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": match,
 				}
 			}

--- a/pkg/detectors/fastlypersonaltoken/fastlypersonaltoken_integration_test.go
+++ b/pkg/detectors/fastlypersonaltoken/fastlypersonaltoken_integration_test.go
@@ -102,7 +102,7 @@ func TestFastlyPersonalToken_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("FastlyPersonalToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/figmapersonalaccesstoken/v1/figmapersonalaccesstoken.go
+++ b/pkg/detectors/figmapersonalaccesstoken/v1/figmapersonalaccesstoken.go
@@ -76,7 +76,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.SetVerificationError(err, resMatch)
 			}
 			if s1.Verified {
-				s1.AnalysisInfo = map[string]string{"token": resMatch}
+				s1.SecretParts = map[string]string{"token": resMatch}
 			}
 		}
 

--- a/pkg/detectors/figmapersonalaccesstoken/v2/figmapersonalaccesstoken_v2.go
+++ b/pkg/detectors/figmapersonalaccesstoken/v2/figmapersonalaccesstoken_v2.go
@@ -80,7 +80,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.SetVerificationError(err, resMatch)
 			}
 			if s1.Verified {
-				s1.AnalysisInfo = map[string]string{"token": resMatch}
+				s1.SecretParts = map[string]string{"token": resMatch}
 			}
 		}
 

--- a/pkg/detectors/flyio/flyio_integration_test.go
+++ b/pkg/detectors/flyio/flyio_integration_test.go
@@ -138,7 +138,7 @@ func TestFlyio_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "SecretParts")
 			ignoreUnexported := cmpopts.IgnoreUnexported(detectors.Result{})
 			if diff := cmp.Diff(got, tt.want, ignoreOpts, ignoreUnexported); diff != "" {
 				t.Errorf("Flyio.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/gcp/gcp.go
+++ b/pkg/detectors/gcp/gcp.go
@@ -118,7 +118,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/gcp/",
 				"project":        creds.ProjectID,
 			},
-			AnalysisInfo: map[string]string{
+			SecretParts: map[string]string{
 				"key": string(credBytes),
 			},
 		}
@@ -149,7 +149,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if creds.Type != "" {
-			result.AnalysisInfo["type"] = creds.Type
+			result.SecretParts["type"] = creds.Type
 		}
 
 		if verify {

--- a/pkg/detectors/gcp/gcp_integration_test.go
+++ b/pkg/detectors/gcp/gcp_integration_test.go
@@ -133,7 +133,7 @@ func TestGCP_FromChunk(t *testing.T) {
 				}
 				got[i].Raw = nil
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "SecretParts")
 			ignoreUnexported := cmpopts.IgnoreUnexported(detectors.Result{})
 			if diff := cmp.Diff(got, tt.want, ignoreOpts, ignoreUnexported); diff != "" {
 				t.Errorf("GCP.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/github/v1/github_old.go
+++ b/pkg/detectors/github/v1/github_old.go
@@ -123,7 +123,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
 				"version":        fmt.Sprintf("%d", s.Version()),
 			},
-			AnalysisInfo: map[string]string{"key": token},
+			SecretParts: map[string]string{"key": token},
 		}
 
 		if verify {

--- a/pkg/detectors/github/v2/github.go
+++ b/pkg/detectors/github/v2/github.go
@@ -63,7 +63,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
 				"version":        fmt.Sprintf("%d", s.Version()),
 			},
-			AnalysisInfo: map[string]string{"key": token},
+			SecretParts: map[string]string{"key": token},
 		}
 
 		if verify {

--- a/pkg/detectors/github/v2/github_integration_test.go
+++ b/pkg/detectors/github/v2/github_integration_test.go
@@ -217,7 +217,7 @@ func TestGitHub_FromChunk(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("GitHub.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/gitlab/v1/gitlab.go
+++ b/pkg/detectors/gitlab/v1/gitlab.go
@@ -99,7 +99,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				// for verified keys set the analysis info
 				if s1.Verified {
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"key":  resMatch,
 						"host": endpoint,
 					}

--- a/pkg/detectors/gitlab/v1/gitlab_integration_test.go
+++ b/pkg/detectors/gitlab/v1/gitlab_integration_test.go
@@ -189,7 +189,7 @@ func TestGitlab_FromChunk(t *testing.T) {
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
@@ -287,7 +287,7 @@ func TestGitlab_FromChunk_WithV2Secrets(t *testing.T) {
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
@@ -381,7 +381,7 @@ func TestGitlab_FromChunk_WithV3Secrets(t *testing.T) {
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {

--- a/pkg/detectors/gitlab/v2/gitlab_integration_test.go
+++ b/pkg/detectors/gitlab/v2/gitlab_integration_test.go
@@ -101,7 +101,7 @@ func TestGitlabV2_FromChunk_WithV1Secrets(t *testing.T) {
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
@@ -195,7 +195,7 @@ func TestGitlabV2_FromChunk_WithV3Secrets(t *testing.T) {
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
@@ -374,7 +374,7 @@ func TestGitlabV2_FromChunk(t *testing.T) {
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {

--- a/pkg/detectors/gitlab/v2/gitlab_v2.go
+++ b/pkg/detectors/gitlab/v2/gitlab_v2.go
@@ -82,7 +82,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				// for verified keys set the analysis info
 				if s1.Verified {
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"key":  resMatch,
 						"host": endpoint,
 					}

--- a/pkg/detectors/gitlab/v3/gitlab_v3.go
+++ b/pkg/detectors/gitlab/v3/gitlab_v3.go
@@ -83,7 +83,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				// for verified keys set the analysis info
 				if s1.Verified {
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"key":  resMatch,
 						"host": endpoint,
 					}

--- a/pkg/detectors/gitlab/v3/gitlab_v3_integration_test.go
+++ b/pkg/detectors/gitlab/v3/gitlab_v3_integration_test.go
@@ -170,7 +170,7 @@ func TestGitlabV3_FromChunk(t *testing.T) {
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
@@ -280,7 +280,7 @@ func TestGitlabV3_FromChunk_WithV1Secrets(t *testing.T) {
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {
@@ -362,7 +362,7 @@ func TestGitlabV3_FromChunk_WithV2Secrets(t *testing.T) {
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v,", tt.wantVerificationErr, got[i].VerificationError())
 				}
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			opts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError")
 			if diff := cmp.Diff(got, tt.want, opts); diff != "" {

--- a/pkg/detectors/groq/groq.go
+++ b/pkg/detectors/groq/groq.go
@@ -59,7 +59,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.SetVerificationError(verificationErr, match)
 
 			if isVerified {
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": match,
 				}
 			}

--- a/pkg/detectors/harness/harness.go
+++ b/pkg/detectors/harness/harness.go
@@ -74,7 +74,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.SetVerificationError(verificationErr, match)
 
 			if isVerified {
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": match,
 				}
 			}

--- a/pkg/detectors/huggingface/huggingface.go
+++ b/pkg/detectors/huggingface/huggingface.go
@@ -52,7 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = isVerified
 			s1.ExtraData = extraData
 			s1.SetVerificationError(verificationErr, resMatch)
-			s1.AnalysisInfo = map[string]string{"key": resMatch}
+			s1.SecretParts = map[string]string{"key": resMatch}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/huggingface/huggingface_integration_test.go
+++ b/pkg/detectors/huggingface/huggingface_integration_test.go
@@ -190,7 +190,7 @@ func TestHuggingface_FromChunk(t *testing.T) {
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf(" wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {

--- a/pkg/detectors/jdbc/jdbc.go
+++ b/pkg/detectors/jdbc/jdbc.go
@@ -102,7 +102,7 @@ matchLoop:
 				err = pingRes.err
 				result.SetVerificationError(err, jdbcConn)
 			}
-			result.AnalysisInfo = map[string]string{
+			result.SecretParts = map[string]string{
 				"connection_string": jdbcConn,
 			}
 			// TODO: specialized redaction

--- a/pkg/detectors/jdbc/jdbc_integration_test.go
+++ b/pkg/detectors/jdbc/jdbc_integration_test.go
@@ -125,7 +125,7 @@ func TestJdbcVerified(t *testing.T) {
 					Verified:     true,
 					Redacted: fmt.Sprintf("jdbc:postgresql://%s:%s/%s?sslmode=disable&password=%s&user=%s",
 						postgresHost, postgresPort.Port(), postgresDB, strings.Repeat("*", len(postgresPass)), postgresUser),
-					AnalysisInfo: map[string]string{
+					SecretParts: map[string]string{
 						"connection_string": fmt.Sprintf("jdbc:postgresql://%s:%s/%s?sslmode=disable&password=%s&user=%s",
 							postgresHost, postgresPort.Port(), postgresDB, postgresPass, postgresUser),
 					},
@@ -147,7 +147,7 @@ func TestJdbcVerified(t *testing.T) {
 					Verified:     true,
 					Redacted: fmt.Sprintf(`jdbc:mysql://%s:%s@tcp(%s:%s)/%s`,
 						mysqlUser, strings.Repeat("*", len(mysqlPass)), mysqlHost, mysqlPort.Port(), mysqlDatabase),
-					AnalysisInfo: map[string]string{
+					SecretParts: map[string]string{
 						"connection_string": fmt.Sprintf(`jdbc:mysql://%s:%s@tcp(%s:%s)/%s`,
 							mysqlUser, mysqlPass, mysqlHost, mysqlPort.Port(), mysqlDatabase),
 					},
@@ -169,7 +169,7 @@ func TestJdbcVerified(t *testing.T) {
 					Verified:     true,
 					Redacted: fmt.Sprintf("jdbc:sqlserver://odbc:server=%s;port=%s;database=%s;password=%s",
 						sqlServerHost, sqlServerPort.Port(), sqlServerDatabase, strings.Repeat("*", len(sqlServerPass))),
-					AnalysisInfo: map[string]string{
+					SecretParts: map[string]string{
 						"connection_string": fmt.Sprintf("jdbc:sqlserver://odbc:server=%s;port=%s;database=%s;password=%s",
 							sqlServerHost, sqlServerPort.Port(), sqlServerDatabase, sqlServerPass),
 					},
@@ -322,7 +322,7 @@ func TestJdbc_FromChunk(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Jdbc.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/jiratoken/v1/jiratoken.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken.go
@@ -119,7 +119,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						s1.SetVerificationError(verificationErr, token)
 					}
 					if isVerified {
-						s1.AnalysisInfo = map[string]string{
+						s1.SecretParts = map[string]string{
 							"token":  token,
 							"domain": domain,
 							"email":  email,

--- a/pkg/detectors/jiratoken/v2/jiratoken_v2.go
+++ b/pkg/detectors/jiratoken/v2/jiratoken_v2.go
@@ -91,7 +91,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					s1.Verified = isVerified
 					s1.SetVerificationError(verificationErr, token)
 					if isVerified {
-						s1.AnalysisInfo = map[string]string{
+						s1.SecretParts = map[string]string{
 							"token":  token,
 							"domain": domain,
 							"email":  email,

--- a/pkg/detectors/launchdarkly/launchdarkly.go
+++ b/pkg/detectors/launchdarkly/launchdarkly.go
@@ -82,7 +82,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			// only api keys can be analyzed
 			if strings.HasPrefix(resMatch, "api-") {
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": resMatch,
 				}
 			}

--- a/pkg/detectors/launchdarkly/launchdarkly_integration_test.go
+++ b/pkg/detectors/launchdarkly/launchdarkly_integration_test.go
@@ -129,7 +129,7 @@ func TestLaunchDarkly_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 
 				// Do we expect to be comparing the ExtraData?
 				got[i].ExtraData = nil

--- a/pkg/detectors/mailchimp/mailchimp.go
+++ b/pkg/detectors/mailchimp/mailchimp.go
@@ -64,7 +64,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					result.Verified = true
 				}
 			}
-			result.AnalysisInfo = map[string]string{
+			result.SecretParts = map[string]string{
 				"key": match,
 			}
 		}

--- a/pkg/detectors/mailchimp/mailchimp_integration_test.go
+++ b/pkg/detectors/mailchimp/mailchimp_integration_test.go
@@ -93,7 +93,7 @@ func TestMailchimp_FromChunk(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 				got[i].ExtraData = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {

--- a/pkg/detectors/mailgun/mailgun.go
+++ b/pkg/detectors/mailgun/mailgun.go
@@ -61,7 +61,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: s.Type(),
 			Raw:          []byte(match),
-			AnalysisInfo: map[string]string{"key": match},
+			SecretParts: map[string]string{"key": match},
 		}
 
 		if verify {

--- a/pkg/detectors/mailgun/mailgun_integration_test.go
+++ b/pkg/detectors/mailgun/mailgun_integration_test.go
@@ -129,7 +129,7 @@ func TestMailgun_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 				got[i].ExtraData = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {

--- a/pkg/detectors/monday/monday.go
+++ b/pkg/detectors/monday/monday.go
@@ -52,7 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.SetVerificationError(verificationErr)
 
 			if s1.Verified {
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": resMatch,
 				}
 			}

--- a/pkg/detectors/monday/monday_integration_test.go
+++ b/pkg/detectors/monday/monday_integration_test.go
@@ -95,7 +95,7 @@ func TestMonday_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Monday.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/mongodb/mongodb.go
+++ b/pkg/detectors/mongodb/mongodb.go
@@ -104,7 +104,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			r.SetVerificationError(vErr, password)
 
 			if isVerified {
-				r.AnalysisInfo = map[string]string{
+				r.SecretParts = map[string]string{
 					"key": connStr,
 				}
 			}

--- a/pkg/detectors/mux/mux.go
+++ b/pkg/detectors/mux/mux.go
@@ -67,7 +67,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					}
 				}
 				if s1.Verified {
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"key":    resMatch,
 						"secret": resSecretMatch,
 					}

--- a/pkg/detectors/netlify/v1/netlify_v1.go
+++ b/pkg/detectors/netlify/v1/netlify_v1.go
@@ -64,7 +64,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.SetVerificationError(verificationErr, match)
 
 			if s1.Verified {
-				s1.AnalysisInfo = map[string]string{"key": match}
+				s1.SecretParts = map[string]string{"key": match}
 			}
 		}
 

--- a/pkg/detectors/netlify/v1/netlify_v1_integration_test.go
+++ b/pkg/detectors/netlify/v1/netlify_v1_integration_test.go
@@ -103,7 +103,7 @@ func TestNetlify_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Netlify.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/netlify/v2/netlify_v2.go
+++ b/pkg/detectors/netlify/v2/netlify_v2.go
@@ -64,7 +64,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.SetVerificationError(verificationErr, match)
 
 			if s1.Verified {
-				s1.AnalysisInfo = map[string]string{"key": match}
+				s1.SecretParts = map[string]string{"key": match}
 			}
 		}
 

--- a/pkg/detectors/netlify/v2/netlify_v2_integration_test.go
+++ b/pkg/detectors/netlify/v2/netlify_v2_integration_test.go
@@ -103,7 +103,7 @@ func TestNetlify_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Netlify.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/ngrok/ngrok.go
+++ b/pkg/detectors/ngrok/ngrok.go
@@ -67,7 +67,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			r.Verified = isVerified
 			r.SetVerificationError(vErr, token)
 			if isVerified {
-				r.AnalysisInfo = map[string]string{"key": token}
+				r.SecretParts = map[string]string{"key": token}
 			}
 		}
 

--- a/pkg/detectors/notion/notion.go
+++ b/pkg/detectors/notion/notion.go
@@ -60,7 +60,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					// Notion returns 401 for all non-valid keys, thus 403 indicates it has fine-tuned permissions,
 					// /v1/search, /v1/databases/*, etc. may work.
 					s1.Verified = true
-					s1.AnalysisInfo = map[string]string{"key": resMatch}
+					s1.SecretParts = map[string]string{"key": resMatch}
 
 				}
 			} else {

--- a/pkg/detectors/npmtoken/npmtoken.go
+++ b/pkg/detectors/npmtoken/npmtoken.go
@@ -60,7 +60,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"key": resMatch,
 					}
 				}

--- a/pkg/detectors/npmtokenv2/npmtokenv2.go
+++ b/pkg/detectors/npmtokenv2/npmtokenv2.go
@@ -61,7 +61,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"key": resMatch,
 					}
 				}

--- a/pkg/detectors/openai/openai.go
+++ b/pkg/detectors/openai/openai.go
@@ -66,7 +66,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = verified
 			s1.ExtraData = extraData
 			s1.SetVerificationError(verificationErr)
-			s1.AnalysisInfo = map[string]string{"key": token}
+			s1.SecretParts = map[string]string{"key": token}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/openai/openai_integration_test.go
+++ b/pkg/detectors/openai/openai_integration_test.go
@@ -100,7 +100,7 @@ func TestOpenAI_FromChunk(t *testing.T) {
 				}
 				got[i].Raw = nil
 				got[i].ExtraData = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("OpenAI.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/openaiadmin/openaiadmin.go
+++ b/pkg/detectors/openaiadmin/openaiadmin.go
@@ -59,7 +59,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, verificationErr := verifyMatch(ctx, client, token)
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr, token)
-			s1.AnalysisInfo = map[string]string{
+			s1.SecretParts = map[string]string{
 				"key": token,
 			}
 		}

--- a/pkg/detectors/openaiadmin/openaiadmin_integration_test.go
+++ b/pkg/detectors/openaiadmin/openaiadmin_integration_test.go
@@ -136,7 +136,7 @@ func TestOpenAIAdmin_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "AnalysisInfo", "Redacted")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "SecretParts", "Redacted")
 			ignoreUnexported := cmpopts.IgnoreUnexported(detectors.Result{})
 			if diff := cmp.Diff(got, tt.want, ignoreOpts, ignoreUnexported); diff != "" {
 				t.Errorf("OpenAIAdmin.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/opsgenie/opsgenie.go
+++ b/pkg/detectors/opsgenie/opsgenie.go
@@ -76,7 +76,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if isVerified {
 				r.Verified = isVerified
 				r.ExtraData = extraData
-				r.AnalysisInfo = map[string]string{
+				r.SecretParts = map[string]string{
 					"key": key,
 				}
 			}

--- a/pkg/detectors/opsgenie/opsgenie_integration_test.go
+++ b/pkg/detectors/opsgenie/opsgenie_integration_test.go
@@ -99,7 +99,7 @@ func TestOpsgenie_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Opsgenie.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/plaidkey/plaidkey.go
+++ b/pkg/detectors/plaidkey/plaidkey.go
@@ -88,7 +88,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					s1.ExtraData = map[string]string{"environment": fmt.Sprintf("https://%s.plaid.com", environment)}
 					s1.SetVerificationError(verificationErr, id, secret)
 					if s1.Verified {
-						s1.AnalysisInfo = map[string]string{
+						s1.SecretParts = map[string]string{
 							"secret": secret,
 							"id":     id,
 							"token":  token,

--- a/pkg/detectors/plaidkey/plaidkey_integration_test.go
+++ b/pkg/detectors/plaidkey/plaidkey_integration_test.go
@@ -55,7 +55,7 @@ func TestPlaidKey_FromChunk(t *testing.T) {
 					DetectorType: detector_typepb.DetectorType_PlaidKey,
 					Verified:     true,
 					RawV2:        []byte(fmt.Sprintf("%s:%s:%s", secret, id, token)),
-					AnalysisInfo: map[string]string{
+					SecretParts: map[string]string{
 						"secret": secret,
 						"id":     id,
 						"token":  token,
@@ -115,7 +115,7 @@ func TestPlaidKey_FromChunk(t *testing.T) {
 					t.Fatalf("no raw v2 secret present: \n %+v", got[i])
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "AnalysisInfo", "ExtraData")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "SecretParts", "ExtraData")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("PlaidKey.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/planetscale/planetscale.go
+++ b/pkg/detectors/planetscale/planetscale.go
@@ -67,7 +67,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					defer res.Body.Close()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
-						s1.AnalysisInfo = map[string]string{
+						s1.SecretParts = map[string]string{
 							"id":    username,
 							"token": password,
 						}

--- a/pkg/detectors/planetscale/planetscale_integration_test.go
+++ b/pkg/detectors/planetscale/planetscale_integration_test.go
@@ -139,7 +139,7 @@ func TestPlanetscale_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "AnalysisInfo", "ExtraData")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "SecretParts", "ExtraData")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Planetscale.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/postgres/postgres.go
+++ b/pkg/detectors/postgres/postgres.go
@@ -164,7 +164,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 			isVerified, verificationErr := verifyPostgres(params)
 			result.Verified = isVerified
 			result.SetVerificationError(verificationErr, password)
-			result.AnalysisInfo = map[string]string{
+			result.SecretParts = map[string]string{
 				"connection_string": string(raw),
 			}
 		}

--- a/pkg/detectors/postgres/postgres_integration_test.go
+++ b/pkg/detectors/postgres/postgres_integration_test.go
@@ -335,7 +335,7 @@ func TestPostgres_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.want[i].VerificationError(), got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "verificationError", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "verificationError", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Postgres.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/posthog/posthog.go
+++ b/pkg/detectors/posthog/posthog.go
@@ -59,7 +59,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
-					s1.AnalysisInfo = map[string]string{
+					s1.SecretParts = map[string]string{
 						"key": resMatch,
 					}
 				} else if res.StatusCode == 401 {
@@ -69,7 +69,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						defer res.Body.Close()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
-							s1.AnalysisInfo = map[string]string{
+							s1.SecretParts = map[string]string{
 								"key": resMatch,
 							}
 						}

--- a/pkg/detectors/postman/postman.go
+++ b/pkg/detectors/postman/postman.go
@@ -54,7 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, verificationErr := verifyPostman(ctx, client, resMatch)
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr, resMatch)
-			s1.AnalysisInfo = map[string]string{
+			s1.SecretParts = map[string]string{
 				"key": resMatch,
 			}
 		}

--- a/pkg/detectors/postman/postman_integration_test.go
+++ b/pkg/detectors/postman/postman_integration_test.go
@@ -133,7 +133,7 @@ func TestPostman_FromChunk(t *testing.T) {
 					t.Errorf("Postman.FromData() error = %v, wantErr %v", got[i].VerificationError(), tt.wantVerificationErr)
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Postman.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/postmark/postmark.go
+++ b/pkg/detectors/postmark/postmark.go
@@ -53,7 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.SetVerificationError(err)
 
 			if valid {
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": resMatch,
 				}
 			}

--- a/pkg/detectors/privatekey/privatekey.go
+++ b/pkg/detectors/privatekey/privatekey.go
@@ -154,7 +154,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 
 				// enabled th
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"token": token,
 				}
 			} else {

--- a/pkg/detectors/privatekey/privatekey_integration_test.go
+++ b/pkg/detectors/privatekey/privatekey_integration_test.go
@@ -154,7 +154,7 @@ func TestPrivatekey_FromChunk(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("PrivatekeyCI.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/salesforceoauth2/salesforceoauth2.go
+++ b/pkg/detectors/salesforceoauth2/salesforceoauth2.go
@@ -107,7 +107,7 @@ domainLoop:
 					}
 
 					if isVerified {
-						s1.AnalysisInfo = map[string]string{
+						s1.SecretParts = map[string]string{
 							"domain":        domain,
 							"client_id":     key,
 							"client_secret": secret,

--- a/pkg/detectors/sendgrid/sendgrid.go
+++ b/pkg/detectors/sendgrid/sendgrid.go
@@ -60,7 +60,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = verified
 			s1.ExtraData = extraData
 			s1.SetVerificationError(verificationErr)
-			s1.AnalysisInfo = map[string]string{"key": token}
+			s1.SecretParts = map[string]string{"key": token}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/sendgrid/sendgrid_integration_test.go
+++ b/pkg/detectors/sendgrid/sendgrid_integration_test.go
@@ -127,7 +127,7 @@ func TestSendgrid_FromChunk(t *testing.T) {
 				t.Errorf("Sendgrid.FromData() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "AnalysisInfo", "ExtraData")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "SecretParts", "ExtraData")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Sendgrid.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/shopify/shopify.go
+++ b/pkg/detectors/shopify/shopify.go
@@ -77,7 +77,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 							s1.ExtraData = map[string]string{
 								"access_scopes": strings.Join(handleArray, ","),
 							}
-							s1.AnalysisInfo = map[string]string{
+							s1.SecretParts = map[string]string{
 								"key":       key,
 								"store_url": domainRes,
 							}

--- a/pkg/detectors/shopify/shopify_integration_test.go
+++ b/pkg/detectors/shopify/shopify_integration_test.go
@@ -102,7 +102,7 @@ func TestShopify_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Shopify.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/shopifyoauth/shopifyoauth_integration_test.go
+++ b/pkg/detectors/shopifyoauth/shopifyoauth_integration_test.go
@@ -154,7 +154,7 @@ func TestShopifyOAuth_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "AnalysisInfo", "primarySecret")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "SecretParts", "primarySecret")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("ShopifyOAuth.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/slack/slack.go
+++ b/pkg/detectors/slack/slack.go
@@ -113,7 +113,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				} else {
 					s1.SetVerificationError(err, token)
 				}
-				s1.AnalysisInfo = map[string]string{
+				s1.SecretParts = map[string]string{
 					"key": token,
 				}
 			}

--- a/pkg/detectors/slack/slack_integration_test.go
+++ b/pkg/detectors/slack/slack_integration_test.go
@@ -179,7 +179,7 @@ func TestSlack_FromChunk(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())

--- a/pkg/detectors/sourcegraph/sourcegraph.go
+++ b/pkg/detectors/sourcegraph/sourcegraph.go
@@ -78,7 +78,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			} else {
 				s1.SetVerificationError(err, resMatch)
 			}
-			s1.AnalysisInfo = map[string]string{"key": resMatch}
+			s1.SecretParts = map[string]string{"key": resMatch}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/sourcegraph/sourcegraph_integration_test.go
+++ b/pkg/detectors/sourcegraph/sourcegraph_integration_test.go
@@ -226,7 +226,7 @@ func TestSourcegraph_FromChunk(t *testing.T) {
 				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "VerificationError", "ExtraData")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {

--- a/pkg/detectors/square/square.go
+++ b/pkg/detectors/square/square.go
@@ -77,7 +77,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					result.Verified = true
 				}
 			}
-			result.AnalysisInfo = map[string]string{"key": resMatch}
+			result.SecretParts = map[string]string{"key": resMatch}
 		}
 
 		results = append(results, result)

--- a/pkg/detectors/square/square_integration_test.go
+++ b/pkg/detectors/square/square_integration_test.go
@@ -95,7 +95,7 @@ func TestSquare_FromChunk(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Square.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/stripe/stripe.go
+++ b/pkg/detectors/stripe/stripe.go
@@ -66,7 +66,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					result.Verified = true
 				}
 			}
-			result.AnalysisInfo = map[string]string{"key": match}
+			result.SecretParts = map[string]string{"key": match}
 		}
 
 		results = append(results, result)

--- a/pkg/detectors/stripe/stripe_integration_test.go
+++ b/pkg/detectors/stripe/stripe_integration_test.go
@@ -100,7 +100,7 @@ func TestStripe_FromChunk(t *testing.T) {
 					t.Fatal("no raw secret present")
 				}
 				got[i].Raw = nil
-				got[i].AnalysisInfo = nil
+				got[i].SecretParts = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("Stripe.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/tableau/tableau.go
+++ b/pkg/detectors/tableau/tableau.go
@@ -98,7 +98,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					maps.Copy(result.ExtraData, extraData)
 					result.SetVerificationError(verificationErr, tokenName, tokenSecret, endpoint)
 					if isVerified {
-						result.AnalysisInfo = map[string]string{"token_name": tokenName, "pat_secret": tokenSecret, "endpoint": endpoint}
+						result.SecretParts = map[string]string{"token_name": tokenName, "pat_secret": tokenSecret, "endpoint": endpoint}
 					}
 				}
 				results = append(results, result)

--- a/pkg/detectors/tableau/tableau_integration_test.go
+++ b/pkg/detectors/tableau/tableau_integration_test.go
@@ -69,7 +69,7 @@ func TestTableau_FromChunk(t *testing.T) {
 						"verification_status":   "valid",
 						"auth_token_received":   "true",
 					},
-					AnalysisInfo: map[string]string{
+					SecretParts: map[string]string{
 						"endpoint":   tableauURL,
 						"pat_secret": tokenSecret,
 						"token_name": tokenName,
@@ -299,7 +299,7 @@ func TestTableau_FromChunk_MultipleMixedVerificationResults(t *testing.T) {
 		}
 	}
 	ignoreOpts := []cmp.Option{
-		cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "ExtraData", "AnalysisInfo"),
+		cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "ExtraData", "SecretParts"),
 		cmpopts.IgnoreUnexported(detectors.Result{}),
 	}
 

--- a/pkg/detectors/twilio/twilio.go
+++ b/pkg/detectors/twilio/twilio.go
@@ -82,7 +82,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 
 				if s1.Verified {
-					s1.AnalysisInfo = map[string]string{"key": key, "sid": sid}
+					s1.SecretParts = map[string]string{"key": key, "sid": sid}
 				}
 			}
 

--- a/pkg/detectors/twilio/twilio_integration_test.go
+++ b/pkg/detectors/twilio/twilio_integration_test.go
@@ -156,7 +156,7 @@ func TestTwilio_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Twilio.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/twilioapikey/twilioapikey.go
+++ b/pkg/detectors/twilioapikey/twilioapikey.go
@@ -77,7 +77,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 
 				if s1.Verified {
-					s1.AnalysisInfo = map[string]string{"key": apiKey, "sid": secret}
+					s1.SecretParts = map[string]string{"key": apiKey, "sid": secret}
 				}
 			}
 

--- a/pkg/detectors/twilioapikey/twilioapikey_integration_test.go
+++ b/pkg/detectors/twilioapikey/twilioapikey_integration_test.go
@@ -110,7 +110,7 @@ func TestTwilioAPIKey_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "AnalysisInfo")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Twilio.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/output/plain.go
+++ b/pkg/output/plain.go
@@ -102,7 +102,7 @@ func (p *PlainPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata)
 	}
 
 	// if analysis info is not nil, means the detector added key for analyzer and result is verified
-	if r.Result.AnalysisInfo != nil && r.Result.Verified {
+	if r.Result.SecretParts != nil && r.Result.Verified {
 		printer.Printf("Analyze: Run `trufflehog analyze` to analyze this key's permissions\n")
 	}
 


### PR DESCRIPTION

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Mechanical rename of the detectors.Result.AnalysisInfo field to SecretParts to prepare for its replacement for Raw.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad mechanical rename of a core struct field used across many detectors and tests; risk is mainly compile/runtime breakage for downstream code expecting `AnalysisInfo` and any analyzers/output paths not fully updated.
> 
> **Overview**
> Renames the `detectors.Result` field used to pass analyzer inputs from `AnalysisInfo` to `SecretParts`, updating the struct comment to reflect multi-part credential components.
> 
> Updates a large set of detectors to populate `SecretParts` (instead of `AnalysisInfo`) on verified results, and adjusts integration/unit tests to ignore/clear `SecretParts` accordingly.
> 
> Tweaks plain-text output (`pkg/output/plain.go`) to show the analysis hint based on `SecretParts` being present for verified results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 718568152090ae112361d4efb5f6378869ae4c52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->