### PR TITLE
fix(iobuf): reset per-phase count in BufferedReadSeeker.Read

### DIFF
--- a/pkg/iobuf/bufferedreaderseeker.go
+++ b/pkg/iobuf/bufferedreaderseeker.go
@@ -143,12 +143,13 @@ func (br *BufferedReadSeeker) Read(out []byte) (int, error) {
 
 	// If the current read position is within the in-memory buffer.
 	if br.index < int64(br.buf.Len()) {
-		totalBytesRead = copy(out, br.buf.Bytes()[br.index:])
-		br.index += int64(totalBytesRead)
-		if totalBytesRead == len(out) {
+		n := copy(out, br.buf.Bytes()[br.index:])
+		totalBytesRead += n
+		br.index += int64(n)
+		if n == len(out) {
 			return totalBytesRead, nil
 		}
-		out = out[totalBytesRead:]
+		out = out[n:]
 	}
 
 	// If we've exceeded the in-memory threshold and have a temp file.
@@ -162,10 +163,10 @@ func (br *BufferedReadSeeker) Read(out []byte) (int, error) {
 		if err != nil && !errors.Is(err, io.EOF) {
 			return totalBytesRead, err
 		}
-		if totalBytesRead == len(out) {
+		if m == len(out) {
 			return totalBytesRead, nil
 		}
-		out = out[totalBytesRead:]
+		out = out[m:]
 	}
 
 	if len(out) == 0 {

--- a/pkg/iobuf/bufferedreaderseeker_test.go
+++ b/pkg/iobuf/bufferedreaderseeker_test.go
@@ -154,55 +154,116 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 }
 
 // TestBufferedReaderSeekerRead_SpansBufferAndTempFile is a regression test
-// for issue #4569: when a single Read() satisfies its request from both the
-// in-memory buffer and the on-disk temp file, the slice arithmetic must use
+// for issue #4569: when a single Read() runs both the in-memory buffer
+// branch and the on-disk temp file branch, the slice arithmetic must use
 // the per-branch read count (not the cumulative total) when re-slicing
 // `out`. Previously this panicked with `slice bounds out of range [N:M]`
 // where N was the cumulative count and M the remaining length.
+//
+// The bug requires a state where buf.Len() > 0 AND diskBufferSize > 0 AND
+// the read position falls inside both ranges. Reaching that state needs
+// a flush followed by additional buffered writes that do not flush again,
+// then a Seek back so the next Read enters branch 1 with a small `out`.
 func TestBufferedReaderSeekerRead_SpansBufferAndTempFile(t *testing.T) {
 	t.Parallel()
 
-	const (
-		// Small threshold so the first writeData() flushes to disk and
-		// subsequent writes accumulate in the buffer again — gives us a
-		// state where both `buf` and `tempFile` contain data.
-		threshold = 32
-		// Reader payload is large enough that the read spans buffer + disk.
-		payloadSize = 256
-	)
-
-	payload := make([]byte, payloadSize)
-	for i := range payload {
-		payload[i] = byte(i % 251)
+	type primingStep struct {
+		// size is the number of bytes to Read from brs in this step.
+		size int
 	}
 
-	// Wrap the bytes in a non-seekable reader so the buffered/disk path runs.
-	brs := NewBufferedReaderSeeker(io.MultiReader(bytes.NewReader(payload)))
-	defer brs.Close()
-	brs.threshold = threshold
-
-	// Force an initial fill so part of the payload lives on disk.
-	primer := make([]byte, threshold*2)
-	if _, err := io.ReadFull(brs, primer); err != nil {
-		t.Fatalf("primer read: %v", err)
+	tests := []struct {
+		name string
+		// threshold controls when writeData() flushes buf to tempFile.
+		threshold int64
+		// payloadSize must be larger than every read so reader.Read never
+		// hits EOF (sizeKnown stays false, keeping the buffered/disk path
+		// active instead of the sizeKnown fast path).
+		payloadSize int
+		// priming reads run before the seek-back; each one drives writeData()
+		// and shapes the buf / tempFile state.
+		priming []primingStep
+		// seekTo is the virtual position to seek to before the final Read.
+		seekTo int64
+		// finalReadSize is the size of the read that must span both branches.
+		// Picked so that the cumulative-count bug would slice past the
+		// already-shortened tail of `out`.
+		finalReadSize int
+	}{
+		{
+			// Original #4569 shape: one flush, then a small follow-up read
+			// leaves a few bytes in buf. Seek to 0 and request 20 bytes;
+			// branch 1 returns 8, branch 2 returns the remaining 12, and
+			// the pre-fix code re-slices with totalBytesRead=20 against a
+			// 12-byte tail, panicking with "slice bounds out of range".
+			name:          "small-read across boundary",
+			threshold:     32,
+			payloadSize:   1 << 12,
+			priming:       []primingStep{{size: 32}, {size: 8}},
+			seekTo:        0,
+			finalReadSize: 20,
+		},
+		{
+			// Adjacent edge case: branch 2 fully fills the post-branch-1
+			// tail of `out`. Pre-fix this also panicked because the
+			// `if totalBytesRead == len(out)` guard compared the cumulative
+			// count to the shortened slice length.
+			name:          "branch 2 exactly fills tail",
+			threshold:     32,
+			payloadSize:   1 << 12,
+			priming:       []primingStep{{size: 32}, {size: 16}},
+			seekTo:        0,
+			finalReadSize: 32, // 16 from buf + 16 from tempFile
+		},
+		{
+			// Branch 1 alone satisfies the read; branch 2 must not run.
+			// Verifies the early-return short-circuit still works after
+			// the per-branch counter rewrite.
+			name:          "branch 1 satisfies read",
+			threshold:     32,
+			payloadSize:   1 << 12,
+			priming:       []primingStep{{size: 32}, {size: 16}},
+			seekTo:        0,
+			finalReadSize: 8,
+		},
 	}
 
-	// Seek back to the start and read a window that crosses the
-	// buf/tempFile boundary in a single Read() call.
-	if _, err := brs.Seek(0, io.SeekStart); err != nil {
-		t.Fatalf("seek: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	out := make([]byte, threshold*2+16)
-	n, err := brs.Read(out)
-	if err != nil && !errors.Is(err, io.EOF) {
-		t.Fatalf("read: unexpected error: %v", err)
-	}
-	if n == 0 {
-		t.Fatalf("read returned 0 bytes; expected partial fill")
-	}
-	if !bytes.Equal(out[:n], payload[:n]) {
-		t.Fatalf("read returned wrong bytes; first 16 = %x want %x", out[:16], payload[:16])
+			payload := make([]byte, tt.payloadSize)
+			for i := range payload {
+				payload[i] = byte(i % 251)
+			}
+
+			// Wrap so the reader is not detected as seekable; this forces
+			// the buffered/disk path through Read() instead of delegating
+			// to the underlying Seeker.
+			brs := NewBufferedReaderSeeker(io.MultiReader(bytes.NewReader(payload)))
+			defer brs.Close()
+			brs.threshold = tt.threshold
+
+			for i, step := range tt.priming {
+				buf := make([]byte, step.size)
+				if _, err := io.ReadFull(brs, buf); err != nil {
+					t.Fatalf("priming step %d: %v", i, err)
+				}
+			}
+
+			if _, err := brs.Seek(tt.seekTo, io.SeekStart); err != nil {
+				t.Fatalf("seek: %v", err)
+			}
+
+			out := make([]byte, tt.finalReadSize)
+			n, err := brs.Read(out)
+			if err != nil && !errors.Is(err, io.EOF) {
+				t.Fatalf("read: unexpected error: %v", err)
+			}
+			if n != tt.finalReadSize {
+				t.Fatalf("read: got n=%d, want %d", n, tt.finalReadSize)
+			}
+		})
 	}
 }
 

--- a/pkg/iobuf/bufferedreaderseeker_test.go
+++ b/pkg/iobuf/bufferedreaderseeker_test.go
@@ -153,6 +153,59 @@ func TestBufferedReaderSeekerRead(t *testing.T) {
 	}
 }
 
+// TestBufferedReaderSeekerRead_SpansBufferAndTempFile is a regression test
+// for issue #4569: when a single Read() satisfies its request from both the
+// in-memory buffer and the on-disk temp file, the slice arithmetic must use
+// the per-branch read count (not the cumulative total) when re-slicing
+// `out`. Previously this panicked with `slice bounds out of range [N:M]`
+// where N was the cumulative count and M the remaining length.
+func TestBufferedReaderSeekerRead_SpansBufferAndTempFile(t *testing.T) {
+	t.Parallel()
+
+	const (
+		// Small threshold so the first writeData() flushes to disk and
+		// subsequent writes accumulate in the buffer again — gives us a
+		// state where both `buf` and `tempFile` contain data.
+		threshold = 32
+		// Reader payload is large enough that the read spans buffer + disk.
+		payloadSize = 256
+	)
+
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+
+	// Wrap the bytes in a non-seekable reader so the buffered/disk path runs.
+	brs := NewBufferedReaderSeeker(io.MultiReader(bytes.NewReader(payload)))
+	defer brs.Close()
+	brs.threshold = threshold
+
+	// Force an initial fill so part of the payload lives on disk.
+	primer := make([]byte, threshold*2)
+	if _, err := io.ReadFull(brs, primer); err != nil {
+		t.Fatalf("primer read: %v", err)
+	}
+
+	// Seek back to the start and read a window that crosses the
+	// buf/tempFile boundary in a single Read() call.
+	if _, err := brs.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+
+	out := make([]byte, threshold*2+16)
+	n, err := brs.Read(out)
+	if err != nil && !errors.Is(err, io.EOF) {
+		t.Fatalf("read: unexpected error: %v", err)
+	}
+	if n == 0 {
+		t.Fatalf("read returned 0 bytes; expected partial fill")
+	}
+	if !bytes.Equal(out[:n], payload[:n]) {
+		t.Fatalf("read returned wrong bytes; first 16 = %x want %x", out[:16], payload[:16])
+	}
+}
+
 func TestBufferedReaderSeekerSeek(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
Fixes trufflesecurity/trufflehog#4569.

## Problem

`BufferedReadSeeker.Read` panics with `slice bounds out of range` when scanning APK/DEX archives via `apkHandler.HandleFile`:

```
error: runtime error: slice bounds out of range [65536:28672]
iobuf.(*BufferedReadSeeker).Read bufferedreaderseeker.go:170
```

After each phase (in-memory buffer → temp file → live reader) the code reslices `out` to continue filling the tail. But the guard that decided whether the phase fully satisfied the caller compared the cumulative `totalBytesRead` to `len(out)`, where `out` had already been shortened by the previous phase. When the temp-file phase returned exactly the remaining needed bytes, `totalBytesRead > len(out)` and `out = out[totalBytesRead:]` panicked.

## Fix

Track the per-phase count in local `n` / `m` and use those for the 'phase filled the slice' short-circuit and the slice advance. `totalBytesRead` stays a pure cumulative counter for the return value.

The fast path for `sizeKnown && tempFile != nil` is unchanged.

## Test

`go test ./pkg/iobuf/...` passes locally. I'll happily add a targeted regression test if maintainers prefer, reproducing the panic requires driving the reader past `diskBufferSize` with a specific final-phase read size, which is a few lines more but worth it if desired.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized fix to `BufferedReadSeeker.Read` slice advancement logic plus a focused regression test; behavior change is limited to a previously panicking edge case when reads span in-memory and on-disk buffers.
> 
> **Overview**
> Fixes a panic in `BufferedReadSeeker.Read` when a single read spans both the in-memory buffer and the temp-file buffer by using **per-branch byte counts** (instead of the cumulative total) for the phase-complete checks and `out` re-slicing.
> 
> Adds a targeted regression test (`TestBufferedReaderSeekerRead_SpansBufferAndTempFile`) that reproduces the cross-buffer read scenario (including edge cases where the temp-file phase exactly fills the remaining slice) to ensure the panic does not recur.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a800407f1261d5947b3abba83765f6a9bfd901. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->