### PR TITLE
Add GitLab OAuth application secret detector

### DIFF
--- a/pkg/detectors/gitlaboauthapplication/gitlaboauthapplication.go
+++ b/pkg/detectors/gitlaboauthapplication/gitlaboauthapplication.go
@@ -1,0 +1,46 @@
+package gitlaboauthapplication
+
+import (
+	"context"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+type Scanner struct{}
+
+var _ detectors.Detector = (*Scanner)(nil)
+
+var keyPat = regexp.MustCompile(`\b(gloas-[a-f0-9]{64})\b`)
+
+func (s Scanner) Keywords() []string {
+	return []string{"gloas-"}
+}
+
+func (s Scanner) FromData(_ context.Context, _ bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	uniqueMatches := make(map[string]struct{})
+	for _, match := range keyPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueMatches[match[1]] = struct{}{}
+	}
+
+	for match := range uniqueMatches {
+		results = append(results, detectors.Result{
+			DetectorType: detector_typepb.DetectorType_GitlabOauthApplication,
+			Raw:          []byte(match),
+		})
+	}
+
+	return results, nil
+}
+
+func (s Scanner) Type() detector_typepb.DetectorType {
+	return detector_typepb.DetectorType_GitlabOauthApplication
+}
+
+func (s Scanner) Description() string {
+	return "GitLab OAuth application secrets (client secrets) authenticate GitLab OAuth applications and must be paired with the application ID for token exchange."
+}

--- a/pkg/detectors/gitlaboauthapplication/gitlaboauthapplication_test.go
+++ b/pkg/detectors/gitlaboauthapplication/gitlaboauthapplication_test.go
@@ -1,0 +1,77 @@
+package gitlaboauthapplication
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+)
+
+func TestGitlabOauthApplication_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name: "valid pattern",
+			input: `
+				[INFO] Sending request to the gloas API
+				[DEBUG] Using Key=gloas-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+				[INFO] Response received: 200 OK
+			`,
+			want: []string{"gloas-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"},
+		},
+		{
+			name: "invalid pattern",
+			input: `
+				[INFO] Sending request to the gloas API
+				[DEBUG] Using Key=gloas-!!invalid!!abcdefghij
+				[ERROR] Response received: 401 UnAuthorized
+			`,
+			want: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(matchedDetectors) == 0 {
+				t.Errorf("test %q failed: expected keywords %v to be found in the input", test.name, d.Keywords())
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			require.NoError(t, err)
+
+			if len(results) != len(test.want) {
+				t.Errorf("mismatch in result count: expected %d, got %d", len(test.want), len(results))
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.RawV2) > 0 {
+					actual[string(r.RawV2)] = struct{}{}
+				} else {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -333,6 +333,7 @@ import (
 	gitlabv1 "github.com/trufflesecurity/trufflehog/v3/pkg/detectors/gitlab/v1"
 	gitlabv2 "github.com/trufflesecurity/trufflehog/v3/pkg/detectors/gitlab/v2"
 	gitlabv3 "github.com/trufflesecurity/trufflehog/v3/pkg/detectors/gitlab/v3"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/gitlaboauthapplication"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/gitter"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/glassnode"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/gocanvas"
@@ -1210,6 +1211,7 @@ func buildDetectorList() []detectors.Detector {
 		&gitlabv1.Scanner{},
 		&gitlabv2.Scanner{},
 		&gitlabv3.Scanner{},
+		&gitlaboauthapplication.Scanner{},
 		&gitter.Scanner{},
 		&glassnode.Scanner{},
 		&gocanvas.Scanner{},

--- a/pkg/pb/detector_typepb/detector_type.pb.go
+++ b/pkg/pb/detector_typepb/detector_type.pb.go
@@ -1101,6 +1101,7 @@ const (
 	DetectorType_BitbucketDataCenter                     DetectorType = 1045
 	DetectorType_JiraDataCenterPAT                       DetectorType = 1046
 	DetectorType_ConfluenceDataCenter                    DetectorType = 1047
+	DetectorType_GitlabOauthApplication                  DetectorType = 1048
 )
 
 // Enum value maps for DetectorType.
@@ -2150,6 +2151,7 @@ var (
 		1045: "BitbucketDataCenter",
 		1046: "JiraDataCenterPAT",
 		1047: "ConfluenceDataCenter",
+		1048: "GitlabOauthApplication",
 	}
 	DetectorType_value = map[string]int32{
 		"Alibaba":                               0,
@@ -3196,6 +3198,7 @@ var (
 		"BitbucketDataCenter":               1045,
 		"JiraDataCenterPAT":                 1046,
 		"ConfluenceDataCenter":              1047,
+		"GitlabOauthApplication":            1048,
 	}
 )
 

--- a/proto/detector_type.proto
+++ b/proto/detector_type.proto
@@ -1049,4 +1049,5 @@ enum DetectorType {
   BitbucketDataCenter = 1045;
   JiraDataCenterPAT = 1046;
   ConfluenceDataCenter = 1047;
+  GitlabOauthApplication = 1048;
 }


### PR DESCRIPTION
## Summary
- Adds a pattern-only detector for GitLab OAuth application secrets (prefix `gloas-`, 64 hex chars).
- GitLab introduced the `gloas-` prefix for OAuth application client secrets to make them identifiable in scans.
- Detection is pattern-only: these secrets act as `client_secret` at the OAuth token endpoint and require the application ID + host to verify, neither of which is available from the secret alone.
- Reserves DetectorType `GitlabOauthApplication = 1048`.

## Test plan
- [x] `go test ./pkg/detectors/gitlaboauthapplication/` passes locally
- [x] `go build ./...` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new detector and registers a new protobuf `DetectorType` enum value, which can affect downstream consumers expecting a fixed detector-type mapping. Detection logic is pattern-only and isolated, so runtime risk is otherwise limited to potential false positives/scan noise.
> 
> **Overview**
> Adds a new **pattern-only** detector for GitLab OAuth application client secrets matching `gloas-` + 64 hex chars, including unit tests to validate matching vs non-matching inputs.
> 
> Registers the detector in the default detector list and reserves a new detector type enum value `GitlabOauthApplication = 1048` in `proto/detector_type.proto` (and regenerated `detector_type.pb.go`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89c85df3d8bf31498e941f0e9f32ec7de0fc984d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->