### PR TITLE
Make checksecretparts required in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,17 +51,14 @@ jobs:
       - uses: actions/checkout@v4
       - run: semgrep --config=hack/semgrep-rules/detectors.yaml pkg/detectors/
   checksecretparts:
-    # Warning-only: reports detector packages that construct detectors.Result
-    # without populating SecretParts. Flip to hard-fail (drop continue-on-error
-    # and run with -fail) after every detector has been migrated. See
-    # hack/checksecretparts/README.md.
-    name: checksecretparts (warning)
+    # Reports detector packages that construct detectors.Result without
+    # populating SecretParts. See hack/checksecretparts/README.md.
+    name: checksecretparts
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version: "1.25"
       - name: Run checksecretparts
-        run: go run ./hack/checksecretparts ./pkg/detectors
+        run: go run ./hack/checksecretparts -fail ./pkg/detectors


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Enforces a lint check to ensure `SecretParts` is populated on all detectors.
Related: #4913 

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI now hard-fails when any detector constructs `detectors.Result` without populating `SecretParts`, which can newly block merges until detectors are compliant. The change is limited to GitHub Actions configuration but affects the repo’s merge gate.
> 
> **Overview**
> Makes the `checksecretparts` CI job *gating* by removing the previous warning-only behavior and running it with `-fail`, so PRs fail when detector packages don’t populate `SecretParts` on `detectors.Result`.
> 
> Also updates the job’s comment/name to reflect that it is no longer best-effort.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e4872963dad325c37f32fcdc5468fa76f50dc8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->