### PR TITLE
Add detector invariants project rule

### DIFF
--- a/.cursor/rules/detector-invariants.mdc
+++ b/.cursor/rules/detector-invariants.mdc
@@ -1,0 +1,16 @@
+---
+description: Detector invariants for detector Go changes
+globs: pkg/detectors/**/*.go
+alwaysApply: false
+---
+
+# Detector Invariants
+
+- Keep detector signal high. `Keywords()` are a union prefilter, so keep them selective and avoid regex or verifier changes that broaden noisy matches.
+- Verification must separate determinate invalid credentials from indeterminate verification failures. Invalid credentials leave `VerificationError` unset; only timeouts, transport failures, and unexpected responses should call `SetVerificationError(...)`, with secrets redacted.
+- Verifiers must use non-destructive API checks and never leak secret keys, tokens, or passwords into errors.
+- `Raw` and `RawV2` are compatibility boundaries. Single-part credentials use `Raw` only, set to the token. Multi-part credentials set `Raw` to the key or secret value and `RawV2` to every piece needed for verification, including varying URL or host, IDs, and token. Once defined, do not change the shape or effective value.
+- `Redacted` is display-only and must stay non-sensitive. When a stable key, account, or credential ID exists, set `Redacted` to that ID; never put the actual secret value there.
+- `SecretParts` is the credential source of truth, and analyzer-facing keys must stay aligned with what analyzers expect.
+- Do not weaken result-cleaning invariants: by default, keep all verified results or a single unverified result unless a detector-specific cleaner intentionally overrides that behavior.
+- `FromData` must stay concurrency-safe, and verification changes should preserve the standard detector test matrix: verified, determinate unverified, indeterminate timeout, indeterminate unexpected response, and not found.

--- a/.cursor/rules/detector-invariants.mdc
+++ b/.cursor/rules/detector-invariants.mdc
@@ -11,6 +11,6 @@ alwaysApply: false
 - Verifiers must use non-destructive API checks and never leak secret keys, tokens, or passwords into errors.
 - `Raw` and `RawV2` are compatibility boundaries. Single-part credentials use `Raw` only, set to the token. Multi-part credentials set `Raw` to the key or secret value and `RawV2` to every piece needed for verification, including varying URL or host, IDs, and token. Once defined, do not change the shape or effective value.
 - `Redacted` is display-only and must stay non-sensitive. When a stable key, account, or credential ID exists, set `Redacted` to that ID; never put the actual secret value there.
-- `SecretParts` is the credential source of truth, and analyzer-facing keys must stay aligned with what analyzers expect.
+- `SecretParts` is the credential source of truth when analyzer support exists or the detector already exposes analyzer-facing keys. Preserve established keys and keep them aligned with analyzer expectations, but do not require new `SecretParts` solely for analyzers that are not available in OSS.
 - Do not weaken result-cleaning invariants: by default, keep all verified results or a single unverified result unless a detector-specific cleaner intentionally overrides that behavior.
 - `FromData` must stay concurrency-safe, and verification changes should preserve the standard detector test matrix: verified, determinate unverified, indeterminate timeout, indeterminate unexpected response, and not found.


### PR DESCRIPTION
## Summary
- add a repo-local Cursor project rule for detector Go changes under `.cursor/rules/detector-invariants.mdc`. These will apply for Cursor users but also Bugbot CI automation.
- encode detector invariants around verification semantics, `Raw`/`RawV2`, `Redacted`, `SecretParts`, result cleaning, and concurrency safety
- give reviewers a concise checklist to catch compatibility and sensitivity regressions consistently

## Test plan
- [x] Confirm the rule file is scoped to `pkg/detectors/**/*.go`
- [x] Verify the new `.mdc` file has no linter errors


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to `.cursor/rules`; no runtime or detector code is modified.
> 
> **Overview**
> Adds a **repo-local Cursor project rule** at `.cursor/rules/detector-invariants.mdc`, scoped to `pkg/detectors/**/*.go` (`alwaysApply: false`), so Cursor and Bugbot CI can apply the same guidance on detector changes.
> 
> The rule documents **detector invariants** for reviewers and automation: selective `Keywords()`, verification error semantics (`VerificationError` vs invalid creds), non-destructive verifiers without secret leakage, stable `Raw`/`RawV2`/`Redacted`/`SecretParts` contracts, default result-cleaning behavior, concurrency-safe `FromData`, and the standard verification test matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd06837b89206d9f97a322b434aaeb9118b0d3f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->