### PR TITLE
log non-critical chunk errors at V(2).Info instead of Error

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -425,7 +425,7 @@ func handleChunksWithError(
 				if isFatal(dataOrErr.Err) {
 					return dataOrErr.Err
 				}
-				ctx.Logger().Error(dataOrErr.Err, "non-critical error processing chunk")
+				ctx.Logger().V(2).Info("non-critical error processing chunk", "error", dataOrErr.Err)
 				continue
 			}
 			if len(dataOrErr.Data) > 0 {


### PR DESCRIPTION
Non-fatal scanning errors aren't really "errors" - they're consequences of the vicissitudes of scanning a ton of data. They're actionable _if you're looking for them_ but if you're not they're extremely noisy. This PR downgrades them to only show up when you look for them.

## Test plan
- [x] CI passes (existing handler tests cover the success/fatal paths; non-fatal logging path is purely observational)