### PR TITLE
wrap inner chunk reader error with %w to preserve errors.Is identity

### DIFF
--- a/pkg/handlers/default.go
+++ b/pkg/handlers/default.go
@@ -134,7 +134,7 @@ func (h *defaultHandler) handleNonArchiveContent(
 		dataOrErr := DataOrErr{}
 		if err := chunkResult.Error(); err != nil {
 			h.metrics.incErrors()
-			dataOrErr.Err = fmt.Errorf("%w: error reading chunk: %w", ErrProcessingWarning, err)
+			dataOrErr.Err = fmt.Errorf("%w: error reading chunk: %v", ErrProcessingWarning, err)
 			if writeErr := common.CancellableWrite(ctx, dataOrErrChan, dataOrErr); writeErr != nil {
 				return fmt.Errorf("%w: error writing to data channel: %v", ErrProcessingFatal, writeErr)
 			}

--- a/pkg/handlers/default.go
+++ b/pkg/handlers/default.go
@@ -134,7 +134,7 @@ func (h *defaultHandler) handleNonArchiveContent(
 		dataOrErr := DataOrErr{}
 		if err := chunkResult.Error(); err != nil {
 			h.metrics.incErrors()
-			dataOrErr.Err = fmt.Errorf("%w: error reading chunk: %v", ErrProcessingWarning, err)
+			dataOrErr.Err = fmt.Errorf("%w: error reading chunk: %w", ErrProcessingWarning, err)
 			if writeErr := common.CancellableWrite(ctx, dataOrErrChan, dataOrErr); writeErr != nil {
 				return fmt.Errorf("%w: error writing to data channel: %v", ErrProcessingFatal, writeErr)
 			}

--- a/pkg/handlers/default_test.go
+++ b/pkg/handlers/default_test.go
@@ -1,6 +1,9 @@
 package handlers
 
 import (
+	stdctx "context"
+	"errors"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -116,4 +119,59 @@ func TestHandleFileLineNumbers(t *testing.T) {
 		// Second chunk should start at line 11 (only 10 lines counted from first chunk's content)
 		assert.Equal(t, int64(11), results[1].LineNumber, "peek data should not be counted")
 	})
+}
+
+// TestDefaultHandler_ChunkErrorPreservesIdentity is a regression test for the
+// %v wrap at default.go:137. Before the fix, wrapping the inner chunk-reader
+// error with %v dropped its identity from the errors.Is chain, which caused
+// isFatal in handleChunksWithError to misclassify real per-chunk timeouts as
+// non-fatal warnings. The test asserts both that the outer ErrProcessingWarning
+// wrap is preserved (so warning-class consumers still see it) and that the
+// inner cause remains inspectable.
+func TestDefaultHandler_ChunkErrorPreservesIdentity(t *testing.T) {
+	cases := []struct {
+		name      string
+		innerErr  error
+		wantFatal bool
+	}{
+		{
+			name:      "context.DeadlineExceeded is fatal",
+			innerErr:  stdctx.DeadlineExceeded,
+			wantFatal: true,
+		},
+		{
+			name:      "context.Canceled is fatal",
+			innerErr:  stdctx.Canceled,
+			wantFatal: true,
+		},
+		{
+			name:      "io.EOF is non-fatal",
+			innerErr:  io.EOF,
+			wantFatal: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			chunks := []sources.ChunkResult{sources.NewChunkResultError(tc.innerErr)}
+			handler := newDefaultHandler(defaultHandlerType, withChunkReader(mockChunkReader(chunks)))
+			reader, err := newFileReader(context.Background(), strings.NewReader("ignored"))
+			require.NoError(t, err)
+
+			var got []DataOrErr
+			for dataOrErr := range handler.HandleFile(context.Background(), reader) {
+				got = append(got, dataOrErr)
+			}
+
+			require.Len(t, got, 1)
+			require.Error(t, got[0].Err)
+
+			assert.True(t, errors.Is(got[0].Err, ErrProcessingWarning),
+				"outer ErrProcessingWarning wrap should be preserved")
+			assert.True(t, errors.Is(got[0].Err, tc.innerErr),
+				"inner cause should be inspectable via errors.Is")
+			assert.Equal(t, tc.wantFatal, isFatal(got[0].Err),
+				"isFatal should classify based on the inner cause")
+		})
+	}
 }

--- a/pkg/handlers/default_test.go
+++ b/pkg/handlers/default_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	stdctx "context"
-	"errors"
 	"io"
 	"os"
 	"strings"
@@ -166,10 +165,8 @@ func TestDefaultHandler_ChunkErrorPreservesIdentity(t *testing.T) {
 			require.Len(t, got, 1)
 			require.Error(t, got[0].Err)
 
-			assert.True(t, errors.Is(got[0].Err, ErrProcessingWarning),
-				"outer ErrProcessingWarning wrap should be preserved")
-			assert.True(t, errors.Is(got[0].Err, tc.innerErr),
-				"inner cause should be inspectable via errors.Is")
+			assert.ErrorIs(t, got[0].Err, ErrProcessingWarning)
+			assert.ErrorIs(t, got[0].Err, tc.innerErr)
 			assert.Equal(t, tc.wantFatal, isFatal(got[0].Err),
 				"isFatal should classify based on the inner cause")
 		})


### PR DESCRIPTION
## Summary

`pkg/handlers/default.go:137` wraps the inner chunk reader error with `%v`, which breaks `errors.Is` for the wrapped cause:

```diff
-dataOrErr.Err = fmt.Errorf("%w: error reading chunk: %v", ErrProcessingWarning, err)
+dataOrErr.Err = fmt.Errorf("%w: error reading chunk: %w", ErrProcessingWarning, err)
```

Go 1.20+ supports multiple `%w` verbs in a single `Errorf`, and this repo is on Go 1.24 (`go.mod`). The outer `ErrProcessingWarning` wrap is preserved; the inner cause becomes inspectable via `errors.Is`.

## Why this matters

`isFatal()` in `pkg/handlers/handlers.go:482-493` classifies errors using `errors.Is(err, context.Canceled)` / `errors.Is(err, context.DeadlineExceeded)` / `errors.Is(err, ErrProcessingFatal)`. With the current `%v` wrap, a `context.DeadlineExceeded` raised by `chunkResult.Error()` loses its identity in the chain — `isFatal` returns false for it, and the error falls into the non-fatal path where the file-processing loop continues to read chunks from a reader whose context is already dead.

In recent production log samples, **~71 out of 200** entries at `handlers/handlers.go:428` were `context deadline exceeded` errors emitted as non-fatal warnings. With this PR they would correctly classify as fatal and terminate per-file processing on real timeouts.

## Behavior change

This is **not purely a logging fix.** Switching the wrap will cause `isFatal` to return true for `context.DeadlineExceeded` (and any other previously-shadowed sentinel errors) in this code path. That changes runtime behavior:

- Before: per-chunk timeout -> log non-fatal warning -> keep reading from a dead context -> probably more wasted work and more "non-critical" log noise until something else terminates.
- After: per-chunk timeout -> `isFatal` returns true -> `handleChunksWithError` returns the error -> per-file processing terminates immediately.

This is arguably the correct behavior — once the context is cancelled, continuing to read chunks is pointless. But reviewers should confirm there are no implicit dependencies on the current "swallow-and-continue" semantics in source-specific handlers (S3, Git, Bitbucket, etc.) that would surface as new fatal errors at higher levels.

## Companion PR

trufflesecurity/trufflehog#4928 (one-line severity downgrade at `handlers.go:428`) addresses the alert-volume problem at the call site. This PR addresses the underlying classification bug. They are independent and can land in any order:

- Land severity-downgrade alone -> log volume drops, behavior unchanged, deadline-exceeded errors keep silently classifying as non-fatal warnings.
- Land errwrap alone -> per-file processing correctly terminates on real timeouts; remaining non-fatal errors still log at `Error`.
- Both -> intended end state.

## Out-of-scope follow-ups (flagged for later)

- `pkg/handlers/default.go:139` has the same pattern wrapping `ErrProcessingFatal` with `%v` for `writeErr`. The fatal path returns immediately so the `errors.Is` identity is less load-bearing there, but consistency would argue for the same `%w` change. Left out of this PR to keep scope tight.
- `pkg/handlers/archive.go:openArchive` and `pkg/handlers/rpm.go:107` return raw errors that should be wrapped explicitly with `ErrProcessingWarning` so the intent is documented at the source. No runtime change, but improves the class story.

## Test plan
- [ ] CI passes
- [ ] Verify `errors.Is(err, context.DeadlineExceeded)` returns true for a synthesized chunk-reader timeout (existing handler tests likely don't exercise this)
- [ ] Manual: confirm per-file processing terminates on context deadline rather than emitting repeat non-fatal warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-wrapping semantics so per-chunk `context.Canceled`/`context.DeadlineExceeded` now propagate through `errors.Is` and can terminate file processing; this alters runtime behavior on timeouts/cancellation but is tightly scoped and covered by a regression test.
> 
> **Overview**
> Fixes `defaultHandler` to wrap chunk-reader errors with `%w` (instead of `%v`) so the underlying cause remains discoverable via `errors.Is` while still tagging the error with `ErrProcessingWarning`.
> 
> Adds a regression test (`TestDefaultHandler_ChunkErrorPreservesIdentity`) asserting that `ErrProcessingWarning` is preserved, the inner sentinel error is still matchable, and `isFatal` classification follows the inner cause (e.g., deadline/cancel become fatal, `io.EOF` stays non-fatal).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 727a7cf91bf799c5f53047879998d8b4af85e9df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->