### PR TITLE
Fix data-channel-write error wrap to preserve context.DeadlineExceeded identity

### DIFF
--- a/pkg/handlers/default.go
+++ b/pkg/handlers/default.go
@@ -136,7 +136,7 @@ func (h *defaultHandler) handleNonArchiveContent(
 			h.metrics.incErrors()
 			dataOrErr.Err = fmt.Errorf("%w: error reading chunk: %v", ErrProcessingWarning, err)
 			if writeErr := common.CancellableWrite(ctx, dataOrErrChan, dataOrErr); writeErr != nil {
-				return fmt.Errorf("%w: error writing to data channel: %v", ErrProcessingFatal, writeErr)
+				return fmt.Errorf("%w: error writing to data channel: %w", ErrProcessingFatal, writeErr)
 			}
 			continue
 		}

--- a/pkg/handlers/default_test.go
+++ b/pkg/handlers/default_test.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	stdctx "context"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -116,4 +118,67 @@ func TestHandleFileLineNumbers(t *testing.T) {
 		// Second chunk should start at line 11 (only 10 lines counted from first chunk's content)
 		assert.Equal(t, int64(11), results[1].LineNumber, "peek data should not be counted")
 	})
+}
+
+// TestDefaultHandler_DataChannelWriteErrorPreservesIdentity is a regression test
+// for the %v wrap at default.go:139. When CancellableWrite fails because the
+// handler context terminated mid-processing, the returned error must preserve
+// the underlying ctx.Err() identity. measureLatencyAndHandleErrors uses
+// errors.Is(err, context.DeadlineExceeded) to drive the timeout metric and the
+// "error processing chunk" framing; with %v that branch is unreachable for the
+// data-channel write failure path.
+func TestDefaultHandler_DataChannelWriteErrorPreservesIdentity(t *testing.T) {
+	cases := []struct {
+		name    string
+		makeCtx func() (stdctx.Context, stdctx.CancelFunc)
+		want    error
+	}{
+		{
+			name: "DeadlineExceeded preserved through writeErr wrap",
+			makeCtx: func() (stdctx.Context, stdctx.CancelFunc) {
+				return stdctx.WithDeadline(stdctx.Background(), time.Now().Add(-time.Second))
+			},
+			want: stdctx.DeadlineExceeded,
+		},
+		{
+			name: "Canceled preserved through writeErr wrap",
+			makeCtx: func() (stdctx.Context, stdctx.CancelFunc) {
+				ctx, cancel := stdctx.WithCancel(stdctx.Background())
+				cancel()
+				return ctx, cancel
+			},
+			want: stdctx.Canceled,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			deadCtx, cancel := tc.makeCtx()
+			defer cancel()
+			ctx := context.AddLogger(deadCtx)
+
+			// Any non-nil error works here; what matters is that the chunk-error
+			// branch runs and reaches CancellableWrite, which then fails because
+			// ctx is already terminal.
+			chunks := []sources.ChunkResult{sources.NewChunkResultError(errors.New("simulated chunk read failure"))}
+			handler := newDefaultHandler(defaultHandlerType, withChunkReader(mockChunkReader(chunks)))
+
+			reader, err := newFileReader(context.Background(), strings.NewReader("ignored"))
+			require.NoError(t, err)
+			defer reader.Close()
+
+			// Unbuffered channel forces CancellableWrite to consult ctx.Done() and
+			// return ctx.Err() since no reader is draining.
+			dataOrErrChan := make(chan DataOrErr)
+
+			err = handler.handleNonArchiveContent(ctx, newMimeTypeReaderFromFileReader(reader), dataOrErrChan)
+			require.Error(t, err)
+
+			assert.True(t, errors.Is(err, ErrProcessingFatal),
+				"outer ErrProcessingFatal wrap must be preserved so isFatal classifies the failure")
+			assert.True(t, errors.Is(err, tc.want),
+				"inner ctx.Err() must remain inspectable so measureLatencyAndHandleErrors "+
+					"can correctly increment the timeout metric")
+		})
+	}
 }


### PR DESCRIPTION
## Summary

`pkg/handlers/default.go:139` wraps the `CancellableWrite` failure with `%v`, which drops `context.DeadlineExceeded` / `context.Canceled` identity from the `errors.Is` chain on the returned `ErrProcessingFatal`:

```diff
-return fmt.Errorf("%w: error writing to data channel: %v", ErrProcessingFatal, writeErr)
+return fmt.Errorf("%w: error writing to data channel: %w", ErrProcessingFatal, writeErr)
```

`measureLatencyAndHandleErrors` at `default.go:81` does its own `errors.Is(err, context.DeadlineExceeded)` to drive `incFileProcessingTimeouts` and apply the `error processing chunk` framing. With `%v`, that branch is unreachable for this failure path, so:

- the file-processing timeout metric under-counts when the data-channel write fails because the context hit its deadline
- the `error processing chunk` framing is missing for those errors

The outer `ErrProcessingFatal` wrap is preserved either way, so `isFatal` continues to classify correctly. Multiple `%w` verbs in a single `Errorf` are supported on Go 1.20+; this repo is on Go 1.24 (`go.mod`).

## Why this matters

Lower severity than #4929: that PR fixes a control-flow bug at line 137 (chunk-reader errors misclassified as non-fatal). This one is metric/observability correctness on a different classifier (`measureLatencyAndHandleErrors`, `default.go:81`). Both are the same `%v`-shadows-`%w` shape.

A separate audit of `errors.Is` identity preservation across the handlers package flagged this site as a follow-up to #4929.

## Behavior change

None for control flow. Same fatal classification, same termination semantics. The only observable change is:

- `incFileProcessingTimeouts` now counts data-channel write failures whose root cause is `context.DeadlineExceeded`
- the resulting `DataOrErr.Err` carries the `error processing chunk` framing for those cases

## Related

- #4929: canonical case at line 137 (control-flow severity)

## Test plan
- [ ] CI passes
- [ ] `go test ./pkg/handlers/ -count=1` (verified locally)
- [ ] New regression test `TestDefaultHandler_DataChannelWriteErrorPreservesIdentity` asserts both the outer `ErrProcessingFatal` wrap and the inner `ctx.Err()` identity are preserved for `DeadlineExceeded` and `Canceled`. Verified to fail against the pre-fix `%v` form and pass against the `%w` form.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small error-wrapping change plus a focused regression test; behavior impact is limited to error identity/observability (metrics/framing) rather than control flow or data handling.
> 
> **Overview**
> Fixes `defaultHandler.handleNonArchiveContent` to wrap `CancellableWrite` failures with `%w` (instead of `%v`), preserving `context.DeadlineExceeded`/`context.Canceled` in the returned `ErrProcessingFatal` error chain.
> 
> Adds `TestDefaultHandler_DataChannelWriteErrorPreservesIdentity` to assert `errors.Is` continues to match both `ErrProcessingFatal` and the underlying context termination error when the data-channel write fails under a terminal context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919aecc518b81998ef7e6ce90ccfbc6b8f8b0983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->