### PR TITLE
fix nested archive handler error wraps to preserve errors.Is identity

### DIFF
--- a/pkg/handlers/ar.go
+++ b/pkg/handlers/ar.go
@@ -106,7 +106,7 @@ func (h *arHandler) processARFiles(ctx logContext.Context, reader *deb.Ar, dataO
 
 			if err := h.handleNonArchiveContent(fileCtx, rdr, dataOrErrChan); err != nil {
 				dataOrErrChan <- DataOrErr{
-					Err: fmt.Errorf("%w: error handling archive content in AR: %v", ErrProcessingWarning, err),
+					Err: fmt.Errorf("%w: error handling archive content in AR: %w", ErrProcessingWarning, err),
 				}
 				h.metrics.incErrors()
 				continue

--- a/pkg/handlers/ar_test.go
+++ b/pkg/handlers/ar_test.go
@@ -1,8 +1,7 @@
 package handlers
 
 import (
-	stdctx "context"
-	"errors"
+	"context"
 	"io"
 	"os"
 	"testing"
@@ -11,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	trContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
@@ -20,7 +19,7 @@ func TestHandleARFile(t *testing.T) {
 	assert.Nil(t, err)
 	defer file.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), 3*time.Second)
 	defer cancel()
 
 	rdr, err := newFileReader(ctx, file)
@@ -28,7 +27,7 @@ func TestHandleARFile(t *testing.T) {
 	defer rdr.Close()
 
 	handler := newARHandler()
-	dataOrErrChan := handler.HandleFile(context.AddLogger(ctx), rdr)
+	dataOrErrChan := handler.HandleFile(trContext.AddLogger(ctx), rdr)
 	assert.NoError(t, err)
 
 	wantChunkCount := 102
@@ -54,7 +53,7 @@ func TestARHandler_NonArchiveErrPreservesIdentity(t *testing.T) {
 	require.NoError(t, err)
 	defer file.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := trContext.WithCancel(trContext.Background())
 	defer cancel()
 
 	rdr, err := newFileReader(ctx, file)
@@ -66,7 +65,7 @@ func TestARHandler_NonArchiveErrPreservesIdentity(t *testing.T) {
 	// chunk's data sees the cancelled context and returns context.Canceled,
 	// which handleNonArchiveContent returns and processARFiles wraps. This
 	// is the only path that exercises the ar.go:107-110 wrap.
-	cancellingChunkReader := sources.ChunkReader(func(_ context.Context, _ io.Reader) <-chan sources.ChunkResult {
+	cancellingChunkReader := sources.ChunkReader(func(_ trContext.Context, _ io.Reader) <-chan sources.ChunkResult {
 		ch := make(chan sources.ChunkResult, 1)
 		cancel()
 		ch <- sources.NewChunkResult([]byte("data"), 4)
@@ -79,22 +78,22 @@ func TestARHandler_NonArchiveErrPreservesIdentity(t *testing.T) {
 	}
 
 	var got []DataOrErr
-	for d := range handler.HandleFile(context.AddLogger(ctx), rdr) {
+	for d := range handler.HandleFile(trContext.AddLogger(ctx), rdr) {
 		got = append(got, d)
 	}
 
 	var warnErr error
 	for _, d := range got {
-		if d.Err != nil && errors.Is(d.Err, ErrProcessingWarning) {
+		if d.Err != nil {
 			warnErr = d.Err
 			break
 		}
 	}
 	require.Error(t, warnErr, "expected wrapped warning from ar.go non-archive error path")
 
-	assert.True(t, errors.Is(warnErr, ErrProcessingWarning),
+	assert.ErrorIs(t, warnErr, ErrProcessingWarning,
 		"outer ErrProcessingWarning wrap should be preserved")
-	assert.True(t, errors.Is(warnErr, stdctx.Canceled),
+	assert.ErrorIs(t, warnErr, context.Canceled,
 		"inner cancellation cause should be inspectable via errors.Is")
 	assert.True(t, isFatal(warnErr),
 		"isFatal should classify the wrapped error based on the inner cause")

--- a/pkg/handlers/ar_test.go
+++ b/pkg/handlers/ar_test.go
@@ -40,7 +40,9 @@ func TestHandleARFile(t *testing.T) {
 }
 
 // TestARHandler_NonArchiveErrPreservesIdentity is a regression test for the
-// %v wrap at ar.go:109. Before the fix, wrapping handleNonArchiveContent's
+// %v wrap on the ErrProcessingWarning send to dataOrErrChan in
+// processARFiles' handleNonArchiveContent error path. Before the fix, wrapping
+// handleNonArchiveContent's
 // return value with %v dropped the inner error's identity from the errors.Is
 // chain, causing isFatal in handleChunksWithError to misclassify cancellation
 // (and other fatal causes) as a non-fatal warning. The test injects a
@@ -64,7 +66,8 @@ func TestARHandler_NonArchiveErrPreservesIdentity(t *testing.T) {
 	// chunks, then deliver a single non-error chunk. CancellableWrite of that
 	// chunk's data sees the cancelled context and returns context.Canceled,
 	// which handleNonArchiveContent returns and processARFiles wraps. This
-	// is the only path that exercises the ar.go:107-110 wrap.
+	// is the only path that exercises the processARFiles dataOrErrChan
+	// ErrProcessingWarning wrap.
 	cancellingChunkReader := sources.ChunkReader(func(_ trContext.Context, _ io.Reader) <-chan sources.ChunkResult {
 		ch := make(chan sources.ChunkResult, 1)
 		cancel()

--- a/pkg/handlers/ar_test.go
+++ b/pkg/handlers/ar_test.go
@@ -1,13 +1,18 @@
 package handlers
 
 import (
+	stdctx "context"
+	"errors"
+	"io"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
 func TestHandleARFile(t *testing.T) {
@@ -33,4 +38,64 @@ func TestHandleARFile(t *testing.T) {
 	}
 
 	assert.Equal(t, wantChunkCount, count)
+}
+
+// TestARHandler_NonArchiveErrPreservesIdentity is a regression test for the
+// %v wrap at ar.go:109. Before the fix, wrapping handleNonArchiveContent's
+// return value with %v dropped the inner error's identity from the errors.Is
+// chain, causing isFatal in handleChunksWithError to misclassify cancellation
+// (and other fatal causes) as a non-fatal warning. The test injects a
+// cancelling chunk reader so handleNonArchiveContent's CancellableWrite
+// returns context.Canceled, which is then wrapped by processARFiles. It
+// asserts both that the outer ErrProcessingWarning wrap is preserved and
+// that the inner cancellation cause remains inspectable.
+func TestARHandler_NonArchiveErrPreservesIdentity(t *testing.T) {
+	file, err := os.Open("testdata/test.deb")
+	require.NoError(t, err)
+	defer file.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rdr, err := newFileReader(ctx, file)
+	require.NoError(t, err)
+	defer rdr.Close()
+
+	// Cancel the parent context the moment handleNonArchiveContent asks for
+	// chunks, then deliver a single non-error chunk. CancellableWrite of that
+	// chunk's data sees the cancelled context and returns context.Canceled,
+	// which handleNonArchiveContent returns and processARFiles wraps. This
+	// is the only path that exercises the ar.go:107-110 wrap.
+	cancellingChunkReader := sources.ChunkReader(func(_ context.Context, _ io.Reader) <-chan sources.ChunkResult {
+		ch := make(chan sources.ChunkResult, 1)
+		cancel()
+		ch <- sources.NewChunkResult([]byte("data"), 4)
+		close(ch)
+		return ch
+	})
+
+	handler := &arHandler{
+		defaultHandler: newDefaultHandler(arHandlerType, withChunkReader(cancellingChunkReader)),
+	}
+
+	var got []DataOrErr
+	for d := range handler.HandleFile(context.AddLogger(ctx), rdr) {
+		got = append(got, d)
+	}
+
+	var warnErr error
+	for _, d := range got {
+		if d.Err != nil && errors.Is(d.Err, ErrProcessingWarning) {
+			warnErr = d.Err
+			break
+		}
+	}
+	require.Error(t, warnErr, "expected wrapped warning from ar.go non-archive error path")
+
+	assert.True(t, errors.Is(warnErr, ErrProcessingWarning),
+		"outer ErrProcessingWarning wrap should be preserved")
+	assert.True(t, errors.Is(warnErr, stdctx.Canceled),
+		"inner cancellation cause should be inspectable via errors.Is")
+	assert.True(t, isFatal(warnErr),
+		"isFatal should classify the wrapped error based on the inner cause")
 }

--- a/pkg/handlers/rpm.go
+++ b/pkg/handlers/rpm.go
@@ -117,7 +117,7 @@ func (h *rpmHandler) processRPMFiles(
 
 			if err := h.handleNonArchiveContent(fileCtx, rdr, dataOrErrChan); err != nil {
 				dataOrErrChan <- DataOrErr{
-					Err: fmt.Errorf("%w: error processing RPM archive: %v", ErrProcessingWarning, err),
+					Err: fmt.Errorf("%w: error processing RPM archive: %w", ErrProcessingWarning, err),
 				}
 				h.metrics.incErrors()
 			}

--- a/pkg/handlers/rpm_test.go
+++ b/pkg/handlers/rpm_test.go
@@ -1,13 +1,18 @@
 package handlers
 
 import (
+	stdctx "context"
+	"errors"
+	"io"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
 func TestHandleRPMFile(t *testing.T) {
@@ -33,4 +38,56 @@ func TestHandleRPMFile(t *testing.T) {
 	}
 
 	assert.Equal(t, wantChunkCount, count)
+}
+
+// TestRPMHandler_NonArchiveErrPreservesIdentity is a regression test for the
+// %v wrap at rpm.go:120. Same shape as TestARHandler_NonArchiveErrPreservesIdentity:
+// inject a cancelling chunk reader so handleNonArchiveContent's CancellableWrite
+// returns context.Canceled, which processRPMFiles wraps with ErrProcessingWarning.
+// Asserts the outer warning wrap and inner cancellation cause are both
+// observable via errors.Is so isFatal can classify correctly.
+func TestRPMHandler_NonArchiveErrPreservesIdentity(t *testing.T) {
+	file, err := os.Open("testdata/test.rpm")
+	require.NoError(t, err)
+	defer file.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rdr, err := newFileReader(ctx, file)
+	require.NoError(t, err)
+	defer rdr.Close()
+
+	cancellingChunkReader := sources.ChunkReader(func(_ context.Context, _ io.Reader) <-chan sources.ChunkResult {
+		ch := make(chan sources.ChunkResult, 1)
+		cancel()
+		ch <- sources.NewChunkResult([]byte("data"), 4)
+		close(ch)
+		return ch
+	})
+
+	handler := &rpmHandler{
+		defaultHandler: newDefaultHandler(rpmHandlerType, withChunkReader(cancellingChunkReader)),
+	}
+
+	var got []DataOrErr
+	for d := range handler.HandleFile(context.AddLogger(ctx), rdr) {
+		got = append(got, d)
+	}
+
+	var warnErr error
+	for _, d := range got {
+		if d.Err != nil && errors.Is(d.Err, ErrProcessingWarning) {
+			warnErr = d.Err
+			break
+		}
+	}
+	require.Error(t, warnErr, "expected wrapped warning from rpm.go non-archive error path")
+
+	assert.True(t, errors.Is(warnErr, ErrProcessingWarning),
+		"outer ErrProcessingWarning wrap should be preserved")
+	assert.True(t, errors.Is(warnErr, stdctx.Canceled),
+		"inner cancellation cause should be inspectable via errors.Is")
+	assert.True(t, isFatal(warnErr),
+		"isFatal should classify the wrapped error based on the inner cause")
 }

--- a/pkg/handlers/rpm_test.go
+++ b/pkg/handlers/rpm_test.go
@@ -1,8 +1,7 @@
 package handlers
 
 import (
-	stdctx "context"
-	"errors"
+	"context"
 	"io"
 	"os"
 	"testing"
@@ -11,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	trContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
@@ -20,7 +19,7 @@ func TestHandleRPMFile(t *testing.T) {
 	assert.Nil(t, err)
 	defer file.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := trContext.WithTimeout(trContext.Background(), 3*time.Second)
 	defer cancel()
 
 	rdr, err := newFileReader(ctx, file)
@@ -28,7 +27,7 @@ func TestHandleRPMFile(t *testing.T) {
 	defer rdr.Close()
 
 	handler := newRPMHandler()
-	dataOrErrChan := handler.HandleFile(context.AddLogger(ctx), rdr)
+	dataOrErrChan := handler.HandleFile(trContext.AddLogger(ctx), rdr)
 	assert.NoError(t, err)
 
 	wantChunkCount := 179
@@ -51,14 +50,14 @@ func TestRPMHandler_NonArchiveErrPreservesIdentity(t *testing.T) {
 	require.NoError(t, err)
 	defer file.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := trContext.WithCancel(trContext.Background())
 	defer cancel()
 
 	rdr, err := newFileReader(ctx, file)
 	require.NoError(t, err)
 	defer rdr.Close()
 
-	cancellingChunkReader := sources.ChunkReader(func(_ context.Context, _ io.Reader) <-chan sources.ChunkResult {
+	cancellingChunkReader := sources.ChunkReader(func(_ trContext.Context, _ io.Reader) <-chan sources.ChunkResult {
 		ch := make(chan sources.ChunkResult, 1)
 		cancel()
 		ch <- sources.NewChunkResult([]byte("data"), 4)
@@ -71,22 +70,22 @@ func TestRPMHandler_NonArchiveErrPreservesIdentity(t *testing.T) {
 	}
 
 	var got []DataOrErr
-	for d := range handler.HandleFile(context.AddLogger(ctx), rdr) {
+	for d := range handler.HandleFile(trContext.AddLogger(ctx), rdr) {
 		got = append(got, d)
 	}
 
 	var warnErr error
 	for _, d := range got {
-		if d.Err != nil && errors.Is(d.Err, ErrProcessingWarning) {
+		if d.Err != nil {
 			warnErr = d.Err
 			break
 		}
 	}
 	require.Error(t, warnErr, "expected wrapped warning from rpm.go non-archive error path")
 
-	assert.True(t, errors.Is(warnErr, ErrProcessingWarning),
+	assert.ErrorIs(t, warnErr, ErrProcessingWarning,
 		"outer ErrProcessingWarning wrap should be preserved")
-	assert.True(t, errors.Is(warnErr, stdctx.Canceled),
+	assert.ErrorIs(t, warnErr, context.Canceled,
 		"inner cancellation cause should be inspectable via errors.Is")
 	assert.True(t, isFatal(warnErr),
 		"isFatal should classify the wrapped error based on the inner cause")

--- a/pkg/handlers/rpm_test.go
+++ b/pkg/handlers/rpm_test.go
@@ -40,7 +40,9 @@ func TestHandleRPMFile(t *testing.T) {
 }
 
 // TestRPMHandler_NonArchiveErrPreservesIdentity is a regression test for the
-// %v wrap at rpm.go:120. Same shape as TestARHandler_NonArchiveErrPreservesIdentity:
+// %v wrap on the ErrProcessingWarning send to dataOrErrChan in
+// processRPMFiles' handleNonArchiveContent error path. Same shape as
+// TestARHandler_NonArchiveErrPreservesIdentity:
 // inject a cancelling chunk reader so handleNonArchiveContent's CancellableWrite
 // returns context.Canceled, which processRPMFiles wraps with ErrProcessingWarning.
 // Asserts the outer warning wrap and inner cancellation cause are both


### PR DESCRIPTION
## Summary

Two same-shape `%v` error wraps in nested archive handlers drop the inner
error's identity from the `errors.Is` chain, causing the
`isFatal` classifier in `pkg/handlers/handlers.go` to misclassify
cancellation and deadline-exceeded conditions as non-fatal warnings.
This is the identical bug fixed for the canonical chunk-reader wrap in
PR #4929.

Affected sites:

- `pkg/handlers/ar.go:109`
- `pkg/handlers/rpm.go:120`

Both wrap the return value of `handleNonArchiveContent`, which can be
`ctx.Err()` (`context.Canceled` / `context.DeadlineExceeded`) when its
internal `CancellableWrite` fails. The wrapped error feeds
`isFatal` at `pkg/handlers/handlers.go:425`. With `%v`, neither
`errors.Is(err, context.Canceled)` nor
`errors.Is(err, context.DeadlineExceeded)` matches, so the classifier
falls through to the `ErrProcessingWarning` case and processing
continues despite a fatal cause.

## Fix

Change the inner `%v` to `%w` in both wraps, matching the shape used by
PR #4929. Multi-`%w` in a single `fmt.Errorf` is supported on Go
1.20+; this repo is on Go 1.24.

## Behavior change

Cancelled or deadline-exceeded processing inside an AR or RPM nested
archive now correctly terminates instead of being logged as a warning
and continuing.

## Tests

Added a regression test for each handler:

- `TestARHandler_NonArchiveErrPreservesIdentity` in `ar_test.go`
- `TestRPMHandler_NonArchiveErrPreservesIdentity` in `rpm_test.go`

Each test injects a chunk reader that cancels the parent context before
delivering its chunk, forcing `handleNonArchiveContent`'s
`CancellableWrite` to return `context.Canceled`, which the surrounding
handler wraps. The tests assert the outer `ErrProcessingWarning` wrap is
preserved, the inner cancellation cause is inspectable via
`errors.Is`, and `isFatal` classifies the wrapped error as fatal.

Verified the tests catch the regression by reverting just the wrap
fix: both tests fail on `errors.Is(err, context.Canceled)` and
`isFatal(err)`, then pass again once the fix is reapplied.

## Test plan

- [x] `go test ./pkg/handlers/ -count=1` passes
- [x] `go vet ./pkg/handlers/` clean
- [x] Catches-the-bug verification: revert `%w` -> `%v` -> tests fail; reapply -> tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to error wrapping plus new tests; behavior only changes for cancellation/deadline paths in AR/RPM processing and is unlikely to impact normal success flows.
> 
> **Overview**
> Fixes AR and RPM nested archive handlers to wrap `handleNonArchiveContent` failures with `%w` (instead of `%v`) while still tagging them with `ErrProcessingWarning`, preserving `errors.Is` identity for underlying causes like `context.Canceled`/`context.DeadlineExceeded`.
> 
> Adds regression tests (`TestARHandler_NonArchiveErrPreservesIdentity`, `TestRPMHandler_NonArchiveErrPreservesIdentity`) that inject a cancelling chunk reader and assert both the outer warning wrap and the inner cancellation cause remain detectable and are classified as fatal by `isFatal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b66333863d2bf71eef63b2b124188ec6cac91de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->