### PR TITLE
ci: bump JS actions to Node 24 majors (incl. CodeQL v4 + WIF auth v3)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,14 +38,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,4 +56,4 @@ jobs:
         run: |
           go build .
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/detector-tests.yml
+++ b/.github/workflows/detector-tests.yml
@@ -14,10 +14,10 @@ jobs:
       contents: "read"
       id-token: "write"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
       - name: Install gotestsum
-        uses: jaxxstorm/action-install-gh-release@v1.14.0
+        uses: jaxxstorm/action-install-gh-release@v3.0.0  # immutable release; no rolling @v3 tag
         with:
           repo: gotestyourself/gotestsum
       - uses: rwx-research/setup-captain@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,8 +15,8 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
       - name: golangci-lint
@@ -29,8 +29,8 @@ jobs:
     name: man-page-staleness
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
       - name: Regenerate man page
@@ -48,7 +48,7 @@ jobs:
       image: returntocorp/semgrep
     if: (github.actor != 'dependabot[bot]')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: semgrep --config=hack/semgrep-rules/detectors.yaml pkg/detectors/
   checksecretparts:
     # Reports detector packages that construct detectors.Result without
@@ -56,8 +56,8 @@ jobs:
     name: checksecretparts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
       - name: Run checksecretparts

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}
 
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
 
@@ -54,7 +54,7 @@ jobs:
           echo PREVIOUS_TAG=$(cat previous_tag.txt) >> $GITHUB_ENV
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ env.PREVIOUS_TAG }}

--- a/.github/workflows/release-bot.yml
+++ b/.github/workflows/release-bot.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
     - name: Login to GCP
       id: auth
-      uses: "google-github-actions/auth@v2"
+      uses: "google-github-actions/auth@v3"
       with:
         credentials_json: ${{ secrets.GCP_SA_TRUFFLE_RELEASE_BOT }}
 
     - name: Login to GAR
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: us-central1-docker.pkg.dev
         username: _json_key

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,24 +18,24 @@ jobs:
     steps:
       # Setup steps - no external side effects.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Docker Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Docker Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
       - name: Cosign install
@@ -64,7 +64,7 @@ jobs:
       # version. The release is NOT marked latest (make_latest: false), so
       # /releases/latest still points to the previous good release.
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser-pro
           version: latest

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.head_ref }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
       - name: Smoke
@@ -23,9 +23,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
       - name: Run trufflehog

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,13 @@ jobs:
       id-token: "write"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
       - id: "auth"
-        uses: "google-github-actions/auth@v2"
+        uses: "google-github-actions/auth@v3"
         with:
           workload_identity_provider: "projects/811013774421/locations/global/workloadIdentityPools/github-pool/providers/github-provider"
           service_account: "github-ci-external@trufflehog-testing.iam.gserviceaccount.com"
@@ -48,7 +48,7 @@ jobs:
           secret: ${{ secrets.BUILDPULSE_SECRET_ACCESS_KEY }}
           tags: integration
       - name: Annotate test results
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@v6
         if: success() || failure() # always run even if the previous step fails
         with:
           report_paths: "tmp/test-results/*.xml"
@@ -60,9 +60,9 @@ jobs:
       contents: "read"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: "1.25"
       - name: Test


### PR DESCRIPTION
## Summary

Bumps every Node-20-era action ref across 9 workflow files to its Node-24 major. Part of the org-wide Node 24 baseline cleanup ahead of GitHub's **2026-09-16 Node 20 removal** deadline.

> **THIS IS THE HIGHEST-RISK PR IN THE BASELINE BURST.** Two Higher-risk bumps in one PR: CodeQL v3 -> v4 AND WIF auth v2 -> v3. Please coordinate with security + infra owners before merge.

## Action bumps

| action | from | to |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-go` | `@v5` | `@v6` |
| `mikepenz/action-junit-report` | `@v5` | `@v6` |
| `goreleaser/goreleaser-action` | `@v6` | `@v7` |
| `docker/login-action` | `@v3` | `@v4` |
| `docker/setup-qemu-action` | `@v3` | `@v4` |
| **`github/codeql-action/init`** | `@v3` | `@v4` |
| **`github/codeql-action/analyze`** | `@v3` | `@v4` |
| **`google-github-actions/auth`** | `@v2` | `@v3` |
| `jaxxstorm/action-install-gh-release` | `@v1.14.0` | `@v3.0.0` (immutable patch pin) |

`sigstore/cosign-installer@<SHA>` is SHA-pinned, untouched. `buildpulse/buildpulse-action@main` is `@main`-tracking (separate hygiene followup, not in scope). Out-of-scope: `golangci/golangci-lint-action@v7` (deferred to sweep), `rwx-research/setup-captain@v1`.

## Per-PR preflight

- [x] Rolling tags verified for all "to" majors (2026-04-29): checkout `de0fac2e`, setup-go `4a360112`, mikepenz `bccf2e31`, goreleaser `1a80836c`, docker/login `4907a6dd`, docker/setup-qemu `ce360397`, codeql `v4` (latest patch v4.31.11), google-github-actions/auth `7c6bc770`.
- [x] `jaxxstorm/action-install-gh-release` ships immutable releases — pinned to `@v3.0.0` with inline comment.
- [x] No conflicting Dependabot/Renovate PRs (Renovate #4890 is for `aws-sdk-go-v2`, not actions).
- [x] No surprise reusable-workflow dependencies.
- [x] golangci-lint-action explicitly deferred (separate sweep).

## Risk

**Highest.** Two Higher-risk bumps requiring focused review:

1. **CodeQL v3 -> v4** changes default query packs and SARIF emission. **Post-merge: confirm the GHAS Security tab still populates with the expected alert categories and the alert count is in the expected range.** This is the most common failure mode for CodeQL major bumps.

2. **google-github-actions/auth v2 -> v3** is a major version jump. Verify the GCP workload-identity-pool + provider config still authenticates against `auth@v3` (used in `test.yml` and `release-bot.yml` — both reference `"google-github-actions/auth@v2"` with double-quoted YAML).

3. **goreleaser v7** — pin GoReleaser binary version explicitly if relying on a specific binary semver.

Other bumps are Low/Medium risk: pure Node-runtime bumps (checkout, setup-go, mikepenz, docker login/qemu) plus jaxxstorm v1->v3.

## Validation

PR-time CI exercises most workflows. `release.yml` and `release-bot.yml` won't fire on PR; the next release will validate. Confirm via:

\`\`\`
gh run view <run-id> --repo trufflesecurity/trufflehog --log 2>/dev/null | \\
  grep -E \"Node\\.js (16|20) actions are deprecated\"
\`\`\`

Post-merge, also verify:
1. GHAS Security tab still populates (CodeQL v4).
2. `auth@v3` step authenticates successfully.

Empty grep output = green for the bumped refs (the `buildpulse/buildpulse-action@main` deprecation warning will still appear if the action is still on Node 20 — out of this PR's scope).

## References

- Org-wide plan: \`.cursor/plans/org-wide_node_24_follow-up_a33207ac.plan.md\`
- Approval doc: \`projects/node24-baseline-approval-plan.md\`
- Predecessor PRs (already merged 2026-04-29): trufflesecurity/.github#6, trufflesecurity/.github-private#9
- CodeQL v3 deprecation announcement: https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Upgrades CodeQL (v3→v4) and GCP OIDC auth (v2→v3), which can break security scanning output or CI/release authentication; releases are affected but won’t be exercised until the next tag/published release.
> 
> **Overview**
> Updates GitHub Actions across the CI/release workflows to newer major versions, primarily to move off Node 20-era actions (e.g., `actions/checkout@v6`, `actions/setup-go@v6`, Docker actions v4, `mikepenz/action-junit-report@v6`, and `goreleaser/goreleaser-action@v7`).
> 
> The security- and release-critical workflows are also bumped: CodeQL is upgraded from v3 to v4 (`codeql-action/init`/`analyze`), and GCP Workload Identity auth moves from `google-github-actions/auth@v2` to `@v3` (used in `test.yml` and `release-bot.yml`). `detector-tests.yml` additionally updates `jaxxstorm/action-install-gh-release` to `v3.0.0` and pins it to that immutable version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac1f504c061ab47cb859eae68179767469f6deef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->