### PR TITLE
Join errors so they are detectable by errors.Is

### DIFF
--- a/pkg/handlers/default.go
+++ b/pkg/handlers/default.go
@@ -134,9 +134,9 @@ func (h *defaultHandler) handleNonArchiveContent(
 		dataOrErr := DataOrErr{}
 		if err := chunkResult.Error(); err != nil {
 			h.metrics.incErrors()
-			dataOrErr.Err = fmt.Errorf("%w: error reading chunk: %v", ErrProcessingWarning, err)
+			dataOrErr.Err = fmt.Errorf("error reading chunk: %w", errors.Join(ErrProcessingWarning, err))
 			if writeErr := common.CancellableWrite(ctx, dataOrErrChan, dataOrErr); writeErr != nil {
-				return fmt.Errorf("%w: error writing to data channel: %v", ErrProcessingFatal, writeErr)
+				return fmt.Errorf("error writing to data channel: %w", errors.Join(ErrProcessingFatal, writeErr))
 			}
 			continue
 		}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The purpose of this PR is to have both of the errors emitted by their log lines be joined so that they are detectable by `isFatal` in `handlers.go.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change limited to error composition in non-archive chunk processing; main risk is altered error strings/unwrap structure affecting tests or log expectations.
> 
> **Overview**
> Updates `defaultHandler.handleNonArchiveContent` error wrapping to use `errors.Join` so emitted chunk read/write errors retain `ErrProcessingWarning`/`ErrProcessingFatal` in the error chain and can be detected via `errors.Is` (e.g., by `isFatal`).
> 
> This changes the formatting of the propagated errors to wrap the joined sentinel+underlying error as the `%w` cause while keeping the log message text stable ("error reading chunk" / "error writing to data channel").
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7771e851afc0f3992718d8510ba3672112897aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->