### PR TITLE
chore: bump golangci-lint-action v7 → v9 (Node 24)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           go-version: "1.25"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           # NOTE: Version and args must match scripts/lint.sh
           version: v2.11.4


### PR DESCRIPTION
## Summary

Bumps `golangci/golangci-lint-action` from **v7** to **v9** (Node 24 runtime).

- **v8** changed working-directory to absolute paths and requires golangci-lint ≥ v2.1.0
- **v9** is dependency maintenance on top of v8 (Node 24, updated checkout/setup-go)
- This repo pins `version: v2.11.4` (already v2) — no config migration needed
- No `.golangci.yml` config file exists; lint args are passed inline via `args:`

### Risk

Low. The only functional change is the Node runtime (20 → 24). The golangci-lint binary version and args are unchanged.

## Test plan

- [x] CI golangci-lint job passes on this PR

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI maintenance change that only updates the `golangci-lint` GitHub Action version; lint binary version and args remain pinned, so impact should be limited to CI runtime/environment differences.
> 
> **Overview**
> Updates the `golangci-lint` GitHub Actions workflow to use `golangci/golangci-lint-action@v9` instead of `@v7`.
> 
> The pinned `golangci-lint` version (`v2.11.4`) and invocation args are unchanged, so the functional behavior should remain the same aside from the action/runtime updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d950591c6cf6e15a99aa25cbf9bdf0d3319eccae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->