### PR TITLE
Add custom HTTP header support

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ var (
 	results             = cli.Flag("results", "Specifies which type(s) of results to output: verified (confirmed valid by API), unknown (verification failed due to error), unverified (detected but not verified), filtered_unverified (unverified but would have been filtered out). Defaults to verified,unverified,unknown.").String()
 	noColor             = cli.Flag("no-color", "Disable colorized output").Bool()
 	noColour            = cli.Flag("no-colour", "Alias for --no-color").Hidden().Bool()
+	customHeaders       = cli.Flag("header", "Custom header to add to all outbound HTTP requests; repeatable. Format 'Name: value' or 'Name=value'.").Strings()
 
 	allowVerificationOverlap   = cli.Flag("allow-verification-overlap", "Allow verification of similar credentials across detectors").Bool()
 	filterUnverified           = cli.Flag("filter-unverified", "Only output first unverified result per chunk per detector if there are more than one results.").Bool()
@@ -510,6 +511,36 @@ func run(state overseer.State, logSync func() error) {
 
 	if *userAgentSuffix != "" {
 		feature.UserAgentSuffix.Store(*userAgentSuffix)
+	}
+
+	// Parse and set any custom headers specified via --header
+	if customHeaders != nil && len(*customHeaders) > 0 {
+		hdr := http.Header{}
+		for _, h := range *customHeaders {
+			var key, val string
+			colonIdx := strings.Index(h, ":")
+			equalsIdx := strings.Index(h, "=")
+			switch {
+			case colonIdx == -1 && equalsIdx == -1:
+				logger.V(1).Info("skipping invalid --header format; expected 'Name: value' or 'Name=value'", "header", h)
+				continue
+			case colonIdx == -1 || (equalsIdx != -1 && equalsIdx < colonIdx):
+				key = strings.TrimSpace(h[:equalsIdx])
+				val = strings.TrimSpace(h[equalsIdx+1:])
+			default:
+				key = strings.TrimSpace(h[:colonIdx])
+				val = strings.TrimSpace(h[colonIdx+1:])
+			}
+			if key == "" || val == "" {
+				logger.V(1).Info("skipping invalid --header with empty key or value", "header", h)
+				continue
+			}
+			hdr.Add(key, val)
+		}
+		if len(hdr) > 0 {
+			feature.CustomHeaders.Store(hdr)
+			logger.V(2).Info("custom headers configured", "count", len(hdr))
+		}
 	}
 
 	// OSS Default APK handling on

--- a/pkg/common/http.go
+++ b/pkg/common/http.go
@@ -96,8 +96,20 @@ func UserAgent() string {
 	return "TruffleHog"
 }
 
+// ApplyCustomHeaders adds any globally configured custom headers to req.
+func ApplyCustomHeaders(req *http.Request) {
+	if hdr := feature.CustomHeaders.Load(); hdr != nil {
+		for k, vals := range hdr {
+			for _, v := range vals {
+				req.Header.Add(k, v)
+			}
+		}
+	}
+}
+
 func (t *CustomTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Add("User-Agent", UserAgent())
+	ApplyCustomHeaders(req)
 	return t.T.RoundTrip(req)
 }
 

--- a/pkg/detectors/http.go
+++ b/pkg/detectors/http.go
@@ -75,6 +75,7 @@ type detectorTransport struct {
 
 func (t *detectorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	req.Header.Add("User-Agent", userAgent())
+	common.ApplyCustomHeaders(req)
 	return t.T.RoundTrip(req)
 }
 

--- a/pkg/detectors/readme/readme.go
+++ b/pkg/detectors/readme/readme.go
@@ -48,7 +48,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 			req.SetBasicAuth(resMatch, "")
 			req.Header.Add("accept", "application/json")
-			res, err := http.DefaultClient.Do(req)
+			res, err := detectors.DetectorHttpClientWithLocalAddresses.Do(req)
 			if err == nil {
 				defer res.Body.Close()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -1,6 +1,7 @@
 package feature
 
 import (
+	"net/http"
 	"sync/atomic"
 )
 
@@ -16,6 +17,7 @@ var (
 	GitlabProjectsPerPage          atomic.Int64
 	UseGithubGraphQLAPI            atomic.Bool // use github graphql api to fetch issues, pr's and comments
 	HTMLDecoderEnabled             atomic.Bool
+	CustomHeaders                  AtomicHeader
 )
 
 type AtomicString struct {
@@ -40,4 +42,22 @@ func (as *AtomicString) Swap(newValue string) string {
 	oldValue := as.Load()
 	as.Store(newValue)
 	return oldValue
+}
+
+// AtomicHeader stores an http.Header atomically for global access.
+type AtomicHeader struct {
+	value atomic.Value
+}
+
+// Load returns the current http.Header value; may be nil if unset.
+func (ah *AtomicHeader) Load() http.Header {
+	if v := ah.value.Load(); v != nil {
+		return v.(http.Header)
+	}
+	return nil
+}
+
+// Store sets the http.Header value.
+func (ah *AtomicHeader) Store(h http.Header) {
+	ah.value.Store(h)
 }

--- a/pkg/sources/huggingface/client.go
+++ b/pkg/sources/huggingface/client.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 )
 
 // Maps for API and HTML paths
@@ -125,7 +126,8 @@ func NewHFClient(baseURL, apiKey string, timeout time.Duration) *HFClient {
 		BaseURL: baseURL,
 		APIKey:  apiKey,
 		HTTPClient: &http.Client{
-			Timeout: timeout,
+			Timeout:   timeout,
+			Transport: common.NewInstrumentedTransport(common.NewCustomTransport(nil)),
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- Adds repeatable `--header` CLI support for outbound HTTP requests.
- Stores configured custom headers globally via `feature.CustomHeaders`.
- Applies custom headers through common and detector HTTP transports.
- Routes the HuggingFace client through the common instrumented custom transport.

## Verification
- `git diff --check origin/main..HEAD`
- `go build ./...`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds user-supplied headers to all outbound HTTP requests, which can change authentication/behavior across many integrations and may unintentionally leak sensitive header values to third-party endpoints if misused.
> 
> **Overview**
> Adds repeatable `--header` CLI support, parses `Name: value` / `Name=value`, and stores the resulting `http.Header` globally via `feature.CustomHeaders`.
> 
> Updates shared HTTP transports (`common.CustomTransport` and detector transport) to apply these custom headers on every request, switches the ReadMe verifier to use the detector HTTP client (so headers/transport controls are honored), and routes the HuggingFace client through the instrumented custom transport so it also receives the global headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00add70407151a19cdaf0c4279d171e201ff7a4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->