### PR TITLE
fix(iobuf): translate index by diskBufferSize in BufferedReadSeeker.Read

### DIFF
--- a/pkg/iobuf/bufferedreaderseeker.go
+++ b/pkg/iobuf/bufferedreaderseeker.go
@@ -141,22 +141,14 @@ func (br *BufferedReadSeeker) Read(out []byte) (int, error) {
 		err            error
 	)
 
-	// If the current read position is within the in-memory buffer.
-	//
-	// The buffer holds bytes [diskBufferSize, diskBufferSize+buf.Len()) of the
-	// virtual stream: any bytes flushed to disk live in tempFile, and the buffer
-	// only retains data appended after the most recent flush. Translate the
-	// logical index into a buffer-relative offset before slicing; otherwise a
-	// post-flush read whose index falls below diskBufferSize would silently
-	// return data from the wrong offset.
-	if br.index >= br.diskBufferSize && br.index < br.diskBufferSize+int64(br.buf.Len()) {
-		totalBytesRead = copy(out, br.buf.Bytes()[br.index-br.diskBufferSize:])
-		br.index += int64(totalBytesRead)
-		if totalBytesRead == len(out) {
-			return totalBytesRead, nil
-		}
-		out = out[totalBytesRead:]
-	}
+	// The virtual stream is laid out as [0, diskBufferSize) on disk followed
+	// by [diskBufferSize, diskBufferSize+buf.Len()) in the post-flush buffer.
+	// A single Read may span the disk→buffer boundary (e.g. seek into the
+	// disk tail then read past it), so the disk branch runs first and the
+	// buffer branch handles whatever remains. If the buffer branch ran first
+	// it would skip on the spanning case (index < diskBufferSize) and the
+	// disk branch would only fill the disk portion; the reader would then
+	// be hit prematurely, mark sizeKnown, and orphan the buffered tail.
 
 	// If we've exceeded the in-memory threshold and have a temp file.
 	if br.tempFile != nil && br.index < br.diskBufferSize {
@@ -168,7 +160,16 @@ func (br *BufferedReadSeeker) Read(out []byte) (int, error) {
 		if _, err := br.tempFile.Seek(br.index, io.SeekStart); err != nil {
 			return totalBytesRead, err
 		}
-		m, err := br.tempFile.Read(out)
+		// Cap the disk read at the disk region so a spanning read does not
+		// pull buffered bytes from the underlying file (writeData appends to
+		// buf and may flush to disk later, so reading past diskBufferSize
+		// here could either short-read or surface stale data).
+		diskRemaining := br.diskBufferSize - br.index
+		diskSlice := out
+		if int64(len(diskSlice)) > diskRemaining {
+			diskSlice = diskSlice[:diskRemaining]
+		}
+		m, err := br.tempFile.Read(diskSlice)
 		totalBytesRead += m
 		br.index += int64(m)
 		if err != nil && !errors.Is(err, io.EOF) {
@@ -177,7 +178,22 @@ func (br *BufferedReadSeeker) Read(out []byte) (int, error) {
 		if totalBytesRead == len(out) {
 			return totalBytesRead, nil
 		}
-		out = out[totalBytesRead:]
+		out = out[m:]
+	}
+
+	// If the current read position is within the in-memory buffer.
+	//
+	// Translate the logical index into a buffer-relative offset before
+	// slicing; otherwise a post-flush read whose index falls below
+	// diskBufferSize would silently return data from the wrong offset.
+	if br.index >= br.diskBufferSize && br.index < br.diskBufferSize+int64(br.buf.Len()) {
+		bufBytesRead := copy(out, br.buf.Bytes()[br.index-br.diskBufferSize:])
+		totalBytesRead += bufBytesRead
+		br.index += int64(bufBytesRead)
+		if bufBytesRead == len(out) {
+			return totalBytesRead, nil
+		}
+		out = out[bufBytesRead:]
 	}
 
 	if len(out) == 0 {

--- a/pkg/iobuf/bufferedreaderseeker.go
+++ b/pkg/iobuf/bufferedreaderseeker.go
@@ -142,8 +142,15 @@ func (br *BufferedReadSeeker) Read(out []byte) (int, error) {
 	)
 
 	// If the current read position is within the in-memory buffer.
-	if br.index < int64(br.buf.Len()) {
-		totalBytesRead = copy(out, br.buf.Bytes()[br.index:])
+	//
+	// The buffer holds bytes [diskBufferSize, diskBufferSize+buf.Len()) of the
+	// virtual stream: any bytes flushed to disk live in tempFile, and the buffer
+	// only retains data appended after the most recent flush. Translate the
+	// logical index into a buffer-relative offset before slicing; otherwise a
+	// post-flush read whose index falls below diskBufferSize would silently
+	// return data from the wrong offset.
+	if br.index >= br.diskBufferSize && br.index < br.diskBufferSize+int64(br.buf.Len()) {
+		totalBytesRead = copy(out, br.buf.Bytes()[br.index-br.diskBufferSize:])
 		br.index += int64(totalBytesRead)
 		if totalBytesRead == len(out) {
 			return totalBytesRead, nil
@@ -153,7 +160,12 @@ func (br *BufferedReadSeeker) Read(out []byte) (int, error) {
 
 	// If we've exceeded the in-memory threshold and have a temp file.
 	if br.tempFile != nil && br.index < br.diskBufferSize {
-		if _, err := br.tempFile.Seek(br.index-int64(br.buf.Len()), io.SeekStart); err != nil {
+		// The temp file holds bytes [0, diskBufferSize) of the virtual stream,
+		// so seek directly to br.index. Subtracting buf.Len() (the prior
+		// behaviour) was only correct when the buffer was empty — after a
+		// flush followed by additional buffered writes, the subtraction
+		// produced a negative offset and a wrong-region read.
+		if _, err := br.tempFile.Seek(br.index, io.SeekStart); err != nil {
 			return totalBytesRead, err
 		}
 		m, err := br.tempFile.Read(out)

--- a/pkg/iobuf/bufferedreaderseeker.go
+++ b/pkg/iobuf/bufferedreaderseeker.go
@@ -154,7 +154,7 @@ func (br *BufferedReadSeeker) Read(out []byte) (int, error) {
 	if br.tempFile != nil && br.index < br.diskBufferSize {
 		// The temp file holds bytes [0, diskBufferSize) of the virtual stream,
 		// so seek directly to br.index. Subtracting buf.Len() (the prior
-		// behaviour) was only correct when the buffer was empty — after a
+		// behaviour) was only correct when the buffer was empty, after a
 		// flush followed by additional buffered writes, the subtraction
 		// produced a negative offset and a wrong-region read.
 		if _, err := br.tempFile.Seek(br.index, io.SeekStart); err != nil {

--- a/pkg/iobuf/bufferedreaderseeker_test.go
+++ b/pkg/iobuf/bufferedreaderseeker_test.go
@@ -522,6 +522,62 @@ func TestBufferedReaderSeekerReadAfterFlushBackwardSeek(t *testing.T) {
 	assert.Equal(t, payload[40:44], tail, "buffered tail read returned wrong bytes")
 }
 
+// TestBufferedReaderSeekerReadSpansDiskAndBuffer covers the disk→buffer
+// spanning read: a single Read() that begins inside the on-disk region and
+// extends into the post-flush in-memory buffer. Before the fix, the buffer
+// branch ran first (and skipped because index < diskBufferSize), the disk
+// branch only filled the disk portion, and the call fell through to the
+// underlying reader. Once the reader returned io.EOF the code set
+// sizeKnown=true without flushing the buffer to disk, leaving the buffered
+// tail bytes permanently inaccessible.
+func TestBufferedReaderSeekerReadSpansDiskAndBuffer(t *testing.T) {
+	payload := make([]byte, 48)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	brs := NewBufferedReaderSeeker(bytes.NewBuffer(payload))
+	defer brs.Close()
+	brs.threshold = 32
+
+	// Fill exactly to the threshold to trigger a flush on writeData.
+	if _, err := io.ReadFull(brs, make([]byte, 32)); err != nil {
+		t.Fatalf("priming disk read: %v", err)
+	}
+	// Read 16 more bytes; these are appended back into the (now-empty)
+	// in-memory buffer without triggering another flush.
+	if _, err := io.ReadFull(brs, make([]byte, 16)); err != nil {
+		t.Fatalf("priming buffer read: %v", err)
+	}
+	assert.Equal(t, int64(32), brs.diskBufferSize)
+	assert.Equal(t, 16, brs.buf.Len())
+
+	// Seek into the disk tail and read past the disk/buffer boundary in a
+	// single call. The read must complete from disk + buffer without
+	// touching the underlying reader (which is exhausted).
+	if _, err := brs.Seek(28, io.SeekStart); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+	got := make([]byte, 12)
+	n, err := brs.Read(got)
+	assert.NoError(t, err)
+	assert.Equal(t, 12, n)
+	assert.Equal(t, payload[28:40], got, "spanning read returned wrong bytes")
+
+	// The buffered tail (bytes 32-48) must remain accessible after the
+	// spanning read; before the fix sizeKnown was set with the buffer still
+	// holding 16 unflushed bytes, and the fast path at the top of Read
+	// would only see the 32 bytes already on disk.
+	if _, err := brs.Seek(40, io.SeekStart); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+	tail := make([]byte, 8)
+	n, err = brs.Read(tail)
+	assert.NoError(t, err)
+	assert.Equal(t, 8, n)
+	assert.Equal(t, payload[40:48], tail, "buffered tail orphaned by spanning read")
+}
+
 // errorReader is an io.Reader that returns an error after reading a specified number of bytes.
 // It's used to simulate non-EOF errors during read operations.
 type errorReader struct {

--- a/pkg/iobuf/bufferedreaderseeker_test.go
+++ b/pkg/iobuf/bufferedreaderseeker_test.go
@@ -457,6 +457,71 @@ func TestBufferedReadSeekerSize(t *testing.T) {
 	}
 }
 
+// TestBufferedReaderSeekerReadAfterFlushBackwardSeek guards against a
+// regression where Read mishandled the offset translation between the
+// virtual stream index and the in-memory buffer / on-disk temp file.
+//
+// After the in-memory buffer was flushed to disk and then refilled with
+// subsequent data, two paths were broken:
+//
+//  1. The in-memory branch sliced `buf.Bytes()[br.index:]`, treating the
+//     logical stream index as a buffer-relative offset, so a backward seek
+//     would silently return data from the wrong offset within the buffer.
+//  2. The on-disk branch seeked the temp file to `br.index - buf.Len()`,
+//     producing a negative offset (and seek error) once the buffer had
+//     been refilled with post-flush data.
+func TestBufferedReaderSeekerReadAfterFlushBackwardSeek(t *testing.T) {
+	payload := make([]byte, 48)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+
+	// bytes.NewBuffer is non-seekable, so the BufferedReadSeeker must buffer.
+	brs := NewBufferedReaderSeeker(bytes.NewBuffer(payload))
+	defer brs.Close()
+	// Use a small threshold so the prime read flushes to disk.
+	brs.threshold = 32
+
+	// Fill exactly to the threshold to trigger a flush on writeData.
+	first := make([]byte, 32)
+	n, err := brs.Read(first)
+	assert.NoError(t, err)
+	assert.Equal(t, 32, n)
+	assert.Equal(t, payload[:32], first)
+
+	// Read 16 more bytes; these are appended back into the (now-empty) buffer.
+	second := make([]byte, 16)
+	n, err = brs.Read(second)
+	assert.NoError(t, err)
+	assert.Equal(t, 16, n)
+	assert.Equal(t, payload[32:48], second)
+
+	// Sanity: buffer holds the post-flush tail, disk holds the prefix.
+	assert.Equal(t, int64(32), brs.diskBufferSize)
+	assert.Equal(t, 16, brs.buf.Len())
+
+	// Seek back to the start and read 8 bytes — these live on disk.
+	_, err = brs.Seek(0, io.SeekStart)
+	assert.NoError(t, err)
+
+	got := make([]byte, 8)
+	n, err = brs.Read(got)
+	assert.NoError(t, err)
+	assert.Equal(t, 8, n)
+	assert.Equal(t, payload[0:8], got, "backward seek after flush returned wrong bytes")
+
+	// Backward read into the disk region followed by a forward read into
+	// the buffered tail must also return the right bytes (exercises both
+	// branches in the same Read sequence).
+	_, err = brs.Seek(40, io.SeekStart)
+	assert.NoError(t, err)
+	tail := make([]byte, 4)
+	n, err = brs.Read(tail)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, n)
+	assert.Equal(t, payload[40:44], tail, "buffered tail read returned wrong bytes")
+}
+
 // errorReader is an io.Reader that returns an error after reading a specified number of bytes.
 // It's used to simulate non-EOF errors during read operations.
 type errorReader struct {

--- a/pkg/iobuf/bufferedreaderseeker_test.go
+++ b/pkg/iobuf/bufferedreaderseeker_test.go
@@ -578,6 +578,42 @@ func TestBufferedReaderSeekerReadSpansDiskAndBuffer(t *testing.T) {
 	assert.Equal(t, payload[40:48], tail, "buffered tail orphaned by spanning read")
 }
 
+// TestBufferedReaderSeekerReadRewindAfterFlush is the issue #4569 shape
+// (slice bounds panic during APK/DEX scans): flush the buffer to disk, pull a
+// few more bytes into the refilled buffer, seek back to the start, then issue
+// a Read that the old code split across both branches. The cumulative-count
+// reslice (`out = out[totalBytesRead:]`) then walked past the already
+// shortened tail of `out` and panicked.
+func TestBufferedReaderSeekerReadRewindAfterFlush(t *testing.T) {
+	payload := make([]byte, 4096)
+	for i := range payload {
+		payload[i] = byte(i % 251)
+	}
+
+	brs := NewBufferedReaderSeeker(bytes.NewBuffer(payload))
+	defer brs.Close()
+	brs.threshold = 32
+
+	// Flush 32 bytes to disk, then leave 8 more sitting in the buffer.
+	if _, err := io.ReadFull(brs, make([]byte, 32)); err != nil {
+		t.Fatalf("priming disk read: %v", err)
+	}
+	if _, err := io.ReadFull(brs, make([]byte, 8)); err != nil {
+		t.Fatalf("priming buffer read: %v", err)
+	}
+
+	if _, err := brs.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("seek: %v", err)
+	}
+
+	// 20 bytes from position 0; the pre-fix code panicked here.
+	got := make([]byte, 20)
+	n, err := brs.Read(got)
+	assert.NoError(t, err)
+	assert.Equal(t, 20, n)
+	assert.Equal(t, payload[:20], got, "rewound read returned wrong bytes")
+}
+
 // errorReader is an io.Reader that returns an error after reading a specified number of bytes.
 // It's used to simulate non-EOF errors during read operations.
 type errorReader struct {

--- a/pkg/iobuf/bufferedreaderseeker_test.go
+++ b/pkg/iobuf/bufferedreaderseeker_test.go
@@ -500,7 +500,7 @@ func TestBufferedReaderSeekerReadAfterFlushBackwardSeek(t *testing.T) {
 	assert.Equal(t, int64(32), brs.diskBufferSize)
 	assert.Equal(t, 16, brs.buf.Len())
 
-	// Seek back to the start and read 8 bytes — these live on disk.
+	// Seek back to the start and read 8 bytes, these live on disk.
 	_, err = brs.Seek(0, io.SeekStart)
 	assert.NoError(t, err)
 

--- a/pkg/iobuf/bufferedreaderseeker_test.go
+++ b/pkg/iobuf/bufferedreaderseeker_test.go
@@ -478,7 +478,7 @@ func TestBufferedReaderSeekerReadAfterFlushBackwardSeek(t *testing.T) {
 
 	// bytes.NewBuffer is non-seekable, so the BufferedReadSeeker must buffer.
 	brs := NewBufferedReaderSeeker(bytes.NewBuffer(payload))
-	defer brs.Close()
+	defer func() { assert.NoError(t, brs.Close()) }()
 	// Use a small threshold so the prime read flushes to disk.
 	brs.threshold = 32
 
@@ -537,7 +537,7 @@ func TestBufferedReaderSeekerReadSpansDiskAndBuffer(t *testing.T) {
 	}
 
 	brs := NewBufferedReaderSeeker(bytes.NewBuffer(payload))
-	defer brs.Close()
+	defer func() { assert.NoError(t, brs.Close()) }()
 	brs.threshold = 32
 
 	// Fill exactly to the threshold to trigger a flush on writeData.
@@ -591,7 +591,7 @@ func TestBufferedReaderSeekerReadRewindAfterFlush(t *testing.T) {
 	}
 
 	brs := NewBufferedReaderSeeker(bytes.NewBuffer(payload))
-	defer brs.Close()
+	defer func() { assert.NoError(t, brs.Close()) }()
 	brs.threshold = 32
 
 	// Flush 32 bytes to disk, then leave 8 more sitting in the buffer.


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
`BufferedReadSeeker.Read` mistranslates the virtual stream index when the in-memory buffer has been flushed to disk and then refilled with post-flush data:

- Buffer branch (`bufferedreaderseeker.go` line 146 in main):
  ```go
  if br.index < int64(br.buf.Len()) {
      totalBytesRead = copy(out, br.buf.Bytes()[br.index:])
  ```
  `br.index` is the *logical* stream position, not a buffer offset. After a flush + refill (e.g. `diskBufferSize=32`, `buf.Len()=16`), a backward read at index 0 satisfies `0 < 16` and slices `buf.Bytes()[0:]`, returning the post-flush tail (bytes 32..47) instead of the bytes that were flushed to disk.

- Temp-file branch (line 156 in main):
  ```go
  if _, err := br.tempFile.Seek(br.index-int64(br.buf.Len()), io.SeekStart); err != nil {
  ```
  Subtracting `buf.Len()` is only correct when the buffer is empty. Once the buffer carries any post-flush data, this produces a negative offset and a seek error (or a wrong-region read).

Both branches now use the same anchor `diskBufferSize`. The invariant is:
- Bytes `[0, diskBufferSize)` live in `tempFile`.
- Bytes `[diskBufferSize, diskBufferSize + buf.Len())` live in `buf`.

Reproducer (now a regression test in `bufferedreaderseeker_test.go`):
1. Wrap a non-seekable reader of 48 bytes, set `threshold = 32`.
2. Read 32 bytes (triggers flush to disk).
3. Read 16 more (refills the buffer).
4. `Seek(0, io.SeekStart)` then `Read(8)`, previously returned bytes `[32..39]` instead of `[0..7]`.

Distinct from #4914, which fixed a per-phase counter inside the same `Read` method; that change did not touch the index translation.

### Checklist:
* [x] Tests passing (`go test ./pkg/iobuf/... -race`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

### Documentation:
N/A. Internal package, behaviour-only fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Correctness fix on a shared I/O path used for MIME detection and APK/DEX scanning; behavior changes only for post-flush seek/read edge cases, with strong new test coverage.
> 
> **Overview**
> Fixes **`BufferedReadSeeker.Read`** when data has been flushed to a temp file and the in-memory buffer holds a post-flush tail. Reads and seeks now treat the stream as **`[0, diskBufferSize)` on disk** plus **`[diskBufferSize, …)` in the buffer**, anchored on `diskBufferSize`.
> 
> **Disk reads run before buffer reads** so one `Read` can cross the boundary without hitting the exhausted underlying reader and incorrectly marking `sizeKnown`, which had left buffered bytes unreachable. Temp-file seeks use **`br.index`** (not `index - buf.Len()`), and disk reads are **capped** to the on-disk region. The buffer path slices at **`index - diskBufferSize`** instead of treating the logical index as a buffer offset.
> 
> Adds regression tests for backward seek after flush, disk→buffer spanning reads, and the rewind-after-flush **slice bounds panic** seen in APK/DEX scans (#4569).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db696b1c2f231ddb706003650f977319e9983e77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->