### PR TITLE
fix: user token now correctly scans specified user repos instead of token owner's repos

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -526,7 +526,7 @@ func (s *Source) ensureRepoInfoCache(ctx context.Context, repo string, reporter 
 func (s *Source) enumerateBasicAuth(ctx context.Context, reporter sources.UnitReporter) error {
 	for _, org := range s.orgsCache.Keys() {
 		orgCtx := context.WithValue(ctx, "account", org)
-		userType, err := s.getReposByOrgOrUser(ctx, org, true, reporter)
+		userType, err := s.getReposByOrgOrUser(ctx, org, reporter)
 		if err != nil {
 			orgCtx.Logger().Error(err, "error fetching repos for org or user")
 			continue
@@ -551,7 +551,7 @@ func (s *Source) enumerateUnauthenticated(ctx context.Context, reporter sources.
 
 	for _, org := range s.orgsCache.Keys() {
 		orgCtx := context.WithValue(ctx, "account", org)
-		userType, err := s.getReposByOrgOrUser(ctx, org, false, reporter)
+		userType, err := s.getReposByOrgOrUser(ctx, org, reporter)
 		if err != nil {
 			orgCtx.Logger().Error(err, "error fetching repos for org or user")
 			continue
@@ -601,7 +601,7 @@ func (s *Source) enumerateWithToken(ctx context.Context, isGithubEnterprise bool
 	if len(s.orgsCache.Keys()) > 0 {
 		for _, org := range s.orgsCache.Keys() {
 			orgCtx := context.WithValue(ctx, "account", org)
-			userType, err := s.getReposByOrgOrUser(ctx, org, true, reporter)
+			userType, err := s.getReposByOrgOrUser(ctx, org, reporter)
 			if err != nil {
 				orgCtx.Logger().Error(err, "Unable to fetch repos for org or user")
 				continue

--- a/pkg/sources/github/repo.go
+++ b/pkg/sources/github/repo.go
@@ -199,7 +199,7 @@ const (
 )
 
 // getReposByOrgOrUser retrieves repositories for an organization or user.
-func (s *Source) getReposByOrgOrUser(ctx context.Context, name string, authenticated bool, reporter sources.UnitReporter) (userType, error) {
+func (s *Source) getReposByOrgOrUser(ctx context.Context, name string, reporter sources.UnitReporter) (userType, error) {
 	var err error
 
 	// try to get repositories for the organization first.
@@ -215,7 +215,10 @@ func (s *Source) getReposByOrgOrUser(ctx context.Context, name string, authentic
 	}
 
 	// if organization repos aren't found, try user repos.
-	err = s.getReposByUser(ctx, name, authenticated, reporter)
+	// Always use unauthenticated user listing since `name` is the target user,
+	// not the authenticated user. Using authenticated listing would incorrectly
+	// return the authenticated user's repos instead of the specified user's.
+	err = s.getReposByUser(ctx, name, false, reporter)
 	if err == nil {
 		if err := s.addUserGistsToCache(ctx, name, reporter); err != nil {
 			ctx.Logger().Error(err, "Unable to add user to cache")


### PR DESCRIPTION
## Description

When using `--org $user --token $GITHUB_TOKEN`, the tool was incorrectly scanning the token owner's repositories instead of the specified user's.

## Root Cause

The issue was in `getReposByOrgOrUser` which passed the `authenticated` flag to `getReposByUser`. When `authenticated=true`, it used the `ListByAuthenticatedUser` API which returns the authenticated user's repos, not the target user's repos.

## Fix

- Removed the `authenticated` parameter from `getReposByOrgOrUser`
- Always uses unauthenticated user listing (`ListByUser`) when looking up user repos, since the target is the specified user, not the token owner

Fixes #4517

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to GitHub repo enumeration that only affects which API endpoint is used for user repo listing; main risk is reduced visibility into private repos if the unauthenticated user listing lacks access.
> 
> **Overview**
> Fixes GitHub enumeration so `--org <user> --token <token>` scans the *specified user’s* repositories rather than the token owner’s.
> 
> This removes the `authenticated` flag from `getReposByOrgOrUser` and always uses `ListByUser` (unauthenticated user listing) when falling back from org repos to user repos, updating all call sites accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdeb027d52427a4291a8f07f5a6fc5bcb6aedb2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->