### PR TITLE
Add Together AI secret detector

### DIFF
--- a/pkg/detectors/togetherai/togetherai.go
+++ b/pkg/detectors/togetherai/togetherai.go
@@ -1,0 +1,103 @@
+package togetherai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+type Scanner struct {
+	client *http.Client
+}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	defaultClient = common.SaneHttpClient()
+
+	// Together AI API key pattern: tgp_v1_ followed by 43 characters (alphanumeric, underscore, hyphen)
+	keyPat = regexp.MustCompile(`\b(tgp_v1_[A-Za-z0-9_-]{43})\b`)
+)
+
+// Keywords are used for efficiently pre-filtering chunks.
+func (s Scanner) Keywords() []string {
+	return []string{"tgp_v1_"}
+}
+
+func (s Scanner) getClient() *http.Client {
+	if s.client != nil {
+		return s.client
+	}
+	return defaultClient
+}
+
+// FromData will find and optionally verify Together AI secrets in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
+
+	for _, match := range matches {
+		if len(match) != 2 {
+			continue
+		}
+		resMatch := strings.TrimSpace(match[1])
+
+		s1 := detectors.Result{
+			DetectorType: detector_typepb.DetectorType_TogetherAI,
+			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
+		}
+
+		if verify {
+			client := s.getClient()
+			isVerified, verificationErr := verifyTogetherAI(ctx, client, resMatch)
+			s1.Verified = isVerified
+			s1.SetVerificationError(verificationErr, resMatch)
+		}
+
+		results = append(results, s1)
+	}
+
+	return results, nil
+}
+
+func verifyTogetherAI(ctx context.Context, client *http.Client, apiKey string) (bool, error) {
+	// https://docs.together.ai/reference/models-list
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.together.xyz/v1/models", nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", apiKey))
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer res.Body.Close()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
+}
+
+func (s Scanner) Type() detector_typepb.DetectorType {
+	return detector_typepb.DetectorType_TogetherAI
+}
+
+func (s Scanner) Description() string {
+	return "Together AI provides API access to various AI models. API keys can be used to access and use these models."
+}

--- a/pkg/detectors/togetherai/togetherai_test.go
+++ b/pkg/detectors/togetherai/togetherai_test.go
@@ -1,0 +1,138 @@
+package togetherai
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+func TestTogetherAI_FromData(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors5")
+	if err != nil {
+		t.Fatalf("could not get test secrets from GCP: %s", err)
+	}
+	secret := testSecrets.MustGetField("TOGETHERAI")
+	inactiveSecret := testSecrets.MustGetField("TOGETHERAI_INACTIVE")
+
+	type args struct {
+		ctx    context.Context
+		data   []byte
+		verify bool
+	}
+	tests := []struct {
+		name                string
+		s                   Scanner
+		args                args
+		want                []detectors.Result
+		wantErr             bool
+		wantVerificationErr bool
+	}{
+		{
+			name: "found, verified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("together ai key: %s", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_TogetherAI,
+					Verified:     true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "found, unverified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("together ai key: %s", inactiveSecret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_TogetherAI,
+					Verified:     false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "not found",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte("no secret here"),
+				verify: true,
+			},
+			want:    nil,
+			wantErr: false,
+		},
+		{
+			name: "found, would be verified if not for timeout",
+			s:    Scanner{},
+			args: args{
+				ctx:    ctx,
+				data:   []byte(fmt.Sprintf("together ai key: %s", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_TogetherAI,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TogetherAI.FromData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if len(got[i].Raw) == 0 {
+					t.Fatalf("no raw secret present: \n %+v", got[i])
+				}
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
+				}
+			}
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "SecretParts", "verificationError", "primarySecret")
+			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
+				t.Errorf("TogetherAI.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			}
+		})
+	}
+}
+
+func BenchmarkFromData(benchmark *testing.B) {
+	ctx := context.Background()
+	s := Scanner{}
+	for name, data := range detectors.MustGetBenchmarkData() {
+		benchmark.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				_, err := s.FromData(ctx, false, data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/detectors/togetherai/togetherai_test.go
+++ b/pkg/detectors/togetherai/togetherai_test.go
@@ -15,14 +15,17 @@ import (
 )
 
 func TestTogetherAI_FromData(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
-	defer cancel()
-	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors5")
+	secretCtx, secretCancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer secretCancel()
+	testSecrets, err := common.GetSecret(secretCtx, "trufflehog-testing", "detectors5")
 	if err != nil {
 		t.Fatalf("could not get test secrets from GCP: %s", err)
 	}
 	secret := testSecrets.MustGetField("TOGETHERAI")
 	inactiveSecret := testSecrets.MustGetField("TOGETHERAI_INACTIVE")
+
+	timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer timeoutCancel()
 
 	type args struct {
 		ctx    context.Context
@@ -84,7 +87,7 @@ func TestTogetherAI_FromData(t *testing.T) {
 			name: "found, would be verified if not for timeout",
 			s:    Scanner{},
 			args: args{
-				ctx:    ctx,
+				ctx:    timeoutCtx,
 				data:   []byte(fmt.Sprintf("together ai key: %s", secret)),
 				verify: true,
 			},

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -767,6 +767,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/tineswebhook"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/tmetric"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/todoist"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/togetherai"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/tokeet"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/tomorrowio"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/tomtom"
@@ -1659,6 +1660,7 @@ func buildDetectorList() []detectors.Detector {
 		&tmetric.Scanner{},
 		&todoist.Scanner{},
 		// &toggltrack.Scanner{},
+		&togetherai.Scanner{},
 		&tokeet.Scanner{},
 		&tomorrowio.Scanner{},
 		&tomtom.Scanner{},

--- a/pkg/pb/detector_typepb/detector_type.pb.go
+++ b/pkg/pb/detector_typepb/detector_type.pb.go
@@ -1102,6 +1102,7 @@ const (
 	DetectorType_JiraDataCenterPAT                       DetectorType = 1046
 	DetectorType_ConfluenceDataCenter                    DetectorType = 1047
 	DetectorType_Cloudinary                              DetectorType = 1048
+	DetectorType_TogetherAI                              DetectorType = 1049
 )
 
 // Enum value maps for DetectorType.
@@ -2152,6 +2153,7 @@ var (
 		1046: "JiraDataCenterPAT",
 		1047: "ConfluenceDataCenter",
 		1048: "Cloudinary",
+		1049: "TogetherAI",
 	}
 	DetectorType_value = map[string]int32{
 		"Alibaba":                               0,
@@ -3199,6 +3201,7 @@ var (
 		"JiraDataCenterPAT":                 1046,
 		"ConfluenceDataCenter":              1047,
 		"Cloudinary":                        1048,
+		"TogetherAI":                        1049,
 	}
 )
 

--- a/proto/detector_type.proto
+++ b/proto/detector_type.proto
@@ -1050,4 +1050,5 @@ enum DetectorType {
   JiraDataCenterPAT = 1046;
   ConfluenceDataCenter = 1047;
   Cloudinary = 1048;
+  TogetherAI = 1049;
 }


### PR DESCRIPTION
## Summary
- Adds a new detector for Together AI API keys (`tgp_v1_` format)
- Verifies keys via read-only `GET https://api.together.xyz/v1/models`
- Registers detector in `defaults.go` and proto as `TogetherAI = 1049`
- Populates `SecretParts` with `"key"` per detector conventions

## Test plan
- [x] `go test ./pkg/detectors/togetherai/... -tags=detectors` passes all 4 cases (found+verified, found+unverified, not found, timeout)
- [x] Verified against a real Together AI key returning HTTP 200
- [x] Invalid key correctly returns HTTP 401 (unverified, no error)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive new detector plus enum registration; main risk is potential false positives/verification HTTP behavior from the external Together API.
> 
> **Overview**
> Adds a new `TogetherAI` secret detector that finds `tgp_v1_...` API keys and can verify them via a read-only `GET https://api.together.xyz/v1/models` call.
> 
> Registers the detector in `defaults.go` and extends `detector_type.proto`/generated protobufs with `TogetherAI = 1049`, with tests/benchmarks covering verified, unverified, not-found, and timeout verification cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3fe5075618a83e36d028849eb254d775486eb85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->