### PR TITLE
Add default Content-Type: application/json header for custom detector verification request

### DIFF
--- a/pkg/custom_detectors/custom_detectors.go
+++ b/pkg/custom_detectors/custom_detectors.go
@@ -285,7 +285,6 @@ func (c *CustomRegexWebhook) createResults(ctx context.Context, match map[string
 		if err != nil {
 			continue
 		}
-		req.Header.Set("Content-Type", "application/json")
 		for _, header := range verifyConfig.GetHeaders() {
 			key, value, found := strings.Cut(header, ":")
 			if !found {
@@ -293,6 +292,9 @@ func (c *CustomRegexWebhook) createResults(ctx context.Context, match map[string
 				continue
 			}
 			req.Header.Add(key, strings.TrimLeft(value, "\t\n\v\f\r "))
+		}
+		if _, ok := req.Header["Content-Type"]; !ok {
+			req.Header.Set("Content-Type", "application/json")
 		}
 		resp, err := httpClient.Do(req)
 		if err != nil {

--- a/pkg/custom_detectors/custom_detectors.go
+++ b/pkg/custom_detectors/custom_detectors.go
@@ -285,6 +285,7 @@ func (c *CustomRegexWebhook) createResults(ctx context.Context, match map[string
 		if err != nil {
 			continue
 		}
+		req.Header.Set("Content-Type", "application/json")
 		for _, header := range verifyConfig.GetHeaders() {
 			key, value, found := strings.Cut(header, ":")
 			if !found {

--- a/pkg/custom_detectors/custom_detectors.go
+++ b/pkg/custom_detectors/custom_detectors.go
@@ -293,7 +293,7 @@ func (c *CustomRegexWebhook) createResults(ctx context.Context, match map[string
 			}
 			req.Header.Add(key, strings.TrimLeft(value, "\t\n\v\f\r "))
 		}
-		if _, ok := req.Header["Content-Type"]; !ok {
+		if req.Header.Get("Content-Type") == "" {
 			req.Header.Set("Content-Type", "application/json")
 		}
 		resp, err := httpClient.Do(req)


### PR DESCRIPTION
### Description
Custom detector verification requests do not currently include a default `Content-Type: application/json` header, which can lead to compatibility issues and may require using `force=true` as a workaround.

This PR updates the custom detector verification flow to always include `Content-Type: application/json` when making HTTP requests. Since verification requests consistently send JSON payloads, standardizing this behavior is safe and ensures more reliable integrations.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to outbound custom detector verification requests; it only adds a default header when one is not already provided, which could affect integrations that relied on an omitted Content-Type.
> 
> **Overview**
> Custom detector webhook verification requests now **default `Content-Type` to `application/json`** when the user-specified verifier headers don’t set one.
> 
> This standardizes verification POSTs (which send JSON bodies) and reduces the need for workarounds with endpoints that require an explicit content type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab5fc9aeaf09d37978787226ef63d74e9888c522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->