### PR TITLE
Make detector Result.SecretParts initialization stricter

### DIFF
--- a/hack/checksecretparts/README.md
+++ b/hack/checksecretparts/README.md
@@ -9,21 +9,8 @@ For each directory under `pkg/detectors/` (recursing into subpackages):
 
 1. Find every composite literal of the form `detectors.Result{...}` or
    `&detectors.Result{...}` in non-test `.go` files.
-2. If the package does not mention `SecretParts` anywhere (neither in the
-   literal nor in a later `x.SecretParts = ...` assignment), emit a warning
+2. If the package does not mention `SecretParts` anywhere, emit a warning
    for each construction site.
-
-Test files (`_test.go`) are ignored on both sides — construction sites in
-tests are not flagged, and `SecretParts` references in tests do not suppress
-findings, because some tests zero the field for comparison.
-
-## Why warning-only
-
-This check ships as **warning-only** because ~907 existing detectors do not
-yet populate `SecretParts` (see the SecretParts design doc, step C).
-Hard-failing today would block every unrelated PR. The check is wired into
-CI with `continue-on-error: true` so the findings are visible without
-gating merges.
 
 ## Running locally
 
@@ -41,8 +28,7 @@ go run ./hack/checksecretparts -fail
 
 ## Flipping warning → fail
 
-Once step C is complete and every detector populates `SecretParts`, make
-this check gating:
+Once every detector populates `SecretParts`, make this check gating:
 
 1. In `.github/workflows/lint.yml`, drop `continue-on-error: true` from the
    `checksecretparts` job and change the run step to pass `-fail`.
@@ -53,7 +39,3 @@ this check gating:
 - It is a syntactic check. It matches `detectors.Result` by selector-expr
   name; packages that rename the import (`d "...detectors"`) would not be
   caught. No such rename exists in the current codebase.
-- It does not verify that `SecretParts` is populated on every code path —
-  only that the package touches the field at all. A finer-grained
-  dataflow check is deliberately out of scope; the rough check is enough
-  to surface unmigrated detectors.

--- a/hack/checksecretparts/check.go
+++ b/hack/checksecretparts/check.go
@@ -21,12 +21,7 @@ type Finding struct {
 }
 
 // CheckPackageDir runs the SecretParts check on a single directory. It returns
-// one Finding per detectors.Result{} construction site in the directory,
-// filtered so that packages which mention SecretParts anywhere produce no
-// findings. Test files (_test.go) are ignored on both sides: construction
-// sites in them are not reported, and references in them do not suppress
-// findings (test files commonly zero the field for comparison — see
-// pkg/detectors/gitlab/v1/gitlab_integration_test.go).
+// one Finding per detectors.Result{} construction site in the directory.
 func CheckPackageDir(dir string) ([]Finding, error) {
 	fset := token.NewFileSet()
 	entries, err := os.ReadDir(dir)
@@ -61,20 +56,10 @@ func CheckPackageDir(dir string) ([]Finding, error) {
 // and returns findings. It is separated from CheckPackageDir so that tests can
 // drive it with synthetic ASTs.
 func checkFiles(fset *token.FileSet, dir string, files []*ast.File) []Finding {
-	var (
-		constructions  []token.Position
-		hasSecretParts bool
-	)
+	var constructions []token.Position
 
 	for _, f := range files {
-		if fileReferencesSecretParts(f) {
-			hasSecretParts = true
-		}
 		constructions = append(constructions, findResultConstructions(fset, f)...)
-	}
-
-	if hasSecretParts || len(constructions) == 0 {
-		return nil
 	}
 
 	sort.Slice(constructions, func(i, j int) bool {
@@ -154,31 +139,4 @@ func hasSecretPartsKey(lit *ast.CompositeLit) bool {
 		}
 	}
 	return false
-}
-
-// fileReferencesSecretParts returns true if the file mentions the identifier
-// "SecretParts" in any form: a composite-literal key, a selector expression
-// (x.SecretParts), or a bare identifier. The rationale is that if a detector
-// package touches SecretParts at all — whether on the construction site or in
-// a later assignment — it has been migrated; the check's job is to find
-// packages that never touch it.
-func fileReferencesSecretParts(f *ast.File) bool {
-	found := false
-	ast.Inspect(f, func(n ast.Node) bool {
-		if found {
-			return false
-		}
-		switch x := n.(type) {
-		case *ast.Ident:
-			if x.Name == "SecretParts" {
-				found = true
-			}
-		case *ast.SelectorExpr:
-			if x.Sel != nil && x.Sel.Name == "SecretParts" {
-				found = true
-			}
-		}
-		return !found
-	})
-	return found
 }

--- a/hack/checksecretparts/check_test.go
+++ b/hack/checksecretparts/check_test.go
@@ -49,7 +49,7 @@ func FromData() detectors.Result {
 			wantLen: 0,
 		},
 		{
-			name: "SecretParts assigned later is accepted",
+			name: "SecretParts assigned later is not accepted",
 			files: map[string]string{
 				"det.go": `package det
 
@@ -65,7 +65,7 @@ func FromData() detectors.Result {
 }
 `,
 			},
-			wantLen: 0,
+			wantLen: 1,
 		},
 		{
 			name: "no detectors.Result construction is a no-op",

--- a/hack/checksecretparts/main.go
+++ b/hack/checksecretparts/main.go
@@ -62,7 +62,7 @@ func main() {
 	}
 
 	for _, f := range findings {
-		fmt.Printf("%s: warning: detectors.Result constructed without SecretParts (no reference to SecretParts anywhere in package)\n", f.Position)
+		fmt.Printf("%s: warning: detectors.Result constructed without SecretParts\n", f.Position)
 	}
 
 	if len(findings) > 0 {

--- a/pkg/detectors/airbrakeprojectkey/airbrakeprojectkey.go
+++ b/pkg/detectors/airbrakeprojectkey/airbrakeprojectkey.go
@@ -56,6 +56,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detector_typepb.DetectorType_AirbrakeProjectKey,
 				Raw:          []byte(key),
 				RawV2:        []byte(key + id),
+				SecretParts:  map[string]string{"key": key, "id": id},
 			}
 			s1.ExtraData = map[string]string{
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/airbrake/",
@@ -70,9 +71,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				isVerified, verificationErr := verifyAirbrakeProjectKey(ctx, client, key, id)
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr)
-				if isVerified {
-					s1.SecretParts = map[string]string{"key": key}
-				}
 			}
 
 			results = append(results, s1)

--- a/pkg/detectors/airbrakeuserkey/airbrakeuserkey.go
+++ b/pkg/detectors/airbrakeuserkey/airbrakeuserkey.go
@@ -50,6 +50,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			ExtraData: map[string]string{
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/airbrake/",
 			},
+			SecretParts: map[string]string{"key": key},
 		}
 
 		if verify {
@@ -61,9 +62,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, verificationErr := verifyAirbrakeUserKey(ctx, client, key)
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr)
-			if isVerified {
-				s1.SecretParts = map[string]string{"key": key}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/airtableoauth/airtableoauth.go
+++ b/pkg/detectors/airtableoauth/airtableoauth.go
@@ -47,6 +47,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_AirtableOAuth,
 			Raw:          []byte(match),
+			SecretParts:  map[string]string{"token": match},
 		}
 
 		if verify {
@@ -59,10 +60,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = isVerified
 			s1.ExtraData = extraData
 			s1.SetVerificationError(verificationErr, match)
-
-			if s1.Verified {
-				s1.SecretParts = map[string]string{"token": match}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/airtablepersonalaccesstoken/airtablepersonalaccesstoken.go
+++ b/pkg/detectors/airtablepersonalaccesstoken/airtablepersonalaccesstoken.go
@@ -42,6 +42,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_AirtablePersonalAccessToken,
 			Raw:          []byte(match),
+			SecretParts:  map[string]string{"token": match},
 		}
 
 		if verify {
@@ -54,10 +55,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = isVerified
 			s1.ExtraData = extraData
 			s1.SetVerificationError(verificationErr, match)
-
-			if s1.Verified {
-				s1.SecretParts = map[string]string{"token": match}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/anthropic/anthropic.go
+++ b/pkg/detectors/anthropic/anthropic.go
@@ -50,6 +50,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			DetectorType: detector_typepb.DetectorType_Anthropic,
 			Raw:          []byte(keyMatch),
 			ExtraData:    make(map[string]string),
+			SecretParts:  map[string]string{"key": keyMatch},
 		}
 
 		if verify {
@@ -74,12 +75,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 			s1.Verified = isVerified
 			s1.SetVerificationError(err, keyMatch)
-
-			if s1.Verified {
-				s1.SecretParts = map[string]string{
-					"key": keyMatch,
-				}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/anypointoauth2/anypointoauth2.go
+++ b/pkg/detectors/anypointoauth2/anypointoauth2.go
@@ -70,6 +70,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detector_typepb.DetectorType_AnypointOAuth2,
 				Raw:          []byte(secret),
 				RawV2:        []byte(fmt.Sprintf("%s:%s", id, secret)),
+				SecretParts: map[string]string{
+					"client_id":     id,
+					"client_secret": secret,
+				},
 			}
 
 			if verify {
@@ -77,12 +81,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				isVerified, verificationErr := verifyMatch(ctx, client, id, secret)
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr)
-				if isVerified {
-					s1.SecretParts = map[string]string{
-						"client_id":     id,
-						"client_secret": secret,
-					}
-				}
 			}
 
 			results = append(results, s1)

--- a/pkg/detectors/artifactory/artifactory.go
+++ b/pkg/detectors/artifactory/artifactory.go
@@ -86,6 +86,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detector_typepb.DetectorType_ArtifactoryAccessToken,
 				Raw:          []byte(token),
 				RawV2:        []byte(token + url),
+				SecretParts: map[string]string{
+					"domain": url,
+					"token":  token,
+				},
 			}
 
 			if verify {
@@ -98,13 +102,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					}
 
 					s1.SetVerificationError(verificationErr, token)
-
-					if isVerified {
-						s1.SecretParts = map[string]string{
-							"domain": url,
-							"token":  token,
-						}
-					}
 				}
 			}
 

--- a/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken.go
+++ b/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken.go
@@ -84,6 +84,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detector_typepb.DetectorType_ArtifactoryReferenceToken,
 				Raw:          []byte(token),
 				RawV2:        []byte(token + url),
+				SecretParts: map[string]string{
+					"domain": url,
+					"token":  token,
+				},
 			}
 
 			if verify {
@@ -96,13 +100,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					}
 
 					s1.SetVerificationError(verificationErr, token)
-				}
-
-				if isVerified {
-					s1.SecretParts = map[string]string{
-						"domain": url,
-						"token":  token,
-					}
 				}
 			}
 

--- a/pkg/detectors/asanaoauth/asanaoauth.go
+++ b/pkg/detectors/asanaoauth/asanaoauth.go
@@ -44,13 +44,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_AsanaOauth,
 			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 
 		if verify {
 			isVerified, err := verifyMatch(ctx, client, resMatch)
 			s1.Verified = isVerified
 			s1.SetVerificationError(err, resMatch)
-			s1.SecretParts = map[string]string{"key": resMatch}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/asanapersonalaccesstoken/asanapersonalaccesstoken.go
+++ b/pkg/detectors/asanapersonalaccesstoken/asanapersonalaccesstoken.go
@@ -46,15 +46,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_AsanaPersonalAccessToken,
 			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 
 		if verify {
 			isVerified, err := verifyMatch(ctx, client, resMatch)
 			s1.Verified = isVerified
 			s1.SetVerificationError(err, resMatch)
-			if isVerified {
-				s1.SecretParts = map[string]string{"key": resMatch}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/atlassian/v1/atlassian.go
+++ b/pkg/detectors/atlassian/v1/atlassian.go
@@ -66,6 +66,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/atlassian/",
 				"version":        fmt.Sprintf("%d", s.Version()),
 			},
+			SecretParts: map[string]string{"key": match},
 		}
 
 		if verify {
@@ -80,12 +81,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.ExtraData["Organization"] = orgResponse.Data[0].Attributes.Name
 			}
 			s1.SetVerificationError(verificationErr, match)
-
-			if isVerified {
-				s1.SecretParts = map[string]string{
-					"key": match,
-				}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/atlassian/v2/atlassian.go
+++ b/pkg/detectors/atlassian/v2/atlassian.go
@@ -75,6 +75,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for match := range uniqueMatches {
 		for orgId := range uniqueOrgIdMatches {
+			secretParts := map[string]string{"key": match}
+			if orgId != "" {
+				secretParts["organization_id"] = orgId
+			}
 			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_Atlassian,
 				Raw:          []byte(match),
@@ -82,6 +86,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					"rotation_guide": "https://howtorotate.com/docs/tutorials/atlassian/",
 					"version":        fmt.Sprintf("%d", s.Version()),
 				},
+				SecretParts: secretParts,
 			}
 
 			if verify {
@@ -96,14 +101,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					s1.ExtraData["Organization"] = orgResponse.Data[0].Attributes.Name
 				}
 				s1.SetVerificationError(verificationErr, match)
-				if s1.Verified {
-					s1.SecretParts = map[string]string{
-						"key": match,
-					}
-					if orgId != "" {
-						s1.SecretParts["organization_id"] = orgId
-					}
-				}
 			}
 
 			results = append(results, s1)

--- a/pkg/detectors/buildkite/v1/buildkite.go
+++ b/pkg/detectors/buildkite/v1/buildkite.go
@@ -53,6 +53,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			DetectorType: detector_typepb.DetectorType_Buildkite,
 			Raw:          []byte(resMatch),
 			ExtraData:    make(map[string]string),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 
 		if verify {
@@ -60,12 +61,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr, resMatch)
 			s1.ExtraData = extraData
-
-			if isVerified {
-				s1.SecretParts = map[string]string{
-					"key": resMatch,
-				}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/buildkite/v2/buildkite.go
+++ b/pkg/detectors/buildkite/v2/buildkite.go
@@ -45,6 +45,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Buildkite,
 			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 
 		if verify {
@@ -52,13 +53,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr, resMatch)
 			s1.ExtraData = extraData
-
-			if isVerified {
-				s1.SecretParts = map[string]string{
-					"key": resMatch,
-				}
-			}
-
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/coinbase/coinbase.go
+++ b/pkg/detectors/coinbase/coinbase.go
@@ -106,18 +106,16 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detector_typepb.DetectorType_Coinbase,
 				Raw:          []byte(resPrivateKey),
 				RawV2:        []byte(fmt.Sprintf("%s:%s", resKeyName, resPrivateKey)),
+				SecretParts: map[string]string{
+					"key_name": resKeyName,
+					"key":      resPrivateKey,
+				},
 			}
 
 			if verify {
 				isVerified, verificationErr := s.verifyMatch(ctx, client, resKeyName, resPrivateKey)
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr, resPrivateKey)
-				if isVerified {
-					s1.SecretParts = map[string]string{
-						"key_name": resKeyName,
-						"key":      resPrivateKey,
-					}
-				}
 			}
 			results = append(results, s1)
 

--- a/pkg/detectors/databrickstoken/databrickstoken.go
+++ b/pkg/detectors/databrickstoken/databrickstoken.go
@@ -54,6 +54,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detector_typepb.DetectorType_DatabricksToken,
 				Raw:          []byte(token),
 				RawV2:        []byte(token + domain),
+				SecretParts: map[string]string{
+					"token":  token,
+					"domain": domain,
+				},
 			}
 
 			if verify {
@@ -65,13 +69,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				isVerified, verificationErr := verifyDatabricksToken(client, domain, token)
 				s1.Verified = isVerified
 				s1.SetVerificationError(verificationErr)
-
-				if s1.Verified {
-					s1.SecretParts = map[string]string{
-						"token":  token,
-						"domain": domain,
-					}
-				}
 			}
 
 			results = append(results, s1)

--- a/pkg/detectors/datadogapikey/datadogapikey.go
+++ b/pkg/detectors/datadogapikey/datadogapikey.go
@@ -66,6 +66,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_DatadogApikey,
 			Raw:          []byte(resApiMatch),
+			SecretParts:  map[string]string{"api_key": resApiMatch},
 		}
 
 		if verify {
@@ -74,7 +75,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				isVerified, verificationErr := verifyMatch(ctx, client, resApiMatch, baseURL)
 				if isVerified {
 					s1.Verified = isVerified
-					s1.SecretParts = map[string]string{"api_key": resApiMatch, "endpoint": baseURL}
+					s1.SecretParts["endpoint"] = baseURL
 					// break the loop once we've successfully validated the token against a baseURL
 					break
 				}

--- a/pkg/detectors/datadogapikey/datadogapikey_test.go
+++ b/pkg/detectors/datadogapikey/datadogapikey_test.go
@@ -27,6 +27,7 @@ func TestDataDogApiKey_Pattern_WithValidAPIKey(t *testing.T) {
 		{
 			DetectorType: detector_typepb.DetectorType_DatadogApikey,
 			Raw:          []byte(apiKey),
+			SecretParts:  map[string]string{"api_key": apiKey},
 		},
 	}
 	matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(input))

--- a/pkg/detectors/datadogtoken/datadogtoken.go
+++ b/pkg/detectors/datadogtoken/datadogtoken.go
@@ -126,6 +126,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				ExtraData: map[string]string{
 					"Type": "Application+APIKey",
 				},
+				SecretParts: map[string]string{"api_key": resApiMatch, "app_key": resAppMatch},
 			}
 
 			if verify {
@@ -142,7 +143,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						defer res.Body.Close()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
-							s1.SecretParts = map[string]string{"api_key": resApiMatch, "app_key": resAppMatch, "endpoint": baseURL}
+							s1.SecretParts["endpoint"] = baseURL
 							var serviceResponse userServiceResponse
 							if err := json.NewDecoder(res.Body).Decode(&serviceResponse); err == nil {
 								// setup emails

--- a/pkg/detectors/digitaloceantoken/digitaloceantoken.go
+++ b/pkg/detectors/digitaloceantoken/digitaloceantoken.go
@@ -43,6 +43,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_DigitalOceanToken,
 			Raw:          []byte(token),
+			SecretParts:  map[string]string{"key": token},
 		}
 
 		if verify {
@@ -53,11 +54,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, verificationErr := verifyDigitalOceanToken(ctx, client, token)
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr)
-			if s1.Verified {
-				s1.SecretParts = map[string]string{
-					"key": token,
-				}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/digitaloceanv2/digitaloceanv2.go
+++ b/pkg/detectors/digitaloceanv2/digitaloceanv2.go
@@ -49,6 +49,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_DigitalOceanV2,
 			Raw:          []byte(token),
+			SecretParts:  map[string]string{"key": token},
 		}
 
 		if verify {
@@ -64,19 +65,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.SetVerificationError(verificationErr)
 				s1.Verified = verified
 				if s1.Verified {
-					s1.SecretParts = map[string]string{
-						"key": newAccessToken,
-					}
+					s1.SecretParts["key"] = newAccessToken
 				}
 			case strings.HasPrefix(token, "doo_v1_"), strings.HasPrefix(token, "dop_v1_"):
 				verified, verificationErr := verifyAccessToken(ctx, client, token)
 				s1.Verified = verified
 				s1.SetVerificationError(verificationErr)
-				if s1.Verified {
-					s1.SecretParts = map[string]string{
-						"key": token,
-					}
-				}
 			}
 		}
 

--- a/pkg/detectors/dockerhub/v1/dockerhub.go
+++ b/pkg/detectors/dockerhub/v1/dockerhub.go
@@ -67,10 +67,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: s.Type(),
 			Raw:          []byte(token),
+			SecretParts:  map[string]string{"pat": token},
 		}
 
 		for username := range usernames {
 			s1.RawV2 = []byte(fmt.Sprintf("%s:%s", username, token))
+			s1.SecretParts["username"] = username
 
 			if verify {
 				if s.client == nil {
@@ -81,12 +83,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.Verified = isVerified
 				s1.ExtraData = extraData
 				s1.SetVerificationError(verificationErr)
-				if s1.Verified {
-					s1.SecretParts = map[string]string{
-						"username": username,
-						"pat":      token,
-					}
-				}
 			}
 
 			results = append(results, s1)

--- a/pkg/detectors/dockerhub/v2/dockerhub.go
+++ b/pkg/detectors/dockerhub/v2/dockerhub.go
@@ -67,10 +67,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: s.Type(),
 			Raw:          []byte(token),
+			SecretParts:  map[string]string{"pat": token},
 		}
 
 		for username := range usernames {
 			s1.RawV2 = []byte(fmt.Sprintf("%s:%s", username, token))
+			s1.SecretParts["username"] = username
 
 			if verify {
 				if s.client == nil {
@@ -81,12 +83,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.Verified = isVerified
 				s1.ExtraData = extraData
 				s1.SetVerificationError(verificationErr)
-				if s1.Verified {
-					s1.SecretParts = map[string]string{
-						"username": username,
-						"pat":      token,
-					}
-				}
 			}
 
 			results = append(results, s1)

--- a/pkg/detectors/dropbox/dropbox.go
+++ b/pkg/detectors/dropbox/dropbox.go
@@ -46,6 +46,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Dropbox,
 			Raw:          []byte(key),
+			SecretParts:  map[string]string{"token": key},
 		}
 
 		if verify {
@@ -57,9 +58,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, verificationErr := verifyDropboxToken(ctx, client, key)
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr)
-			if s1.Verified {
-				s1.SecretParts = map[string]string{"token": key}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/elevenlabs/v1/elevenlabs.go
+++ b/pkg/detectors/elevenlabs/v1/elevenlabs.go
@@ -59,6 +59,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				"version":        "1",
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/elevenlabs/",
 			},
+			SecretParts: map[string]string{"key": match},
 		}
 
 		if verify {
@@ -74,12 +75,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.ExtraData["Tier"] = userResponse.Subscription.Tier
 			}
 			s1.SetVerificationError(verificationErr, match)
-
-			if s1.Verified {
-				s1.SecretParts = map[string]string{
-					"key": match,
-				}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/elevenlabs/v2/elevenlabs.go
+++ b/pkg/detectors/elevenlabs/v2/elevenlabs.go
@@ -56,6 +56,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			DetectorType: detector_typepb.DetectorType_ElevenLabs,
 			Raw:          []byte(match),
 			ExtraData:    map[string]string{"version": "2"},
+			SecretParts:  map[string]string{"key": match},
 		}
 
 		if verify {
@@ -71,12 +72,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.ExtraData["Tier"] = userResponse.Subscription.Tier
 			}
 			s1.SetVerificationError(verificationErr, match)
-
-			if s1.Verified {
-				s1.SecretParts = map[string]string{
-					"key": match,
-				}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/fastlypersonaltoken/fastlypersonaltoken.go
+++ b/pkg/detectors/fastlypersonaltoken/fastlypersonaltoken.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_FastlyPersonalToken,
 			Raw:          []byte(match),
+			SecretParts:  map[string]string{"key": match},
 		}
 
 		if verify {
@@ -59,12 +60,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = verified
 			s1.ExtraData = extraData
 			s1.SetVerificationError(verificationErr, match)
-
-			if s1.Verified {
-				s1.SecretParts = map[string]string{
-					"key": match,
-				}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/figmapersonalaccesstoken/v1/figmapersonalaccesstoken.go
+++ b/pkg/detectors/figmapersonalaccesstoken/v1/figmapersonalaccesstoken.go
@@ -50,6 +50,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			ExtraData: map[string]string{
 				"version": fmt.Sprintf("%d", s.Version()),
 			},
+			SecretParts: map[string]string{"token": resMatch},
 		}
 
 		if verify {
@@ -74,9 +75,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 			} else {
 				s1.SetVerificationError(err, resMatch)
-			}
-			if s1.Verified {
-				s1.SecretParts = map[string]string{"token": resMatch}
 			}
 		}
 

--- a/pkg/detectors/figmapersonalaccesstoken/v2/figmapersonalaccesstoken_v2.go
+++ b/pkg/detectors/figmapersonalaccesstoken/v2/figmapersonalaccesstoken_v2.go
@@ -54,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			ExtraData: map[string]string{
 				"version": fmt.Sprintf("%d", s.Version()),
 			},
+			SecretParts: map[string]string{"token": resMatch},
 		}
 
 		if verify {
@@ -78,9 +79,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				}
 			} else {
 				s1.SetVerificationError(err, resMatch)
-			}
-			if s1.Verified {
-				s1.SecretParts = map[string]string{"token": resMatch}
 			}
 		}
 

--- a/pkg/detectors/gitlab/v1/gitlab.go
+++ b/pkg/detectors/gitlab/v1/gitlab.go
@@ -88,6 +88,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					"rotation_guide": "https://howtorotate.com/docs/tutorials/gitlab/",
 					"version":        fmt.Sprintf("%d", s.Version()),
 				},
+				SecretParts: map[string]string{
+					"key":  resMatch,
+					"host": endpoint,
+				},
 			}
 
 			if verify {
@@ -97,14 +101,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				s1.SetVerificationError(verificationErr)
 
-				// for verified keys set the analysis info
+				// for verified keys break out of the endpoint loop to continue to next secret
 				if s1.Verified {
-					s1.SecretParts = map[string]string{
-						"key":  resMatch,
-						"host": endpoint,
-					}
-
-					// if secret is verified with one endpoint, break the loop to continue to next secret
 					results = append(results, s1)
 					break
 				}

--- a/pkg/detectors/gitlab/v2/gitlab_v2.go
+++ b/pkg/detectors/gitlab/v2/gitlab_v2.go
@@ -70,6 +70,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					"rotation_guide": "https://howtorotate.com/docs/tutorials/gitlab/",
 					"version":        fmt.Sprintf("%d", s.Version()),
 				},
+				SecretParts: map[string]string{
+					"key":  resMatch,
+					"host": endpoint,
+				},
 			}
 
 			if verify {
@@ -80,14 +84,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				s1.SetVerificationError(verificationErr)
 
-				// for verified keys set the analysis info
+				// for verified keys break out of the endpoint loop to continue to next secret
 				if s1.Verified {
-					s1.SecretParts = map[string]string{
-						"key":  resMatch,
-						"host": endpoint,
-					}
-
-					// if secret is verified with one endpoint, break the loop to continue to next secret
 					results = append(results, s1)
 					break
 				}

--- a/pkg/detectors/gitlab/v3/gitlab_v3.go
+++ b/pkg/detectors/gitlab/v3/gitlab_v3.go
@@ -71,6 +71,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					"rotation_guide": "https://howtorotate.com/docs/tutorials/gitlab/",
 					"version":        fmt.Sprintf("%d", s.Version()),
 				},
+				SecretParts: map[string]string{
+					"key":  resMatch,
+					"host": endpoint,
+				},
 			}
 
 			if verify {
@@ -81,14 +85,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				s1.SetVerificationError(verificationErr)
 
-				// for verified keys set the analysis info
+				// for verified keys break out of the endpoint loop to continue to next secret
 				if s1.Verified {
-					s1.SecretParts = map[string]string{
-						"key":  resMatch,
-						"host": endpoint,
-					}
-
-					// if secret is verified with one endpoint, break the loop to continue to next secret
 					results = append(results, s1)
 					break
 				}

--- a/pkg/detectors/groq/groq.go
+++ b/pkg/detectors/groq/groq.go
@@ -45,6 +45,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			ExtraData: map[string]string{
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/groq/",
 			},
+			SecretParts: map[string]string{"key": match},
 		}
 
 		if verify {
@@ -57,12 +58,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = isVerified
 			s1.ExtraData = extraData
 			s1.SetVerificationError(verificationErr, match)
-
-			if isVerified {
-				s1.SecretParts = map[string]string{
-					"key": match,
-				}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/harness/harness.go
+++ b/pkg/detectors/harness/harness.go
@@ -63,6 +63,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Harness,
 			Raw:          []byte(match),
+			SecretParts:  map[string]string{"key": match},
 		}
 
 		if verify {
@@ -72,13 +73,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = isVerified
 			s1.ExtraData = extraData
 			s1.SetVerificationError(verificationErr, match)
-
-			if isVerified {
-				s1.SecretParts = map[string]string{
-					"key": match,
-				}
-			}
-
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/huggingface/huggingface.go
+++ b/pkg/detectors/huggingface/huggingface.go
@@ -45,6 +45,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_HuggingFace,
 			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 
 		if verify {
@@ -52,7 +53,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = isVerified
 			s1.ExtraData = extraData
 			s1.SetVerificationError(verificationErr, resMatch)
-			s1.SecretParts = map[string]string{"key": resMatch}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/jdbc/jdbc.go
+++ b/pkg/detectors/jdbc/jdbc.go
@@ -83,6 +83,7 @@ matchLoop:
 			DetectorType: detector_typepb.DetectorType_JDBC,
 			Raw:          []byte(jdbcConn),
 			Redacted:     tryRedactAnonymousJDBC(jdbcConn),
+			SecretParts:  map[string]string{"connection_string": jdbcConn},
 		}
 
 		if verify {
@@ -101,9 +102,6 @@ matchLoop:
 			if pingRes.err != nil && !pingRes.determinate {
 				err = pingRes.err
 				result.SetVerificationError(err, jdbcConn)
-			}
-			result.SecretParts = map[string]string{
-				"connection_string": jdbcConn,
 			}
 			// TODO: specialized redaction
 		}

--- a/pkg/detectors/jiratoken/v1/jiratoken.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken.go
@@ -105,6 +105,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						"rotation_guide": "https://howtorotate.com/docs/tutorials/atlassian/",
 						"version":        fmt.Sprintf("%d", s.Version()),
 					},
+					SecretParts: map[string]string{
+						"token":  token,
+						"domain": domain,
+						"email":  email,
+					},
 				}
 
 				if verify {
@@ -117,13 +122,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						}
 
 						s1.SetVerificationError(verificationErr, token)
-					}
-					if isVerified {
-						s1.SecretParts = map[string]string{
-							"token":  token,
-							"domain": domain,
-							"email":  email,
-						}
 					}
 				}
 

--- a/pkg/detectors/jiratoken/v2/jiratoken_v2.go
+++ b/pkg/detectors/jiratoken/v2/jiratoken_v2.go
@@ -83,6 +83,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						"rotation_guide": "https://howtorotate.com/docs/tutorials/atlassian/",
 						"version":        fmt.Sprintf("%d", s.Version()),
 					},
+					SecretParts: map[string]string{
+						"token":  token,
+						"domain": domain,
+						"email":  email,
+					},
 				}
 
 				if verify {
@@ -90,13 +95,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					isVerified, verificationErr := v1.VerifyJiraToken(ctx, client, email, domain, token)
 					s1.Verified = isVerified
 					s1.SetVerificationError(verificationErr, token)
-					if isVerified {
-						s1.SecretParts = map[string]string{
-							"token":  token,
-							"domain": domain,
-							"email":  email,
-						}
-					}
 				}
 
 				results = append(results, s1)

--- a/pkg/detectors/launchdarkly/launchdarkly.go
+++ b/pkg/detectors/launchdarkly/launchdarkly.go
@@ -72,6 +72,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			DetectorType: detector_typepb.DetectorType_LaunchDarkly,
 			Raw:          []byte(resMatch),
 			ExtraData:    make(map[string]string),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 
 		if verify {
@@ -79,13 +80,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr)
 			s1.ExtraData = extraData
-
-			// only api keys can be analyzed
-			if strings.HasPrefix(resMatch, "api-") {
-				s1.SecretParts = map[string]string{
-					"key": resMatch,
-				}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/mailchimp/mailchimp.go
+++ b/pkg/detectors/mailchimp/mailchimp.go
@@ -42,6 +42,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		result := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Mailchimp,
 			Raw:          []byte(match),
+			SecretParts:  map[string]string{"key": match},
 		}
 		result.ExtraData = map[string]string{
 			"rotation_guide": "https://howtorotate.com/docs/tutorials/mailchimp/",
@@ -63,9 +64,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					result.Verified = true
 				}
-			}
-			result.SecretParts = map[string]string{
-				"key": match,
 			}
 		}
 

--- a/pkg/detectors/monday/monday.go
+++ b/pkg/detectors/monday/monday.go
@@ -44,18 +44,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Monday,
 			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 
 		if verify {
 			isVerified, verificationErr := verifyMondayPAT(ctx, client, resMatch)
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr)
-
-			if s1.Verified {
-				s1.SecretParts = map[string]string{
-					"key": resMatch,
-				}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/mongodb/mongodb.go
+++ b/pkg/detectors/mongodb/mongodb.go
@@ -88,6 +88,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			ExtraData: map[string]string{
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/mongo/",
 			},
+			SecretParts: map[string]string{"key": connStr},
 		}
 
 		if verify {
@@ -102,12 +103,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				continue
 			}
 			r.SetVerificationError(vErr, password)
-
-			if isVerified {
-				r.SecretParts = map[string]string{
-					"key": connStr,
-				}
-			}
 		}
 		results = append(results, r)
 	}

--- a/pkg/detectors/mux/mux.go
+++ b/pkg/detectors/mux/mux.go
@@ -50,6 +50,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detector_typepb.DetectorType_Mux,
 				Raw:          []byte(resMatch),
 				RawV2:        []byte(resMatch + resSecretMatch),
+				SecretParts: map[string]string{
+					"key":    resMatch,
+					"secret": resSecretMatch,
+				},
 			}
 
 			if verify {
@@ -64,12 +68,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					defer res.Body.Close()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
-					}
-				}
-				if s1.Verified {
-					s1.SecretParts = map[string]string{
-						"key":    resMatch,
-						"secret": resSecretMatch,
 					}
 				}
 			}

--- a/pkg/detectors/netlify/v1/netlify_v1.go
+++ b/pkg/detectors/netlify/v1/netlify_v1.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Netlify,
 			Raw:          []byte(match),
+			SecretParts:  map[string]string{"key": match},
 		}
 		s1.ExtraData = map[string]string{
 			"rotation_guide": rotationGuideUrl,
@@ -62,10 +63,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, verificationErr := verifyMatch(ctx, client, match)
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr, match)
-
-			if s1.Verified {
-				s1.SecretParts = map[string]string{"key": match}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/netlify/v2/netlify_v2.go
+++ b/pkg/detectors/netlify/v2/netlify_v2.go
@@ -52,6 +52,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Netlify,
 			Raw:          []byte(match),
+			SecretParts:  map[string]string{"key": match},
 		}
 		s1.ExtraData = map[string]string{
 			"rotation_guide": rotationGuideUrl,
@@ -62,10 +63,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, verificationErr := verifyMatch(ctx, client, match)
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr, match)
-
-			if s1.Verified {
-				s1.SecretParts = map[string]string{"key": match}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/ngrok/ngrok.go
+++ b/pkg/detectors/ngrok/ngrok.go
@@ -57,6 +57,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		r := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Ngrok,
 			Raw:          []byte(token),
+			SecretParts:  map[string]string{"key": token},
 		}
 
 		if verify {
@@ -66,9 +67,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, vErr := verifyMatch(ctx, s.client, token)
 			r.Verified = isVerified
 			r.SetVerificationError(vErr, token)
-			if isVerified {
-				r.SecretParts = map[string]string{"key": token}
-			}
 		}
 
 		results = append(results, r)

--- a/pkg/detectors/notion/notion.go
+++ b/pkg/detectors/notion/notion.go
@@ -42,6 +42,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Notion,
 			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 
 		if verify {
@@ -60,7 +61,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					// Notion returns 401 for all non-valid keys, thus 403 indicates it has fine-tuned permissions,
 					// /v1/search, /v1/databases/*, etc. may work.
 					s1.Verified = true
-					s1.SecretParts = map[string]string{"key": resMatch}
 
 				}
 			} else {

--- a/pkg/detectors/npmtoken/npmtoken.go
+++ b/pkg/detectors/npmtoken/npmtoken.go
@@ -44,6 +44,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_NpmToken,
 			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 		s1.ExtraData = map[string]string{
 			"rotation_guide": "https://howtorotate.com/docs/tutorials/npm/",
@@ -60,9 +61,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
-					s1.SecretParts = map[string]string{
-						"key": resMatch,
-					}
 				}
 			}
 		}

--- a/pkg/detectors/npmtokenv2/npmtokenv2.go
+++ b/pkg/detectors/npmtokenv2/npmtokenv2.go
@@ -45,6 +45,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_NpmToken,
 			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 		s1.ExtraData = map[string]string{
 			"rotation_guide": "https://howtorotate.com/docs/tutorials/npm/",
@@ -61,9 +62,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
-					s1.SecretParts = map[string]string{
-						"key": resMatch,
-					}
 				}
 			}
 		}

--- a/pkg/detectors/openai/openai.go
+++ b/pkg/detectors/openai/openai.go
@@ -54,6 +54,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			DetectorType: detector_typepb.DetectorType_OpenAI,
 			Redacted:     token[:3] + "..." + token[min(len(token)-1, 47):],
 			Raw:          []byte(token),
+			SecretParts:  map[string]string{"key": token},
 		}
 
 		if verify {
@@ -66,7 +67,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = verified
 			s1.ExtraData = extraData
 			s1.SetVerificationError(verificationErr)
-			s1.SecretParts = map[string]string{"key": token}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/openaiadmin/openaiadmin.go
+++ b/pkg/detectors/openaiadmin/openaiadmin.go
@@ -48,6 +48,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			DetectorType: detector_typepb.DetectorType_OpenAIAdmin,
 			Redacted:     token[:11] + "..." + token[len(token)-4:],
 			Raw:          []byte(token),
+			SecretParts:  map[string]string{"key": token},
 		}
 
 		if verify {
@@ -59,9 +60,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, verificationErr := verifyMatch(ctx, client, token)
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr, token)
-			s1.SecretParts = map[string]string{
-				"key": token,
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/opsgenie/opsgenie.go
+++ b/pkg/detectors/opsgenie/opsgenie.go
@@ -64,6 +64,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		r := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Opsgenie,
 			Raw:          []byte(key),
+			SecretParts:  map[string]string{"key": key},
 		}
 
 		if verify {
@@ -76,9 +77,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if isVerified {
 				r.Verified = isVerified
 				r.ExtraData = extraData
-				r.SecretParts = map[string]string{
-					"key": key,
-				}
 			}
 			r.SetVerificationError(vErr, key)
 		}

--- a/pkg/detectors/plaidkey/plaidkey.go
+++ b/pkg/detectors/plaidkey/plaidkey.go
@@ -76,6 +76,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					DetectorType: detector_typepb.DetectorType_PlaidKey,
 					Raw:          []byte(secret),
 					RawV2:        []byte(fmt.Sprintf(`%s:%s:%s`, secret, id, token)),
+					SecretParts: map[string]string{
+						"secret": secret,
+						"id":     id,
+						"token":  token,
+					},
 				}
 
 				if verify {
@@ -87,13 +92,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					s1.Verified = isVerified
 					s1.ExtraData = map[string]string{"environment": fmt.Sprintf("https://%s.plaid.com", environment)}
 					s1.SetVerificationError(verificationErr, id, secret)
-					if s1.Verified {
-						s1.SecretParts = map[string]string{
-							"secret": secret,
-							"id":     id,
-							"token":  token,
-						}
-					}
 				}
 				results = append(results, s1)
 			}

--- a/pkg/detectors/planetscale/planetscale.go
+++ b/pkg/detectors/planetscale/planetscale.go
@@ -45,6 +45,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_PlanetScale,
 				Raw:          []byte(credentials),
+				SecretParts: map[string]string{
+					"id":    username,
+					"token": password,
+				},
 			}
 
 			if verify {
@@ -67,10 +71,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					defer res.Body.Close()
 					if res.StatusCode >= 200 && res.StatusCode < 300 {
 						s1.Verified = true
-						s1.SecretParts = map[string]string{
-							"id":    username,
-							"token": password,
-						}
 					} else if res.StatusCode == 401 {
 						// The secret is determinately not verified
 						s1.Verified = false

--- a/pkg/detectors/postgres/postgres.go
+++ b/pkg/detectors/postgres/postgres.go
@@ -139,6 +139,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 			DetectorType: detector_typepb.DetectorType_Postgres,
 			Raw:          raw,
 			RawV2:        raw,
+			SecretParts:  map[string]string{"connection_string": string(raw)},
 		}
 
 		// We don't need to normalize the (deprecated) requiressl option into the (up-to-date) sslmode option - pq can
@@ -164,9 +165,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 			isVerified, verificationErr := verifyPostgres(params)
 			result.Verified = isVerified
 			result.SetVerificationError(verificationErr, password)
-			result.SecretParts = map[string]string{
-				"connection_string": string(raw),
-			}
 		}
 
 		// We gather SSL information into ExtraData in case it's useful for later reporting.

--- a/pkg/detectors/posthog/posthog.go
+++ b/pkg/detectors/posthog/posthog.go
@@ -42,6 +42,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_PosthogApp,
 			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 
 		if verify {
@@ -59,9 +60,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				defer res.Body.Close()
 				if res.StatusCode >= 200 && res.StatusCode < 300 {
 					s1.Verified = true
-					s1.SecretParts = map[string]string{
-						"key": resMatch,
-					}
 				} else if res.StatusCode == 401 {
 					// Try EU Endpoint only if other one fails.
 					res, err := client.Do(reqEU)
@@ -69,9 +67,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						defer res.Body.Close()
 						if res.StatusCode >= 200 && res.StatusCode < 300 {
 							s1.Verified = true
-							s1.SecretParts = map[string]string{
-								"key": resMatch,
-							}
 						}
 					}
 				}

--- a/pkg/detectors/postman/postman.go
+++ b/pkg/detectors/postman/postman.go
@@ -47,6 +47,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Postman,
 			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 
 		if verify {
@@ -54,9 +55,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, verificationErr := verifyPostman(ctx, client, resMatch)
 			s1.Verified = isVerified
 			s1.SetVerificationError(verificationErr, resMatch)
-			s1.SecretParts = map[string]string{
-				"key": resMatch,
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/postmark/postmark.go
+++ b/pkg/detectors/postmark/postmark.go
@@ -44,6 +44,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Postmark,
 			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 
 		if verify {
@@ -51,12 +52,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = valid
 			s1.ExtraData = extraData
 			s1.SetVerificationError(err)
-
-			if valid {
-				s1.SecretParts = map[string]string{
-					"key": resMatch,
-				}
-			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/privatekey/privatekey.go
+++ b/pkg/detectors/privatekey/privatekey.go
@@ -69,6 +69,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			Raw:          []byte(token),
 			Redacted:     token[0:64],
 			ExtraData:    make(map[string]string),
+			SecretParts:  map[string]string{"token": token},
 		}
 
 		// set not normalized match as primary secret value so it is used to calculate line of code
@@ -151,11 +152,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				s1.Verified = true
 				for k, v := range extraData.data {
 					s1.ExtraData[k] = v
-				}
-
-				// enabled th
-				s1.SecretParts = map[string]string{
-					"token": token,
 				}
 			} else {
 				s1.ExtraData = nil

--- a/pkg/detectors/salesforceoauth2/salesforceoauth2.go
+++ b/pkg/detectors/salesforceoauth2/salesforceoauth2.go
@@ -92,6 +92,11 @@ domainLoop:
 					DetectorType: detector_typepb.DetectorType_SalesforceOauth2,
 					Raw:          []byte(secret),
 					RawV2:        fmt.Appendf([]byte{}, "%s:%s:%s", domain, key, secret),
+					SecretParts: map[string]string{
+						"domain":        domain,
+						"client_id":     key,
+						"client_secret": secret,
+					},
 				}
 
 				if verify {
@@ -104,15 +109,6 @@ domainLoop:
 						}
 
 						s1.SetVerificationError(verificationErr, secret)
-					}
-
-					if isVerified {
-						s1.SecretParts = map[string]string{
-							"domain":        domain,
-							"client_id":     key,
-							"client_secret": secret,
-						}
-
 					}
 				}
 

--- a/pkg/detectors/sendgrid/sendgrid.go
+++ b/pkg/detectors/sendgrid/sendgrid.go
@@ -48,6 +48,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_SendGrid,
 			Raw:          []byte(token),
+			SecretParts:  map[string]string{"key": token},
 		}
 
 		if verify {
@@ -60,7 +61,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.Verified = verified
 			s1.ExtraData = extraData
 			s1.SetVerificationError(verificationErr)
-			s1.SecretParts = map[string]string{"key": token}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/shopify/shopify.go
+++ b/pkg/detectors/shopify/shopify.go
@@ -51,6 +51,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				DetectorType: detector_typepb.DetectorType_Shopify,
 				Redacted:     domainRes,
 				Raw:          []byte(key + domainRes),
+				SecretParts: map[string]string{
+					"key":       key,
+					"store_url": domainRes,
+				},
 			}
 
 			// set key as the primary secret for engine to find the line number
@@ -76,10 +80,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 							s1.Verified = true
 							s1.ExtraData = map[string]string{
 								"access_scopes": strings.Join(handleArray, ","),
-							}
-							s1.SecretParts = map[string]string{
-								"key":       key,
-								"store_url": domainRes,
 							}
 						}
 						res.Body.Close()

--- a/pkg/detectors/slack/slack.go
+++ b/pkg/detectors/slack/slack.go
@@ -61,6 +61,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_Slack,
 				Raw:          []byte(token),
+				SecretParts:  map[string]string{"key": token},
 			}
 			s1.ExtraData = map[string]string{
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/slack/",
@@ -112,9 +113,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					}
 				} else {
 					s1.SetVerificationError(err, token)
-				}
-				s1.SecretParts = map[string]string{
-					"key": token,
 				}
 			}
 

--- a/pkg/detectors/sourcegraph/sourcegraph.go
+++ b/pkg/detectors/sourcegraph/sourcegraph.go
@@ -44,6 +44,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Sourcegraph,
 			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 		s1.ExtraData = map[string]string{
 			"rotation_guide": "https://howtorotate.com/docs/tutorials/sourcegraph/",
@@ -78,7 +79,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			} else {
 				s1.SetVerificationError(err, resMatch)
 			}
-			s1.SecretParts = map[string]string{"key": resMatch}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/square/square.go
+++ b/pkg/detectors/square/square.go
@@ -46,6 +46,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		result := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Square,
 			Raw:          []byte(resMatch),
+			SecretParts:  map[string]string{"key": resMatch},
 		}
 		result.ExtraData = map[string]string{
 			"rotation_guide": "https://howtorotate.com/docs/tutorials/square/",
@@ -77,7 +78,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					result.Verified = true
 				}
 			}
-			result.SecretParts = map[string]string{"key": resMatch}
 		}
 
 		results = append(results, result)

--- a/pkg/detectors/stripe/stripe.go
+++ b/pkg/detectors/stripe/stripe.go
@@ -40,6 +40,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		result := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Stripe,
 			Raw:          []byte(match),
+			SecretParts:  map[string]string{"key": match},
 		}
 		result.ExtraData = map[string]string{
 			"rotation_guide": "https://howtorotate.com/docs/tutorials/stripe/",
@@ -66,7 +67,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					result.Verified = true
 				}
 			}
-			result.SecretParts = map[string]string{"key": match}
 		}
 
 		results = append(results, result)

--- a/pkg/detectors/tableau/tableau.go
+++ b/pkg/detectors/tableau/tableau.go
@@ -89,6 +89,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					Raw:          []byte(tokenName),
 					RawV2:        []byte(fmt.Sprintf("%s:%s:%s", tokenName, tokenSecret, endpoint)),
 					ExtraData:    make(map[string]string),
+					SecretParts:  map[string]string{"token_name": tokenName, "pat_secret": tokenSecret, "endpoint": endpoint},
 				}
 
 				if verify {
@@ -97,9 +98,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					result.Verified = isVerified
 					maps.Copy(result.ExtraData, extraData)
 					result.SetVerificationError(verificationErr, tokenName, tokenSecret, endpoint)
-					if isVerified {
-						result.SecretParts = map[string]string{"token_name": tokenName, "pat_secret": tokenSecret, "endpoint": endpoint}
-					}
 				}
 				results = append(results, result)
 			}

--- a/pkg/detectors/twilio/twilio.go
+++ b/pkg/detectors/twilio/twilio.go
@@ -66,6 +66,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				Raw:          []byte(sid),
 				RawV2:        []byte(sid + key),
 				Redacted:     sid,
+				SecretParts:  map[string]string{"key": key, "sid": sid},
 			}
 
 			s1.ExtraData = map[string]string{
@@ -79,10 +80,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				for key, value := range extraData {
 					s1.ExtraData[key] = value
-				}
-
-				if s1.Verified {
-					s1.SecretParts = map[string]string{"key": key, "sid": sid}
 				}
 			}
 

--- a/pkg/detectors/twilioapikey/twilioapikey.go
+++ b/pkg/detectors/twilioapikey/twilioapikey.go
@@ -65,6 +65,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				RawV2:        []byte(apiKey + secret),
 				Redacted:     secret[:5] + "...",
 				ExtraData:    make(map[string]string),
+				SecretParts:  map[string]string{"key": apiKey, "sid": secret},
 			}
 
 			if verify {
@@ -74,10 +75,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 				for key, value := range extraData {
 					s1.ExtraData[key] = value
-				}
-
-				if s1.Verified {
-					s1.SecretParts = map[string]string{"key": apiKey, "sid": secret}
 				}
 			}
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Update the `hack/checksecretparts` tool to enforce initializing `Result` with a `SecretParts` field and clean up existing detectors to pass this lint check.

The reason for this change is because *all* `Result` objects *must* have `SecretParts` set.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many detector implementations and changes the static check to fail any `detectors.Result{}` literal missing `SecretParts`, which could surface new CI failures or subtly change reported metadata. Core scanning/verification logic is largely unchanged, but the breadth of detector edits raises regression risk.
> 
> **Overview**
> Updates `hack/checksecretparts` to be **stricter**: it now flags *every* `detectors.Result{}` / `&detectors.Result{}` composite literal that omits a `SecretParts` key, and no longer treats later `SecretParts` assignments or other package references as satisfying the rule; messaging/docs/tests were updated accordingly.
> 
> Migrates a broad set of detectors to comply by initializing `Result.SecretParts` at construction time (and in a few cases mutating the map later to add fields like endpoints/usernames), removing prior patterns that only set `SecretParts` after successful verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e6aaa4106fa145f0b0d2923b2d75bb40058300d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->