### PR TITLE
fix: stream CircleCI action output

### DIFF
--- a/pkg/sources/circleci/circleci.go
+++ b/pkg/sources/circleci/circleci.go
@@ -152,7 +152,7 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 
 				for _, step := range projBuildJobs.Steps {
 					for _, action := range step.Actions {
-						data, err := s.getOutputUrlResponse(action.OutputUrl)
+						data, err := s.getOutputUrlResponse(ctx, action.OutputUrl)
 						if err != nil {
 							ctx.Logger().Error(err, "error getting action output url response")
 							errors = append(errors, err)
@@ -160,7 +160,10 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 							continue
 						}
 
-						if err = s.chunk(ctx, project, buildNum, step.Name, data, chunksChan); err != nil {
+						if err = func() error {
+							defer data.Close()
+							return s.chunk(ctx, project, buildNum, step.Name, data, chunksChan)
+						}(); err != nil {
 							ctx.Logger().Error(err, "error chunking action")
 							errors = append(errors, err)
 
@@ -169,7 +172,7 @@ func (s *Source) Chunks(ctx context.Context, chunksChan chan *sources.Chunk, _ .
 					}
 				}
 
-				if err = s.chunk(ctx, project, buildNum, "", projBuildJobs.CircleYaml.YamlString, chunksChan); err != nil {
+				if err = s.chunk(ctx, project, buildNum, "", strings.NewReader(projBuildJobs.CircleYaml.YamlString), chunksChan); err != nil {
 					ctx.Logger().Error(err, "error chunking build yaml")
 					errors = append(errors, err)
 
@@ -328,34 +331,31 @@ func (s *Source) listProjBuildJobs(ctx context.Context, proj *project, buildNum 
 	}
 }
 
-func (s *Source) getOutputUrlResponse(outputUrl string) (string, error) {
-	req, err := http.NewRequest(http.MethodGet, outputUrl, nil)
+func (s *Source) getOutputUrlResponse(ctx context.Context, outputUrl string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, outputUrl, http.NoBody)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	resp, err := s.client.Do(req)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	defer func() {
+
+	if resp.StatusCode >= http.StatusBadRequest {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
-	}()
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to read response body: %w", err)
+		return nil, fmt.Errorf("unexpected status code: %d while fetching action output", resp.StatusCode)
 	}
 
-	return string(bodyBytes), nil
+	return resp.Body, nil
 }
 
-func (s *Source) chunk(ctx context.Context, proj project, buildNum BuildNum, stepName, chunkData string, chunksChan chan *sources.Chunk) error {
+func (s *Source) chunk(ctx context.Context, proj project, buildNum BuildNum, stepName string, chunkData io.Reader, chunksChan chan *sources.Chunk) error {
 	linkURL := fmt.Sprintf("https://app.circleci.com/pipelines/%s/%s/%s/%d", proj.VCS, proj.Username, proj.Reponame, buildNum)
 
 	chunkReader := sources.NewChunkReader()
-	chunkResChan := chunkReader(ctx, strings.NewReader(chunkData))
+	chunkResChan := chunkReader(ctx, chunkData)
 	for data := range chunkResChan {
 		chunk := &sources.Chunk{
 			SourceType: s.Type(),

--- a/pkg/sources/circleci/circleci_test.go
+++ b/pkg/sources/circleci/circleci_test.go
@@ -2,10 +2,15 @@ package circleci
 
 import (
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
@@ -106,6 +111,84 @@ func TestSource_Scan(t *testing.T) {
 			assert.Equal(t, tt.totalScannedProjects, progress.SectionsCompleted)
 		})
 	}
+}
+
+func TestGetOutputUrlResponseStreamsBody(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("partial log\n"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+
+		close(started)
+		<-release
+		_, _ = w.Write([]byte("rest of log\n"))
+	}))
+	defer server.Close()
+	defer close(release)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	s := &Source{client: server.Client()}
+	done := make(chan struct {
+		body io.ReadCloser
+		err  error
+	}, 1)
+
+	go func() {
+		body, err := s.getOutputUrlResponse(ctx, server.URL)
+		done <- struct {
+			body io.ReadCloser
+			err  error
+		}{body: body, err: err}
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("test server did not start streaming the response")
+	}
+
+	select {
+	case got := <-done:
+		assert.NoError(t, got.err)
+		if got.body != nil {
+			_ = got.body.Close()
+		}
+	case <-time.After(time.Second):
+		t.Fatal("getOutputUrlResponse waited for the whole response body")
+	}
+}
+
+func TestChunkReadsFromReader(t *testing.T) {
+	ctx := context.Background()
+	s := Source{name: "test-circleci", verify: true}
+	chunksCh := make(chan *sources.Chunk, 10)
+
+	proj := project{
+		VCS:      "github",
+		Username: "trufflesecurity",
+		Reponame: "trufflehog",
+	}
+
+	err := s.chunk(ctx, proj, 42, "run tests", strings.NewReader("hello\nCIRCLE_SHA1=abc123\nworld"), chunksCh)
+	close(chunksCh)
+
+	assert.NoError(t, err)
+	require.Len(t, chunksCh, 1)
+
+	chunk := <-chunksCh
+	assert.Equal(t, "test-circleci", chunk.SourceName)
+	assert.Equal(t, SourceType, chunk.SourceType)
+	assert.True(t, chunk.SourceVerify)
+	assert.NotContains(t, string(chunk.Data), "CIRCLE_SHA1")
+	assert.Equal(t, "run tests", chunk.SourceMetadata.GetCircleci().BuildStep)
+	assert.Equal(t, int64(42), chunk.SourceMetadata.GetCircleci().BuildNumber)
 }
 
 // additional test for edge cases


### PR DESCRIPTION
### Description:
CircleCI action output is build-log data, but this path was reading the whole response body before passing it to the chunker. Large step output can make the source hold much more data in memory than it needs to.

This keeps the response body as a stream and passes it straight into the existing chunk reader. The CircleCI config string still goes through the same chunk path with a `strings.Reader`.

The output fetch now also returns an error for 4xx/5xx responses, draining and closing the response body before returning.

This follows the same idea as the Jenkins build-log streaming fix in #4225, but keeps the change scoped to the CircleCI source.

### Tests:
* [x] `GOCACHE=/Users/nsatyakrishna/Sandbox/.cache/go-build GOMODCACHE=/Users/nsatyakrishna/Sandbox/.cache/go-mod go test ./pkg/sources/circleci -run 'Test(GetOutputUrlResponseStreamsBody|ChunkReadsFromReader)'`
* [x] `make lint`

I ran the source-specific tests here because `make test-community` skips `pkg/sources`, so it does not cover this change.

### Checklist:
* [x] Targeted tests passing
* [x] Lint passing
