### PR TITLE
Allow `:` and `-` in Azure App Config Id (#4955)

### DIFF
--- a/pkg/detectors/azureappconfigconnectionstring/azureappconfigconnectionstring.go
+++ b/pkg/detectors/azureappconfigconnectionstring/azureappconfigconnectionstring.go
@@ -27,7 +27,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 
 var (
 	defaultClient       = common.SaneHttpClient()
-	connectionStringPat = regexp.MustCompile(`Endpoint=(https:\/\/[a-zA-Z0-9-]+\.azconfig\.io);Id=([a-zA-Z0-9+\/=]+);Secret=([a-zA-Z0-9+\/=]+)`)
+	connectionStringPat = regexp.MustCompile(`Endpoint=(https:\/\/[a-zA-Z0-9-]+\.azconfig\.io);Id=([a-zA-Z0-9+\/:=-]+);Secret=([a-zA-Z0-9+\/=]+)`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/azureappconfigconnectionstring/azureappconfigconnectionstring_test.go
+++ b/pkg/detectors/azureappconfigconnectionstring/azureappconfigconnectionstring_test.go
@@ -40,6 +40,11 @@ func TestAzureAppConfigConnectionString_Pattern(t *testing.T) {
 			want: []string{"Endpoint=https://iTHzRfnepCddRiYoBbPj-drVzUjwTNduwb3EUOTsuSAgg1e83Q7bw.azconfig.io;Id=eO04L+/m9rYn;Secret=G4jQ3GmcsYqlLkkG8uoIVbx08PZIJSdfB/7"},
 		},
 		{
+			name:  "valid pattern - canonical Id with hyphen prefix and colon",
+			input: `Endpoint=https://myappconfig001.azconfig.io;Id=aB1c-d2-e3:+XyZ12345AbCdEfGhIjKl;Secret=MnOpQrSt67UvWxYz89AbCdEf0123GhIjKlMnOpQrStUvWxYz1234=`,
+			want:  []string{"Endpoint=https://myappconfig001.azconfig.io;Id=aB1c-d2-e3:+XyZ12345AbCdEfGhIjKl;Secret=MnOpQrSt67UvWxYz89AbCdEf0123GhIjKlMnOpQrStUvWxYz1234="},
+		},
+		{
 			name:  "invalid pattern",
 			input: `Endpoint=https://trufflesecurity.azconfig.io;Secret=80DtxZkndXpMTmV2J3JjX2vL1x4gm1hHn8Y3KeFV4N0PPLSO5D70JQQJ79BBAC1i4FpRkb5wAAACAAZC26dr`,
 			want:  nil,


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Azure-issued App Configuration connection strings encode `Id` as `<prefix>:<base64>`, where the prefix typically contains hyphens. The previous character class accepted only the base64 alphabet, so every real key was silently dropped. Extend the class to include `:` and `-`, and add a test covering the canonical shape.

Closes https://github.com/trufflesecurity/trufflehog/issues/4955

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only broadens the Azure App Config connection-string regex and adds test coverage, with no changes to verification or network behavior.
> 
> **Overview**
> Updates the Azure App Configuration connection-string detector to accept canonical `Id` values containing `-` and `:` (e.g. `<prefix>:<base64>`), preventing valid keys from being missed.
> 
> Adds a unit test covering this canonical `Id` shape to ensure the updated regex matches real-world connection strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d054fa2d377b66c953af999f10dab49329c2c56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->