### PR TITLE
fix(detectors/azureappconfigconnectionstring): allow hyphen and colon in Id

### DIFF
--- a/pkg/detectors/azureappconfigconnectionstring/azureappconfigconnectionstring.go
+++ b/pkg/detectors/azureappconfigconnectionstring/azureappconfigconnectionstring.go
@@ -27,7 +27,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 
 var (
 	defaultClient       = common.SaneHttpClient()
-	connectionStringPat = regexp.MustCompile(`Endpoint=(https:\/\/[a-zA-Z0-9-]+\.azconfig\.io);Id=([a-zA-Z0-9+\/=]+);Secret=([a-zA-Z0-9+\/=]+)`)
+	connectionStringPat = regexp.MustCompile(`Endpoint=(https:\/\/[a-zA-Z0-9-]+\.azconfig\.io);Id=([a-zA-Z0-9+\/=:-]+);Secret=([a-zA-Z0-9+\/=]+)`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/azureappconfigconnectionstring/azureappconfigconnectionstring_test.go
+++ b/pkg/detectors/azureappconfigconnectionstring/azureappconfigconnectionstring_test.go
@@ -40,6 +40,11 @@ func TestAzureAppConfigConnectionString_Pattern(t *testing.T) {
 			want: []string{"Endpoint=https://iTHzRfnepCddRiYoBbPj-drVzUjwTNduwb3EUOTsuSAgg1e83Q7bw.azconfig.io;Id=eO04L+/m9rYn;Secret=G4jQ3GmcsYqlLkkG8uoIVbx08PZIJSdfB/7"},
 		},
 		{
+			name:  "valid pattern - id with prefix and hyphen",
+			input: `Endpoint=https://trufflesecurity.azconfig.io;Id=abcd-l0:u+DeEXamPleIdValue==;Secret=80DtxZkndXpM2mV2J1JjX2vL1x4gm1hHn8Y3JeFJ4N0PPLSO5D70JQQJ99BBAC1i4FpQkb5wAAACAAZC26dr`,
+			want:  []string{"Endpoint=https://trufflesecurity.azconfig.io;Id=abcd-l0:u+DeEXamPleIdValue==;Secret=80DtxZkndXpM2mV2J1JjX2vL1x4gm1hHn8Y3JeFJ4N0PPLSO5D70JQQJ99BBAC1i4FpQkb5wAAACAAZC26dr"},
+		},
+		{
 			name:  "invalid pattern",
 			input: `Endpoint=https://trufflesecurity.azconfig.io;Secret=80DtxZkndXpMTmV2J3JjX2vL1x4gm1hHn8Y3KeFV4N0PPLSO5D70JQQJ79BBAC1i4FpRkb5wAAACAAZC26dr`,
 			want:  nil,


### PR DESCRIPTION
## Summary

The `AzureAppConfigConnectionString` detector misses real Azure-issued connection strings because the `Id` capture group only allows the base64 alphabet. Azure's documented connection-string format is

```
Endpoint=https://<store>.azconfig.io;Id=<prefix>:<base64>;Secret=<base64>
```

where `<prefix>` is a short identifier that can contain letters, digits, and hyphens, joined to the base64 portion with a colon. See Microsoft's docs on the connection-string shape and on rotating access keys, both of which show the `prefix:base64` form for `Id`:

- https://learn.microsoft.com/en-us/azure/azure-app-configuration/howto-create-snapshots#connection-strings
- https://learn.microsoft.com/en-us/azure/azure-app-configuration/howto-best-practices

The current regex is

```go
Endpoint=(https:\/\/[a-zA-Z0-9-]+\.azconfig\.io);Id=([a-zA-Z0-9+\/=]+);Secret=([a-zA-Z0-9+\/=]+)
```

The colon separator alone is enough to break the match, and any hyphen inside the prefix breaks it too. Both happen on every store created in the portal or via `az appconfig credential list`.

## Fix

Add `:` and `-` to the `Id` character class. The `Endpoint` host class already permits hyphens, the `Secret` is unchanged, and no other detector calls were affected.

```diff
-Endpoint=(https:\/\/[a-zA-Z0-9-]+\.azconfig\.io);Id=([a-zA-Z0-9+\/=]+);Secret=([a-zA-Z0-9+\/=]+)
+Endpoint=(https:\/\/[a-zA-Z0-9-]+\.azconfig\.io);Id=([a-zA-Z0-9+\/=:-]+);Secret=([a-zA-Z0-9+\/=]+)
```

## Test plan

- Added a new subtest `valid pattern - id with prefix and hyphen` to `azureappconfigconnectionstring_test.go` that feeds a real-shape `Id=abcd-l0:u+DeEXamPleIdValue==` connection string.
- `go test ./pkg/detectors/azureappconfigconnectionstring/...` passes all four subtests.
- Manually verified that the new subtest fails before the regex change and passes after it, so the test exercises the bug.

Closes #4955

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small regex broadening plus a new unit test; behavior change is limited to matching more valid Azure App Config connection strings.
> 
> **Overview**
> Improves `AzureAppConfigConnectionString` detection by widening the `Id` capture group in `connectionStringPat` to accept `-` and `:` (matching Azure’s `prefix:base64` `Id` format).
> 
> Adds a new pattern test case covering an `Id` with a hyphenated prefix and colon separator to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7793ac09d17241e6bade18b878a10a91bdd7f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->