### PR TITLE
feat: add Stripe Webhook Secret detector (whsec_)

### DIFF
--- a/pkg/detectors/stripewebhook/stripewebhook.go
+++ b/pkg/detectors/stripewebhook/stripewebhook.go
@@ -19,7 +19,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	defaultClient = common.SaneHttpClient()
 	// whsec_ followed by 32 or 64 base64-style characters
-	keyPat = regexp.MustCompile(`\b(whsec_[A-Za-z0-9+/]{32}(?:[A-Za-z0-9+/]{32})?)\b`)
+	keyPat = regexp.MustCompile(`\b(whsec_[A-Za-z0-9]{32}(?:[A-Za-z0-9]{32})?)\b`)
 )
 
 func (s Scanner) Keywords() []string {

--- a/pkg/detectors/stripewebhook/stripewebhook.go
+++ b/pkg/detectors/stripewebhook/stripewebhook.go
@@ -1,0 +1,66 @@
+package stripewebhook
+
+import (
+	"context"
+	"net/http"
+	"regexp"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	detector_typepb "github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+type Scanner struct {
+	Client *http.Client
+}
+
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	defaultClient = common.SaneHttpClient()
+	// whsec_ followed by 32 or 64 base64-style characters
+	keyPat = regexp.MustCompile(`\b(whsec_[A-Za-z0-9+/]{32}(?:[A-Za-z0-9+/]{32})?)\b`)
+)
+
+func (s Scanner) Keywords() []string {
+	return []string{"whsec_"}
+}
+
+func (s Scanner) Description() string {
+	return "Stripe Webhook Secrets are used to verify that webhook events are sent by Stripe. Exposure allows attackers to forge webhook events."
+}
+
+func (s Scanner) Type() detector_typepb.DetectorType {
+	return detector_typepb.DetectorType_StripeWebhook
+}
+
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
+	for _, match := range matches {
+		if len(match) != 2 {
+			continue
+		}
+		resMatch := match[1]
+
+		s1 := detectors.Result{
+			DetectorType: detector_typepb.DetectorType_StripeWebhook,
+			Raw:          []byte(resMatch),
+		}
+
+		if verify {
+			client := s.Client
+			if client == nil {
+				client = defaultClient
+			}
+			_ = client
+			// Stripe webhook secrets cannot be verified via API directly.
+			// They are used client-side to validate HMAC signatures on webhooks.
+		}
+
+		results = append(results, s1)
+	}
+
+	return results, nil
+}

--- a/pkg/detectors/stripewebhook/stripewebhook.go
+++ b/pkg/detectors/stripewebhook/stripewebhook.go
@@ -2,23 +2,19 @@ package stripewebhook
 
 import (
 	"context"
-	"net/http"
 	"regexp"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	detector_typepb "github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
 )
 
-type Scanner struct {
-	Client *http.Client
-}
+type Scanner struct{}
 
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = common.SaneHttpClient()
-	// whsec_ followed by 32 or 64 base64-style characters
+	// Stripe webhook secrets are purely alphanumeric (no +/ chars).
+	// Using \b boundaries is safe because the charset is all word characters.
 	keyPat = regexp.MustCompile(`\b(whsec_[A-Za-z0-9]{32}(?:[A-Za-z0-9]{32})?)\b`)
 )
 
@@ -42,22 +38,14 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		if len(match) != 2 {
 			continue
 		}
-		resMatch := match[1]
 
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_StripeWebhook,
-			Raw:          []byte(resMatch),
+			Raw:          []byte(match[1]),
 		}
 
-		if verify {
-			client := s.Client
-			if client == nil {
-				client = defaultClient
-			}
-			_ = client
-			// Stripe webhook secrets cannot be verified via API directly.
-			// They are used client-side to validate HMAC signatures on webhooks.
-		}
+		// Stripe webhook secrets cannot be verified via API directly.
+		// They are used client-side to validate HMAC signatures on webhook payloads.
 
 		results = append(results, s1)
 	}

--- a/pkg/detectors/stripewebhook/stripewebhook_test.go
+++ b/pkg/detectors/stripewebhook/stripewebhook_test.go
@@ -1,0 +1,65 @@
+package stripewebhook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	detector_typepb "github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+func TestStripeWebhook_Pattern(t *testing.T) {
+	d := Scanner{}
+	ctx := context.Background()
+
+	// Note: test values use clearly fake/invalid secrets for pattern testing only.
+	// Integration tests with real credentials should use Google Secret Manager.
+	tests := []struct {
+		name  string
+		input string
+		want  []detectors.Result
+	}{
+		{
+			name:  "valid 32-char pattern",
+			input: "STRIPE_WEBHOOK_SECRET=whsec_" + "A2345678901234567890123456789012",
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_StripeWebhook,
+					Verified:     false,
+				},
+			},
+		},
+		{
+			name:  "valid 64-char pattern",
+			input: "webhook_secret: whsec_" + "A2345678901234567890123456789012" + "B2345678901234567890123456789012",
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_StripeWebhook,
+					Verified:     false,
+				},
+			},
+		},
+		{
+			name:  "no match - too short",
+			input: "whsec_tooshort",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := d.FromData(ctx, false, []byte(tt.input))
+			if err != nil {
+				t.Fatalf("FromData() error = %v", err)
+			}
+			if diff := cmp.Diff(tt.want, got,
+				cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "StructuredData"),
+				cmpopts.IgnoreUnexported(detectors.Result{}),
+			); diff != "" {
+				t.Errorf("FromData() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -732,6 +732,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/streak"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/stripe"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/stripepaymentintent"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/stripewebhook"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/stripo"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/stytch"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/sugester"
@@ -1628,6 +1629,7 @@ func buildDetectorList() []detectors.Detector {
 		&streak.Scanner{},
 		&stripe.Scanner{},
 		&stripepaymentintent.Scanner{},
+		&stripewebhook.Scanner{},
 		&stripo.Scanner{},
 		&stytch.Scanner{},
 		&sugester.Scanner{},

--- a/pkg/pb/detector_typepb/detector_type.pb.go
+++ b/pkg/pb/detector_typepb/detector_type.pb.go
@@ -1080,7 +1080,8 @@ const (
 	DetectorType_AzureDirectManagementKey                DetectorType = 1024
 	DetectorType_AzureAppConfigConnectionString          DetectorType = 1025
 	DetectorType_DeepSeek                                DetectorType = 1026
-	DetectorType_StripePaymentIntent                     DetectorType = 1027
+	DetectorType_StripePaymentIntent DetectorType = 1027
+	DetectorType_StripeWebhook          DetectorType = 1053
 	DetectorType_LangSmith                               DetectorType = 1028
 	DetectorType_BitbucketAppPassword                    DetectorType = 1029
 	DetectorType_Hasura                                  DetectorType = 1030
@@ -2135,6 +2136,7 @@ var (
 		1025: "AzureAppConfigConnectionString",
 		1026: "DeepSeek",
 		1027: "StripePaymentIntent",
+		1053: "StripeWebhook",
 		1028: "LangSmith",
 		1029: "BitbucketAppPassword",
 		1030: "Hasura",
@@ -3186,6 +3188,7 @@ var (
 		"AzureAppConfigConnectionString":    1025,
 		"DeepSeek":                          1026,
 		"StripePaymentIntent":               1027,
+		"StripeWebhook":                    1053,
 		"LangSmith":                         1028,
 		"BitbucketAppPassword":              1029,
 		"Hasura":                            1030,

--- a/proto/detector_type.proto
+++ b/proto/detector_type.proto
@@ -1054,4 +1054,5 @@ enum DetectorType {
   GitLabOauth2 = 1050;
   SpectralOps = 1051;
   AWSAppSync = 1052;
+  StripeWebhook = 1053;
 }


### PR DESCRIPTION
## Summary

Closes #4711

Adds a new detector for **Stripe Webhook Secrets** (`whsec_` prefix).

Webhook secrets are used by developers to verify that incoming webhook events were sent by Stripe. They are commonly found hardcoded in `.env` files, config files, and source code.

## Secret Format

```
whsec_[A-Za-z0-9+/]{32}   # 32-char format
whsec_[A-Za-z0-9+/]{64}   # 64-char format
```

## Changes

- `pkg/detectors/stripewebhook/stripewebhook.go` — new detector
- `pkg/detectors/stripewebhook/stripewebhook_test.go` — 3 tests, all passing
- `proto/detector_type.proto` — registers `StripeWebhook = 1053`
- `pkg/pb/detector_typepb/detector_type.pb.go` — generated pb updated

## Verification

Stripe webhook secrets cannot be verified against a Stripe API endpoint directly — they are used client-side to validate HMAC signatures on incoming webhook payloads. Results are returned as unverified/detected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new default-enabled detector and introduces a new `DetectorType` enum value, which can affect scan results and any downstream consumers that rely on stable detector type IDs.
> 
> **Overview**
> Adds a new `stripewebhook` detector that flags Stripe webhook signing secrets matching the `whsec_` 32/64-char alphanumeric pattern and always returns results as unverified.
> 
> Registers the new detector in the default detector list and introduces `StripeWebhook = 1053` in `detector_type.proto` (with corresponding generated protobuf updates), plus unit tests covering matching and non-matching cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14f25538602b7944359ca7a184d0e3f119b24484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->