### PR TITLE
Remove over speculation from Corpora CI workflow

### DIFF
--- a/pkg/detectors/lob/lob.go
+++ b/pkg/detectors/lob/lob.go
@@ -2,6 +2,7 @@ package lob
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -12,22 +13,31 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
 )
 
-type Scanner struct{}
+type Scanner struct {
+	client *http.Client
+}
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClient()
+	defaultClient = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"lob"}) + `\b([a-zA-Z0-9_]{40})\b`)
+	keyPat = regexp.MustCompile(`\b((live|test)_[a-zA-Z0-9_]{35})\b`)
 )
+
+func (s Scanner) getClient() *http.Client {
+	if s.client != nil {
+		return s.client
+	}
+	return defaultClient
+}
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"lob"}
+	return []string{"live_", "test_"}
 }
 
 // FromData will find and optionally verify Lob secrets in a given set of bytes.
@@ -36,34 +46,55 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
+	uniqueMatches := make(map[string]struct{})
 	for _, match := range matches {
-		resMatch := strings.TrimSpace(match[1])
+		uniqueMatches[strings.TrimSpace(match[1])] = struct{}{}
+	}
 
+	for resMatch := range uniqueMatches {
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Lob,
 			Raw:          []byte(resMatch),
 			SecretParts:  map[string]string{"key": resMatch},
+			ExtraData: map[string]string{
+				"environment": resMatch[:4], // live or test
+			},
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.lob.com/v1/addresses", nil)
-			if err != nil {
-				continue
-			}
-			req.SetBasicAuth(resMatch, "")
-			res, err := client.Do(req)
-			if err == nil {
-				defer func() { _ = res.Body.Close() }()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					s1.Verified = true
-				}
-			}
+			verified, err := s.verify(ctx, resMatch)
+			s1.Verified = verified
+			s1.SetVerificationError(err)
 		}
 
 		results = append(results, s1)
 	}
 
 	return results, nil
+}
+
+func (s Scanner) verify(ctx context.Context, key string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.lob.com/v1/us_verifications", nil)
+	if err != nil {
+		return false, err
+	}
+	req.SetBasicAuth(key, "")
+	client := s.getClient()
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = res.Body.Close() }()
+	switch res.StatusCode {
+	case http.StatusForbidden, http.StatusUnprocessableEntity:
+		// 403 indicates key is active but no billing method on file
+		// 422 indicates key is active but request body is invalid
+		return true, nil
+	case http.StatusUnauthorized:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
 }
 
 func (s Scanner) Type() detector_typepb.DetectorType {

--- a/pkg/detectors/lob/lob.go
+++ b/pkg/detectors/lob/lob.go
@@ -2,7 +2,6 @@ package lob
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -13,31 +12,22 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
 )
 
-type Scanner struct {
-	client *http.Client
-}
+type Scanner struct{}
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = common.SaneHttpClient()
+	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(`\b((live|test)_[a-zA-Z0-9_]{35})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"lob"}) + `\b([a-zA-Z0-9_]{40})\b`)
 )
-
-func (s Scanner) getClient() *http.Client {
-	if s.client != nil {
-		return s.client
-	}
-	return defaultClient
-}
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"live_", "test_"}
+	return []string{"lob"}
 }
 
 // FromData will find and optionally verify Lob secrets in a given set of bytes.
@@ -46,55 +36,34 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
-	uniqueMatches := make(map[string]struct{})
 	for _, match := range matches {
-		uniqueMatches[strings.TrimSpace(match[1])] = struct{}{}
-	}
+		resMatch := strings.TrimSpace(match[1])
 
-	for resMatch := range uniqueMatches {
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Lob,
 			Raw:          []byte(resMatch),
 			SecretParts:  map[string]string{"key": resMatch},
-			ExtraData: map[string]string{
-				"environment": resMatch[:4], // live or test
-			},
 		}
 
 		if verify {
-			verified, err := s.verify(ctx, resMatch)
-			s1.Verified = verified
-			s1.SetVerificationError(err)
+			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.lob.com/v1/addresses", nil)
+			if err != nil {
+				continue
+			}
+			req.SetBasicAuth(resMatch, "")
+			res, err := client.Do(req)
+			if err == nil {
+				defer func() { _ = res.Body.Close() }()
+				if res.StatusCode >= 200 && res.StatusCode < 300 {
+					s1.Verified = true
+				}
+			}
 		}
 
 		results = append(results, s1)
 	}
 
 	return results, nil
-}
-
-func (s Scanner) verify(ctx context.Context, key string) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.lob.com/v1/us_verifications", nil)
-	if err != nil {
-		return false, err
-	}
-	req.SetBasicAuth(key, "")
-	client := s.getClient()
-	res, err := client.Do(req)
-	if err != nil {
-		return false, err
-	}
-	defer func() { _ = res.Body.Close() }()
-	switch res.StatusCode {
-	case http.StatusForbidden, http.StatusUnprocessableEntity:
-		// 403 indicates key is active but no billing method on file
-		// 422 indicates key is active but request body is invalid
-		return true, nil
-	case http.StatusUnauthorized:
-		return false, nil
-	default:
-		return false, fmt.Errorf("unexpected status code: %d", res.StatusCode)
-	}
 }
 
 func (s Scanner) Type() detector_typepb.DetectorType {

--- a/scripts/test/diff_corpora_results.py
+++ b/scripts/test/diff_corpora_results.py
@@ -123,16 +123,13 @@ def render(main, pr, changed=None, new_detectors=None):
     new_detectors = new_detectors or set()
 
     if changed:
-        all_names = {d for d in (set(main) | set(pr))
-                     if d.lower() in changed}
+        all_names = {d for d in (set(main) | set(pr)) if d.lower() in changed}
         # Detectors that the PR claims to have changed (or added) but that
-        # produced zero matches on either side. These don't appear in JSONL,
-        # so we surface them as a warning row.
-        seen_lower = {d.lower() for d in (set(main) | set(pr))}
-        missing = sorted(d for d in changed if d not in seen_lower)
+        # produced zero matches on either side don't appear in JSONL, so we
+        # add them explicitly so they get a 0/0 row in the table.
+        all_names |= changed - {d.lower() for d in all_names}
     else:
         all_names = set(main) | set(pr)
-        missing = []
 
     _empty = {"identities": set(), "total": 0}
     rows = []
@@ -177,70 +174,54 @@ def render(main, pr, changed=None, new_detectors=None):
         PREAMBLE,
         "",
     ]
-    if rows:
-        parts += [build_top_line_summary(rows, changed), ""]
-
-    if not rows and not missing:
-        parts += ["_(No findings on either side for the changed detectors.)_", ""]
+    if not rows:
+        parts += ["_0 findings on either side for the changed detectors._", ""]
         return "\n".join(parts)
 
-    if rows:
-        if has_diff or any(r["is_new"] for r in rows):
-            rows.sort(
-                key=lambda r: (
-                    0 if r["is_new"] else 1,
-                    -(r["new_count"] + r["removed_count"]),
-                    r["detector"],
-                )
+    parts += [build_top_line_summary(rows, changed), ""]
+
+    if has_diff or any(r["is_new"] for r in rows):
+        rows.sort(
+            key=lambda r: (
+                0 if r["is_new"] else 1,
+                -(r["new_count"] + r["removed_count"]),
+                r["detector"],
             )
+        )
+    else:
+        rows.sort(key=lambda r: r["detector"])
+
+    cols = ["Status", "Detector", "Unique matches (main)", "Unique matches (PR)",
+            "New", "Removed"]
+    aligns = ["", "", "---:", "---:", "---:", "---:"]
+    parts += [
+        "| " + " | ".join(cols) + " |",
+        "|" + "|".join(a if a else "---" for a in aligns) + "|",
+    ]
+
+    for r in rows:
+        if r["is_new"]:
+            cells = [
+                r["emoji"],
+                r["detector"],
+                "—",
+                str(r["unique_pr"]),
+                "—",
+                "—",
+            ]
         else:
-            rows.sort(key=lambda r: r["detector"])
-
-        cols = ["Status", "Detector", "Unique matches (main)", "Unique matches (PR)",
-                "New", "Removed"]
-        aligns = ["", "", "---:", "---:", "---:", "---:"]
-        parts += [
-            "| " + " | ".join(cols) + " |",
-            "|" + "|".join(a if a else "---" for a in aligns) + "|",
-        ]
-
-        for r in rows:
-            if r["is_new"]:
-                cells = [
-                    r["emoji"],
-                    r["detector"],
-                    "—",
-                    str(r["unique_pr"]),
-                    "—",
-                    "—",
-                ]
-            else:
-                cells = [
-                    r["emoji"],
-                    r["detector"],
-                    str(r["unique_main"]),
-                    str(r["unique_pr"]),
-                    str(r["new_count"]),
-                    str(r["removed_count"]),
-                ]
-            parts.append("| " + " | ".join(cells) + " |")
-        parts.append("")
-        parts.append(STATUS_KEY)
-        parts.append("")
-
-    if missing:
-        parts += [
-            "### ⚠️ Changed detectors with zero matches in both builds",
-            "",
-            "These detectors were modified by the PR but produced no matches "
-            "against the corpus on either side. Could be a deliberate scope "
-            "narrowing, or — more concerning — a regex so loose the engine "
-            "silently filtered the flood (issue #3578). Worth a manual look.",
-            "",
-        ]
-        for d in missing:
-            parts.append(f"- `{d}`")
-        parts.append("")
+            cells = [
+                r["emoji"],
+                r["detector"],
+                str(r["unique_main"]),
+                str(r["unique_pr"]),
+                str(r["new_count"]),
+                str(r["removed_count"]),
+            ]
+        parts.append("| " + " | ".join(cells) + " |")
+    parts.append("")
+    parts.append(STATUS_KEY)
+    parts.append("")
 
     return "\n".join(parts)
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Detectors with 0 matches on both sides were previously tracked separately and rendered in their own `### ⚠️ Changed detectors with zero matches in both builds` section with speculative commentary about what might have gone wrong. They are now included as a 0/0 row in the main results table alongside all other detectors. The author can interpret the result without the tool guessing at causes.

Minor code cleanup in `render()`: removed the redundant `missing` list and `seen_lower` intermediate variable, and flattened a dead `if rows:` guard that was unreachable after the early-return on the empty case.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes Markdown report rendering for corpora diff output and does not affect scanning or detector logic.
> 
> **Overview**
> Updates `diff_corpora_results.py` to stop emitting a separate warning section for changed detectors with zero matches on both main and PR, and instead include them directly in the main results table as explicit 0/0 rows.
> 
> Also simplifies `render()` flow by removing the `missing` tracking and flattening table-generation logic, with a clearer empty-results message when no rows are produced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f9dfe9fb49d8017a8b3596d8f395eb242e92313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->