### PR TITLE
feat(githubapp): pair PEM keys with App IDs across chunks

### DIFF
--- a/pkg/detectors/githubapp/githubapp.go
+++ b/pkg/detectors/githubapp/githubapp.go
@@ -2,110 +2,386 @@ package githubapp
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
+	lru "github.com/hashicorp/golang-lru/v2"
 	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
 type Scanner struct {
-	detectors.DefaultMultiPartCredentialProvider
+	perSource sync.Map
+	lastReap  atomic.Int64
 }
 
-// Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.MaxSecretSizeProvider = (*Scanner)(nil)
+var _ detectors.MultiPartCredentialProvider = (*Scanner)(nil)
+var _ detectors.CustomFalsePositiveChecker = (*Scanner)(nil)
+
+const (
+	maxSecretSize     = 4096
+	maxCredentialSpan = 4096
+
+	perSourceHalfCap = 256
+	sourceTTL        = 30 * time.Minute
+	reapInterval     = 5 * time.Minute
+)
+
+type halfInfo struct {
+	value    string
+	location string
+}
+
+type sourceState struct {
+	mu        sync.Mutex
+	pems      *lru.Cache[string, halfInfo]
+	appIDs    *lru.Cache[string, halfInfo]
+	lastTouch atomic.Int64
+}
+
+func newSourceState() *sourceState {
+	p, err := lru.New[string, halfInfo](perSourceHalfCap)
+	if err != nil {
+		panic(fmt.Errorf("githubapp: lru.New pems: %w", err))
+	}
+	a, err := lru.New[string, halfInfo](perSourceHalfCap)
+	if err != nil {
+		panic(fmt.Errorf("githubapp: lru.New appIDs: %w", err))
+	}
+	return &sourceState{pems: p, appIDs: a}
+}
+
+func (s *Scanner) stateFor(sid sources.SourceID) *sourceState {
+	if v, ok := s.perSource.Load(sid); ok {
+		return v.(*sourceState)
+	}
+	fresh := newSourceState()
+	actual, _ := s.perSource.LoadOrStore(sid, fresh)
+	return actual.(*sourceState)
+}
+
+func (s *Scanner) maybeReap(now time.Time) {
+	last := s.lastReap.Load()
+	nowNS := now.UnixNano()
+	if nowNS-last < int64(reapInterval) {
+		return
+	}
+	if !s.lastReap.CompareAndSwap(last, nowNS) {
+		return
+	}
+	cutoff := nowNS - int64(sourceTTL)
+	s.perSource.Range(func(k, v any) bool {
+		state := v.(*sourceState)
+		if state.lastTouch.Load() < cutoff {
+			s.perSource.Delete(k)
+		}
+		return true
+	})
+}
 
 var (
 	client = common.SaneHttpClient()
 
-	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	appPat = regexp.MustCompile(detectors.PrefixRegex([]string{"github"}) + `\b([0-9]{6})\b`)
-
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"github"}) + `(-----BEGIN RSA PRIVATE KEY-----\s[A-Za-z0-9+\/\s]*\s-----END RSA PRIVATE KEY-----)`)
+	keyPat = regexp.MustCompile(`(?i)-----\s*?BEGIN[ A-Z0-9_-]*?PRIVATE KEY\s*?-----[\s\S]*?-----\s*?END[ A-Z0-9_-]*?PRIVATE KEY\s*?-----`)
+	appPat = regexp.MustCompile(`(?i)(?:github[-_ ]?app[-_ ]?id|gh[-_ ]?app[-_ ]?id|app[-_ ]?id)\W{1,5}([0-9]{4,9})\b`)
 )
 
-// Keywords are used for efficiently pre-filtering chunks.
-// Use identifiers in the secret preferably, or the provider name.
-func (s Scanner) Keywords() []string {
-	return []string{"github"}
+func (s *Scanner) Keywords() []string {
+	return []string{"github", "private key"}
 }
 
-// FromData will find and optionally verify GitHubApp secrets in a given set of bytes.
-func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+func (s *Scanner) MaxSecretSize() int64     { return maxSecretSize }
+func (s *Scanner) MaxCredentialSpan() int64 { return maxCredentialSpan }
+
+func (s *Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]detectors.Result, error) {
 	dataStr := string(data)
-	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
+
+	keyMatches := keyPat.FindAllString(dataStr, -1)
 	appMatches := appPat.FindAllStringSubmatch(dataStr, -1)
-
-	for _, match := range matches {
-
-		resMatch := strings.TrimSpace(match[1])
-		for _, appMatch := range appMatches {
-			appResMatch := strings.TrimSpace(appMatch[1])
-			s1 := detectors.Result{
-				DetectorType: detector_typepb.DetectorType_GitHubApp,
-				Raw:          []byte(resMatch),
-				SecretParts:  map[string]string{"key": resMatch},
-			}
-			s1.ExtraData = map[string]string{
-				"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
-			}
-
-			if verify {
-				signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(resMatch))
-				if err != nil {
-					continue
-				}
-				// issued at time
-				iat := time.Now().Add(-60 * time.Second)
-				exp := time.Now().Add(9 * 60 * time.Second)
-
-				iss := appResMatch
-				token := jwt.New(jwt.SigningMethodRS256)
-				claims := token.Claims.(jwt.MapClaims)
-				claims["iat"] = iat.Unix()
-				claims["exp"] = exp.Unix()
-				claims["iss"] = iss
-				tokenString, err := token.SignedString(signKey)
-				if err != nil {
-					continue
-				}
-				// end get token
-
-				req, err := http.NewRequestWithContext(ctx, "GET", "https://api.github.com/app", nil)
-				if err != nil {
-					continue
-				}
-				req.Header.Add("Accept", "application/vnd.github.v3+json")
-				req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokenString))
-				res, err := client.Do(req)
-				if err == nil {
-					defer func() { _ = res.Body.Close() }()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						s1.Verified = true
-					}
-				}
-
-			}
-
-			results = append(results, s1)
-		}
-
+	if len(keyMatches) == 0 && len(appMatches) == 0 {
+		return nil, nil
 	}
 
+	chunkPEMs := make(map[string]string)
+	for _, k := range keyMatches {
+		trimmed := strings.TrimSpace(k)
+		if !isGitHubAppKeyShape(trimmed) {
+			continue
+		}
+		chunkPEMs[pemFingerprint(trimmed)] = trimmed
+	}
+	chunkAppIDs := make(map[string]struct{})
+	for _, a := range appMatches {
+		chunkAppIDs[strings.TrimSpace(a[1])] = struct{}{}
+	}
+	if len(chunkPEMs) == 0 && len(chunkAppIDs) == 0 {
+		return nil, nil
+	}
+
+	var results []detectors.Result
+
+	for _, pemStr := range chunkPEMs {
+		for appID := range chunkAppIDs {
+			results = append(results, makeResult(ctx, pemStr, appID, "", "in-chunk", verify))
+		}
+	}
+
+	sid, hasSource := sourceIDFromCtx(ctx)
+	if !hasSource {
+		return results, nil
+	}
+
+	now := time.Now()
+	s.maybeReap(now)
+	state := s.stateFor(sid)
+	state.lastTouch.Store(now.UnixNano())
+	companionLoc := sourceMetadataFromCtx(ctx)
+
+	type pairCandidate struct {
+		pem, appID, companionLoc string
+	}
+	var pairs []pairCandidate
+
+	state.mu.Lock()
+	for _, pemStr := range chunkPEMs {
+		for _, appKey := range state.appIDs.Keys() {
+			if _, inChunk := chunkAppIDs[appKey]; inChunk {
+				continue
+			}
+			cached, ok := state.appIDs.Get(appKey)
+			if !ok {
+				continue
+			}
+			pairs = append(pairs, pairCandidate{
+				pem: pemStr, appID: appKey, companionLoc: cached.location,
+			})
+		}
+	}
+	for appID := range chunkAppIDs {
+		for _, fp := range state.pems.Keys() {
+			if _, inChunk := chunkPEMs[fp]; inChunk {
+				continue
+			}
+			cached, ok := state.pems.Get(fp)
+			if !ok {
+				continue
+			}
+			pairs = append(pairs, pairCandidate{
+				pem: cached.value, appID: appID, companionLoc: cached.location,
+			})
+		}
+	}
+	for fp, pemStr := range chunkPEMs {
+		state.pems.Add(fp, halfInfo{value: pemStr, location: companionLoc})
+	}
+	for appID := range chunkAppIDs {
+		state.appIDs.Add(appID, halfInfo{value: appID, location: companionLoc})
+	}
+	state.mu.Unlock()
+
+	for _, p := range pairs {
+		results = append(results, makeResult(ctx, p.pem, p.appID, p.companionLoc, "cross-chunk", verify))
+	}
 	return results, nil
 }
 
-func (s Scanner) Type() detector_typepb.DetectorType {
+func sourceIDFromCtx(ctx context.Context) (sources.SourceID, bool) {
+	v := ctx.Value("chunk_source_id")
+	if v == nil {
+		return 0, false
+	}
+	sid, ok := v.(sources.SourceID)
+	if !ok || sid == 0 {
+		return 0, false
+	}
+	return sid, true
+}
+
+func sourceMetadataFromCtx(ctx context.Context) string {
+	v := ctx.Value("chunk_source_metadata")
+	if v == nil {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+func makeResult(ctx context.Context, pemStr, appID, companionLoc, pairing string, verify bool) detectors.Result {
+	extraData := map[string]string{
+		"app_id":         appID,
+		"pairing":        pairing,
+		"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
+	}
+	if companionLoc != "" {
+		extraData["companion_location"] = companionLoc
+	}
+	r := detectors.Result{
+		DetectorType: detector_typepb.DetectorType_GitHubApp,
+		Raw:          []byte(pemStr),
+		RawV2:        []byte(appID + ":" + pemStr),
+		SecretParts: map[string]string{
+			"private_key": pemStr,
+			"app_id":      appID,
+		},
+		ExtraData: extraData,
+	}
+	if verify {
+		verified, extra, vErr := verifyApp(ctx, pemStr, appID)
+		if vErr != nil {
+			r.SetVerificationError(vErr, pemStr)
+		} else {
+			r.Verified = verified
+			for k, v := range extra {
+				r.ExtraData[k] = v
+			}
+		}
+	}
+	return r
+}
+
+func pemFingerprint(pemStr string) string {
+	normalized := strings.Join(strings.Fields(pemStr), "")
+	sum := sha256.Sum256([]byte(normalized))
+	return hex.EncodeToString(sum[:])
+}
+
+func isGitHubAppKeyShape(pemStr string) bool {
+	block, _ := pem.Decode([]byte(dedentPEM(pemStr)))
+	if block == nil {
+		return false
+	}
+	if block.Type != "RSA PRIVATE KEY" {
+		return false
+	}
+	if _, ok := block.Headers["Proc-Type"]; ok {
+		return false
+	}
+	if _, ok := block.Headers["DEK-Info"]; ok {
+		return false
+	}
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return false
+	}
+	if len(key.Primes) != 2 {
+		return false
+	}
+	if key.N.BitLen() != 2048 {
+		return false
+	}
+	if key.E != 65537 {
+		return false
+	}
+	for _, p := range key.Primes {
+		if p.BitLen() != 1024 {
+			return false
+		}
+	}
+	return true
+}
+
+func dedentPEM(s string) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimLeft(line, " \t")
+	}
+	return strings.Join(lines, "\n")
+}
+
+func verifyApp(ctx context.Context, pemStr, appID string) (bool, map[string]string, error) {
+	signKey, err := jwt.ParseRSAPrivateKeyFromPEM([]byte(dedentPEM(pemStr)))
+	if err != nil {
+		return false, nil, nil
+	}
+	now := time.Now()
+	token := jwt.New(jwt.SigningMethodRS256)
+	claims := token.Claims.(jwt.MapClaims)
+	claims["iat"] = now.Add(-60 * time.Second).Unix()
+	claims["exp"] = now.Add(9 * 60 * time.Second).Unix()
+	claims["iss"] = appID
+	tokenString, err := token.SignedString(signKey)
+	if err != nil {
+		return false, nil, fmt.Errorf("jwt sign: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.github.com/app", nil)
+	if err != nil {
+		return false, nil, err
+	}
+	req.Header.Add("Accept", "application/vnd.github+json")
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", tokenString))
+	req.Header.Add("X-GitHub-Api-Version", "2022-11-28")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, nil, err
+	}
+	defer res.Body.Close()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		var app struct {
+			Slug  string `json:"slug"`
+			Name  string `json:"name"`
+			Owner struct {
+				Login string `json:"login"`
+				Type  string `json:"type"`
+			} `json:"owner"`
+			Permissions map[string]string `json:"permissions"`
+			Events      []string          `json:"events"`
+			CreatedAt   string            `json:"created_at"`
+		}
+		if err := json.NewDecoder(res.Body).Decode(&app); err != nil {
+			return true, nil, nil
+		}
+		perms := make([]string, 0, len(app.Permissions))
+		for k, v := range app.Permissions {
+			perms = append(perms, k+"="+v)
+		}
+		sort.Strings(perms)
+		events := append([]string(nil), app.Events...)
+		sort.Strings(events)
+		return true, map[string]string{
+			"app_slug":    app.Slug,
+			"app_name":    app.Name,
+			"owner_login": app.Owner.Login,
+			"owner_type":  app.Owner.Type,
+			"permissions": strings.Join(perms, ","),
+			"events":      strings.Join(events, ","),
+			"created_at":  app.CreatedAt,
+		}, nil
+	case http.StatusUnauthorized, http.StatusNotFound:
+		return false, nil, nil
+	default:
+		return false, nil, fmt.Errorf("unexpected status %d", res.StatusCode)
+	}
+}
+
+func (s *Scanner) IsFalsePositive(_ detectors.Result) (bool, string) {
+	return false, ""
+}
+
+func (s *Scanner) Type() detector_typepb.DetectorType {
 	return detector_typepb.DetectorType_GitHubApp
 }
 
-func (s Scanner) Description() string {
+func (s *Scanner) Description() string {
 	return "GitHub Apps allow you to automate and improve your workflow. GitHub App keys can be used to authenticate and interact with the GitHub API on behalf of the app."
 }

--- a/pkg/detectors/githubapp/githubapp_integration_test.go
+++ b/pkg/detectors/githubapp/githubapp_integration_test.go
@@ -48,7 +48,7 @@ func TestGitHubApp_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a githubapp secret %s within githubapp %s", sDec, appKey)),
+				data:   []byte(fmt.Sprintf("github_app_id: %s\ngithub_app_private_key: |\n%s", appKey, sDec)),
 				verify: true,
 			},
 			want: []detectors.Result{
@@ -63,9 +63,8 @@ func TestGitHubApp_FromChunk(t *testing.T) {
 			name: "found, unverified",
 			s:    Scanner{},
 			args: args{
-				ctx:  context.Background(),
-				data: []byte(fmt.Sprintf("You can find a githubapp secret %s within githubapp %s but not valid", inactiveSDec, appKey)), // the secret would satisfy the regex but not pass validation
-
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("github_app_id: %s\ngithub_app_private_key: |\n%s", appKey, inactiveSDec)),
 				verify: true,
 			},
 			want: []detectors.Result{
@@ -101,6 +100,8 @@ func TestGitHubApp_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				got[i].RawV2 = nil
+				got[i].SecretParts = nil
 				got[i].ExtraData = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {

--- a/pkg/detectors/githubapp/githubapp_test.go
+++ b/pkg/detectors/githubapp/githubapp_test.go
@@ -2,88 +2,213 @@ package githubapp
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
-var (
-	validPattern = `[{
-		"_id": "1a8d0cca-e1a9-4318-bc2f-f5658ab2dcb5",
-		"name": "GithubApp",
-		"type": "Detector",
-		"api": true,
-		"authentication_type": "",
-		"verification_url": "https://api.example.com/example",
-		"test_secrets": {
-			"githubapp_key": "456731",
-			"githubapp_secret": "-----BEGIN RSA PRIVATE KEY----- Rg8Tc1jrjetAy G+zTXJG+iTiGMZLmwHSO49LMIAnMHZYUJcXpxFw Y+ -----END RSA PRIVATE KEY-----"
-		},
-		"expected_response": "200",
-		"method": "GET",
-		"deprecated": false
-	}]`
-	secret = "-----BEGIN RSA PRIVATE KEY----- Rg8Tc1jrjetAy G+zTXJG+iTiGMZLmwHSO49LMIAnMHZYUJcXpxFw Y+ -----END RSA PRIVATE KEY-----"
-)
+func newTestPEM(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	der := x509.MarshalPKCS1PrivateKey(key)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}))
+}
+
+func ctxWithSource(sid sources.SourceID, metadata string) context.Context {
+	ctx := context.WithValue(context.Background(), "chunk_source_id", sid)
+	return context.WithValue(ctx, "chunk_source_metadata", metadata)
+}
 
 func TestGithubApp_Pattern(t *testing.T) {
-	d := Scanner{}
-	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+	pemStr := newTestPEM(t)
+	appID := "456731"
+	input := fmt.Sprintf("github_app_id: %s\ngithub_app_private_key: |\n%s", appID, pemStr)
 
-	tests := []struct {
-		name  string
-		input string
-		want  []string
-	}{
-		{
-			name:  "valid pattern",
-			input: validPattern,
-			want:  []string{secret},
-		},
+	d := &Scanner{}
+	core := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+
+	if matched := core.FindDetectorMatches([]byte(input)); len(matched) == 0 {
+		t.Fatalf("keywords %v not matched in input", d.Keywords())
 	}
 
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
-			if len(matchedDetectors) == 0 {
-				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
-				return
-			}
+	results, err := d.FromData(context.Background(), false, []byte(input))
+	if err != nil {
+		t.Fatalf("FromData err = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
 
-			results, err := d.FromData(context.Background(), false, []byte(test.input))
-			if err != nil {
-				t.Errorf("error = %v", err)
-				return
-			}
+	got := results[0]
+	want := appID + ":" + strings.TrimSpace(pemStr)
+	if diff := cmp.Diff(want, string(got.RawV2)); diff != "" {
+		t.Errorf("RawV2 mismatch (-want +got):\n%s", diff)
+	}
+	if got.SecretParts["app_id"] != appID {
+		t.Errorf("SecretParts[app_id] = %q, want %q", got.SecretParts["app_id"], appID)
+	}
+	if !strings.Contains(got.SecretParts["private_key"], "RSA PRIVATE KEY") {
+		t.Errorf("SecretParts[private_key] missing PEM header")
+	}
+	if got.ExtraData["pairing"] != "in-chunk" {
+		t.Errorf("ExtraData[pairing] = %q, want %q", got.ExtraData["pairing"], "in-chunk")
+	}
+}
 
-			if len(results) != len(test.want) {
-				if len(results) == 0 {
-					t.Errorf("did not receive result")
-				} else {
-					t.Errorf("expected %d results, only received %d", len(test.want), len(results))
-				}
-				return
-			}
+func TestGithubApp_RejectsNonAppShapeKey(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8: %v", err)
+	}
+	pkcs8PEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+	input := fmt.Sprintf("github_app_id: 1234567\nkey:\n%s", pkcs8PEM)
 
-			actual := make(map[string]struct{}, len(results))
-			for _, r := range results {
-				if len(r.RawV2) > 0 {
-					actual[string(r.RawV2)] = struct{}{}
-				} else {
-					actual[string(r.Raw)] = struct{}{}
-				}
-			}
-			expected := make(map[string]struct{}, len(test.want))
-			for _, v := range test.want {
-				expected[v] = struct{}{}
-			}
+	results, err := (&Scanner{}).FromData(context.Background(), false, []byte(input))
+	if err != nil {
+		t.Fatalf("FromData err = %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for PKCS#8 key, got %d", len(results))
+	}
+}
 
-			if diff := cmp.Diff(expected, actual); diff != "" {
-				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
-			}
-		})
+func TestGithubApp_NoSourceID_NoCrossChunk(t *testing.T) {
+	s := &Scanner{}
+	pemStr := newTestPEM(t)
+
+	r1, err := s.FromData(context.Background(), false, []byte("private_key: "+pemStr))
+	if err != nil {
+		t.Fatalf("FromData #1 err = %v", err)
+	}
+	if len(r1) != 0 {
+		t.Errorf("PEM-only chunk produced %d results, want 0", len(r1))
+	}
+
+	r2, err := s.FromData(context.Background(), false, []byte("github_app_id: 3787015"))
+	if err != nil {
+		t.Fatalf("FromData #2 err = %v", err)
+	}
+	if len(r2) != 0 {
+		t.Errorf("App-ID-only chunk (no source) produced %d results, want 0", len(r2))
+	}
+}
+
+func TestGithubApp_CrossChunk_SameSource(t *testing.T) {
+	s := &Scanner{}
+	pemStr := newTestPEM(t)
+	appID := "3787015"
+
+	ctx1 := ctxWithSource(42, "git://repo/path/key.pem:line 1")
+	r1, err := s.FromData(ctx1, false, []byte("private_key: "+pemStr))
+	if err != nil {
+		t.Fatalf("FromData #1 err = %v", err)
+	}
+	if len(r1) != 0 {
+		t.Errorf("PEM-only chunk produced %d results, want 0", len(r1))
+	}
+
+	ctx2 := ctxWithSource(42, "git://repo/path/values.yaml:line 7")
+	r2, err := s.FromData(ctx2, false, []byte("github_app_id: "+appID))
+	if err != nil {
+		t.Fatalf("FromData #2 err = %v", err)
+	}
+	if len(r2) != 1 {
+		t.Fatalf("App-ID chunk produced %d results, want 1", len(r2))
+	}
+	got := r2[0]
+	if got.ExtraData["pairing"] != "cross-chunk" {
+		t.Errorf("ExtraData[pairing] = %q, want %q", got.ExtraData["pairing"], "cross-chunk")
+	}
+	if got.ExtraData["app_id"] != appID {
+		t.Errorf("ExtraData[app_id] = %q, want %q", got.ExtraData["app_id"], appID)
+	}
+	if got.ExtraData["companion_location"] != "git://repo/path/key.pem:line 1" {
+		t.Errorf("ExtraData[companion_location] = %q, want PEM chunk location",
+			got.ExtraData["companion_location"])
+	}
+}
+
+func TestGithubApp_CrossChunk_DifferentSourcesDoNotPair(t *testing.T) {
+	s := &Scanner{}
+	pemStr := newTestPEM(t)
+
+	r1, err := s.FromData(
+		ctxWithSource(1, "git://orgA/repo/key.pem"),
+		false,
+		[]byte("private_key: "+pemStr),
+	)
+	if err != nil {
+		t.Fatalf("FromData #1 err = %v", err)
+	}
+	if len(r1) != 0 {
+		t.Errorf("PEM in source A produced %d results, want 0", len(r1))
+	}
+
+	r2, err := s.FromData(
+		ctxWithSource(2, "git://orgB/repo/values.yaml"),
+		false,
+		[]byte("github_app_id: 9876543"),
+	)
+	if err != nil {
+		t.Fatalf("FromData #2 err = %v", err)
+	}
+	if len(r2) != 0 {
+		t.Errorf("App ID in source B produced %d results, want 0 (different sources must not pair)", len(r2))
+	}
+}
+
+func TestGithubApp_DedupesWithinChunk(t *testing.T) {
+	pemStr := newTestPEM(t)
+	appID := "1234567"
+	input := fmt.Sprintf(
+		"github_app_id: %s\nkey: %s\ngithub_app_id: %s\nkey: %s",
+		appID, pemStr, appID, pemStr,
+	)
+
+	results, err := (&Scanner{}).FromData(context.Background(), false, []byte(input))
+	if err != nil {
+		t.Fatalf("FromData err = %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 deduped result, got %d", len(results))
+	}
+}
+
+func TestGithubApp_CrossChunk_BothHalvesInSameChunkLater(t *testing.T) {
+	s := &Scanner{}
+	pemStr := newTestPEM(t)
+	appID := "5555555"
+	ctx := ctxWithSource(7, "git://repo/file1.pem")
+
+	if _, err := s.FromData(ctx, false, []byte("private_key: "+pemStr)); err != nil {
+		t.Fatalf("FromData #1 err = %v", err)
+	}
+
+	r, err := s.FromData(ctx, false, []byte(fmt.Sprintf("github_app_id: %s\n%s", appID, pemStr)))
+	if err != nil {
+		t.Fatalf("FromData #2 err = %v", err)
+	}
+	if len(r) != 1 {
+		t.Errorf("expected 1 result (in-chunk only), got %d", len(r))
+	}
+	if r[0].ExtraData["pairing"] != "in-chunk" {
+		t.Errorf("ExtraData[pairing] = %q, want %q", r[0].ExtraData["pairing"], "in-chunk")
 	}
 }


### PR DESCRIPTION
### Description:
  - Reworks `pkg/detectors/githubapp` so a PEM private key in one chunk and an App ID in another chunk (same source) can be paired and verified, instead of requiring both halves to live in the same chunk.
  - Pairing state is held in a `sync.Map[SourceID]*sourceState`, where each `sourceState` holds two `hashicorp/golang-lru/v2` caches (PEMs, App IDs) capped at 256 entries each. Entries TTL out after 30m; a best-effort reaper runs at most every 5m.
  - Regexes widened: `keyPat` now matches any `BEGIN/END … PRIVATE KEY` block (not just `RSA`); `appPat` matches `github_app_id`, `gh-app-id`, `app id`, etc. with 4–9 digit IDs.
  - PEMs are validated via a shape check and de-duplicated by SHA-256 fingerprint before being cached or paired.
  - Implements `MaxSecretSizeProvider` (4096), `MultiPartCredentialProvider` (4096), and `CustomFalsePositiveChecker`.
  - `Keywords()` now returns `{"github", "private key"}`.
  - No new dependencies — `hashicorp/golang-lru/v2` is already in `go.mod`.

### Checklist:
* [ x] Tests passing (`make test-community`)?
* [ x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core secret-matching and adds per-source in-memory pairing plus live GitHub API verification; broader regexes may shift false-positive/negative behavior until exercised in production scans.
> 
> **Overview**
> Reworks the GitHub App detector so a **2048-bit RSA PKCS#1 PEM** and an **App ID** no longer have to appear in the same scan chunk. When `chunk_source_id` is present, each source keeps bounded LRU caches of “half” credentials and pairs new chunks with prior halves (with `companion_location` and `pairing` metadata); without a source ID, only **in-chunk** pairs are emitted.
> 
> Detection is tightened and broadened at once: PEM blocks match generic `BEGIN/END … PRIVATE KEY` text but are accepted only after a GitHub-app-shaped key check (no encrypted PEM headers, fixed RSA parameters); App IDs match more config-style labels (`github_app_id`, `gh-app-id`, etc.) with **4–9** digits. Results now use **`RawV2`**, structured **`SecretParts`**, and optional verification that calls GitHub’s `/app` API and records app/owner/permission fields on success.
> 
> The scanner becomes **stateful** (`sync.Map` + TTL reaping), advertises **4096**-byte max secret/credential span, adds **`private key`** as a keyword, and unit/integration tests are updated for YAML-style fixtures and cross-chunk behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73b9ad6b742214af1042ae33c123ba55bb02faba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->