### PR TITLE
Update CODEOWNERS: replace 5 slugs with scanning + integrations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,8 +4,6 @@
 # Scan engine and pipeline
 pkg/decoders/ @trufflesecurity/scanning
 pkg/engine/ @trufflesecurity/scanning
-pkg/gitparse/ @trufflesecurity/scanning
-pkg/giturl/ @trufflesecurity/scanning
 pkg/handlers/ @trufflesecurity/scanning
 pkg/iobuf/ @trufflesecurity/scanning
 pkg/sanitizer/ @trufflesecurity/scanning

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,56 +1,15 @@
-# catch-all
-* @trufflesecurity/product-eng
+# Default -- Integrations owns OSS, community, detectors, sources, analyzers
+* @trufflesecurity/integrations
 
-# Shared
-pkg/decoders/ @trufflesecurity/Scanning @trufflesecurity/OSS
-pkg/engine/ @trufflesecurity/Scanning  @trufflesecurity/OSS
-pkg/gitparse/ @trufflesecurity/Scanning  @trufflesecurity/OSS
-pkg/giturl/ @trufflesecurity/Scanning  @trufflesecurity/OSS
-pkg/handlers/ @trufflesecurity/Scanning  @trufflesecurity/OSS
-pkg/iobuf/ @trufflesecurity/Scanning  @trufflesecurity/OSS
-pkg/sanitizer/ @trufflesecurity/Scanning  @trufflesecurity/OSS
-proto/ @trufflesecurity/Scanning  @trufflesecurity/Integrations
+# Scan engine and pipeline
+pkg/decoders/ @trufflesecurity/scanning
+pkg/engine/ @trufflesecurity/scanning
+pkg/gitparse/ @trufflesecurity/scanning
+pkg/giturl/ @trufflesecurity/scanning
+pkg/handlers/ @trufflesecurity/scanning
+pkg/iobuf/ @trufflesecurity/scanning
+pkg/sanitizer/ @trufflesecurity/scanning
+pkg/writers/ @trufflesecurity/scanning
 
-# Scanning
-pkg/sources/ @trufflesecurity/Scanning
-pkg/writers/ @trufflesecurity/Scanning
-
-# Integrations
-pkg/sources/circleci/ @trufflesecurity/Integrations
-pkg/sources/docker/ @trufflesecurity/Integrations
-pkg/sources/elasticsearch/ @trufflesecurity/Integrations
-pkg/sources/filesystem/ @trufflesecurity/Integrations
-pkg/sources/gcs/ @trufflesecurity/Integrations
-pkg/sources/git/ @trufflesecurity/Integrations
-pkg/sources/github/ @trufflesecurity/Integrations
-pkg/sources/gitlab/ @trufflesecurity/Integrations
-pkg/sources/jenkins/ @trufflesecurity/Integrations
-pkg/sources/postman/ @trufflesecurity/Integrations
-pkg/sources/s3/ @trufflesecurity/Integrations
-pkg/sources/travisci/ @trufflesecurity/Integrations
-proto/detector_type.proto @trufflesecurity/Integrations
-
-# OSS
-pkg/detectors/ @trufflesecurity/OSS
-pkg/common/ @trufflesecurity/OSS
-pkg/custom_detectors/ @trufflesecurity/OSS
-pkg/analyzer/ @trufflesecurity/OSS
-pkg/engine/defaults/defaults.go @trufflesecurity/OSS
-pkg/engine/defaults/defaults_test.go @trufflesecurity/OSS
-
-# critical detectors
-pkg/detectors/aws/ @trufflesecurity/backend
-pkg/detectors/gcp/ @trufflesecurity/backend
-pkg/detectors/azure/ @trufflesecurity/backend
-pkg/detectors/okta/ @trufflesecurity/backend
-pkg/detectors/privatekey/ @trufflesecurity/backend
-pkg/detectors/slack/ @trufflesecurity/backend
-pkg/detectors/slackwebhook/ @trufflesecurity/backend
-pkg/detectors/microsoftteamswebhook/ @trufflesecurity/backend
-pkg/detectors/twilio/ @trufflesecurity/backend
-pkg/detectors/sendgrid/ @trufflesecurity/backend
-pkg/detectors/gitlab/ @trufflesecurity/backend
-pkg/detectors/gitlabv2/ @trufflesecurity/backend
-pkg/detectors/github/ @trufflesecurity/backend
-pkg/detectors/github_old/ @trufflesecurity/backend
-pkg/detectors/githubapp/ @trufflesecurity/backend
+# Contracts -- co-owned, changes affect both teams
+proto/ @trufflesecurity/integrations @trufflesecurity/scanning


### PR DESCRIPTION
## Summary

Simplifies CODEOWNERS from 5 team slugs to 2, aligned with the cross-repo ownership redesign.

### Team slug changes
- `product-eng` catch-all → removed (no longer in CODEOWNERS)
- `OSS` → merged into `integrations`
- `backend` (critical detectors) → `integrations` via default
- `Scanning` → `scanning` (casing fix)
- `Integrations` → `integrations` (casing fix)

### Ownership model
- **Default (`*`)**: `@trufflesecurity/integrations` — owns OSS, community, detectors (including critical), sources, analyzers
- **Engine/pipeline dirs**: `@trufflesecurity/scanning` — decoders, engine, handlers, iobuf, sanitizer, writers
- **`proto/`**: co-owned by both teams (contract changes affect both)

### What changed
- 50 lines → 14 lines
- Individual source dir overrides removed (all sources fall to integrations default)
- Critical detector overrides removed (fall to integrations default)
- `proto/detector_type.proto` override removed (inherits co-owned proto/ rule)

## Notes
- The FTE approval gate (`@trufflesecurity/ftes`) is enforced via the org-level ruleset, not CODEOWNERS
- `product-eng` is kept as the parent team for repo access but removed from all CODEOWNERS files
- Part of the cross-repo ownership redesign

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub review routing changes; no application, auth, or runtime behavior is modified.
> 
> **Overview**
> **Replaces a granular CODEOWNERS map with a two-team model** aligned to integrations vs scanning.
> 
> The old **catch-all** (`product-eng`), **per-package** overrides (sources, OSS detectors, `backend` on critical detectors, `gitparse`/`giturl`, etc.), and mixed team slugs are removed. **Default review** for the repo is now `@trufflesecurity/integrations`. **Engine/pipeline** paths under `pkg/decoders`, `pkg/engine`, `pkg/handlers`, `pkg/iobuf`, `pkg/sanitizer`, and `pkg/writers` go to `@trufflesecurity/scanning`. **`proto/`** is **co-owned** by integrations and scanning. Team handles are normalized to lowercase (`scanning`, `integrations`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81b1302e92bdba762e70a954ca1e562d0d66e25f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->