### PR TITLE
fix: add filetype=sdist param to pypi detector

### DIFF
--- a/pkg/detectors/pypi/pypi.go
+++ b/pkg/detectors/pypi/pypi.go
@@ -77,6 +77,7 @@ func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, 
 	_ = writer.WriteField(":action", "file_upload")
 	_ = writer.WriteField("name", "dummy-package")
 	_ = writer.WriteField("version", "0.0.1")
+	_ = writer.WriteField("filetype", "sdist")
 	_ = writer.WriteField("content", "dummy-content")
 
 	// Close the writer to finalize the form


### PR DESCRIPTION
### Description:

The PyPI detector verification was broken, returning the incorrect message and therefore no being verified correctly. This was caused by the request missing a parameter `filetype=sdist`.

Example verification request we send:

```
❯ curl -i -X POST https://upload.pypi.org/legacy/ -H "Authorization: token pypi-REDACTED" -F ":action=file_upload" -F "name=dummy-package" -F "version=0.0.1" -F "content=dummy-content"
HTTP/2 400
<html>
 <head>
  <title>400 Invalid value for filetype. Error: This field is required.</title>
 </head>
 <body>
  <h1>400 Invalid value for filetype. Error: This field is required.</h1>
  The server could not comply with the request since it is either malformed or otherwise incorrect.<br/><br/>
Invalid value for filetype. Error: This field is required.


 </body>
</html>%
```

The response returns `400 Invalid value for filetype. Error: This field is required` which does not match our verification logic.

Example TruffleHog scan results:

```
❯ trufflehog filesystem pypi_token.txt
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

2026-05-28T08:30:25+10:00	info-0	trufflehog	running source	{"source_manager_worker_id": "ZEcOX", "with_units": true}
Found unverified result 🐷🔑❓
Verification issue: unexpected HTTP response status 400
Detector Type: PyPI
Decoder Type: PLAIN
Raw result: pypi-REDACTED
File: pypi_token.txt
Line: 1

2026-05-28T08:30:26+10:00	info-0	trufflehog	finished scanning	{"chunks": 1, "bytes": 180, "verified_secrets": 0, "unverified_secrets": 1, "scan_duration": "667.270041ms", "trufflehog_version": "3.95.3", "verification_caching": {"Hits":0,"Misses":1,"HitsWasted":0,"AttemptsSaved":0,"VerificationTimeSpentMS":664}}

trufflehog on  fix/pypi-detector-verification [$!?] ⎇ trufflehog
❯ trufflehog filesystem pypi_token.txt --only-verified
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

2026-05-28T08:30:34+10:00	info-0	trufflehog	running source	{"source_manager_worker_id": "dCiHb", "with_units": true}
2026-05-28T08:30:34+10:00	info-0	trufflehog	finished scanning	{"chunks": 1, "bytes": 180, "verified_secrets": 0, "unverified_secrets": 0, "scan_duration": "682.568333ms", "trufflehog_version": "3.95.3", "verification_caching": {"Hits":0,"Misses":1,"HitsWasted":0,"AttemptsSaved":0,"VerificationTimeSpentMS":680}}
```

To fix this we can easily add the `filetype=sdist` param, this returns the expected response and verifies the token.

```
❯ ./trufflehog filesystem pypi_token.txt --only-verified
🐷🔑🐷  TruffleHog. Unearth your secrets. 🐷🔑🐷

2026-05-28T08:30:51+10:00	info-0	trufflehog	running source	{"source_manager_worker_id": "DFDkH", "with_units": true}
✅ Found verified result 🐷🔑
Detector Type: PyPI
Decoder Type: PLAIN
Raw result: pypi-REDACTED
File: pypi_token.txt
Line: 1
Analyze: Run `trufflehog analyze` to analyze this key's permissions

2026-05-28T08:30:52+10:00	info-0	trufflehog	finished scanning	{"chunks": 1, "bytes": 180, "verified_secrets": 1, "unverified_secrets": 0, "scan_duration": "681.699208ms", "trufflehog_version": "dev", "verification_caching": {"Hits":0,"Misses":1,"HitsWasted":0,"AttemptsSaved":0,"VerificationTimeSpentMS":678}}

```

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field change to the PyPI detector’s test upload request; no auth, data, or broader scanner behavior changes beyond fixing verification.
> 
> **Overview**
> Fixes **PyPI API token verification** by including the required **`filetype=sdist`** field on the legacy upload probe in `verifyMatch`.
> 
> Without it, PyPI responds with **400** (“filetype … required”) instead of the digest-related **400** the detector treats as proof of a valid token, so valid keys were reported as unverified with an unexpected status error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38427dbe2d025c455397207bc2fcd6c7f8c448fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->