### PR TITLE
fix(postgres): honor ignore tag without explicit port

### DIFF
--- a/pkg/detectors/postgres/postgres.go
+++ b/pkg/detectors/postgres/postgres.go
@@ -52,6 +52,11 @@ var (
 	connStrPartPattern                    = regexp.MustCompile(`([[:alpha:]]+)='(.+?)' ?`)
 )
 
+type uriMatch struct {
+	uri    string
+	params map[string]string
+}
+
 type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
 	detectLoopback bool // Automated tests run against localhost, but we want to ignore those results in the wild
@@ -93,9 +98,10 @@ func (s Scanner) Keywords() []string {
 
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]detectors.Result, error) {
 	var results []detectors.Result
-	candidateParamSets := findUriMatches(data, s.ignorePatterns)
+	candidateMatches := findUriMatches(data, s.ignorePatterns)
 
-	for _, params := range candidateParamSets {
+	for _, candidate := range candidateMatches {
+		params := candidate.params
 		if common.IsDone(ctx) {
 			break
 		}
@@ -141,6 +147,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 			RawV2:        raw,
 			SecretParts:  map[string]string{"connection_string": string(raw)},
 		}
+		result.SetPrimarySecretValue(candidate.uri)
 
 		// We don't need to normalize the (deprecated) requiressl option into the (up-to-date) sslmode option - pq can
 		// do it for us - but we will do it anyway here so that when we later capture sslmode into ExtraData we will
@@ -199,8 +206,8 @@ func (s Scanner) IsFalsePositive(_ detectors.Result) (bool, string) {
 	return false, ""
 }
 
-func findUriMatches(data []byte, ignorePatterns []*regexp.Regexp) []map[string]string {
-	var matches []map[string]string
+func findUriMatches(data []byte, ignorePatterns []*regexp.Regexp) []uriMatch {
+	var matches []uriMatch
 	for _, uri := range uriPattern.FindAll(data, -1) {
 		if shouldIgnore(uri, ignorePatterns) {
 			continue
@@ -224,7 +231,10 @@ func findUriMatches(data []byte, ignorePatterns []*regexp.Regexp) []map[string]s
 		}
 
 		params[pgDbType] = dbType
-		matches = append(matches, params)
+		matches = append(matches, uriMatch{
+			uri:    string(uri),
+			params: params,
+		})
 	}
 	return matches
 }

--- a/pkg/detectors/postgres/postgres.go
+++ b/pkg/detectors/postgres/postgres.go
@@ -147,6 +147,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 			RawV2:        raw,
 			SecretParts:  map[string]string{"connection_string": string(raw)},
 		}
+		// Set the un-normalized raw match as the primary secret value. This
+		// ensures that the engine's line-offset and ignore-tag matching logic
+		// can locate the match even though Raw/RawV2 are stored normalized.
 		result.SetPrimarySecretValue(candidate.uri)
 
 		// We don't need to normalize the (deprecated) requiressl option into the (up-to-date) sslmode option - pq can

--- a/pkg/detectors/postgres/postgres_test.go
+++ b/pkg/detectors/postgres/postgres_test.go
@@ -130,6 +130,18 @@ func TestPostgres_ExtraData(t *testing.T) {
 	}
 }
 
+func TestPostgres_PrimarySecretUsesMatchedURI(t *testing.T) {
+	const uri = "postgresql://admin:secret@10.0.0.1/production"
+
+	s := Scanner{detectLoopback: true}
+	results, err := s.FromData(context.Background(), false, []byte(uri))
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Equal(t, "postgresql://admin:secret@10.0.0.1:5432", string(results[0].Raw))
+	assert.Equal(t, uri, results[0].GetPrimarySecretValue())
+}
+
 func TestPostgres_FromDataWithIgnorePattern(t *testing.T) {
 	s := New(
 		WithIgnorePattern([]string{

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1509,6 +1509,18 @@ def test_something():
 			expectedFindings: 0,
 		},
 		{
+			name: "ignore at end of line without explicit postgres port",
+			content: `
+# tests/example_false_positive.py
+
+def test_something():
+    connection_string = "who-cares"
+
+    # Ignoring this does not work
+    assert connection_string == "postgres://master_user:master_password@hostname/main"  # trufflehog:ignore`,
+			expectedFindings: 0,
+		},
+		{
 			name: "ignore not on secret line",
 			content: `
 # tests/example_false_positive.py


### PR DESCRIPTION
## What changed

- Preserved the exact matched Postgres URI as the result primary secret for line-location purposes.
- Kept the existing normalized `Raw`/`RawV2` value unchanged, including the default `:5432` port.
- Added regression coverage for `# trufflehog:ignore` on a Postgres URI without an explicit port.

## Why

Postgres detector output normalizes missing ports into `:5432`. For a source line like:

```text
DB=postgresql://user:secret@host/db  # trufflehog:ignore
```

that normalized value does not appear verbatim in the source chunk, so the engine cannot locate the finding line and the same-line ignore tag is skipped and **also the line number is ignored making it hard to locate secret from sources that support line number**. Using the matched URI as the line-location primary secret lets the engine find the original source text while preserving the existing normalized finding identity.

Fixes #4962.

## Tests run

- Before the fix: `PATH="/opt/homebrew/opt/go@1.25/bin:$PATH" go test ./pkg/engine -run TestEngineignoreLine -count=1` failed on the new no-port regression with `expected: 0`, `actual: 1`.
- `PATH="/opt/homebrew/opt/go@1.25/bin:$PATH" gofmt -w pkg/detectors/postgres/postgres.go pkg/detectors/postgres/postgres_test.go pkg/engine/engine_test.go`.
- `PATH="/opt/homebrew/opt/go@1.25/bin:$PATH" go test ./pkg/detectors/postgres -run 'TestPostgres_(Pattern|ExtraData|PrimarySecretUsesMatchedURI|FromDataWithIgnorePattern)' -count=1` passed.
- `PATH="/opt/homebrew/opt/go@1.25/bin:$PATH" go test ./pkg/engine -run TestEngineignoreLine -count=1` passed.
- `PATH="/opt/homebrew/opt/go@1.25/bin:$PATH" go test ./pkg/detectors/postgres -count=1` passed.
- `PATH="/opt/homebrew/opt/go@1.25/bin:$PATH" go test ./pkg/engine -run 'Test(FragmentLineOffset|AssignDuplicateLineOffsets|EngineignoreLine)' -count=1` passed.
- `PATH="/opt/homebrew/opt/go@1.25/bin:$PATH" go test ./pkg/detectors/postgres ./pkg/engine -run 'TestPostgres_|TestFragmentLineOffset|TestAssignDuplicateLineOffsets|TestEngineignoreLine' -count=1` passed.
- `PATH="/opt/homebrew/opt/go@1.25/bin:$PATH" go test ./pkg/engine -count=1` passed.
- `git diff --check` passed.

CLI proof on the built branch binary:

```text
no-port-ignore exit=0
with-port-ignore exit=0
no-ignore exit=183
no-ignore finding lines=1
```

## Compatibility and risk

This does not change the emitted Postgres `Raw`, `RawV2`, `SecretParts`, verification parameters, or default-port normalization. The matched URI is only used for line-number and ignore-tag lookup, matching the engine's existing primary-secret path for detectors whose displayed result differs from the exact source match.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Postgres line-location metadata; normalized secret output and verification paths are unchanged per PR intent.
> 
> **Overview**
> Fixes **Postgres** findings where the detector normalizes URIs (e.g. injects default `:5432`) so the emitted `Raw` no longer appears verbatim in the source. The engine could not match the secret to a line, so **`# trufflehog:ignore` on the same line failed** and line numbers were wrong when the URI omitted an explicit port.
> 
> The detector now keeps the **exact matched URI** as the **primary secret** (via `SetPrimarySecretValue`) for line-offset and ignore-tag lookup, while **`Raw` / `RawV2` / verification behavior stay normalized** as before. `findUriMatches` returns `uriMatch` pairs of original URI plus parsed params. Regression tests cover primary-secret vs normalized `Raw` and an engine case for ignore tags on URIs without an explicit port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8bd18eb1acd875e7d0fe40f6b116aedb1f36400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->