### PR TITLE
fix: avoid terminal probes before CLI output

### DIFF
--- a/pkg/tui/components/textinputs/textinputs.go
+++ b/pkg/tui/components/textinputs/textinputs.go
@@ -18,10 +18,16 @@ var (
 	helpStyle    = blurredStyle
 	// cursorStyle         = focusedStyle.
 	// cursorModeHelpStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
-
-	focusedSkipButton = lipgloss.NewStyle().Foreground(lipgloss.Color("205")).Render("[ Run with defaults ]")
-	blurredSkipButton = fmt.Sprintf("[ %s ]", lipgloss.NewStyle().Foreground(lipgloss.Color("240")).Render("Run with defaults"))
 )
+
+func skipButtonView(focused bool) string {
+	// Keep rendering lazy. Rendering lipgloss styles at package init can make
+	// terminal color detection write escape sequences before non-TUI commands run.
+	if focused {
+		return focusedStyle.Render("[ Run with defaults ]")
+	}
+	return fmt.Sprintf("[ %s ]", blurredStyle.Render("Run with defaults"))
+}
 
 // SelectNextMsg used for emitting events when the 'Next' button is selected.
 type SelectNextMsg int
@@ -179,11 +185,7 @@ func (m Model) View() string {
 	}
 
 	if m.skipButton {
-		button := &blurredSkipButton
-		if m.focusIndex == -1 {
-			button = &focusedSkipButton
-		}
-		fmt.Fprintf(&b, "%s\n\n\n", *button)
+		fmt.Fprintf(&b, "%s\n\n\n", skipButtonView(m.focusIndex == -1))
 	}
 
 	for i := range m.inputs {

--- a/pkg/tui/components/textinputs/textinputs_test.go
+++ b/pkg/tui/components/textinputs/textinputs_test.go
@@ -1,0 +1,26 @@
+package textinputs
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSkipButtonViewIsRenderedLazily(t *testing.T) {
+	m := New(nil).SetSkip(true)
+
+	view := m.View()
+
+	if !strings.Contains(view, "Run with defaults") {
+		t.Fatalf("expected skip button text in view, got %q", view)
+	}
+}
+
+func TestSkipButtonViewIsHiddenByDefault(t *testing.T) {
+	m := New(nil)
+
+	view := m.View()
+
+	if strings.Contains(view, "Run with defaults") {
+		t.Fatalf("did not expect skip button text in default view, got %q", view)
+	}
+}


### PR DESCRIPTION
## Background

Fixes #4654.

When TruffleHog runs in a TTY-like environment with machine-readable output, terminal probe escape sequences can be written before the first JSON log line. That makes the output invalid JSON for tools such as `jq`.

## Problem

`pkg/tui/components/textinputs` rendered the skip button at package initialization time:

- `focusedSkipButton = ...Render(...)`
- `blurredSkipButton = ...Render(...)`

Because `main.go` imports the TUI package, this render-time side effect can happen even for non-TUI CLI commands. Rendering a lipgloss style may trigger terminal color/profile detection, which can write terminal probe sequences to stdout before command output starts.

## Solution

Render the skip button lazily from `Model.View()` instead of pre-rendering it in package-level variables.

This keeps the visible TUI behavior the same while avoiding terminal rendering side effects during package initialization.

## Validation

Ran:

```sh
go test ./pkg/tui/components/textinputs
go test ./pkg/tui/...
git diff --check
```

Also ran a focused pseudo-terminal check with a small local program that imports `pkg/tui/components/textinputs` and prints JSON. The captured stdout started directly with:

```json
{"ok":true}
```

The first 80 bytes contained no ESC byte.

## Risk

Low. The change only moves skip button rendering from package initialization to view rendering. It does not change TUI state, key handling, or CLI output formatting directly.

## Breaking Changes

None.

## Reviewer Notes

The important part to review is that no lipgloss `Render()` call remains in package-level initialization for `pkg/tui/components/textinputs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only timing change for one button string; no auth, data, or CLI formatting logic changes beyond avoiding init-time terminal side effects.
> 
> **Overview**
> **Lazy-renders the TUI “Run with defaults” skip control** so importing `pkg/tui/components/textinputs` no longer runs lipgloss `Render()` at package init. Pre-rendered `focusedSkipButton` / `blurredSkipButton` globals are removed in favor of `skipButtonView()`, called from `Model.View()` when the skip option is enabled.
> 
> This targets machine-readable CLI output (e.g. JSON for `jq`) that was getting terminal probe escape sequences on stdout before the first log line when the TUI package was linked but the interactive UI was not shown.
> 
> **Tests** assert the skip label appears when `SetSkip(true)` and stays out of the default view.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 540eb1e89813b70384dc280914457b363fc57785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->