### PR TITLE
fix(detectors): skip GitLab v1 candidates with no digits to reduce false positives

### DIFF
--- a/pkg/detectors/gitlab/v1/gitlab.go
+++ b/pkg/detectors/gitlab/v1/gitlab.go
@@ -79,6 +79,14 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			continue
 		}
 
+		// real tokens are random and always contain at least one digit;
+		// variable names like MAVEN_SETTINGS_PROFILE have no digits and
+		// are a common source of false positives when they appear within
+		// 40 characters of a "gitlab" keyword on a preceding line.
+		if !detectors.KeyIsRandom(resMatch) {
+			continue
+		}
+
 		for _, endpoint := range s.Endpoints() {
 			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_Gitlab,

--- a/pkg/detectors/gitlab/v1/gitlab_v1_test.go
+++ b/pkg/detectors/gitlab/v1/gitlab_v1_test.go
@@ -45,6 +45,16 @@ func TestGitLab_Pattern(t *testing.T) {
 			input: "GITLAB_TOKEN=ABc123456789dEFghIJK",
 			want:  []string{"ABc123456789dEFghIJKhttps://gitlab.com"},
 		},
+		{
+			// Regression test for https://github.com/trufflesecurity/trufflehog/issues/4756
+			// ARG variable names that appear after GITLAB_* args in a Dockerfile must not be
+			// flagged as secrets because they contain no digits (KeyIsRandom check).
+			name: "no false positive for Dockerfile ARG variable name after GITLAB_ACCESS_TOKEN",
+			input: `ARG GITLAB_ACCESS_TOKEN_TYPE=Private-Token
+ARG GITLAB_ACCESS_TOKEN
+ARG MAVEN_SETTINGS_PROFILE=test`,
+			want: []string{},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

Fixes a false positive in the **GitLab v1** detector where Dockerfile `ARG` variable names (e.g. `MAVEN_SETTINGS_PROFILE`) are reported as GitLab secrets.

**Root cause:** `PrefixRegex` matches up to 40 characters ahead of a `gitlab` keyword, *including newlines*. In a Dockerfile like:

```dockerfile
ARG GITLAB_ACCESS_TOKEN_TYPE=Private-Token
ARG GITLAB_ACCESS_TOKEN
ARG MAVEN_SETTINGS_PROFILE=test
```

`MAVEN_SETTINGS_PROFILE` (22 chars, all `[a-zA-Z0-9_]`) falls within the 40-char window of the second `GITLAB` keyword and clears the Shannon-entropy check (~4.1 > 3.6 threshold) because its letters are varied. It is then emitted as a finding.

**Fix:** Add the `detectors.KeyIsRandom` guard that already exists elsewhere in the codebase. Real GitLab personal access tokens are random and always contain at least one digit; environment-variable names like `MAVEN_SETTINGS_PROFILE` never do. Candidates with no digits are now skipped before the (potentially network-bound) verification step.

Closes #4756

## Test plan

- [x] New pattern test `no_false_positive_for_Dockerfile_ARG_variable_name_after_GITLAB_ACCESS_TOKEN` reproduces the exact Dockerfile from the issue and asserts zero results
- [x] Existing pattern tests (`valid pattern`, `valid pattern (with = before secret)`) continue to pass — real tokens contain digits and are unaffected
- [x] `go test ./pkg/detectors/gitlab/v1/... -run TestGitLab_Pattern -v` → all PASS

Signed-off-by: Oleksandr Sanin <alexaaander.sanin@gmail.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local heuristic filter on detector candidates only; legitimate tokens with digits are unchanged.
> 
> **Overview**
> The **GitLab v1** detector now drops candidate matches that fail `detectors.KeyIsRandom` (no digit in the string), after the existing Shannon-entropy filter and before verification.
> 
> This targets false positives where Dockerfile `ARG` names (e.g. `MAVEN_SETTINGS_PROFILE`) sit within the `PrefixRegex` window of a `gitlab` keyword across newlines and still pass entropy. Real v1 tokens are expected to include at least one digit.
> 
> A **pattern regression test** covers the issue #4756 Dockerfile snippet and expects zero findings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52ba5e91db775ec737c47fd9b01c865650da5aa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->