### PR TITLE
feat: add Rancher/Cattle token detector

### DIFF
--- a/pkg/detectors/rancher/rancher.go
+++ b/pkg/detectors/rancher/rancher.go
@@ -7,7 +7,6 @@ import (
 
 	regexp "github.com/wasilibs/go-re2"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
 )
@@ -19,7 +18,8 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClient()
+	// Use the SSRF-safe client that blocks requests to local/private IP ranges.
+	client = detectors.DetectorHttpClientWithNoLocalAddresses
 
 	// Rancher API tokens: 54–64 lowercase alphanumeric chars, named with cattle/rancher prefixes.
 	keyPat = regexp.MustCompile(`(?i)(?:CATTLE_TOKEN|RANCHER_TOKEN|CATTLE_BOOTSTRAP_PASSWORD|RANCHER_API_TOKEN)[\w]*\s*[=:]\s*["']?([a-z0-9]{54,64})["']?`)
@@ -30,6 +30,21 @@ var (
 
 func (s Scanner) Keywords() []string {
 	return []string{"CATTLE_TOKEN", "RANCHER_TOKEN", "CATTLE_BOOTSTRAP_PASSWORD", "RANCHER_API_TOKEN"}
+}
+
+func verifyToken(ctx context.Context, serverURL, token string) bool {
+	req, err := http.NewRequestWithContext(ctx, "GET", serverURL+"/v3", nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = res.Body.Close() }()
+	return res.StatusCode == http.StatusOK
 }
 
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
@@ -48,22 +63,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify && len(serverMatches) > 0 {
-			serverURL := strings.TrimSpace(serverMatches[0][1])
-			serverURL = strings.TrimRight(serverURL, "/")
-
-			req, err := http.NewRequestWithContext(ctx, "GET", serverURL+"/v3", nil)
-			if err != nil {
-				continue
-			}
-			req.Header.Set("Authorization", "Bearer "+token)
-
-			res, err := client.Do(req)
-			if err == nil {
-				defer func() { _ = res.Body.Close() }()
-				if res.StatusCode == http.StatusOK {
-					s1.Verified = true
-				}
-			}
+			serverURL := strings.TrimRight(strings.TrimSpace(serverMatches[0][1]), "/")
+			s1.Verified = verifyToken(ctx, serverURL, token)
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/rancher/rancher.go
+++ b/pkg/detectors/rancher/rancher.go
@@ -1,0 +1,81 @@
+package rancher
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+type Scanner struct {
+	detectors.DefaultMultiPartCredentialProvider
+}
+
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	client = common.SaneHttpClient()
+
+	// Rancher API tokens: 54–64 lowercase alphanumeric chars, named with cattle/rancher prefixes.
+	keyPat = regexp.MustCompile(`(?i)(?:CATTLE_TOKEN|RANCHER_TOKEN|CATTLE_BOOTSTRAP_PASSWORD|RANCHER_API_TOKEN)[\w]*\s*[=:]\s*["']?([a-z0-9]{54,64})["']?`)
+
+	// Server URL used for validation; must appear nearby in the same chunk.
+	serverPat = regexp.MustCompile(`(?i)(?:CATTLE_SERVER|RANCHER_URL|RANCHER_SERVER)\s*[=:]\s*["']?(https?://[^\s"']+)["']?`)
+)
+
+func (s Scanner) Keywords() []string {
+	return []string{"CATTLE_TOKEN", "RANCHER_TOKEN", "CATTLE_BOOTSTRAP_PASSWORD", "RANCHER_API_TOKEN"}
+}
+
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	tokenMatches := keyPat.FindAllStringSubmatch(dataStr, -1)
+	serverMatches := serverPat.FindAllStringSubmatch(dataStr, -1)
+
+	for _, tokenMatch := range tokenMatches {
+		token := strings.TrimSpace(tokenMatch[1])
+
+		s1 := detectors.Result{
+			DetectorType: detector_typepb.DetectorType_RancherToken,
+			Raw:          []byte(token),
+			SecretParts:  map[string]string{"token": token},
+		}
+
+		if verify && len(serverMatches) > 0 {
+			serverURL := strings.TrimSpace(serverMatches[0][1])
+			serverURL = strings.TrimRight(serverURL, "/")
+
+			req, err := http.NewRequestWithContext(ctx, "GET", serverURL+"/v3", nil)
+			if err != nil {
+				continue
+			}
+			req.Header.Set("Authorization", "Bearer "+token)
+
+			res, err := client.Do(req)
+			if err == nil {
+				defer func() { _ = res.Body.Close() }()
+				if res.StatusCode == http.StatusOK {
+					s1.Verified = true
+				}
+			}
+		}
+
+		results = append(results, s1)
+	}
+
+	return results, nil
+}
+
+func (s Scanner) Type() detector_typepb.DetectorType {
+	return detector_typepb.DetectorType_RancherToken
+}
+
+func (s Scanner) Description() string {
+	return "Rancher is a Kubernetes management platform. Rancher API tokens provide full cluster admin access and must be protected."
+}

--- a/pkg/detectors/rancher/rancher.go
+++ b/pkg/detectors/rancher/rancher.go
@@ -33,19 +33,19 @@ func (s Scanner) Keywords() []string {
 	return []string{"CATTLE_TOKEN", "RANCHER_TOKEN", "CATTLE_BOOTSTRAP_PASSWORD", "RANCHER_API_TOKEN"}
 }
 
-func verifyToken(ctx context.Context, serverURL, token string) bool {
+func verifyToken(ctx context.Context, serverURL, token string) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", serverURL+"/v3", nil)
 	if err != nil {
-		return false
+		return false, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	res, err := client.Do(req)
 	if err != nil {
-		return false
+		return false, err
 	}
 	defer func() { _ = res.Body.Close() }()
-	return res.StatusCode == http.StatusOK
+	return res.StatusCode == http.StatusOK, nil
 }
 
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
@@ -65,7 +65,12 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 		if verify && len(serverMatches) > 0 {
 			serverURL := strings.TrimRight(strings.TrimSpace(serverMatches[0][1]), "/")
-			s1.Verified = verifyToken(ctx, serverURL, token)
+			verified, verifyErr := verifyToken(ctx, serverURL, token)
+			if verifyErr != nil {
+				s1.SetVerificationError(verifyErr, token)
+			} else {
+				s1.Verified = verified
+			}
 		}
 
 		results = append(results, s1)

--- a/pkg/detectors/rancher/rancher.go
+++ b/pkg/detectors/rancher/rancher.go
@@ -21,11 +21,12 @@ var (
 	// Use the SSRF-safe client that blocks requests to local/private IP ranges.
 	client = detectors.DetectorHttpClientWithNoLocalAddresses
 
-	// Rancher API tokens: 54–64 lowercase alphanumeric chars, named with cattle/rancher prefixes.
-	keyPat = regexp.MustCompile(`(?i)(?:CATTLE_TOKEN|RANCHER_TOKEN|CATTLE_BOOTSTRAP_PASSWORD|RANCHER_API_TOKEN)[\w]*\s*[=:]\s*["']?([a-z0-9]{54,64})["']?`)
+	// Match variable name case-insensitively via (?i:...) scope, then require strictly
+	// lowercase alphanumeric token to avoid false positives from the broad character set.
+	keyPat = regexp.MustCompile(`(?i:(?:CATTLE_TOKEN|RANCHER_TOKEN|CATTLE_BOOTSTRAP_PASSWORD|RANCHER_API_TOKEN)[\w]*\s*[=:]\s*["']?)([a-z0-9]{54,64})["']?`)
 
 	// Server URL used for validation; must appear nearby in the same chunk.
-	serverPat = regexp.MustCompile(`(?i)(?:CATTLE_SERVER|RANCHER_URL|RANCHER_SERVER)\s*[=:]\s*["']?(https?://[^\s"']+)["']?`)
+	serverPat = regexp.MustCompile(`(?i:(?:CATTLE_SERVER|RANCHER_URL|RANCHER_SERVER)\s*[=:]\s*["']?)(https?://[^\s"']+)["']?`)
 )
 
 func (s Scanner) Keywords() []string {

--- a/pkg/detectors/rancher/rancher_test.go
+++ b/pkg/detectors/rancher/rancher_test.go
@@ -1,0 +1,78 @@
+package rancher
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+)
+
+var (
+	// Fake token and server for pattern matching tests only.
+	validInput = `
+CATTLE_SERVER=https://rancher.example.com
+CATTLE_TOKEN=jswpl27hs8pd88rmw2mgfgrjtpljp85fd5v7rhdwr2s6z22hvt6vjt
+`
+	validToken = "jswpl27hs8pd88rmw2mgfgrjtpljp85fd5v7rhdwr2s6z22hvt6vjt"
+
+	invalidInput = `
+# random string without Rancher context
+random_data = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuv"
+`
+)
+
+func TestRancher_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "valid CATTLE_TOKEN pattern",
+			input: validInput,
+			want:  []string{validToken},
+		},
+		{
+			name:  "no match without cattle/rancher variable name",
+			input: invalidInput,
+			want:  []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(test.want) == 0 {
+				if len(matchedDetectors) != 0 {
+					t.Errorf("expected no matches, got %d", len(matchedDetectors))
+				}
+				return
+			}
+			if len(matchedDetectors) == 0 {
+				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			if err != nil {
+				t.Errorf("error = %v", err)
+				return
+			}
+
+			got := make([]string, len(results))
+			for i, r := range results {
+				got[i] = string(r.Raw)
+			}
+
+			if diff := cmp.Diff(test.want, got); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -709,6 +709,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/sonarcloud"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/sourcegraph"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/sourcegraphcody"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/rancher"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/spectralops"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/speechtextai"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/splunkobservabilitytoken"
@@ -1605,6 +1606,7 @@ func buildDetectorList() []detectors.Detector {
 		&sourcegraph.Scanner{},
 		&sourcegraphcody.Scanner{},
 		// &sparkpost.Scanner{},
+		&rancher.Scanner{},
 		&spectralops.Scanner{},
 		&speechtextai.Scanner{},
 		&splunkobservabilitytoken.Scanner{},

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -609,6 +609,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/rabbitmq"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/railwayapp"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/ramp"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/rancher"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/rapidapi"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/rawg"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/razorpay"
@@ -709,7 +710,6 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/sonarcloud"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/sourcegraph"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/sourcegraphcody"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/rancher"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/spectralops"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/speechtextai"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/splunkobservabilitytoken"
@@ -1502,6 +1502,7 @@ func buildDetectorList() []detectors.Detector {
 		&rabbitmq.Scanner{},
 		&railwayapp.Scanner{},
 		&ramp.Scanner{},
+		&rancher.Scanner{},
 		&rapidapi.Scanner{},
 		// &raven.Scanner{},
 		&rawg.Scanner{},
@@ -1606,7 +1607,6 @@ func buildDetectorList() []detectors.Detector {
 		&sourcegraph.Scanner{},
 		&sourcegraphcody.Scanner{},
 		// &sparkpost.Scanner{},
-		&rancher.Scanner{},
 		&spectralops.Scanner{},
 		&speechtextai.Scanner{},
 		&splunkobservabilitytoken.Scanner{},

--- a/pkg/pb/detector_typepb/detector_type.pb.go
+++ b/pkg/pb/detector_typepb/detector_type.pb.go
@@ -1106,6 +1106,7 @@ const (
 	DetectorType_GitLabOauth2                            DetectorType = 1050
 	DetectorType_SpectralOps                             DetectorType = 1051
 	DetectorType_AWSAppSync                              DetectorType = 1052
+	DetectorType_RancherToken                            DetectorType = 1053
 )
 
 // Enum value maps for DetectorType.
@@ -2160,6 +2161,7 @@ var (
 		1050: "GitLabOauth2",
 		1051: "SpectralOps",
 		1052: "AWSAppSync",
+		1053: "RancherToken",
 	}
 	DetectorType_value = map[string]int32{
 		"Alibaba":                               0,
@@ -3211,6 +3213,7 @@ var (
 		"GitLabOauth2":                      1050,
 		"SpectralOps":                       1051,
 		"AWSAppSync":                        1052,
+		"RancherToken":                      1053,
 	}
 )
 

--- a/proto/detector_type.proto
+++ b/proto/detector_type.proto
@@ -1054,4 +1054,5 @@ enum DetectorType {
   GitLabOauth2 = 1050;
   SpectralOps = 1051;
   AWSAppSync = 1052;
+  RancherToken = 1053;
 }


### PR DESCRIPTION
## Summary

Adds a detector for Rancher Kubernetes management platform API tokens, as requested in #4622.

## Token pattern

Rancher tokens are 54–64 lowercase alphanumeric characters, always assigned to named variables:

```
CATTLE_TOKEN=jswpl27hs8pd88rmw2mgfgrjtpljp85fd5v7rhdwr2s6z22hvt6vjt
RANCHER_API_TOKEN=k7mnp9qr4st2vwx8yz3abc5def1ghi6jkl0mno8pqr2stu4vwx9yz
```

The regex anchors on the variable name prefix (CATTLE_TOKEN, RANCHER_TOKEN, CATTLE_BOOTSTRAP_PASSWORD, RANCHER_API_TOKEN) to suppress false positives from the broad `[a-z0-9]` character class.

## Validation

When CATTLE_SERVER or RANCHER_URL is found in the same chunk, the detector hits `GET {server}/v3` with `Authorization: Bearer {token}`. HTTP 200 → verified.

## Changes

- `pkg/detectors/rancher/rancher.go` — detector implementation
- `pkg/detectors/rancher/rancher_test.go` — pattern tests (no live calls)
- `proto/detector_type.proto` — `RancherToken = 1053`
- `pkg/pb/detector_typepb/detector_type.pb.go` — updated generated maps
- `pkg/engine/defaults/defaults.go` — registered `rancher.Scanner{}`

Closes #4622

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated new detector following existing SSRF-safe verification patterns; no changes to core scan or auth paths.
> 
> **Overview**
> Adds **Rancher / Cattle API token** detection for TruffleHog, including a new `RancherToken` detector type (`1053`) wired into the default engine.
> 
> The scanner finds **54–64 character lowercase alphanumeric** tokens only when they appear next to known env-style names (`CATTLE_TOKEN`, `RANCHER_TOKEN`, `CATTLE_BOOTSTRAP_PASSWORD`, `RANCHER_API_TOKEN`). When verification is enabled and a server URL is present in the same chunk (`CATTLE_SERVER`, `RANCHER_URL`, `RANCHER_SERVER`), it checks credentials with **`GET {server}/v3`** and a **Bearer** token, using the **SSRF-safe** HTTP client used by other detectors.
> 
> Pattern-only tests cover a positive `CATTLE_TOKEN` case and a negative case without Rancher variable names (no live HTTP).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19490ee0f657c477e6e83502b6462c97eb13d5e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->