### PR TITLE
Metabase: match only UUID session tokens (reduce false positives)

### DIFF
--- a/pkg/detectors/metabase/metabase.go
+++ b/pkg/detectors/metabase/metabase.go
@@ -24,7 +24,8 @@ var (
 	client = detectors.DetectorHttpClientWithLocalAddresses
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"metabase"}) + `\b([a-zA-Z0-9-]{36})\b`)
+	// Metabase session tokens are UUIDs (see src/metabase/session/models/session.clj: (str (random-uuid))).
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"metabase"}) + `\b([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})\b`)
 
 	baseURL = regexp.MustCompile(detectors.PrefixRegex([]string{"metabase"}) + `\b(https?:\/\/[-a-zA-Z0-9@:%._\+~#=]{7,256})\b`)
 )

--- a/pkg/detectors/metabase/metabase_test.go
+++ b/pkg/detectors/metabase/metabase_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	validKeyPattern       = "Y49ftoUer6aYZOzdkRzlENnW8PHnD9zf9dP9"
+	validKeyPattern       = "38f4939c-ad7f-4cbe-ae54-30946daf8593"
 	invalidKeyPattern     = "=49ftoUer6aYZOzdkRzlENnW8PHnD9zf9dP9"
 	validBaseUrlPattern   = "https://tiwRdoa.metabase.com"
 	invalidBaseUrlPattern = "https://tiwRdo^.metabase.com"
@@ -40,6 +40,11 @@ func TestMetabase_Pattern(t *testing.T) {
 		{
 			name:  "invalid pattern",
 			input: fmt.Sprintf("%s key = '%s' url = '%s'", keyword, invalidKeyPattern, invalidBaseUrlPattern),
+			want:  []string{},
+		},
+		{
+			name:  "false positive - 36-char url slug is not a session token",
+			input: fmt.Sprintf("%s '%s' %s '%s'", keyword, "prod-analytics-dashboard-public-link", keyword, validBaseUrlPattern),
 			want:  []string{},
 		},
 	}


### PR DESCRIPTION
Fixes #4633

### Description
The Metabase detector matches any 36-character `[a-zA-Z0-9-]` string near the `metabase` keyword, so URL slugs and other descriptive strings get flagged as session tokens (the case reported in #4633).

Metabase session tokens (`X-Metabase-Session`) are UUIDs:
- `src/metabase/session/models/session.clj` — `generate-session-key` returns `(str (random-uuid))`
- `POST /api/session` returns `{"id": "<uuid>"}`

This tightens `keyPat` to the UUID format, which removes the false positives at the source without extra heuristics. Detection of real tokens is unchanged.

### Tests
Added a regression case (a 36-char URL slug is no longer flagged). `go test ./pkg/detectors/metabase/` and `go vet` pass.

### Note
@rootranjan already opened #4634 for this same issue using a slug/word-filtering approach — thanks for that work. This is a smaller, root-cause alternative (a one-line regex change) in case it's helpful; happy to defer to #4634 or close this if you'd prefer that direction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped regex and test updates in the Metabase detector only; no auth or verification flow changes beyond stricter matching.
> 
> **Overview**
> Tightens the Metabase session-token detector so it only matches **UUID-shaped** `X-Metabase-Session` values instead of any 36-character alphanumeric string near the `metabase` keyword. That stops URL slugs and similar descriptive strings (e.g. `prod-analytics-dashboard-public-link`) from being reported as secrets while keeping real tokens detectable.
> 
> Tests now use a UUID example and add a regression case asserting those slugs are **not** flagged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9342babc28f252e881a679187eccaf8d0538e569. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->