### PR TITLE
Fix Renovate lookup: update setup-captain version comment

### DIFF
--- a/.github/workflows/detector-tests.yml
+++ b/.github/workflows/detector-tests.yml
@@ -20,7 +20,7 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@25e24d2d23ae098373794ef1d6faecb48ee52da8 # v3.0.0
         with:
           repo: gotestyourself/gotestsum
-      - uses: rwx-research/setup-captain@f761ee3671e4c027299f8a5842a53fba8ddd8e37 # v1
+      - uses: rwx-research/setup-captain@f761ee3671e4c027299f8a5842a53fba8ddd8e37 # v1.4.1
       - name: Test Go
         run: |
           export CGO_ENABLED=1


### PR DESCRIPTION
## Summary

- Corrects the SHA pin comment for `rwx-research/setup-captain` from `# v1` to `# v1.4.1`
- The SHA digest is **unchanged** -- this is a comment-only fix with zero runtime impact
- `rwx-research/setup-captain` does not publish a rolling `v1` tag, only specific versions (e.g. `v1.4.1`), which caused Renovate to fail with: _"Could not determine new digest for update (github-tags package rwx-research/setup-captain)"_

## Test plan

- [x] CI passes (no workflow behavior changes since the SHA is identical)
- [ ] After merge, verify the Renovate lookup error for `setup-captain` is resolved

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only workflow change with no SHA or runtime impact.
> 
> **Overview**
> Updates the version comment on the pinned `rwx-research/setup-captain` step in **detector-tests** from `# v1` to `# v1.4.1`. The **SHA is unchanged**, so CI behavior is the same.
> 
> This aligns the comment with the actual release tag so **Renovate** can resolve digest updates for that action (it was failing when the comment implied a non-existent rolling `v1` tag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4568570e84f651e374347f48fd8665bea1e106c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->