### PR TITLE
fix(detectors): report Todoist verifier errors

### DIFF
--- a/pkg/detectors/todoist/todoist.go
+++ b/pkg/detectors/todoist/todoist.go
@@ -3,6 +3,7 @@ package todoist
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -13,13 +14,15 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
 )
 
-type Scanner struct{}
+type Scanner struct {
+	client *http.Client
+}
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClient()
+	defaultClient = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"todoist"}) + `\b([0-9a-z]{40})\b`)
@@ -47,24 +50,51 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.todoist.com/api/v1/projects", nil)
-			if err != nil {
-				continue
+			client := s.client
+			if client == nil {
+				client = defaultClient
 			}
-			req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", resMatch))
-			res, err := client.Do(req)
-			if err == nil {
-				defer func() { _ = res.Body.Close() }()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					s1.Verified = true
-				}
-			}
+
+			isVerified, verificationErr := verifyMatch(ctx, client, resMatch)
+			s1.Verified = isVerified
+			s1.SetVerificationError(verificationErr, resMatch)
 		}
 
 		results = append(results, s1)
 	}
 
 	return results, nil
+}
+
+func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.todoist.com/api/v1/projects", nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if res.Body != nil {
+			_, _ = io.Copy(io.Discard, res.Body)
+			_ = res.Body.Close()
+		}
+	}()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return false, nil
+	default:
+		if res.StatusCode >= 200 && res.StatusCode < 300 {
+			return true, nil
+		}
+		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
 }
 
 func (s Scanner) Type() detector_typepb.DetectorType {

--- a/pkg/detectors/todoist/todoist_test.go
+++ b/pkg/detectors/todoist/todoist_test.go
@@ -2,6 +2,7 @@ package todoist
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -100,31 +101,27 @@ func TestTodoist_Pattern(t *testing.T) {
 }
 
 func TestTodoist_VerificationEndpoint(t *testing.T) {
-	d := Scanner{}
 	input := fmt.Sprintf("%s token = '%s'", keyword, validPattern)
 
-	prevClient := client
-	t.Cleanup(func() {
-		client = prevClient
-	})
-
 	called := false
-	client = &http.Client{
-		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			called = true
-			if req.URL.String() != "https://api.todoist.com/api/v1/projects" {
-				t.Fatalf("unexpected verification URL: %s", req.URL.String())
-			}
-			if req.Header.Get("Authorization") == "" {
-				t.Fatal("missing Authorization header")
-			}
+	d := Scanner{
+		client: &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				called = true
+				if req.URL.String() != "https://api.todoist.com/api/v1/projects" {
+					t.Fatalf("unexpected verification URL: %s", req.URL.String())
+				}
+				if req.Header.Get("Authorization") == "" {
+					t.Fatal("missing Authorization header")
+				}
 
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader("{}")),
-				Header:     make(http.Header),
-			}, nil
-		}),
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader("{}")),
+					Header:     make(http.Header),
+				}, nil
+			}),
+		},
 	}
 
 	results, err := d.FromData(context.Background(), true, []byte(input))
@@ -139,5 +136,91 @@ func TestTodoist_VerificationEndpoint(t *testing.T) {
 	}
 	if !results[0].Verified {
 		t.Fatal("expected result to be verified")
+	}
+}
+
+func TestTodoist_VerificationResponses(t *testing.T) {
+	input := fmt.Sprintf("%s token = '%s'", keyword, validPattern)
+
+	tests := []struct {
+		name                string
+		response            *http.Response
+		responseErr         error
+		wantVerified        bool
+		wantVerificationErr bool
+	}{
+		{
+			name: "valid token",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+				Header:     make(http.Header),
+			},
+			wantVerified: true,
+		},
+		{
+			name: "valid token with nil body",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+			},
+			wantVerified: true,
+		},
+		{
+			name: "unauthorized token",
+			response: &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+				Header:     make(http.Header),
+			},
+		},
+		{
+			name: "forbidden token",
+			response: &http.Response{
+				StatusCode: http.StatusForbidden,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+				Header:     make(http.Header),
+			},
+		},
+		{
+			name:                "client error",
+			responseErr:         errors.New("network failure"),
+			wantVerificationErr: true,
+		},
+		{
+			name: "unexpected status",
+			response: &http.Response{
+				StatusCode: http.StatusInternalServerError,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+				Header:     make(http.Header),
+			},
+			wantVerificationErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := Scanner{
+				client: &http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						return tt.response, tt.responseErr
+					}),
+				},
+			}
+
+			results, err := d.FromData(context.Background(), true, []byte(input))
+			if err != nil {
+				t.Fatalf("FromData returned error: %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(results))
+			}
+			if results[0].Verified != tt.wantVerified {
+				t.Fatalf("Verified = %v, want %v", results[0].Verified, tt.wantVerified)
+			}
+			if (results[0].VerificationError() != nil) != tt.wantVerificationErr {
+				t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, results[0].VerificationError())
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Description:

Related to #4051. This updates the Todoist detector verifier to report indeterminate verification failures instead of silently ignoring them.

Before this change, Todoist verification only set `Verified` for 2xx responses. Network/client errors and unexpected API statuses were dropped, which made verifier failures indistinguishable from determinately invalid credentials.

This PR keeps the detector behavior narrow:
- 2xx responses verify the secret.
- 401 and 403 remain determinately unverified without a verification error.
- client/request failures and unexpected statuses now populate `VerificationError`.
- response bodies are drained and closed on verifier responses.

This intentionally does not use a closing keyword for #4051 because that issue tracks many detector verifier cleanups.

### Local validation:

- [x] `go test -count=1 ./pkg/detectors/todoist`
- [x] `go test -count=1 ./pkg/detectors`
- [x] `go test -timeout=5m ./pkg/detectors/...`
- [x] `go vet ./pkg/detectors/todoist`
- [x] `go run ./hack/checksecretparts -fail ./pkg/detectors`
- [x] `golangci-lint run --enable bodyclose,copyloopvar,misspell --timeout 10m ./pkg/detectors/todoist`

### Checklist:

* [x] Tests passing (`make test-community` equivalent is covered by GitHub Actions for fork PRs; local Docker full `make test-community` did not complete within 20m, so I ran the detector subtree plus changed package directly.)
* [x] Lint passing (`golangci-lint` passed for the changed package. Full local lint reported `0 issues` but exited on timeout under Docker/Windows; GitHub Actions will run full lint on Linux.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the Todoist detector verifier and tests; behavior change is clearer error reporting, not auth or data handling.
> 
> **Overview**
> Refactors the **Todoist** detector verifier so indeterminate failures are visible instead of being dropped.
> 
> Verification moves into `verifyMatch`, with an injectable `Scanner.client` (replacing a package-level HTTP client). **2xx** still marks secrets verified; **401/403** stay unverified with no error. Network/request failures and unexpected status codes now set **`VerificationError`** via `SetVerificationError`. Response bodies are drained and closed on verifier responses.
> 
> Tests inject the client on `Scanner` and add **`TestTodoist_VerificationResponses`** for OK, auth failures, client errors, and unexpected HTTP statuses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6085d0bfeb0fa989d12332ec97fc556647ff9ea6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->