### PR TITLE
[INS-469] Added Rev detectors to defaults.go and gated it behind feature flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -253,7 +253,6 @@ require (
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect
-	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
@@ -320,6 +319,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251222181119-0a764e51fe1b // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gotest.tools/v3 v3.5.2 // indirect
 	pault.ag/go/topsort v0.1.1 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -536,6 +536,7 @@ func run(state overseer.State, logSync func() error) {
 	feature.DatadogApiKeyDetectorEnabled.Store(true)
 	feature.TlyDetectorEnabled.Store(true)
 	feature.WitDetectorEnabled.Store(true)
+	feature.RevDetectorEnabled.Store(true)
 
 	conf := &config.Config{}
 	if *configFilename != "" {

--- a/pkg/detectors/rev/rev.go
+++ b/pkg/detectors/rev/rev.go
@@ -3,9 +3,10 @@ package rev
 import (
 	"context"
 	"fmt"
-	regexp "github.com/wasilibs/go-re2"
 	"net/http"
 	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -49,7 +50,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_Rev,
 				Raw:          []byte(resUserMatch),
-				SecretParts:  map[string]string{"key": resUserMatch},
+				SecretParts:  map[string]string{"key": resUserMatch, "client": resClientMatch},
 			}
 
 			if verify {

--- a/pkg/detectors/rev/rev_integration_test.go
+++ b/pkg/detectors/rev/rev_integration_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kylelemons/godebug/pretty"
-
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
@@ -98,8 +98,18 @@ func TestRev_FromChunk(t *testing.T) {
 				}
 				got[i].Raw = nil
 			}
-			if diff := pretty.Compare(got, tt.want); diff != "" {
-				t.Errorf("Rev.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			ignoreOpts := cmpopts.IgnoreFields(
+				detectors.Result{},
+				"ExtraData",
+				"verificationError",
+				"primarySecret",
+				"SecretParts",
+				"chunkOffset",
+				"chunkOffsetSet",
+			)
+
+			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
+				t.Errorf("SpectralOps.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
 		})
 	}

--- a/pkg/detectors/rev/rev_integration_test.go
+++ b/pkg/detectors/rev/rev_integration_test.go
@@ -109,7 +109,7 @@ func TestRev_FromChunk(t *testing.T) {
 			)
 
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
-				t.Errorf("SpectralOps.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+				t.Errorf("Rev.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
 		})
 	}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -627,6 +627,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/requestfinance"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/restpackhtmltopdfapi"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/restpackscreenshotapi"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/rev"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/revampcrm"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/ringcentral"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/ritekit"
@@ -1524,6 +1525,7 @@ func buildDetectorList() []detectors.Detector {
 		// &restpack.Scanner{},
 		&restpackhtmltopdfapi.Scanner{},
 		&restpackscreenshotapi.Scanner{},
+		&rev.Scanner{},
 		&revampcrm.Scanner{},
 		&ringcentral.Scanner{},
 		&ritekit.Scanner{},
@@ -1792,6 +1794,8 @@ func buildDetectorList() []detectors.Detector {
 			return !feature.TlyDetectorEnabled.Load()
 		case *wit.Scanner:
 			return !feature.WitDetectorEnabled.Load()
+		case *rev.Scanner:
+			return !feature.RevDetectorEnabled.Load()
 		default:
 			return false
 		}

--- a/pkg/engine/defaults/defaults_test.go
+++ b/pkg/engine/defaults/defaults_test.go
@@ -121,7 +121,6 @@ var excludedFromDefaultList = map[detector_typepb.DetectorType]struct{}{
 	detector_typepb.DetectorType_Guru:   {},
 	detector_typepb.DetectorType_IPInfo: {},
 	detector_typepb.DetectorType_Lob:    {},
-	detector_typepb.DetectorType_Rev:    {},
 	detector_typepb.DetectorType_Tru:    {},
 	detector_typepb.DetectorType_User:   {},
 
@@ -134,6 +133,7 @@ var excludedFromDefaultList = map[detector_typepb.DetectorType]struct{}{
 	detector_typepb.DetectorType_Pinecone:      {},
 	detector_typepb.DetectorType_TLy:           {},
 	detector_typepb.DetectorType_Wit:           {},
+	detector_typepb.DetectorType_Rev:           {},
 
 	// Reserved / special types.
 	detector_typepb.DetectorType_CustomRegex: {}, // added dynamically via engine config, not via buildDetectorList()

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -23,6 +23,7 @@ var (
 	DatadogApiKeyDetectorEnabled   atomic.Bool
 	TlyDetectorEnabled             atomic.Bool
 	WitDetectorEnabled             atomic.Bool
+	RevDetectorEnabled             atomic.Bool
 )
 
 type AtomicString struct {


### PR DESCRIPTION
### Description:
This PR adds the existing `Rev` detector to `defaults.go` and ensures it is gated behind the appropriate feature flag.

Additionally, the PR updates the assertions in the existing integration tests to account for the changes made to the `detector.Result` struct.

### Corpora Test:
The detector doesn't appear in the list.
<img width="278" height="625" alt="image" src="https://github.com/user-attachments/assets/ce95a32a-e139-42e1-9f09-1a4f9cfbe3a4" />

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turning on a new default detector can change scan findings and verification traffic; rollout is mitigated by the same feature-flag pattern as other recently enabled detectors.
> 
> **Overview**
> **Enables the existing Rev (transcription API) detector in the default engine** by registering `rev.Scanner` in `buildDetectorList()`, wiring **`RevDetectorEnabled`** in `pkg/feature`, turning it on in OSS `main.go` with the other gated detectors, and filtering the scanner out when the flag is off.
> 
> The Rev detector now populates **`SecretParts`** with both **`key`** and **`client`** (multi-part credential). Integration tests were updated to compare results with **`go-cmp`**, ignoring newer `detectors.Result` fields. **`defaults_test`** moves `DetectorType_Rev` from the “never added” exclude list into the feature-flag-gated group. **`go.mod`** drops two unused indirect modules after tidy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa45b11ef807383e6de0b48f2ab1d4199cba5b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->