### PR TITLE
[INS-470] Add Tly detector to defaults.go, gate it behind feat flag and update its verification logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -534,6 +534,7 @@ func run(state overseer.State, logSync func() error) {
 	feature.GitLabOAuthDetectorEnabled.Store(true)
 	feature.EnigmaDetectorEnabled.Store(true)
 	feature.DatadogApiKeyDetectorEnabled.Store(true)
+	feature.TlyDetectorEnabled.Store(true)
 
 	conf := &config.Config{}
 	if *configFilename != "" {

--- a/pkg/detectors/tly/tly.go
+++ b/pkg/detectors/tly/tly.go
@@ -2,6 +2,8 @@ package tly
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -31,38 +33,76 @@ func (s Scanner) Keywords() []string {
 }
 
 // FromData will find and optionally verify TLy secrets in a given set of bytes.
-func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+func (s Scanner) FromData(
+	ctx context.Context,
+	verify bool,
+	data []byte,
+) (results []detectors.Result, err error) {
+
 	dataStr := string(data)
 
-	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
+	uniqueKeys := make(map[string]struct{})
+	for _, match := range keyPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueKeys[strings.TrimSpace(match[1])] = struct{}{}
+	}
 
-	for _, match := range matches {
-		resMatch := strings.TrimSpace(match[1])
-
-		s1 := detectors.Result{
+	for key := range uniqueKeys {
+		result := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_TLy,
-			Raw:          []byte(resMatch),
-			SecretParts:  map[string]string{"key": resMatch},
+			Raw:          []byte(key),
+			SecretParts: map[string]string{
+				"key": key,
+			},
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://t.ly/api/v1/link/stats?api_token="+resMatch+"&short_url=https://t.ly/h9YS", nil)
-			if err != nil {
-				continue
-			}
-			res, err := client.Do(req)
-			if err == nil {
-				defer func() { _ = res.Body.Close() }()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					s1.Verified = true
-				}
-			}
+			verified, verificationErr := verifyTLyKey(ctx, client, key)
+			result.SetVerificationError(verificationErr, key)
+			result.Verified = verified
 		}
 
-		results = append(results, s1)
+		results = append(results, result)
 	}
 
-	return results, nil
+	return
+}
+
+func verifyTLyKey(
+	ctx context.Context,
+	client *http.Client,
+	key string,
+) (bool, error) {
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		"https://api.t.ly/api/v1/link/list",
+		http.NoBody,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Accept", "application/json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
 }
 
 func (s Scanner) Type() detector_typepb.DetectorType {

--- a/pkg/detectors/tly/tly_integration_test.go
+++ b/pkg/detectors/tly/tly_integration_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kylelemons/godebug/pretty"
-
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
@@ -96,8 +96,19 @@ func TestTLy_FromChunk(t *testing.T) {
 				}
 				got[i].Raw = nil
 			}
-			if diff := pretty.Compare(got, tt.want); diff != "" {
-				t.Errorf("TLy.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+
+			ignoreOpts := cmpopts.IgnoreFields(
+				detectors.Result{},
+				"ExtraData",
+				"verificationError",
+				"primarySecret",
+				"SecretParts",
+				"chunkOffset",
+				"chunkOffsetSet",
+			)
+
+			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
+				t.Errorf("Tly.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
 		})
 	}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -773,6 +773,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/timecamp"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/timezoneapi"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/tineswebhook"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/tly"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/tmetric"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/todoist"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/tokeet"
@@ -1671,6 +1672,7 @@ func buildDetectorList() []detectors.Detector {
 		&timecamp.Scanner{},
 		&timezoneapi.Scanner{},
 		&tineswebhook.Scanner{},
+		&tly.Scanner{},
 		&tmetric.Scanner{},
 		&todoist.Scanner{},
 		// &toggltrack.Scanner{},
@@ -1784,6 +1786,8 @@ func buildDetectorList() []detectors.Detector {
 			return !feature.EnigmaDetectorEnabled.Load()
 		case *datadogapikey.Scanner:
 			return !feature.DatadogApiKeyDetectorEnabled.Load()
+		case *tly.Scanner:
+			return !feature.TlyDetectorEnabled.Load()
 		default:
 			return false
 		}

--- a/pkg/engine/defaults/defaults_test.go
+++ b/pkg/engine/defaults/defaults_test.go
@@ -122,7 +122,6 @@ var excludedFromDefaultList = map[detector_typepb.DetectorType]struct{}{
 	detector_typepb.DetectorType_IPInfo: {},
 	detector_typepb.DetectorType_Lob:    {},
 	detector_typepb.DetectorType_Rev:    {},
-	detector_typepb.DetectorType_TLy:    {},
 	detector_typepb.DetectorType_Tru:    {},
 	detector_typepb.DetectorType_User:   {},
 	detector_typepb.DetectorType_Wit:    {},
@@ -134,6 +133,7 @@ var excludedFromDefaultList = map[detector_typepb.DetectorType]struct{}{
 	detector_typepb.DetectorType_Enigma:        {},
 	detector_typepb.DetectorType_GitLabOauth2:  {},
 	detector_typepb.DetectorType_Pinecone:      {},
+	detector_typepb.DetectorType_TLy:           {},
 
 	// Reserved / special types.
 	detector_typepb.DetectorType_CustomRegex: {}, // added dynamically via engine config, not via buildDetectorList()

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -21,6 +21,7 @@ var (
 	GitLabOAuthDetectorEnabled     atomic.Bool
 	EnigmaDetectorEnabled          atomic.Bool
 	DatadogApiKeyDetectorEnabled   atomic.Bool
+	TlyDetectorEnabled             atomic.Bool
 )
 
 type AtomicString struct {


### PR DESCRIPTION
### Description:
This PR adds the `Tly` detector to `defaults.go` and gates it behind the appropriate feature flag.

Additionally, the PR updates the detector’s verification logic to align with the latest implementation changes.

### Corpora Test
The detector appear in the list but on the lower side.
<img width="280" height="644" alt="image" src="https://github.com/user-attachments/assets/d2de6a44-bb3a-443c-8813-2f6d27ca4523" />


### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turns on a new default-gated detector (flag defaults true), changing scan coverage and live verification traffic; verification semantics changed from the old endpoint, which may shift verified vs unverified results.
> 
> **Overview**
> **Enables the TLy (t.ly) API key detector in the default engine** by registering `tly.Scanner` in `buildDetectorList()`, wiring `TlyDetectorEnabled` in `pkg/feature`, defaulting it to **on** in OSS `main.go`, and filtering the scanner out when the flag is off (same pattern as Pinecone/Cloudinary). `defaults_test` moves `DetectorType_TLy` from the “never added” exclude list into the feature-flag-gated exclude list so `TestAllDetectorTypesAreInDefaultList` stays consistent.
> 
> **Refactors TLy detection and verification** in `pkg/detectors/tly`: deduplicates matched keys per chunk, records verification failures via `SetVerificationError`, and replaces the old stats URL + query `api_token` check with a `GET https://api.t.ly/api/v1/link/list` call using `Authorization: Bearer`. Integration tests switch from `pretty.Compare` to `go-cmp` with ignored result metadata fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beebeca8491b2fc33ede60eb490e80ffd86bbe13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->