### PR TITLE
[INS-472] [INS-515] Add user detector to defaults.go, gate it behind feat flag, update verification logic and add custom ep configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -536,12 +536,9 @@ func run(state overseer.State, logSync func() error) {
 	feature.DatadogApiKeyDetectorEnabled.Store(true)
 	feature.TlyDetectorEnabled.Store(true)
 	feature.WitDetectorEnabled.Store(true)
-<<<<<<< user-detector
-	feature.UserDetectorEnabled.Store(true)
-=======
 	feature.RevDetectorEnabled.Store(true)
+	feature.UserDetectorEnabled.Store(true)
 
->>>>>>> main
 	conf := &config.Config{}
 	if *configFilename != "" {
 		var err error

--- a/main.go
+++ b/main.go
@@ -536,7 +536,7 @@ func run(state overseer.State, logSync func() error) {
 	feature.DatadogApiKeyDetectorEnabled.Store(true)
 	feature.TlyDetectorEnabled.Store(true)
 	feature.WitDetectorEnabled.Store(true)
-
+	feature.UserDetectorEnabled.Store(true)
 	conf := &config.Config{}
 	if *configFilename != "" {
 		var err error

--- a/pkg/detectors/user/user.go
+++ b/pkg/detectors/user/user.go
@@ -3,14 +3,12 @@ package user
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strings"
 
 	regexp "github.com/wasilibs/go-re2"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
 )
@@ -24,7 +22,7 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = common.SaneHttpClient()
+	defaultClient = detectors.NewClientWithDedup(detectors.DetectorHttpClientWithNoLocalAddresses)
 
 	keyPat     = regexp.MustCompile(detectors.PrefixRegex([]string{"user"}) + `\b([A-Za-z0-9]{64})\b`)
 	userURLPat = regexp.MustCompile(`\b([a-z0-9-]+\.user\.com)\b`)
@@ -107,14 +105,11 @@ func verifyUserToken(ctx context.Context, client *http.Client, token, baseURL st
 
 	req.Header.Set("Authorization", fmt.Sprintf("Token %s", token))
 
-	res, err := client.Do(req)
+	res, err := detectors.DoWithDedup(client, detector_typepb.DetectorType_User, token+":"+baseURL, req)
 	if err != nil {
 		return false, err
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, res.Body)
-		_ = res.Body.Close()
-	}()
+	defer func() { _ = res.Body.Close() }()
 
 	switch res.StatusCode {
 	case http.StatusOK:

--- a/pkg/detectors/user/user.go
+++ b/pkg/detectors/user/user.go
@@ -47,7 +47,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://secretscanner.user.com/api/public/users/", nil)
+			req, err := http.NewRequestWithContext(ctx, "GET", "https://detectors.user.com/api/public/users/", nil)
 			if err != nil {
 				continue
 			}

--- a/pkg/detectors/user/user.go
+++ b/pkg/detectors/user/user.go
@@ -94,7 +94,6 @@ func verifyUserToken(ctx context.Context, client *http.Client, token, baseURL st
 		return false, err
 	}
 	u.Path = "/api/public/users/"
-
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodGet,

--- a/pkg/detectors/user/user.go
+++ b/pkg/detectors/user/user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	regexp "github.com/wasilibs/go-re2"
@@ -14,31 +15,36 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
 )
 
-type Scanner struct{}
+type Scanner struct {
+	client *http.Client
+	detectors.DefaultMultiPartCredentialProvider
+}
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClient()
+	defaultClient = common.SaneHttpClient()
 
-	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"user"}) + `\b([A-Za-z0-9]{64})\b`)
+	keyPat     = regexp.MustCompile(detectors.PrefixRegex([]string{"user"}) + `\b([A-Za-z0-9]{64})\b`)
+	userURLPat = regexp.MustCompile(`\b([a-z0-9-]+\.user\.com)\b`)
 )
 
-// Keywords are used for efficiently pre-filtering chunks.
-// Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
 	return []string{"user"}
 }
 
-// FromData will find and optionally verify User secrets in a given set of bytes.
-func (s Scanner) FromData(
-	ctx context.Context,
-	verify bool,
-	data []byte,
-) (results []detectors.Result, err error) {
+func (s Scanner) getClient() *http.Client {
+	if s.client != nil {
+		return s.client
+	}
+	return defaultClient
+}
 
+// FromData will find and optionally verify User secrets in a given set of bytes.
+// Both an API key and a subdomain URL (e.g. https://acme.user.com) must be present
+// for a result to be reported, since each account has its own endpoint.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
 	dataStr := string(data)
 
 	uniqueTokens := make(map[string]struct{})
@@ -46,41 +52,53 @@ func (s Scanner) FromData(
 		uniqueTokens[strings.TrimSpace(match[1])] = struct{}{}
 	}
 
+	uniqueURLs := make(map[string]struct{})
+	for _, match := range userURLPat.FindAllStringSubmatch(dataStr, -1) {
+		u := url.URL{Scheme: "https", Host: match[1]}
+		uniqueURLs[u.String()] = struct{}{}
+	}
+
+	// Require both parts of the credential to be present.
+	if len(uniqueTokens) == 0 || len(uniqueURLs) == 0 {
+		return
+	}
+
 	for token := range uniqueTokens {
-		result := detectors.Result{
-			DetectorType: detector_typepb.DetectorType_User,
-			Raw:          []byte(token),
-			SecretParts: map[string]string{
-				"key": token,
-			},
-		}
+		for baseURL := range uniqueURLs {
+			result := detectors.Result{
+				DetectorType: detector_typepb.DetectorType_User,
+				Raw:          []byte(token),
+				RawV2:        []byte(token + ":" + baseURL),
+				SecretParts: map[string]string{
+					"key":      token,
+					"endpoint": baseURL,
+				},
+			}
 
-		if verify {
-			verified, verificationErr := verifyUserToken(
-				ctx,
-				client,
-				token,
-			)
-			result.SetVerificationError(verificationErr, token)
-			result.Verified = verified
-		}
+			if verify {
+				isVerified, verificationErr := verifyUserToken(ctx, s.getClient(), token, baseURL)
+				result.Verified = isVerified
+				result.SetVerificationError(verificationErr, token)
+			}
 
-		results = append(results, result)
+			results = append(results, result)
+		}
 	}
 
 	return
 }
 
-func verifyUserToken(
-	ctx context.Context,
-	client *http.Client,
-	token string,
-) (bool, error) {
+func verifyUserToken(ctx context.Context, client *http.Client, token, baseURL string) (bool, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return false, err
+	}
+	u.Path = "/api/public/users/"
 
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodGet,
-		"https://detectors.user.com/api/public/users/",
+		u.String(),
 		http.NoBody,
 	)
 	if err != nil {
@@ -102,13 +120,9 @@ func verifyUserToken(
 	case http.StatusOK:
 		return true, nil
 	case http.StatusUnauthorized, http.StatusForbidden, http.StatusGone:
-		// Token is invalid, revoked, or endpoint no longer valid.
 		return false, nil
 	default:
-		return false, fmt.Errorf(
-			"unexpected HTTP response status %d",
-			res.StatusCode,
-		)
+		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
 	}
 }
 

--- a/pkg/detectors/user/user.go
+++ b/pkg/detectors/user/user.go
@@ -3,6 +3,7 @@ package user
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -32,39 +33,83 @@ func (s Scanner) Keywords() []string {
 }
 
 // FromData will find and optionally verify User secrets in a given set of bytes.
-func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+func (s Scanner) FromData(
+	ctx context.Context,
+	verify bool,
+	data []byte,
+) (results []detectors.Result, err error) {
+
 	dataStr := string(data)
 
-	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
+	uniqueTokens := make(map[string]struct{})
+	for _, match := range keyPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueTokens[strings.TrimSpace(match[1])] = struct{}{}
+	}
 
-	for _, match := range matches {
-		resMatch := strings.TrimSpace(match[1])
-
-		s1 := detectors.Result{
+	for token := range uniqueTokens {
+		result := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_User,
-			Raw:          []byte(resMatch),
-			SecretParts:  map[string]string{"key": resMatch},
+			Raw:          []byte(token),
+			SecretParts: map[string]string{
+				"key": token,
+			},
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://detectors.user.com/api/public/users/", nil)
-			if err != nil {
-				continue
-			}
-			req.Header.Add("Authorization", fmt.Sprintf("Token %s", resMatch))
-			res, err := client.Do(req)
-			if err == nil {
-				defer func() { _ = res.Body.Close() }()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					s1.Verified = true
-				}
-			}
+			verified, verificationErr := verifyUserToken(
+				ctx,
+				client,
+				token,
+			)
+			result.SetVerificationError(verificationErr, token)
+			result.Verified = verified
 		}
 
-		results = append(results, s1)
+		results = append(results, result)
 	}
 
-	return results, nil
+	return
+}
+
+func verifyUserToken(
+	ctx context.Context,
+	client *http.Client,
+	token string,
+) (bool, error) {
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodGet,
+		"https://detectors.user.com/api/public/users/",
+		http.NoBody,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Token %s", token))
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusGone:
+		// Token is invalid, revoked, or endpoint no longer valid.
+		return false, nil
+	default:
+		return false, fmt.Errorf(
+			"unexpected HTTP response status %d",
+			res.StatusCode,
+		)
+	}
 }
 
 func (s Scanner) Type() detector_typepb.DetectorType {

--- a/pkg/detectors/user/user.go
+++ b/pkg/detectors/user/user.go
@@ -94,6 +94,7 @@ func verifyUserToken(ctx context.Context, client *http.Client, token, baseURL st
 		return false, err
 	}
 	u.Path = "/api/public/users/"
+
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodGet,

--- a/pkg/detectors/user/user.go
+++ b/pkg/detectors/user/user.go
@@ -22,7 +22,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"user"}) + `\b([a-zA-Z0-9-._+=]{64})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"user"}) + `\b([A-Za-z0-9]{64})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/user/user.go
+++ b/pkg/detectors/user/user.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -9,6 +10,7 @@ import (
 
 	regexp "github.com/wasilibs/go-re2"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/cache/simple"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
 )
@@ -16,20 +18,29 @@ import (
 type Scanner struct {
 	client *http.Client
 	detectors.DefaultMultiPartCredentialProvider
+	detectors.EndpointSetter
 }
 
-// Ensure the Scanner satisfies the interface at compile time.
-var _ detectors.Detector = (*Scanner)(nil)
-
 var (
+	// Ensure the Scanner satisfies the interface at compile time.
+	_ detectors.Detector           = (*Scanner)(nil)
+	_ detectors.EndpointCustomizer = (*Scanner)(nil)
+
 	defaultClient = detectors.NewClientWithDedup(detectors.DetectorHttpClientWithNoLocalAddresses)
 
 	keyPat     = regexp.MustCompile(detectors.PrefixRegex([]string{"user"}) + `\b([A-Za-z0-9]{64})\b`)
 	userURLPat = regexp.MustCompile(`\b([a-z0-9-]+\.user\.com)\b`)
+
+	invalidHosts = simple.NewCache[struct{}]()
+	errNoHost    = errors.New("no such host")
 )
 
+func (Scanner) CloudEndpoint() string { return "" }
+
+// Keywords are used for efficiently pre-filtering chunks.
+// Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
-	return []string{"user"}
+	return []string{"user.com"}
 }
 
 func (s Scanner) getClient() *http.Client {
@@ -40,73 +51,77 @@ func (s Scanner) getClient() *http.Client {
 }
 
 // FromData will find and optionally verify User secrets in a given set of bytes.
-// Both an API key and a subdomain URL (e.g. https://acme.user.com) must be present
-// for a result to be reported, since each account has its own endpoint.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
 	dataStr := string(data)
 
-	uniqueTokens := make(map[string]struct{})
+	var uniqueTokens, uniqueURLs = make(map[string]struct{}), make(map[string]struct{})
+
 	for _, match := range keyPat.FindAllStringSubmatch(dataStr, -1) {
 		uniqueTokens[strings.TrimSpace(match[1])] = struct{}{}
 	}
 
-	uniqueURLs := make(map[string]struct{})
+	var foundURLs = make([]string, 0)
 	for _, match := range userURLPat.FindAllStringSubmatch(dataStr, -1) {
-		u := url.URL{Scheme: "https", Host: match[1]}
-		uniqueURLs[u.String()] = struct{}{}
+		foundURLs = append(foundURLs, match[1])
 	}
 
-	// Require both parts of the credential to be present.
-	if len(uniqueTokens) == 0 || len(uniqueURLs) == 0 {
-		return
+	// Merge found endpoints with any user-configured endpoints.
+	// Callers must call UseFoundEndpoints(true) to include endpoints extracted from data.
+	for _, endpoint := range s.Endpoints(foundURLs...) {
+		endpoint = strings.TrimPrefix(endpoint, "https://")
+		uniqueURLs[endpoint] = struct{}{}
 	}
 
 	for token := range uniqueTokens {
-		for baseURL := range uniqueURLs {
-			result := detectors.Result{
+		for hostname := range uniqueURLs {
+			if invalidHosts.Exists(hostname) {
+				delete(uniqueURLs, hostname)
+				continue
+			}
+
+			endpointURL := url.URL{Scheme: "https", Host: hostname}
+			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_User,
 				Raw:          []byte(token),
-				RawV2:        []byte(token + ":" + baseURL),
+				RawV2:        []byte(token + ":" + endpointURL.String()),
 				SecretParts: map[string]string{
 					"key":      token,
-					"endpoint": baseURL,
+					"endpoint": endpointURL.String(),
 				},
 			}
 
 			if verify {
-				isVerified, verificationErr := verifyUserToken(ctx, s.getClient(), token, baseURL)
-				result.Verified = isVerified
-				result.SetVerificationError(verificationErr, token)
+				isVerified, verificationErr := verifyUserToken(ctx, s.getClient(), hostname, token)
+				s1.Verified = isVerified
+				if verificationErr != nil {
+					if errors.Is(verificationErr, errNoHost) {
+						invalidHosts.Set(hostname, struct{}{})
+						continue
+					}
+					s1.SetVerificationError(verificationErr, token)
+				}
 			}
 
-			results = append(results, result)
+			results = append(results, s1)
 		}
 	}
 
-	return
+	return results, nil
 }
 
-func verifyUserToken(ctx context.Context, client *http.Client, token, baseURL string) (bool, error) {
-	u, err := url.Parse(baseURL)
+func verifyUserToken(ctx context.Context, client *http.Client, hostname, token string) (bool, error) {
+	u := url.URL{Scheme: "https", Host: hostname, Path: "/api/public/users/"}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), http.NoBody)
 	if err != nil {
 		return false, err
 	}
-	u.Path = "/api/public/users/"
-
-	req, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodGet,
-		u.String(),
-		http.NoBody,
-	)
-	if err != nil {
-		return false, err
-	}
-
 	req.Header.Set("Authorization", fmt.Sprintf("Token %s", token))
 
-	res, err := detectors.DoWithDedup(client, detector_typepb.DetectorType_User, token+":"+baseURL, req)
+	res, err := detectors.DoWithDedup(client, detector_typepb.DetectorType_User, token+":"+hostname, req)
 	if err != nil {
+		if strings.Contains(err.Error(), "no such host") {
+			return false, errNoHost
+		}
 		return false, err
 	}
 	defer func() { _ = res.Body.Close() }()

--- a/pkg/detectors/user/user_integration_test.go
+++ b/pkg/detectors/user/user_integration_test.go
@@ -108,7 +108,7 @@ func TestUser_FromChunk(t *testing.T) {
 			)
 
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
-				t.Errorf("SpectralOps.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+				t.Errorf("User.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
 		})
 	}

--- a/pkg/detectors/user/user_integration_test.go
+++ b/pkg/detectors/user/user_integration_test.go
@@ -26,6 +26,7 @@ func TestUser_FromChunk(t *testing.T) {
 	}
 	secret := testSecrets.MustGetField("USER")
 	inactiveSecret := testSecrets.MustGetField("USER_INACTIVE")
+	endpoint := testSecrets.MustGetField("USER_ENDPOINT")
 
 	type args struct {
 		ctx    context.Context
@@ -44,13 +45,19 @@ func TestUser_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a user secret %s within", secret)),
+				data:   []byte(fmt.Sprintf("user token = %s\nurl = %s", secret, endpoint)),
 				verify: true,
 			},
 			want: []detectors.Result{
 				{
 					DetectorType: detector_typepb.DetectorType_User,
 					Verified:     true,
+					Raw:          []byte(secret),
+					RawV2:        []byte(secret + ":" + endpoint),
+					SecretParts: map[string]string{
+						"key":      secret,
+						"endpoint": endpoint,
+					},
 				},
 			},
 			wantErr: false,
@@ -60,13 +67,19 @@ func TestUser_FromChunk(t *testing.T) {
 			s:    Scanner{},
 			args: args{
 				ctx:    context.Background(),
-				data:   []byte(fmt.Sprintf("You can find a user secret %s within but not valid", inactiveSecret)), // the secret would satisfy the regex but not pass validation
+				data:   []byte(fmt.Sprintf("user token = %s\nurl = %s", inactiveSecret, endpoint)),
 				verify: true,
 			},
 			want: []detectors.Result{
 				{
 					DetectorType: detector_typepb.DetectorType_User,
 					Verified:     false,
+					Raw:          []byte(inactiveSecret),
+					RawV2:        []byte(inactiveSecret + ":" + endpoint),
+					SecretParts: map[string]string{
+						"key":      inactiveSecret,
+						"endpoint": endpoint,
+					},
 				},
 			},
 			wantErr: false,
@@ -91,24 +104,16 @@ func TestUser_FromChunk(t *testing.T) {
 				t.Errorf("User.FromData() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			for i := range got {
-				if len(got[i].Raw) == 0 {
-					t.Fatalf("no raw secret present: \n %+v", got[i])
-				}
-				got[i].Raw = nil
-			}
 			ignoreOpts := cmpopts.IgnoreFields(
 				detectors.Result{},
 				"ExtraData",
 				"verificationError",
 				"primarySecret",
-				"SecretParts",
 				"chunkOffset",
 				"chunkOffsetSet",
 			)
-
-			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
-				t.Errorf("User.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			if diff := cmp.Diff(tt.want, got, ignoreOpts); diff != "" {
+				t.Errorf("User.FromData() %s diff: (-want +got)\n%s", tt.name, diff)
 			}
 		})
 	}

--- a/pkg/detectors/user/user_integration_test.go
+++ b/pkg/detectors/user/user_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
@@ -98,11 +99,28 @@ func TestUser_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := Scanner{}
-			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			tt.s.UseFoundEndpoints(true)
+
+			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("User.FromData() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			for i := range got {
+				if len(got[i].Raw) == 0 {
+					t.Fatalf("no raw secret present: \n %+v", got[i])
+				}
+				gotErr := ""
+				if got[i].VerificationError() != nil {
+					gotErr = got[i].VerificationError().Error()
+				}
+				wantErr := ""
+				if tt.want[i].VerificationError() != nil {
+					wantErr = tt.want[i].VerificationError().Error()
+				}
+				if gotErr != wantErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.want[i].VerificationError(), got[i].VerificationError())
+				}
 			}
 			ignoreOpts := cmpopts.IgnoreFields(
 				detectors.Result{},
@@ -116,6 +134,35 @@ func TestUser_FromChunk(t *testing.T) {
 				t.Errorf("User.FromData() %s diff: (-want +got)\n%s", tt.name, diff)
 			}
 		})
+	}
+}
+
+func TestUser_FromChunk_WithCustomEndpoint(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors1")
+	if err != nil {
+		t.Fatalf("could not get test secrets from GCP: %s", err)
+	}
+	secret := testSecrets.MustGetField("USER")
+	endpoint := testSecrets.MustGetField("USER_ENDPOINT")
+
+	s := Scanner{}
+	s.UseFoundEndpoints(true)
+	if err := s.SetConfiguredEndpoints(endpoint); err != nil {
+		t.Fatal("Error in setting configured endpoint")
+	}
+
+	data := []byte(fmt.Sprintf("user token = %s", secret))
+
+	got, err := s.FromData(ctx, true, data)
+
+	require.NoError(t, err, "unexpected error from FromData")
+	require.Greater(t, len(got), 0, "expected at least 1 result")
+
+	expectedRawV2 := []byte(secret + ":" + endpoint)
+	if string(got[0].RawV2) != string(expectedRawV2) {
+		t.Errorf("User.FromData() rawV2 mismatch: got %s, want %s", string(got[0].RawV2), string(expectedRawV2))
 	}
 }
 

--- a/pkg/detectors/user/user_integration_test.go
+++ b/pkg/detectors/user/user_integration_test.go
@@ -9,7 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kylelemons/godebug/pretty"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
@@ -96,8 +97,18 @@ func TestUser_FromChunk(t *testing.T) {
 				}
 				got[i].Raw = nil
 			}
-			if diff := pretty.Compare(got, tt.want); diff != "" {
-				t.Errorf("User.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			ignoreOpts := cmpopts.IgnoreFields(
+				detectors.Result{},
+				"ExtraData",
+				"verificationError",
+				"primarySecret",
+				"SecretParts",
+				"chunkOffset",
+				"chunkOffsetSet",
+			)
+
+			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
+				t.Errorf("SpectralOps.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}
 		})
 	}

--- a/pkg/detectors/user/user_test.go
+++ b/pkg/detectors/user/user_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 var (
-	validPattern   = "9UgOsRfud4RTyBQpJQFOQiwNQcfeLGHH1DDoxhgzCvBmccmVQ7MYB0ai3LXGZNMf"
-	invalidPattern = "OmFxWjhZvCpOeMsgTJdZMas+dlUpr=fa?+.QOKKYvi7RKWyBeHtaLa7_rzMhLrRd"
-	keyword        = "user"
+	validKey     = "9UgOsRfud4RTyBQpJQFOQiwNQcfeLGHH1DDoxhgzCvBmccmVQ7MYB0ai3LXGZNMf"
+	validURL     = "testdetector.user.com"
+	invalidKey   = "OmFxWjhZvCpOeMsgTJdZMas+dlUpr=fa?+.QOKKYvi7RKWyBeHtaLa7_rzMhLrRd"
+	keyword      = "user"
 )
 
 func TestUser_Pattern(t *testing.T) {
@@ -26,23 +27,33 @@ func TestUser_Pattern(t *testing.T) {
 		want  []string
 	}{
 		{
-			name:  "valid pattern - with keyword user",
-			input: fmt.Sprintf("%s token = '%s'", keyword, validPattern),
-			want:  []string{validPattern},
+			name:  "valid pattern - key and url present",
+			input: fmt.Sprintf("%s token = '%s'\nurl = https://%s", keyword, validKey, validURL),
+			want:  []string{validKey + ":https://" + validURL},
 		},
 		{
-			name:  "valid pattern - ignore duplicate",
-			input: fmt.Sprintf("%s token = '%s' | '%s'", keyword, validPattern, validPattern),
-			want:  []string{validPattern},
+			name:  "valid pattern - ignore duplicate keys",
+			input: fmt.Sprintf("%s token = '%s' | '%s'\nurl = https://%s", keyword, validKey, validKey, validURL),
+			want:  []string{validKey + ":https://" + validURL},
 		},
 		{
-			name:  "valid pattern - key out of prefix range",
-			input: fmt.Sprintf("%s keyword is not close to the real key in the data\n = '%s'", keyword, validPattern),
+			name:  "no result - key without url",
+			input: fmt.Sprintf("%s token = '%s'", keyword, validKey),
 			want:  []string{},
 		},
 		{
-			name:  "invalid pattern",
-			input: fmt.Sprintf("%s = '%s'", keyword, invalidPattern),
+			name:  "no result - url without key",
+			input: fmt.Sprintf("%s url = https://%s", keyword, validURL),
+			want:  []string{},
+		},
+		{
+			name:  "no result - key out of prefix range",
+			input: fmt.Sprintf("%s keyword is not close to the real key in the data\n = '%s'\nurl = https://%s", keyword, validKey, validURL),
+			want:  []string{},
+		},
+		{
+			name:  "no result - invalid key format",
+			input: fmt.Sprintf("%s = '%s'\nurl = https://%s", keyword, invalidKey, validURL),
 			want:  []string{},
 		},
 	}
@@ -50,7 +61,7 @@ func TestUser_Pattern(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
-			if len(matchedDetectors) == 0 {
+			if len(matchedDetectors) == 0 && len(test.want) > 0 {
 				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
 				return
 			}

--- a/pkg/detectors/user/user_test.go
+++ b/pkg/detectors/user/user_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 var (
-	validKey     = "9UgOsRfud4RTyBQpJQFOQiwNQcfeLGHH1DDoxhgzCvBmccmVQ7MYB0ai3LXGZNMf"
-	validURL     = "testdetector.user.com"
-	invalidKey   = "OmFxWjhZvCpOeMsgTJdZMas+dlUpr=fa?+.QOKKYvi7RKWyBeHtaLa7_rzMhLrRd"
-	keyword      = "user"
+	validKey   = "9UgOsRfud4RTyBQpJQFOQiwNQcfeLGHH1DDoxhgzCvBmccmVQ7MYB0ai3LXGZNMf"
+	validURL   = "https://testdetector.user.com"
+	invalidKey = "OmFxWjhZvCpOeMsgTJdZMas+dlUpr=fa?+.QOKKYvi7RKWyBeHtaLa7_rzMhLrRd"
+	keyword    = "user.com"
 )
 
 func TestUser_Pattern(t *testing.T) {
@@ -28,32 +28,32 @@ func TestUser_Pattern(t *testing.T) {
 	}{
 		{
 			name:  "valid pattern - key and url present",
-			input: fmt.Sprintf("%s token = '%s'\nurl = https://%s", keyword, validKey, validURL),
-			want:  []string{validKey + ":https://" + validURL},
+			input: fmt.Sprintf("user token = '%s'\nurl = %s", validKey, validURL),
+			want:  []string{validKey + ":" + validURL},
 		},
 		{
 			name:  "valid pattern - ignore duplicate keys",
-			input: fmt.Sprintf("%s token = '%s' | '%s'\nurl = https://%s", keyword, validKey, validKey, validURL),
-			want:  []string{validKey + ":https://" + validURL},
+			input: fmt.Sprintf("user token = '%s' | '%s'\nurl = %s", validKey, validKey, validURL),
+			want:  []string{validKey + ":" + validURL},
 		},
 		{
 			name:  "no result - key without url",
-			input: fmt.Sprintf("%s token = '%s'", keyword, validKey),
+			input: fmt.Sprintf("user token = '%s'", validKey),
 			want:  []string{},
 		},
 		{
 			name:  "no result - url without key",
-			input: fmt.Sprintf("%s url = https://%s", keyword, validURL),
+			input: fmt.Sprintf("%s url = %s", keyword, validURL),
 			want:  []string{},
 		},
 		{
 			name:  "no result - key out of prefix range",
-			input: fmt.Sprintf("%s keyword is not close to the real key in the data\n = '%s'\nurl = https://%s", keyword, validKey, validURL),
+			input: fmt.Sprintf("user keyword is not close to the real key in the data\n = '%s'\nurl = %s", validKey, validURL),
 			want:  []string{},
 		},
 		{
 			name:  "no result - invalid key format",
-			input: fmt.Sprintf("%s = '%s'\nurl = https://%s", keyword, invalidKey, validURL),
+			input: fmt.Sprintf("user = '%s'\nurl = %s", invalidKey, validURL),
 			want:  []string{},
 		},
 	}
@@ -66,7 +66,9 @@ func TestUser_Pattern(t *testing.T) {
 				return
 			}
 
-			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			s := Scanner{}
+			s.UseFoundEndpoints(true)
+			results, err := s.FromData(context.Background(), false, []byte(test.input))
 			if err != nil {
 				t.Errorf("error = %v", err)
 				return

--- a/pkg/detectors/user/user_test.go
+++ b/pkg/detectors/user/user_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	validPattern   = "OmFxWjhZvCpOeMsgTJdZMas+dlUpr=fa7+.QOKKYvi7RKWyBeHtaLa7_rzMhLrRd"
+	validPattern   = "9UgOsRfud4RTyBQpJQFOQiwNQcfeLGHH1DDoxhgzCvBmccmVQ7MYB0ai3LXGZNMf"
 	invalidPattern = "OmFxWjhZvCpOeMsgTJdZMas+dlUpr=fa?+.QOKKYvi7RKWyBeHtaLa7_rzMhLrRd"
 	keyword        = "user"
 )

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -810,6 +810,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/upwave"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/uri"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/urlscan"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/user"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/userflow"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/userstack"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/vagrantcloudpersonaltoken"
@@ -1711,6 +1712,7 @@ func buildDetectorList() []detectors.Detector {
 		&upwave.Scanner{},
 		&uri.Scanner{},
 		&urlscan.Scanner{},
+		&user.Scanner{},
 		&userflow.Scanner{},
 		&userstack.Scanner{},
 		&vagrantcloudpersonaltoken.Scanner{},
@@ -1792,6 +1794,8 @@ func buildDetectorList() []detectors.Detector {
 			return !feature.TlyDetectorEnabled.Load()
 		case *wit.Scanner:
 			return !feature.WitDetectorEnabled.Load()
+		case *user.Scanner:
+			return !feature.UserDetectorEnabled.Load()
 		default:
 			return false
 		}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -1796,13 +1796,10 @@ func buildDetectorList() []detectors.Detector {
 			return !feature.TlyDetectorEnabled.Load()
 		case *wit.Scanner:
 			return !feature.WitDetectorEnabled.Load()
-<<<<<<< user-detector
-		case *user.Scanner:
-			return !feature.UserDetectorEnabled.Load()
-=======
 		case *rev.Scanner:
 			return !feature.RevDetectorEnabled.Load()
->>>>>>> main
+		case *user.Scanner:
+			return !feature.UserDetectorEnabled.Load()
 		default:
 			return false
 		}

--- a/pkg/engine/defaults/defaults_test.go
+++ b/pkg/engine/defaults/defaults_test.go
@@ -132,11 +132,8 @@ var excludedFromDefaultList = map[detector_typepb.DetectorType]struct{}{
 	detector_typepb.DetectorType_Pinecone:      {},
 	detector_typepb.DetectorType_TLy:           {},
 	detector_typepb.DetectorType_Wit:           {},
-<<<<<<< user-detector
-	detector_typepb.DetectorType_User:          {},
-=======
 	detector_typepb.DetectorType_Rev:           {},
->>>>>>> main
+	detector_typepb.DetectorType_User:          {},
 
 	// Reserved / special types.
 	detector_typepb.DetectorType_CustomRegex: {}, // added dynamically via engine config, not via buildDetectorList()

--- a/pkg/engine/defaults/defaults_test.go
+++ b/pkg/engine/defaults/defaults_test.go
@@ -123,7 +123,6 @@ var excludedFromDefaultList = map[detector_typepb.DetectorType]struct{}{
 	detector_typepb.DetectorType_Lob:    {},
 	detector_typepb.DetectorType_Rev:    {},
 	detector_typepb.DetectorType_Tru:    {},
-	detector_typepb.DetectorType_User:   {},
 
 	// Feature flag gated detectors
 	// These should be removed from this list when we remove the feature flag
@@ -134,6 +133,7 @@ var excludedFromDefaultList = map[detector_typepb.DetectorType]struct{}{
 	detector_typepb.DetectorType_Pinecone:      {},
 	detector_typepb.DetectorType_TLy:           {},
 	detector_typepb.DetectorType_Wit:           {},
+	detector_typepb.DetectorType_User:          {},
 
 	// Reserved / special types.
 	detector_typepb.DetectorType_CustomRegex: {}, // added dynamically via engine config, not via buildDetectorList()

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -23,6 +23,7 @@ var (
 	DatadogApiKeyDetectorEnabled   atomic.Bool
 	TlyDetectorEnabled             atomic.Bool
 	WitDetectorEnabled             atomic.Bool
+	UserDetectorEnabled            atomic.Bool
 )
 
 type AtomicString struct {

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -23,11 +23,8 @@ var (
 	DatadogApiKeyDetectorEnabled   atomic.Bool
 	TlyDetectorEnabled             atomic.Bool
 	WitDetectorEnabled             atomic.Bool
-<<<<<<< user-detector
-	UserDetectorEnabled            atomic.Bool
-=======
 	RevDetectorEnabled             atomic.Bool
->>>>>>> main
+	UserDetectorEnabled            atomic.Bool
 )
 
 type AtomicString struct {


### PR DESCRIPTION
### Description:
This PR adds the `User` detector to `defaults.go` and gates it behind the appropriate feature flag.

It also updates the detector verification logic to align with the latest API behavior and validation requirements, including support for configuring a custom User.com endpoint since API keys must be verified against the workspace-specific domain rather than a single global endpoint.

Additionally, the PR tightens the detector regex by removing support for the `+`, `-`, `_`, `.`, and `=` characters.


### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Turning on a new default-gated detector changes scan behavior and outbound verification traffic; the stricter regex and endpoint pairing may alter findings versus the old fixed-host detector.
> 
> **Overview**
> Registers the **User** (User.com) detector in the default engine list behind a new `UserDetectorEnabled` feature flag (enabled in OSS `main.go`), matching other gated detectors.
> 
> The **User** scanner is reworked so secrets are **token + workspace host** pairs: it finds 64-character alphanumeric API keys and `*.user.com` hosts in chunk data (or via configured endpoints), emits `RawV2` / `SecretParts` with both parts, and verifies with `GET /api/public/users/` on that host using deduplicated HTTP and a cache for bad hostnames. The key regex no longer allows `+`, `-`, `_`, `.`, or `=`; keywords shift to `user.com`.
> 
> Tests cover endpoint-in-data vs custom endpoint-only flows and updated pattern expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05055ae50f6af75d69ff4f16bf9839f5289d4d59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->