### PR TITLE
Updating Klaviyo PK new format

### DIFF
--- a/pkg/detectors/klaviyo/klaviyo.go
+++ b/pkg/detectors/klaviyo/klaviyo.go
@@ -24,7 +24,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	defaultClient = common.SaneHttpClient()
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(`\b(pk_[[:alnum:]]{34})\b`)
+	keyPat = regexp.MustCompile(`\b(pk_([0-9a-f]{34}|[A-Za-z0-9]{6}_[0-9a-f]{34}))\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/klaviyo/klaviyo_test.go
+++ b/pkg/detectors/klaviyo/klaviyo_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	validPattern   = "pk_1234567890abcdefghijklmnopqrstuvwx"
+	validPattern   = "pk_a1b2c3d4e5f60718293a4b5c6d7e8f9012"
 	invalidPattern = "pk_1234567890abcdefghijklmnopqrstu-_="
 	keyword        = "klaviyo"
 )

--- a/pkg/detectors/klaviyo/klaviyo_test.go
+++ b/pkg/detectors/klaviyo/klaviyo_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 var (
-	validPattern   = "pk_a1b2c3d4e5f60718293a4b5c6d7e8f9012"
-	invalidPattern = "pk_1234567890abcdefghijklmnopqrstu-_="
-	keyword        = "klaviyo"
+	validPattern    = "pk_a1b2c3d4e5f60718293a4b5c6d7e8f9012"
+	validPatternNew = "pk_AbCdEf_f0e1d2c3b4a5968778695a4b3c2d1e0f00"
+	invalidPattern  = "pk_1234567890abcdefghijklmnopqrstu-_="
+	keyword         = "klaviyo"
 )
 
 func TestKlaviyo_Pattern(t *testing.T) {
@@ -29,6 +30,11 @@ func TestKlaviyo_Pattern(t *testing.T) {
 			name:  "valid pattern - with keyword klaviyo",
 			input: fmt.Sprintf("%s token = '%s'", keyword, validPattern),
 			want:  []string{validPattern},
+		},
+		{
+			name:  "valid pattern (new format) - with keyword klaviyo",
+			input: fmt.Sprintf("%s token = '%s'", keyword, validPatternNew),
+			want:  []string{validPatternNew},
 		},
 		{
 			name:  "invalid pattern",


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Updating the new Klaviyo Private Key format that supports both new and old pk. 

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped regex and test changes in the Klaviyo detector only; no changes to verification or core scanning infrastructure.
> 
> **Overview**
> Updates the Klaviyo private key (`pk_`) detector regex so it still matches the legacy **34-character hex** keys and also matches the newer **`pk_<6 alnum>_<34 hex>`** format.
> 
> Test fixtures were aligned with the stricter hex rule for the legacy shape, and a pattern test was added for the new key layout. HTTP verification behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a49a651623839f32ffa0b4da12cd538eafb041a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->