### PR TITLE
Enigma detector enhance verification to prevent false verified findings

### DIFF
--- a/main.go
+++ b/main.go
@@ -532,6 +532,7 @@ func run(state overseer.State, logSync func() error) {
 	feature.PineconeDetectorEnabled.Store(true)
 	feature.CloudinaryDetectorEnabled.Store(true)
 	feature.GitLabOAuthDetectorEnabled.Store(true)
+	feature.EnigmaDetectorEnabled.Store(true)
 
 	conf := &config.Config{}
 	if *configFilename != "" {

--- a/pkg/detectors/enigma/enigma.go
+++ b/pkg/detectors/enigma/enigma.go
@@ -2,6 +2,8 @@ package enigma
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -33,7 +35,6 @@ func (s Scanner) Keywords() []string {
 // FromData will find and optionally verify Enigma secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
 	dataStr := string(data)
-
 	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
 
 	for _, match := range matches {
@@ -46,20 +47,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			payload := strings.NewReader(`{"name":"Enigma Technologies, Inc.","person":{"first_name":"","last_name":""},"address":{"street_address1":"245 5th Ave","street_address2":"","city":"New York","state":"NY","postal_code":"10016"}}`)
-			req, err := http.NewRequestWithContext(ctx, "POST", "https://api.enigma.com/businesses/match", payload)
-			if err != nil {
-				continue
-			}
-			req.Header.Add("Content-Type", "application/json")
-			req.Header.Add("x-api-key", resMatch)
-			res, err := client.Do(req)
-			if err == nil {
-				defer func() { _ = res.Body.Close() }()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					s1.Verified = true
-				}
-			}
+			isVerified, verificationErr := verifyKey(ctx, client, resMatch)
+			s1.Verified = isVerified
+			s1.SetVerificationError(verificationErr, resMatch)
 		}
 
 		results = append(results, s1)
@@ -68,10 +58,52 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	return results, nil
 }
 
+// verifyKey checks an Enigma API key against the GraphQL endpoint.
+//
+// The query selects only `__typename`, which the GraphQL spec guarantees on
+// every root type, so verification does not depend on Enigma's evolving schema
+// or any specific entity id. Authentication is driven by the HTTP status code:
+// 200 means the key is valid, 401 mean it is not.
+//
+// A 200 is additionally guarded by a JSON Content-Type check: server could return
+// a 200 HTML block page, which we must not mistake for a live key.
+func verifyKey(ctx context.Context, client *http.Client, key string) (bool, error) {
+	payload := strings.NewReader(`{"query":"{ __typename }"}`)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.enigma.com/graphql", payload)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("x-api-key", key)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		if contentType := res.Header.Get("Content-Type"); !strings.Contains(contentType, "application/json") {
+			return false, fmt.Errorf("got HTTP 200 with unexpected Content-Type %q", contentType)
+		}
+
+		return true, nil
+	case http.StatusUnauthorized:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
+}
+
 func (s Scanner) Type() detector_typepb.DetectorType {
 	return detector_typepb.DetectorType_Enigma
 }
 
 func (s Scanner) Description() string {
-	return "Enigma is a data intelligence company that provides comprehensive data about businesses. Enigma API keys can be used to access and interact with this data."
+	return "Enigma is a business data intelligence platform. Enigma API keys grant access to comprehensive firmographic, legal, and identity datasets."
 }

--- a/pkg/detectors/enigma/enigma_integration_test.go
+++ b/pkg/detectors/enigma/enigma_integration_test.go
@@ -19,7 +19,7 @@ import (
 func TestEnigma_FromChunk(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
-	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors1")
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors6")
 	if err != nil {
 		t.Fatalf("could not get test secrets from GCP: %s", err)
 	}
@@ -50,6 +50,9 @@ func TestEnigma_FromChunk(t *testing.T) {
 				{
 					DetectorType: detector_typepb.DetectorType_Enigma,
 					Verified:     true,
+					SecretParts: map[string]string{
+						"key": secret,
+					},
 				},
 			},
 			wantErr: false,
@@ -66,6 +69,9 @@ func TestEnigma_FromChunk(t *testing.T) {
 				{
 					DetectorType: detector_typepb.DetectorType_Enigma,
 					Verified:     false,
+					SecretParts: map[string]string{
+						"key": inactiveSecret,
+					},
 				},
 			},
 			wantErr: false,

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -1778,6 +1778,8 @@ func buildDetectorList() []detectors.Detector {
 			return !feature.CloudinaryDetectorEnabled.Load()
 		case *gitlaboauth2.Scanner:
 			return !feature.GitLabOAuthDetectorEnabled.Load()
+		case *enigma.Scanner:
+			return !feature.EnigmaDetectorEnabled.Load()
 		default:
 			return false
 		}

--- a/pkg/engine/defaults/defaults_test.go
+++ b/pkg/engine/defaults/defaults_test.go
@@ -119,6 +119,7 @@ var excludedFromDefaultList = map[detector_typepb.DetectorType]struct{}{
 	// Remove each entry once its detector has been carefully added.
 	detector_typepb.DetectorType_Cloudinary:    {},
 	detector_typepb.DetectorType_DatadogApikey: {},
+	detector_typepb.DetectorType_Enigma:        {},
 	detector_typepb.DetectorType_GitLabOauth2:  {},
 	detector_typepb.DetectorType_Guru:          {},
 	detector_typepb.DetectorType_IPInfo:        {},

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -19,6 +19,7 @@ var (
 	PineconeDetectorEnabled        atomic.Bool
 	CloudinaryDetectorEnabled      atomic.Bool
 	GitLabOAuthDetectorEnabled     atomic.Bool
+	EnigmaDetectorEnabled          atomic.Bool
 )
 
 type AtomicString struct {


### PR DESCRIPTION
## Summary
We have seen an Enigma finding that was marked verified but is a false positive. The finding was verified at the first scan then flipped to unverified and marked rotated about 12 hours later. The old verification logic marked a secret verified on any 2xx response from the businesses match endpoint, so a transient upstream 2xx was enough to produce a false verified result.

This PR hardens the verification path so the verified flag reflects a real auth check.

## Changes

- Verify against the GraphQL endpoint at `https://api.enigma.com/graphql` using a minimal query that selects only `__typename`. This does not depend on Enigma schema changes or any specific entity id.
- Mark verified only on HTTP 200 with a JSON content type. A 200 with a non JSON body is treated as a verification error so an intercepting proxy or block page is not mistaken for a live key.
- Treat 401 as unverified.
- Treat any other status as a verification error instead of silently passing or failing.
- Surface transport and verification errors through SetVerificationError.

## What we know
- Confirmed by Postman that a valid key returns 200 with a JSON body and an invalid or missing key returns 401.
- The reported finding self-corrected on rescan. The DB record shows `verified false` and `verification_ever_determinate true`.
- We could not reproduce a 2xx for an invalid key against the old endpoint. The most likely cause is transient upstream behavior.

## Out of scope
- The detection regex is left as is. Valid Enigma keys are 40 character alphanumeric strings and tightening the regex risks missing real keys.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live verification behavior for Enigma (fewer false positives, more unknowns on odd responses); default OSS enables the gated detector, which may increase Enigma hits when enabled.
> 
> **Overview**
> Hardens **Enigma API key verification** so the `verified` flag is not set on weak or misleading HTTP responses (addressing false verified findings from the old businesses-match check that treated any 2xx as success).
> 
> Verification now **POSTs to** `https://api.enigma.com/graphql` with a minimal `{ __typename }` query, marks keys **verified only on HTTP 200** when `Content-Type` includes `application/json`, treats **401 as unverified**, and reports other statuses or non-JSON 200s via **`SetVerificationError`**. Detection regex is unchanged.
> 
> Wires **`EnigmaDetectorEnabled`** (default **on** in OSS `main.go`) so the Enigma scanner is included in the default detector list only when the flag is set, consistent with Pinecone/Cloudinary/GitLab OAuth. Integration tests use the **`detectors6`** secret bundle and expect **`SecretParts`** on results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e638c998ccefdb1505399bb6bae586139662ce2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->