### PR TITLE
fix(dropbox): prevent long sl.u. tokens from being truncated

### DIFF
--- a/pkg/detectors/dropbox/dropbox.go
+++ b/pkg/detectors/dropbox/dropbox.go
@@ -20,6 +20,12 @@ type Scanner struct {
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.MaxSecretSizeProvider = (*Scanner)(nil)
+
+// MaxSecretSize overrides the engine's default keyword window (512 bytes) so the full
+// token is passed to FromData. Newer scoped Dropbox short-lived tokens (sl.u.…) can be
+// ~1.5KB; without this the engine truncates the chunk window and verification fails.
+func (s Scanner) MaxSecretSize() int64 { return 4096 }
 
 var (
 	defaultClient = common.SaneHttpClient()

--- a/pkg/detectors/dropbox/dropbox_test.go
+++ b/pkg/detectors/dropbox/dropbox_test.go
@@ -2,6 +2,7 @@ package dropbox
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -90,5 +91,40 @@ func TestDropBox_Pattern(t *testing.T) {
 				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
 			}
 		})
+	}
+}
+
+// TestDropBox_LongTokenThroughEngineWindow guards the MaxSecretSize override. The scanning
+// engine only passes a keyword-centered window of the chunk to FromData (512 bytes by
+// default). Newer scoped Dropbox tokens (sl.u.…) can be ~1.5KB, so without MaxSecretSize the
+// token is truncated before the regex sees it and verification fails. This exercises the full
+// Aho-Corasick windowing path rather than calling FromData on the whole input directly.
+func TestDropBox_LongTokenThroughEngineWindow(t *testing.T) {
+	token := "sl.u." + strings.Repeat("aB3-_", 300) // 5 + 1500 = 1505 chars, single base64url run
+	chunk := []byte("DROPBOX_TOKEN=" + token + "\n")
+
+	d := Scanner{}
+	core := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+	matches := core.FindDetectorMatches(chunk)
+	if len(matches) == 0 {
+		t.Fatal("no detector matches for long token")
+	}
+
+	var found bool
+	for _, m := range matches {
+		for _, data := range m.Matches() {
+			results, err := d.FromData(context.Background(), false, data)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, r := range results {
+				if string(r.Raw) == token {
+					found = true
+				}
+			}
+		}
+	}
+	if !found {
+		t.Errorf("full %d-char token was not captured through the engine window (MaxSecretSize regression?)", len(token))
 	}
 }


### PR DESCRIPTION
Newer scoped Dropbox short-lived tokens (sl.u.…) can be ~1.5KB. The scanning engine only passes a keyword-centered window of the chunk (512 bytes by default) to FromData, so these tokens were truncated before the regex saw them, producing an invalid token that always verified as false.

Implement detectors.MaxSecretSizeProvider on the Dropbox scanner so the engine widens its window to fit the full token. Add a regression test that drives a long token through the Aho-Corasick windowing path.

### Description:

<img width="2326" height="515" alt="image" src="https://github.com/user-attachments/assets/ebbeaf28-8732-45f1-8178-9a9156f6cc71" />


### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized detector and test changes; no auth, data handling, or engine-wide behavior beyond the Dropbox scanner’s secret window size.
> 
> **Overview**
> Fixes false negatives for **long scoped Dropbox tokens** (`sl.u.…`, ~1.5KB) by implementing `detectors.MaxSecretSizeProvider` on the Dropbox scanner with **`MaxSecretSize()` → 4096**, so the engine widens the keyword-centered chunk window beyond the default 512 bytes before `FromData` runs the regex.
> 
> Adds **`TestDropBox_LongTokenThroughEngineWindow`**, which drives a ~1505-character token through the Aho-Corasick match/window path to guard against regressions on that windowing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 664f47061c66223d5f8efdff8b31bc666183067d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->