### PR TITLE
fix(facebookoauth): verify app creds against /{app-id} instead of /me

### DIFF
--- a/pkg/detectors/facebookoauth/facebookoauth.go
+++ b/pkg/detectors/facebookoauth/facebookoauth.go
@@ -65,9 +65,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				isVerified, extraData, verificationErr := verifyFacebookOAuth(ctx, apiIdRes, apiSecretRes)
 				s1.Verified = isVerified
 				s1.ExtraData = extraData
-				if verificationErr != nil {
-					s1.SetVerificationError(verificationErr, apiSecretRes)
-				}
+				s1.SetVerificationError(verificationErr, apiSecretRes)
 			}
 
 			results = append(results, s1)

--- a/pkg/detectors/facebookoauth/facebookoauth.go
+++ b/pkg/detectors/facebookoauth/facebookoauth.go
@@ -2,8 +2,11 @@ package facebookoauth
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	regexp "github.com/wasilibs/go-re2"
@@ -59,18 +62,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				// thanks https://stackoverflow.com/questions/15621471/validate-a-facebook-app-id-and-app-secret
-				// https://stackoverflow.com/questions/24401241/how-to-get-a-facebook-access-token-using-appid-and-app-secret-without-any-login
-				req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://graph.facebook.com/me?access_token=%s|%s", apiIdRes, apiSecretRes), nil)
-				if err != nil {
-					continue
-				}
-				res, err := client.Do(req)
-				if err == nil {
-					defer func() { _ = res.Body.Close() }()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						s1.Verified = true
-					}
+				isVerified, extraData, verificationErr := verifyFacebookOAuth(ctx, apiIdRes, apiSecretRes)
+				s1.Verified = isVerified
+				s1.ExtraData = extraData
+				if verificationErr != nil {
+					s1.SetVerificationError(verificationErr, apiSecretRes)
 				}
 			}
 
@@ -79,6 +75,74 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	return results, nil
+}
+
+
+// We query /{app-id}?fields=roles, the documented way to validate an app ID/secret
+// pair (https://stackoverflow.com/questions/15621471/validate-a-facebook-app-id-and-app-secret):
+// valid credentials return 200 with the app's roles, while an invalid pair returns a
+// 400 OAuthException (code 190, "Invalid OAuth access token signature.").
+
+func verifyFacebookOAuth(ctx context.Context, appID, appSecret string) (bool, map[string]string, error) {
+	url := fmt.Sprintf("https://graph.facebook.com/%s?fields=roles&access_token=%s|%s", appID, appID, appSecret)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, nil, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, nil, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		var r rolesResponse
+		if err := json.NewDecoder(res.Body).Decode(&r); err != nil {
+			// The credentials are valid (200), so report verified even if we can't
+			// parse the optional roles context.
+			return true, nil, nil
+		}
+		return true, r.extraData(), nil
+	case http.StatusBadRequest, http.StatusUnauthorized:
+		// Invalid app ID/secret pair (e.g. OAuthException code 190).
+		return false, nil, nil
+	default:
+		return false, nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+}
+
+// rolesResponse models the /{app-id}?fields=roles payload.
+type rolesResponse struct {
+	Roles struct {
+		Data []struct {
+			User string `json:"user"`
+			Role string `json:"role"`
+		} `json:"data"`
+	} `json:"roles"`
+}
+
+// extraData flattens the app roles into result ExtraData: a count plus a
+// comma-separated list of "user:role" pairs identifying who has access to the app.
+func (r rolesResponse) extraData() map[string]string {
+	data := r.Roles.Data
+	if len(data) == 0 {
+		return nil
+	}
+
+	pairs := make([]string, 0, len(data))
+	for _, role := range data {
+		pairs = append(pairs, role.User+":"+role.Role)
+	}
+
+	return map[string]string{
+		"app_roles_count": strconv.Itoa(len(data)),
+		"app_roles":       strings.Join(pairs, ", "),
+	}
 }
 
 func (s Scanner) Type() detector_typepb.DetectorType {


### PR DESCRIPTION


### Description:
The verifier built a valid app access token ({app-id}|{app-secret}) but queried the /me node, which only accepts user/page tokens. Facebook rejects an app token there with HTTP 400 OAuthException code 2500 ("An active access token must be used to query information about the current user."), so the check returned 400 for every App ID/Secret pair — valid or not — and could never mark a result verified.

Query the documented validation endpoint instead: GET /{app-id}?fields=roles with the app token. Valid credentials return 200; invalid pairs return 400 OAuthException 190. Status handling now distinguishes verified (200), unverified (400/401), and indeterminate (other statuses -> verification error).

<img width="2317" height="466" alt="image" src="https://github.com/user-attachments/assets/59714734-2aee-4142-906b-b1b2b9a56fdb" />




### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound verification to Facebook’s Graph API and how secrets are classified (verified vs unverified vs error); behavior is more correct but still involves live credential checks against a third-party API.
> 
> **Overview**
> **Fixes Facebook App ID/secret verification** so valid pairs can be marked verified instead of always failing.
> 
> Verification no longer calls **`/me`** with an app access token (`{app-id}|{secret}`), which Facebook rejects for every pair (HTTP 400). It now uses **`GET /{app-id}?fields=roles`** with the same app token: **200** → verified, **400/401** → unverified, other statuses → verification error via **`SetVerificationError`**.
> 
> On a successful **200**, optional **`ExtraData`** is populated from the roles payload (`app_roles_count`, comma-separated `user:role` in `app_roles`). Response bodies are drained on close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d9eff7f28eaa0c4fd1bf59042a92d3c643d1ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->