### PR TITLE
fix(discordbottoken): detect standalone tokens and modern token formats

### DIFF
--- a/pkg/detectors/discordbottoken/discordbottoken.go
+++ b/pkg/detectors/discordbottoken/discordbottoken.go
@@ -2,7 +2,10 @@ package discordbottoken
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -22,8 +25,13 @@ var _ detectors.Detector = (*Scanner)(nil)
 
 var (
 	client = common.SaneHttpClient()
-	idPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"discord"}) + `\b([0-9]{17})\b`)
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"discord"}) + `\b([A-Za-z0-9_-]{24}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27})\b`)
+
+	// A Discord bot token is three base64url segments: the bot's user ID, a
+	// timestamp, and an HMAC. Segment lengths vary across token generations (the
+	// ID segment tracks the snowflake size and the HMAC segment was lengthened in
+	// 2022), so the ranges below stay deliberately loose. The bot ID is embedded
+	// in the first segment, so no separate ID needs to be matched.
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"discord"}) + `\b([A-Za-z0-9_-]{23,28}\.[A-Za-z0-9_-]{6,7}\.[A-Za-z0-9_-]{27,40})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -36,45 +44,98 @@ func (s Scanner) Keywords() []string {
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
 	dataStr := string(data)
 
-	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
-	idMatch := idPat.FindAllStringSubmatch(dataStr, -1)
+	uniqueTokens := make(map[string]struct{})
+	for _, match := range keyPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueTokens[match[1]] = struct{}{}
+	}
 
-	for _, match := range matches {
-		resMatch := strings.TrimSpace(match[1])
-
-		for _, idmatch := range idMatch {
-			resId := strings.TrimSpace(idmatch[1])
-			s1 := detectors.Result{
-				DetectorType: detector_typepb.DetectorType_DiscordBotToken,
-				Redacted:     resId,
-				Raw:          []byte(resMatch),
-				SecretParts: map[string]string{
-					"key": resMatch,
-					"id":  resId,
-				},
-				RawV2: []byte(resMatch + resId),
-			}
-
-			if verify {
-				req, err := http.NewRequestWithContext(ctx, "GET", "https://discord.com/api/v8/users/"+resId, nil)
-				if err != nil {
-					continue
-				}
-				req.Header.Add("Authorization", fmt.Sprintf("Bot %s", resMatch))
-				res, err := client.Do(req)
-				if err == nil {
-					defer func() { _ = res.Body.Close() }()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						s1.Verified = true
-					}
-				}
-			}
-			results = append(results, s1)
+	for token := range uniqueTokens {
+		s1 := detectors.Result{
+			DetectorType: detector_typepb.DetectorType_DiscordBotToken,
+			Raw:          []byte(token),
+			Redacted:     decodeBotID(token),
+			SecretParts:  map[string]string{"key": token},
 		}
 
+		if verify {
+			verified, extraData, vErr := verifyDiscordToken(ctx, client, token)
+			s1.Verified = verified
+			s1.ExtraData = extraData
+			if vErr != nil {
+				s1.SetVerificationError(vErr, token)
+			}
+		}
+
+		results = append(results, s1)
 	}
 
 	return results, nil
+}
+
+// decodeBotID extracts the bot's user ID, which Discord encodes as the first
+// segment of the token (base64url of the snowflake ID). Returns "" if the segment
+// can't be decoded into a numeric ID.
+func decodeBotID(token string) string {
+	first, _, found := strings.Cut(token, ".")
+	if !found {
+		return ""
+	}
+
+	decoded, err := base64.RawURLEncoding.DecodeString(first)
+	if err != nil {
+		return ""
+	}
+
+	id := string(decoded)
+	for _, r := range id {
+		if r < '0' || r > '9' {
+			return ""
+		}
+	}
+	return id
+}
+
+type botUser struct {
+	ID       string `json:"id"`
+	Username string `json:"username"`
+}
+
+// verifyDiscordToken validates a bot token against the current /users/@me endpoint.
+// Using @me avoids needing a separately-parsed bot ID: the token authenticates as
+// the bot, and Discord returns the bot's own user object.
+func verifyDiscordToken(ctx context.Context, client *http.Client, token string) (bool, map[string]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://discord.com/api/v10/users/@me", nil)
+	if err != nil {
+		return false, nil, err
+	}
+	req.Header.Add("Authorization", fmt.Sprintf("Bot %s", token))
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, nil, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		var u botUser
+		if err := json.NewDecoder(res.Body).Decode(&u); err != nil {
+			// Credentials are valid (200); report verified even without the optional context.
+			return true, nil, nil
+		}
+		if u.ID == "" && u.Username == "" {
+			return true, nil, nil
+		}
+		return true, map[string]string{"bot_id": u.ID, "username": u.Username}, nil
+	case http.StatusUnauthorized:
+		// Invalid or revoked token.
+		return false, nil, nil
+	default:
+		return false, nil, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
 }
 
 func (s Scanner) Type() detector_typepb.DetectorType {

--- a/pkg/detectors/discordbottoken/discordbottoken_integration_test.go
+++ b/pkg/detectors/discordbottoken/discordbottoken_integration_test.go
@@ -67,7 +67,7 @@ func TestDiscordBotToken_FromChunk(t *testing.T) {
 			want: []detectors.Result{
 				{
 					DetectorType: detector_typepb.DetectorType_DiscordBotToken,
-					Redacted:     idSecret,
+					Redacted:     decodeBotID(inactiveSecret),
 					Verified:     false,
 				},
 			},
@@ -98,6 +98,8 @@ func TestDiscordBotToken_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
+				got[i].ExtraData = nil
+				got[i].SecretParts = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("DiscordBotToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/discordbottoken/discordbottoken_integration_test.go
+++ b/pkg/detectors/discordbottoken/discordbottoken_integration_test.go
@@ -98,10 +98,6 @@ func TestDiscordBotToken_FromChunk(t *testing.T) {
 					t.Fatalf("no raw secret present: \n %+v", got[i])
 				}
 				got[i].Raw = nil
-				if len(got[i].RawV2) == 0 {
-					t.Fatalf("no raw v2 secret present: \n %+v", got[i])
-				}
-				got[i].RawV2 = nil
 			}
 			if diff := pretty.Compare(got, tt.want); diff != "" {
 				t.Errorf("DiscordBotToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)

--- a/pkg/detectors/discordbottoken/discordbottoken_test.go
+++ b/pkg/detectors/discordbottoken/discordbottoken_test.go
@@ -10,28 +10,12 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 )
 
-var (
-	validPattern = `
-		# Configuration File: config.yaml
-		database:
-			host: $DB_HOST
-			port: $DB_PORT
-			username: $DB_USERNAME
-			password: $DB_PASS  # IMPORTANT: Do not share this password publicly
-
-		api:
-			auth_type: "Token"
-			in: "Header"
-			discord_id: "17014529625858348"
-			discord_secret: "oHILWmk3qakMYbqAikD9R0nJ.Vhu0LY.FK1U_2L2Of8Bm5ESbD6Cy4VKu2K"
-			base_url: "https://api.example.com/v1/example"
-			response_code: 200
-
-		# Notes:
-		# - Remember to rotate the secret every 90 days.
-		# - The above credentials should only be used in a secure environment.
-	`
-	secret = "oHILWmk3qakMYbqAikD9R0nJ.Vhu0LY.FK1U_2L2Of8Bm5ESbD6Cy4VKu2K17014529625858348"
+const (
+	// Modern token shape: 26.6.38 (longer ID and HMAC segments than legacy tokens).
+	// The token appears on its own, with no separate numeric ID alongside it.
+	modernToken = "MTIzNDU2Nzg5MDEyMzQ1Njc4OQ.G00g7H.ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789AB"
+	// Legacy token shape: 24.6.27.
+	legacyToken = "oHILWmk3qakMYbqAikD9R0nJ.Vhu0LY.FK1U_2L2Of8Bm5ESbD6Cy4VKu2K"
 )
 
 func TestDiscordBotToken_Pattern(t *testing.T) {
@@ -44,9 +28,14 @@ func TestDiscordBotToken_Pattern(t *testing.T) {
 		want  []string
 	}{
 		{
-			name:  "valid pattern",
-			input: validPattern,
-			want:  []string{secret},
+			name:  "modern token, no separate id",
+			input: `discord_bot_token = "` + modernToken + `"`,
+			want:  []string{modernToken},
+		},
+		{
+			name:  "legacy token",
+			input: `discord_bot_token = "` + legacyToken + `"`,
+			want:  []string{legacyToken},
 		},
 	}
 


### PR DESCRIPTION

### Description:
The detector required a separate 17-digit ID co-located with the bot token (idPat), and the result loop nested the ID inside the token loop, so a bot token leaked on its own produced zero results. The bot ID is already embedded in the token's first segment, making the separate ID both redundant and the primary reason detection failed.

Changes:
- Match the token on its own; drop the separate idPat requirement.
- Relax keyPat segments to {23,28}.{6,7}.{27,40} (a superset of the old 24.6.27, so no legacy tokens are lost) to cover current token generations.
- Derive the bot ID by base64url-decoding the token's first segment for Redacted.
- Verify via GET /api/v10/users/@me (Authorization: Bot <token>), which needs no separate ID: 200 -> verified, 401 -> unverified, other -> verification error.
- Surface bot_id and username from the verification response as ExtraData.

<img width="1222" height="344" alt="image" src="https://github.com/user-attachments/assets/c865c383-ec16-4901-b39e-6ba316d1c4bf" />


### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the Discord bot token detector and its tests; no auth or core engine changes, with behavior that should improve coverage rather than broaden unrelated risk.
> 
> **Overview**
> Fixes a **detection gap** where Discord bot tokens only surfaced when a separate 17-digit user ID appeared in the same chunk. Detection now matches **standalone tokens** with a looser three-segment regex (`{23,28}.{6,7}.{27,40}`) so modern and legacy token shapes are covered without a co-located ID.
> 
> **Redacted** bot IDs come from base64url-decoding the token’s first segment via `decodeBotID`, and results no longer populate `RawV2` or a separate `id` in `SecretParts`—only the token `key`.
> 
> **Verification** moves from `GET /api/v8/users/{id}` to **`GET /api/v10/users/@me`** with `Authorization: Bot <token>`, with clearer status handling and optional **`bot_id` / `username`** in `ExtraData`. Unit and integration tests are updated for the new pattern and result shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ec4b1e11a0c2c0ca709c621dddc55d464385fbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->