### PR TITLE
Add Google API Key detector

### DIFF
--- a/pkg/detectors/googleapikey/google_api_key.go
+++ b/pkg/detectors/googleapikey/google_api_key.go
@@ -1,0 +1,232 @@
+package googleapikey
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+type Scanner struct {
+	client *http.Client
+}
+
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	defaultClient = common.SaneHttpClient()
+
+	// Google API keys begin with "AIza" followed by exactly 35 characters from [0-9A-Za-z_-].
+	keyPat = regexp.MustCompile(`\bAIza[0-9A-Za-z_-]{35}\b`)
+)
+
+func (s Scanner) Keywords() []string {
+	return []string{"AIza"}
+}
+
+func (s Scanner) Type() detector_typepb.DetectorType {
+	return detector_typepb.DetectorType_GoogleApiKey
+}
+
+func (s Scanner) Description() string {
+	return "Google API keys are used to authenticate requests to Google APIs and services."
+}
+
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	uniqueMatches := make(map[string]struct{})
+	for _, match := range keyPat.FindAllString(dataStr, -1) {
+		uniqueMatches[strings.TrimSpace(match)] = struct{}{}
+	}
+
+	for key := range uniqueMatches {
+		r := detectors.Result{
+			DetectorType: detector_typepb.DetectorType_GoogleApiKey,
+			Raw:          []byte(key),
+			ExtraData: map[string]string{
+				"rotation_guide": "https://howtorotate.com/docs/tutorials/google/",
+			},
+			SecretParts: map[string]string{"key": key},
+		}
+
+		if verify {
+			client := s.client
+			if client == nil {
+				client = defaultClient
+			}
+
+			isVerified, extraData, verificationErr := verifyKey(ctx, client, key)
+			r.Verified = isVerified
+			for k, v := range extraData {
+				r.ExtraData[k] = v
+			}
+			r.SetVerificationError(verificationErr, key)
+		}
+
+		results = append(results, r)
+	}
+
+	return results, nil
+}
+
+func verifyKey(ctx context.Context, client *http.Client, apiKey string) (bool, map[string]string, error) {
+	verified, extraData, err := verifyBooks(ctx, client, apiKey)
+	if verified || err == nil {
+		return verified, extraData, err
+	}
+
+	return verifyGemini(ctx, client, apiKey)
+}
+
+func verifyBooks(ctx context.Context, client *http.Client, apiKey string) (bool, map[string]string, error) {
+	u := "https://www.googleapis.com/books/v1/volumes?q=a&maxResults=1&key=" + url.QueryEscape(apiKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, http.NoBody)
+	if err != nil {
+		return false, nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, nil, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return false, nil, err
+	}
+
+	return classifyResponse(resp.StatusCode, body, "books")
+}
+
+func verifyGemini(ctx context.Context, client *http.Client, apiKey string) (bool, map[string]string, error) {
+	const endpoint = "https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash:generateContent"
+
+	payload := []byte(`{"contents":[{"parts":[{"text":"ping"}]}],"generationConfig":{"maxOutputTokens":1}}`)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return false, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("x-goog-api-key", apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, nil, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return false, nil, err
+	}
+
+	return classifyResponse(resp.StatusCode, body, "gemini")
+}
+
+func classifyResponse(statusCode int, body []byte, source string) (bool, map[string]string, error) {
+	if statusCode >= 200 && statusCode < 300 {
+		return true, nil, nil
+	}
+
+	lower := strings.ToLower(errorText(body))
+
+	switch {
+	case statusCode == http.StatusUnauthorized:
+		return false, nil, nil
+
+	case statusCode == http.StatusTooManyRequests:
+		return true, map[string]string{
+			"restriction": "rate-limited on " + source + " API",
+		}, nil
+
+	case containsAny(lower, []string{
+		"api key not valid",
+		"invalid api key",
+		"keyinvalid",
+		"api key expired",
+		"invalid credentials",
+	}):
+		return false, nil, nil
+
+	case containsAny(lower, []string{
+		"accessnotconfigured",
+		"usagelimits",
+		"ratelimitexceeded",
+		"dailylimitexceeded",
+		"dailylimit",
+		"userratelimitexceeded",
+		"quotaexceeded",
+		"iprefererblocked",
+		"not enabled",
+		"has not been used",
+		"blocked",
+		"forbidden",
+	}):
+		return true, map[string]string{
+			"restriction": "key valid but restricted on " + source + " API",
+		}, nil
+
+	case statusCode == http.StatusForbidden:
+		return true, map[string]string{
+			"restriction": "key valid but access forbidden on " + source + " API",
+		}, nil
+	}
+
+	return false, nil, fmt.Errorf("unexpected HTTP response status %d", statusCode)
+}
+
+type googleErrorBody struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Errors  []struct {
+			Message string `json:"message"`
+			Domain  string `json:"domain"`
+			Reason  string `json:"reason"`
+		} `json:"errors"`
+	} `json:"error"`
+}
+
+func errorText(body []byte) string {
+	var e googleErrorBody
+	if err := json.Unmarshal(body, &e); err != nil {
+		return string(body)
+	}
+
+	parts := []string{e.Error.Message}
+	for _, sub := range e.Error.Errors {
+		parts = append(parts, sub.Reason, sub.Message, sub.Domain)
+	}
+	return strings.Join(parts, " ")
+}
+
+func containsAny(s string, needles []string) bool {
+	for _, n := range needles {
+		if strings.Contains(s, n) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/detectors/googleapikey/google_api_key_test.go
+++ b/pkg/detectors/googleapikey/google_api_key_test.go
@@ -1,0 +1,119 @@
+package googleapikey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+func TestGoogleApiKey_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "valid pattern - assignment context",
+			input: `GOOGLE_API_KEY = "AIzaSyD-9tSrke72I6e0DVQ9y_VoqTepV9AEAZE"`,
+			want:  []string{"AIzaSyD-9tSrke72I6e0DVQ9y_VoqTepV9AEAZE"},
+		},
+		{
+			name: "valid pattern - env file",
+			input: `MAPS_KEY=AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI
+                    DATABASE_URL=postgres://localhost/mydb`,
+			want: []string{"AIzaSyDdI0hCZtE6vySjMm-WEfRq3CPzqKqqsHI"},
+		},
+		{
+			name: "valid pattern - multiple keys",
+			input: `key1: AIzaSyD-9tSrke72I6e0DVQ9y_VoqTepV9AEAZE
+                    key2: AIzaSyBa3j4ker72I6e0DVQ9y_VoqTepV9AEBZE`,
+			want: []string{
+				"AIzaSyD-9tSrke72I6e0DVQ9y_VoqTepV9AEAZE",
+				"AIzaSyBa3j4ker72I6e0DVQ9y_VoqTepV9AEBZE",
+			},
+		},
+		{
+			name:  "valid pattern - xml",
+			input: `<secret>{AQAAABAAA AIzaSyD-9tSrke72I6e0DVQ9y_VoqTepV9AEAZE}</secret>`,
+			want:  []string{"AIzaSyD-9tSrke72I6e0DVQ9y_VoqTepV9AEAZE"},
+		},
+		{
+			name:  "deduplication - repeated key",
+			input: `AIzaSyD-9tSrke72I6e0DVQ9y_VoqTepV9AEAZE AIzaSyD-9tSrke72I6e0DVQ9y_VoqTepV9AEAZE`,
+			want:  []string{"AIzaSyD-9tSrke72I6e0DVQ9y_VoqTepV9AEAZE"},
+		},
+		{
+			name:  "invalid pattern - too short",
+			input: `key = "AIzaSyD-9tSrke72I6e0DVQ"`,
+			want:  nil,
+		},
+		{
+			name:  "invalid pattern - wrong prefix",
+			input: `key = "AIzBSyD-9tSrke72I6e0DVQ9y_VoqTepV9AEAZE"`,
+			want:  nil,
+		},
+		{
+			name:  "invalid pattern - invalid characters",
+			input: `key = "AIzaSyD-9tSrke72I6e0DVQ9y_VoqTepV9AEA!E"`,
+			want:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(test.want) > 0 && len(matchedDetectors) == 0 {
+				t.Errorf("keywords %v not found in input", d.Keywords())
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			require.NoError(t, err)
+
+			if len(results) != len(test.want) {
+				t.Errorf("expected %d results, got %d", len(test.want), len(results))
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.RawV2) > 0 {
+					actual[string(r.RawV2)] = struct{}{}
+				} else {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}
+
+// TestGoogleApiKey_Type asserts the detector reports the exact expected type,
+// not just any non-empty string.
+func TestGoogleApiKey_Type(t *testing.T) {
+	s := Scanner{}
+	require.Equal(t, detector_typepb.DetectorType_GoogleApiKey, s.Type())
+}
+
+// TestGoogleApiKey_Keywords asserts the "AIza" prefix is present in the
+// keyword list used for AhoCorasick pre-filtering.
+func TestGoogleApiKey_Keywords(t *testing.T) {
+	s := Scanner{}
+	require.NotEmpty(t, s.Keywords())
+	require.Contains(t, s.Keywords(), "AIza")
+}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -347,6 +347,7 @@ import (
 	godaddyv1 "github.com/trufflesecurity/trufflehog/v3/pkg/detectors/godaddy/v1"
 	godaddyv2 "github.com/trufflesecurity/trufflehog/v3/pkg/detectors/godaddy/v2"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/goodday"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/googleapikey"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/googlegemini"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/googleoauth2"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/grafana"
@@ -1230,6 +1231,7 @@ func buildDetectorList() []detectors.Detector {
 		&godaddyv1.Scanner{},
 		&godaddyv2.Scanner{},
 		&goodday.Scanner{},
+		&googleapikey.Scanner{},
 		&googlegemini.Scanner{},
 		&googleoauth2.Scanner{},
 		&grafana.Scanner{},

--- a/proto/detector_type.proto
+++ b/proto/detector_type.proto
@@ -74,7 +74,7 @@ enum DetectorType {
   FastlyPersonalToken = 68;
   GoogleOauth2 = 69;
   ReCAPTCHA = 70; // Not yet implemented
-  GoogleApiKey = 71 [deprecated = true];
+  GoogleApiKey = 71;
   Hunter = 72;
   IbmCloudUserKey = 73;
   Netlify = 74;


### PR DESCRIPTION
## Summary
This PR adds a comprehensive detector for Google API keys that were previously deprecated. The detector:

- Detects Google API keys with the `AIza` prefix followed by exactly 35 valid characters `[0-9A-Za-z_-]`
- Verifies keys against two Google API endpoints (Books API and Gemini API) for maximum coverage
- Distinguishes between invalid keys and valid-but-restricted keys
- Provides detailed error classification for different restriction types (rate limits, API not enabled, etc.)
- Includes comprehensive test coverage for pattern matching and edge cases

## Changes
- Un-deprecated `GoogleApiKey` (ID 71) in `proto/detector_type.proto`
- Added new detector implementation at `pkg/detectors/googleapikey/`
- Integrated detector into default detector list in `pkg/engine/defaults/defaults.go`
- Added comprehensive unit tests with 100% pass rate

## Testing
All tests pass successfully:
```
go test ./pkg/detectors/googleapikey -tags=detectors -v
```

The detector includes tests for:
- Valid pattern detection in multiple contexts (env files, assignments, XML, etc.)
- Deduplication of repeated keys
- Rejection of invalid patterns (wrong prefix, invalid characters, incorrect length)
- Proper detector type and keyword registration

## Verification Strategy
The detector uses a fallback verification approach:
1. First attempts verification via Google Books API (free, widely available)
2. Falls back to Gemini API if Books API fails
3. Properly handles and classifies various error responses:
   - Determinately invalid keys (401, "invalid api key" messages)
   - Valid but restricted keys (403, rate limits, API not enabled)
   - Indeterminate failures (unexpected status codes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Verification sends discovered keys to external Google APIs and overlaps keyword/pattern space with the existing Gemini detector, which can affect scan behavior and duplicate findings.
> 
> **Overview**
> Re-enables **`GoogleApiKey`** (detector ID 71) by removing its proto deprecation and wiring a new **`googleapikey`** scanner into the default engine list.
> 
> The scanner finds keys matching **`AIza`** plus 35 allowed characters, deduplicates matches, and attaches a Google rotation guide in result metadata. When verification is on, it probes **Google Books** first, then **Gemini `generateContent`**, classifying responses so invalid keys stay unverified while rate limits, quota, and “API not enabled” style errors can still mark a key as verified with a **`restriction`** note in extra data.
> 
> Unit tests cover pattern matching (including Aho–Corasick keyword **`AIza`**), type registration, and invalid shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91acdaa86041c50e85307e308939efee591645f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->