### PR TITLE
Improve YouTube API key verifier errors

### DIFF
--- a/pkg/detectors/youtubeapikey/youtubeapikey.go
+++ b/pkg/detectors/youtubeapikey/youtubeapikey.go
@@ -2,6 +2,7 @@ package youtubeapikey
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -14,6 +15,7 @@ import (
 
 type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
+	client *http.Client
 }
 
 // Ensure the Scanner satisfies the interface at compile time.
@@ -31,6 +33,13 @@ var (
 // Use identifiers in the secret preferably, or the provider name.
 func (s Scanner) Keywords() []string {
 	return []string{"youtube"}
+}
+
+func (s Scanner) getClient() *http.Client {
+	if s.client != nil {
+		return s.client
+	}
+	return client
 }
 
 // FromData will find and optionally verify YoutubeApiKey secrets in a given set of bytes.
@@ -53,17 +62,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				req, err := http.NewRequestWithContext(ctx, "GET", "https://www.googleapis.com/youtube/v3/channelSections?key="+resMatch+"&channelId="+resIdmatch, nil)
-				if err != nil {
-					continue
-				}
-				res, err := client.Do(req)
-				if err == nil {
-					defer func() { _ = res.Body.Close() }()
-					if res.StatusCode >= 200 && res.StatusCode < 300 {
-						s1.Verified = true
-					}
-				}
+				isVerified, verificationErr := verifyYoutubeAPIKey(ctx, s.getClient(), resMatch, resIdmatch)
+				s1.Verified = isVerified
+				s1.SetVerificationError(verificationErr, resMatch)
 			}
 
 			results = append(results, s1)
@@ -72,6 +73,27 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	return results, nil
+}
+
+func verifyYoutubeAPIKey(ctx context.Context, client *http.Client, key, channelID string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.googleapis.com/youtube/v3/channelSections?key="+key+"&channelId="+channelID, nil)
+	if err != nil {
+		return false, err
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
 }
 
 func (s Scanner) Type() detector_typepb.DetectorType {

--- a/pkg/detectors/youtubeapikey/youtubeapikey.go
+++ b/pkg/detectors/youtubeapikey/youtubeapikey.go
@@ -87,9 +87,10 @@ func verifyYoutubeAPIKey(ctx context.Context, client *http.Client, key, channelI
 	defer func() { _ = res.Body.Close() }()
 
 	switch res.StatusCode {
-	case http.StatusOK:
+	case http.StatusOK, http.StatusForbidden:
+		// YouTube can return 403 for a recognized key that lacks permission or quota.
 		return true, nil
-	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
+	case http.StatusBadRequest, http.StatusUnauthorized:
 		return false, nil
 	default:
 		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)

--- a/pkg/detectors/youtubeapikey/youtubeapikey_test.go
+++ b/pkg/detectors/youtubeapikey/youtubeapikey_test.go
@@ -3,20 +3,23 @@ package youtubeapikey
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 )
 
 var (
-    validKey   = "8SN8OtkzJ6z2tcFtv93Gl63o97LGGBvYAyJviDg"
-    invalidKey = "8SN8OtkzJ6z2tcFtv93?l63o97LGGBvYAyJviDg"
-    validId    = "0ifNmkGT6biPToj9TDGYqyFP"
-    invalidId  = "0ifNmkG?6biPToj9TDGYqyFP"
-    keyword    = "youtubeapikey"
+	validKey   = "8SN8OtkzJ6z2tcFtv93Gl63o97LGGBvYAyJviDg"
+	invalidKey = "8SN8OtkzJ6z2tcFtv93?l63o97LGGBvYAyJviDg"
+	validId    = "0ifNmkGT6biPToj9TDGYqyFP"
+	invalidId  = "0ifNmkG?6biPToj9TDGYqyFP"
+	keyword    = "youtubeapikey"
 )
 
 func TestYoutubeApiKey_Pattern(t *testing.T) {
@@ -77,6 +80,48 @@ func TestYoutubeApiKey_Pattern(t *testing.T) {
 
 			if diff := cmp.Diff(expected, actual); diff != "" {
 				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}
+
+func TestYoutubeApiKey_Verification(t *testing.T) {
+	tests := []struct {
+		name                string
+		statusCode          int
+		wantVerified        bool
+		wantVerificationErr string
+	}{
+		{
+			name:         "verified",
+			statusCode:   http.StatusOK,
+			wantVerified: true,
+		},
+		{
+			name:       "unverified",
+			statusCode: http.StatusBadRequest,
+		},
+		{
+			name:                "verification error",
+			statusCode:          http.StatusInternalServerError,
+			wantVerificationErr: "unexpected HTTP response status 500",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := Scanner{client: common.ConstantResponseHttpClient(test.statusCode, "{}")}
+			input := fmt.Sprintf("%s token - '%s'\n%s token - '%s'\n", keyword, validKey, keyword, validId)
+
+			results, err := d.FromData(context.Background(), true, []byte(input))
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			require.Equal(t, test.wantVerified, results[0].Verified)
+
+			if test.wantVerificationErr == "" {
+				require.NoError(t, results[0].VerificationError())
+			} else {
+				require.EqualError(t, results[0].VerificationError(), test.wantVerificationErr)
 			}
 		})
 	}

--- a/pkg/detectors/youtubeapikey/youtubeapikey_test.go
+++ b/pkg/detectors/youtubeapikey/youtubeapikey_test.go
@@ -98,6 +98,11 @@ func TestYoutubeApiKey_Verification(t *testing.T) {
 			wantVerified: true,
 		},
 		{
+			name:         "verified with restricted access",
+			statusCode:   http.StatusForbidden,
+			wantVerified: true,
+		},
+		{
 			name:       "unverified",
 			statusCode: http.StatusBadRequest,
 		},


### PR DESCRIPTION
## Description
Improves the YouTube API key detector verifier by returning explicit verification errors for transport failures and unexpected API responses.

This is a narrow slice related to the detector verifier error-handling work discussed in #4051. The PR avoids closing keywords so the umbrella issue can stay open for the remaining detectors.

## Changes
- Adds injectable HTTP client support to the YouTube API key scanner
- Extracts verification into a helper that returns verified state plus verification error
- Treats 400 and 401 responses as unverified without a verification error
- Treats 403 responses as verified because YouTube uses them for recognized keys blocked by permissions or quota
- Adds local verifier tests using constant HTTP responses

## Tests
- `go test ./pkg/detectors/youtubeapikey`
- `go vet ./pkg/detectors/youtubeapikey`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to one detector’s verify path and test doubles; behavior change is treating 403 as verified, which reduces false negatives for restricted keys.
> 
> **Overview**
> Refactors the YouTube API key detector so verification reports **verified vs unverified** separately from **verification errors**, matching the broader detector verifier work in #4051.
> 
> Verification moves into `verifyYoutubeAPIKey`, which returns a bool and an error. The scanner can use an injectable `http.Client` (via `getClient`) for tests. **200** and **403** count as verified (403 covers valid keys with quota/permission limits); **400** and **401** are unverified with no error; other status codes and transport failures surface through `SetVerificationError`.
> 
> Adds `TestYoutubeApiKey_Verification` with a stub HTTP client for OK, 403, 400, and unexpected 500 responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b33f557d6b18b323b284242ecf0f5c38723482f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->