### PR TITLE
fix(detectors): validate Kraken base64 matches

### DIFF
--- a/pkg/detectors/kraken/kraken.go
+++ b/pkg/detectors/kraken/kraken.go
@@ -32,8 +32,8 @@ var (
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	// Bounds have been removed because there are some cases that tokens have trailing frontslash(/) or plus sign (+)
-	keyPat     = regexp.MustCompile(detectors.PrefixRegex([]string{"kraken"}) + `\b([0-9A-Za-z\/\+=]{56}[ "'\r\n]{1})`)
-	privKeyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"kraken"}) + `\b([0-9A-Za-z\/\+=]{86,88}[ "'\r\n]{1})`)
+	keyPat     = regexp.MustCompile(detectors.PrefixRegex([]string{"kraken"}) + `\b([0-9A-Za-z\/\+=]{56})[ "'\r\n]`)
+	privKeyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"kraken"}) + `\b([0-9A-Za-z\/\+=]{86,88})[ "'\r\n]`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -51,9 +51,15 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for _, match := range matches {
 		resMatch := strings.TrimSpace(match[1])
+		if !isValidBase64(resMatch) {
+			continue
+		}
 
 		for _, privKeyMatch := range privKeyMatches {
 			resPrivKeyMatch := strings.TrimSpace(privKeyMatch[1])
+			if !isValidBase64(resPrivKeyMatch) {
+				continue
+			}
 
 			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_Kraken,
@@ -100,6 +106,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	return results, nil
+}
+
+func isValidBase64(candidate string) bool {
+	_, err := base64.StdEncoding.DecodeString(candidate)
+	return err == nil
 }
 
 // Code from https://docs.kraken.com/rest/#section/Authentication/Headers-and-Signature

--- a/pkg/detectors/kraken/kraken.go
+++ b/pkg/detectors/kraken/kraken.go
@@ -51,13 +51,14 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for _, match := range matches {
 		resMatch := strings.TrimSpace(match[1])
-		if !isValidBase64(resMatch) {
+		if _, ok := decodeBase64(resMatch); !ok {
 			continue
 		}
 
 		for _, privKeyMatch := range privKeyMatches {
 			resPrivKeyMatch := strings.TrimSpace(privKeyMatch[1])
-			if !isValidBase64(resPrivKeyMatch) {
+			b64DecodedSecret, ok := decodeBase64(resPrivKeyMatch)
+			if !ok {
 				continue
 			}
 
@@ -79,7 +80,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				payload := url.Values{}
 				payload.Add("nonce", apiNonce)
 
-				b64DecodedSecret, _ := base64.StdEncoding.DecodeString(resPrivKeyMatch)
 				signature := getKrakenSignature("/0/private/Balance", payload, b64DecodedSecret)
 
 				req, err := http.NewRequestWithContext(ctx, "POST", "https://api.kraken.com/0/private/Balance", strings.NewReader(payload.Encode()))
@@ -108,9 +108,18 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	return results, nil
 }
 
-func isValidBase64(candidate string) bool {
-	_, err := base64.StdEncoding.DecodeString(candidate)
-	return err == nil
+func decodeBase64(candidate string) ([]byte, bool) {
+	decoded, err := base64.StdEncoding.DecodeString(candidate)
+	if err == nil {
+		return decoded, true
+	}
+
+	decoded, err = base64.RawStdEncoding.DecodeString(candidate)
+	if err == nil {
+		return decoded, true
+	}
+
+	return nil, false
 }
 
 // Code from https://docs.kraken.com/rest/#section/Authentication/Headers-and-Signature

--- a/pkg/detectors/kraken/kraken_test.go
+++ b/pkg/detectors/kraken/kraken_test.go
@@ -3,7 +3,6 @@ package kraken
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -13,10 +12,10 @@ import (
 )
 
 var (
-	validKeyPattern       = "m=MN/0yYJ/5xqpE15JYDJtCFdDF7RDLuiXtTiSF1FU1H9waiub1kgwI= "
-	invalidKeyPattern     = "m=MN/0yYJ/5xqpE15JYDJtCFdDF7RDLuiXtTiSF1FU1H9waiub1kgwI="
-	validPrivKeyPattern   = "Oe1xUe+sNT7F5SboHSpfCubMhJlAaghB3SZ=NMmkIHTSzWVoF3uTOnxv32cgI+WuEDXYS+z5MvX+q9IUJ1cYo=+ "
-	invalidPrivKeyPattern = "Oe1xUe+sNT7F5SboHSpfCubMhJlAaghB3SZ=NMmkIHTSzWVoF3uTOnxv32cgI+WuEDXYS+z5MvX+q9IUJ1cYo=+"
+	validKeyPattern       = "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkq"
+	invalidKeyPattern     = "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCk="
+	validPrivKeyPattern   = "KywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZGVmZ2hpag=="
+	invalidPrivKeyPattern = "KywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZG=mhpag=="
 	keyword               = "kraken"
 )
 
@@ -31,7 +30,15 @@ func TestKraken_Pattern(t *testing.T) {
 		{
 			name:  "valid pattern - with keyword kraken",
 			input: fmt.Sprintf("%s '%s' %s '%s'", keyword, validKeyPattern, keyword, validPrivKeyPattern),
-			want:  []string{strings.TrimSpace(validKeyPattern) + strings.TrimSpace(validPrivKeyPattern)},
+			want:  []string{validKeyPattern + validPrivKeyPattern},
+		},
+		{
+			name: "valid pattern - quoted env vars",
+			input: fmt.Sprintf(`
+KRAKEN_API_KEY="%s"
+KRAKEN_PRIVATE_KEY="%s"
+`, validKeyPattern, validPrivKeyPattern),
+			want: []string{validKeyPattern + validPrivKeyPattern},
 		},
 		{
 			name:  "valid pattern - key out of prefix range",
@@ -39,7 +46,7 @@ func TestKraken_Pattern(t *testing.T) {
 			want:  []string{},
 		},
 		{
-			name:  "invalid pattern",
+			name:  "invalid pattern - malformed base64 padding",
 			input: fmt.Sprintf("%s key = '%s' secret = '%s'", keyword, invalidKeyPattern, invalidPrivKeyPattern),
 			want:  []string{},
 		},

--- a/pkg/detectors/kraken/kraken_test.go
+++ b/pkg/detectors/kraken/kraken_test.go
@@ -53,12 +53,12 @@ KRAKEN_PRIVATE_KEY="%s"
 		},
 		{
 			name:  "invalid pattern - malformed api key base64 padding",
-			input: fmt.Sprintf("%s key = '%s' secret = '%s'", keyword, invalidKeyPattern, validPrivKeyPattern),
+			input: fmt.Sprintf("%s key = '%s' %s secret = '%s'", keyword, invalidKeyPattern, keyword, validPrivKeyPattern),
 			want:  []string{},
 		},
 		{
 			name:  "invalid pattern - malformed private key base64 padding",
-			input: fmt.Sprintf("%s key = '%s' secret = '%s'", keyword, validKeyPattern, invalidPrivKeyPattern),
+			input: fmt.Sprintf("%s key = '%s' %s secret = '%s'", keyword, validKeyPattern, keyword, invalidPrivKeyPattern),
 			want:  []string{},
 		},
 	}

--- a/pkg/detectors/kraken/kraken_test.go
+++ b/pkg/detectors/kraken/kraken_test.go
@@ -12,11 +12,12 @@ import (
 )
 
 var (
-	validKeyPattern       = "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkq"
-	invalidKeyPattern     = "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCk="
-	validPrivKeyPattern   = "KywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZGVmZ2hpag=="
-	invalidPrivKeyPattern = "KywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZG=mhpag=="
-	keyword               = "kraken"
+	validKeyPattern             = "AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyAhIiMkJSYnKCkq"
+	invalidKeyPattern           = "AQIDBAUGBwgJCgsMDQ4PEBESExQV=hcYGRobHB0eHyAhIiMkJSYnKCkq"
+	validPrivKeyPattern         = "KywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZGVmZ2hpag=="
+	validUnpaddedPrivKeyPattern = "KywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZGVmZ2hpag"
+	invalidPrivKeyPattern       = "KywtLi8wMTIzNDU2Nzg5Ojs8PT4/QEFCQ0RFRkdISUpLTE1OT1BRUlNUVVZXWFlaW1xdXl9gYWJjZG=mhpag=="
+	keyword                     = "kraken"
 )
 
 func TestKraken_Pattern(t *testing.T) {
@@ -33,6 +34,11 @@ func TestKraken_Pattern(t *testing.T) {
 			want:  []string{validKeyPattern + validPrivKeyPattern},
 		},
 		{
+			name:  "valid pattern - private key without base64 padding",
+			input: fmt.Sprintf("%s '%s' %s '%s'", keyword, validKeyPattern, keyword, validUnpaddedPrivKeyPattern),
+			want:  []string{validKeyPattern + validUnpaddedPrivKeyPattern},
+		},
+		{
 			name: "valid pattern - quoted env vars",
 			input: fmt.Sprintf(`
 KRAKEN_API_KEY="%s"
@@ -46,8 +52,13 @@ KRAKEN_PRIVATE_KEY="%s"
 			want:  []string{},
 		},
 		{
-			name:  "invalid pattern - malformed base64 padding",
-			input: fmt.Sprintf("%s key = '%s' secret = '%s'", keyword, invalidKeyPattern, invalidPrivKeyPattern),
+			name:  "invalid pattern - malformed api key base64 padding",
+			input: fmt.Sprintf("%s key = '%s' secret = '%s'", keyword, invalidKeyPattern, validPrivKeyPattern),
+			want:  []string{},
+		},
+		{
+			name:  "invalid pattern - malformed private key base64 padding",
+			input: fmt.Sprintf("%s key = '%s' secret = '%s'", keyword, validKeyPattern, invalidPrivKeyPattern),
 			want:  []string{},
 		},
 	}


### PR DESCRIPTION
## Summary
- Fix the Kraken detector so regex boundary characters are not included in captured API/private key values.
- Reject malformed Kraken key candidates that do not decode as standard base64 before emitting results.
- Update Kraken pattern tests with valid base64 fixtures plus a quoted-env-var regression case.

## Problem
Kraken credentials are base64-encoded values. The existing detector test fixtures included `=` padding in the middle of the candidate strings, which is not valid base64. The detector also included the trailing boundary character in the regex capture group, so common quoted forms like `KRAKEN_API_KEY=...` could include the closing quote in the captured secret.

## Fix
The Kraken detector now captures only the credential value and treats the following space/quote/newline as a boundary outside the capture group. It also base64-decodes both the API key and private key candidates before emitting a result, reducing false positives from malformed padding.

## Tests
- `go test ./pkg/detectors/kraken -run '^TestKraken_Pattern$' -tags=detectors -count=1` ✅

## Notes
- Related to #3817. This is intentionally scoped to Kraken and includes production detector behavior, not only fixture cleanup.
- Full `go test ./pkg/detectors/kraken -tags=detectors` is not runnable in this local environment because `TestKraken_FromChunk` requires GCP Secret Manager application default credentials for test secrets.
- I noticed #4831 also touches Kraken test fixtures; this PR is narrower and also fixes the detector capture/base64 validation behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped Kraken secret-detection changes that reduce false positives; no auth or broad infrastructure impact.
> 
> **Overview**
> The Kraken detector now captures only the credential token in regex (trailing space/quote/newline are boundaries, not part of the match) and **drops candidates that do not decode as base64** for both API and private keys, including unpadded private keys via `RawStdEncoding`. Verification reuses the validated decode for signing instead of ignoring decode errors.
> 
> Pattern tests use real base64 fixtures, add quoted env-var and unpadded-private-key cases, and expect no hits when padding is malformed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 360ba92f8ff2743dcb6e562f90b4e40a9c75cf3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->