### PR TITLE
fix(detectors/sonarcloud): reduce false positives by requiring "sonarcloud" prefix

### DIFF
--- a/pkg/detectors/sonarcloud/sonarcloud.go
+++ b/pkg/detectors/sonarcloud/sonarcloud.go
@@ -25,7 +25,7 @@ var (
 	defaultClient = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"sonar"}) + `(?:^|[^@])\b([0-9a-z]{40})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"sonarcloud"}) + `(?:^|[^@])\b([0-9a-z]{40})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/sonarcloud/sonarcloud_test.go
+++ b/pkg/detectors/sonarcloud/sonarcloud_test.go
@@ -50,6 +50,11 @@ func TestSonarCloud_Pattern(t *testing.T) {
 			input: fmt.Sprintf("%s token = '@%s'", keyword, validPattern),
 			want:  []string{},
 		},
+		{
+			name:  "no false positive from sonarqube dependabot commit URLs",
+			input: "https://github.com/sonarsource/sonarqube-scan-action/commit/e050aa9e699112ca0664dd2a5c694ddab05dc555",
+			want:  []string{},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
### Background

The SonarCloud detector uses PrefixRegex([]string{"sonar"}) to scan for 40-character hex tokens near the keyword "sonar". This causes false positives when processing GitHub dependabot PRs that reference sonarsource/sonarqube-scan-action commit URLs - the commit SHAs (e.g., e050aa9e699112ca0664dd2a5c694ddab05dc555) happen to be 40-char hex strings within 40 characters of "sonar".

### Change

Narrowed the prefix keyword from "sonar" to "sonarcloud" so the regex only triggers on explicit references to the SonarCloud service name, not generic "sonar" substrings in repository names, project names, or URLs.

### Test

Added a test case verifying that sonarsource/sonarqube-scan-action commit URLs do not produce false positive results.

### AI assistance disclosure

This contribution was written with the assistance of an AI agent to help identify the root cause, implement the fix, and produce this PR description. All code changes have been reviewed for correctness.

Closes #5000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small detector-regex tweak with a targeted test; may miss tokens only labeled with generic “sonar” wording, but SonarCloud-specific contexts remain covered.
> 
> **Overview**
> The SonarCloud detector’s token regex now requires the **`sonarcloud`** prefix (via `PrefixRegex`) instead of **`sonar`**, so 40-character hex strings are only considered when they appear near an explicit SonarCloud reference—not generic “sonar” text in URLs or repo names (e.g. dependabot **`sonarqube-scan-action`** commit SHAs).
> 
> A pattern test was added to assert that a **`sonarsource/sonarqube-scan-action`** GitHub commit URL does not yield a secret match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 093b39f1be9efe38bde0ba9c8e064b25e6772bf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->