### PR TITLE
fix(detectors): honor ignores for normalized Postgres URIs

### DIFF
--- a/pkg/detectors/postgres/postgres.go
+++ b/pkg/detectors/postgres/postgres.go
@@ -52,6 +52,11 @@ var (
 	connStrPartPattern                    = regexp.MustCompile(`([[:alpha:]]+)='(.+?)' ?`)
 )
 
+type uriMatch struct {
+	params map[string]string
+	uri    string
+}
+
 type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
 	detectLoopback bool // Automated tests run against localhost, but we want to ignore those results in the wild
@@ -95,10 +100,11 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 	var results []detectors.Result
 	candidateParamSets := findUriMatches(data, s.ignorePatterns)
 
-	for _, params := range candidateParamSets {
+	for _, candidate := range candidateParamSets {
 		if common.IsDone(ctx) {
 			break
 		}
+		params := candidate.params
 		user, ok := params[pgUser]
 		if !ok {
 			continue
@@ -141,6 +147,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) ([]dete
 			RawV2:        raw,
 			SecretParts:  map[string]string{"connection_string": string(raw)},
 		}
+		result.SetPrimarySecretValue(candidate.uri)
 
 		// We don't need to normalize the (deprecated) requiressl option into the (up-to-date) sslmode option - pq can
 		// do it for us - but we will do it anyway here so that when we later capture sslmode into ExtraData we will
@@ -199,8 +206,8 @@ func (s Scanner) IsFalsePositive(_ detectors.Result) (bool, string) {
 	return false, ""
 }
 
-func findUriMatches(data []byte, ignorePatterns []*regexp.Regexp) []map[string]string {
-	var matches []map[string]string
+func findUriMatches(data []byte, ignorePatterns []*regexp.Regexp) []uriMatch {
+	var matches []uriMatch
 	for _, uri := range uriPattern.FindAll(data, -1) {
 		if shouldIgnore(uri, ignorePatterns) {
 			continue
@@ -224,7 +231,10 @@ func findUriMatches(data []byte, ignorePatterns []*regexp.Regexp) []map[string]s
 		}
 
 		params[pgDbType] = dbType
-		matches = append(matches, params)
+		matches = append(matches, uriMatch{
+			params: params,
+			uri:    string(uri),
+		})
 	}
 	return matches
 }

--- a/pkg/detectors/postgres/postgres_test.go
+++ b/pkg/detectors/postgres/postgres_test.go
@@ -130,6 +130,18 @@ func TestPostgres_ExtraData(t *testing.T) {
 	}
 }
 
+func TestPostgres_PreservesMatchedURIForLineOffsets(t *testing.T) {
+	s := Scanner{}
+	uri := "postgres://sN19x:d7N8bs@1.2.3.4/mydb"
+
+	results, err := s.FromData(context.Background(), false, []byte(uri))
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	assert.Equal(t, []byte("postgres://sN19x:d7N8bs@1.2.3.4:5432"), results[0].Raw)
+	assert.Equal(t, uri, results[0].GetPrimarySecretValue())
+}
+
 func TestPostgres_FromDataWithIgnorePattern(t *testing.T) {
 	s := New(
 		WithIgnorePattern([]string{

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1517,9 +1517,20 @@ def test_something():
     connection_string = "who-cares"
 
     # Ignoring this does not work
-	assert some_other_stuff == "blah" # trufflehog:ignore
+    assert some_other_stuff == "blah" # trufflehog:ignore
     assert connection_string == "postgres://master_user:master_password@hostname:1234/main"`,
 			expectedFindings: 1,
+		},
+		{
+			name: "ignore postgres URI without explicit port",
+			content: `
+# tests/example_false_positive.py
+
+def test_something():
+    connection_string = "who-cares"
+
+    assert connection_string == "postgres://master_user:master_password@hostname/main"  # trufflehog:ignore`,
+			expectedFindings: 0,
 		},
 	}
 


### PR DESCRIPTION
## Description

Fixes #4962.

Postgres URI detection normalizes candidates before emitting `Raw`, including adding the default `:5432` port when the original URI omitted it. The engine uses the emitted secret value to locate the source line for `trufflehog:ignore`, so an ignored line like:

```text
postgresql://user:password@host/db # trufflehog:ignore
```

could still report because the normalized value (`...@host:5432`) does not appear in the scanned chunk.

This change keeps the normalized `Raw`/`RawV2` behavior for the detector result, but also stores the exact matched URI as the primary secret value so the engine can resolve line numbers and same-line ignore tags against the original source text.

## Tests

- `go test ./pkg/detectors/postgres -count=1`
- `go test ./pkg/engine -run TestEngineignoreLine -count=1`
- `go test ./pkg/engine -count=1`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Postgres detector and ignore-line behavior; normalized secret output is unchanged aside from metadata used for line matching.
> 
> **Overview**
> Fixes **`trufflehog:ignore`** on Postgres connection strings when the detector **normalizes** URIs (e.g. injects default **`:5432`**) so the emitted `Raw` no longer matches the text in the file.
> 
> The Postgres scanner now threads the **exact matched URI** through `findUriMatches` via a `uriMatch` struct and calls **`SetPrimarySecretValue`** with that string while keeping normalized `Raw`/`RawV2` unchanged. The engine already uses the primary secret (via `effectiveSecret`) for line lookup and same-line ignore tags, so ignores work when the source omits an explicit port.
> 
> Tests assert the primary secret stays the unnormalized URI and add an engine case for an ignored Postgres URL without a port; one existing ignore-line fixture gets a whitespace-only alignment fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b97594fba2e08e5493b694b50caadd4a930e402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->