### PR TITLE
fix: scan files with lines exceeding bufio's default 64 KB token limit

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -750,7 +750,6 @@ func (s *Git) ScanCommits(ctx context.Context, repo *git.Repository, path string
 
 		email := commit.Author
 		when := commit.Date.UTC().Format("2006-01-02 15:04:05 -0700")
-
 		if fullHash != lastCommitHash {
 			depth++
 			lastCommitHash = fullHash
@@ -901,6 +900,14 @@ func (s *Git) gitChunk(ctx context.Context, diff *gitparse.Diff, fileName, email
 	defer func() { _ = reader.Close() }()
 
 	originalChunk := bufio.NewScanner(reader)
+	// Default bufio max token size (64 KB) is too small for files with long lines
+	// (e.g. minified JS, base64 blobs). Raise the cap to 10 MB so those lines
+	// are still scanned; the oversize-line path below will chunk them correctly.
+	// The initial buffer starts at 4 KB (same as bufio's default) and grows only
+	// when a line actually exceeds the current size, keeping allocations cheap for
+	// the common case of small diffs.
+	const maxScanTokenSize = 10 * 1024 * 1024
+	originalChunk.Buffer(make([]byte, 4096), maxScanTokenSize)
 	newChunkBuffer := bytes.Buffer{}
 	lastOffset := 0
 	for offset := 0; originalChunk.Scan(); offset++ {
@@ -966,6 +973,9 @@ func (s *Git) gitChunk(ctx context.Context, diff *gitparse.Diff, fileName, email
 		if _, err := newChunkBuffer.Write(line); err != nil {
 			ctx.Logger().Error(err, "error writing to chunk buffer", "filename", fileName, "commit", hash, "file", diff.PathB)
 		}
+	}
+	if err := originalChunk.Err(); err != nil {
+		ctx.Logger().Error(err, "error scanning chunk", "filename", fileName, "commit", hash, "file", diff.PathB)
 	}
 	// Send anything still in the new chunk buffer
 	if newChunkBuffer.Len() > 0 {

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -1163,3 +1163,42 @@ func TestPrepareRepoWithNormalizationBare(t *testing.T) {
 		})
 	}
 }
+
+// TestGitChunk_LongLine verifies that files containing lines longer than
+// bufio's default 64 KB token limit are still scanned. Before the fix,
+// bufio.Scanner would silently stop on the first oversized line and produce
+// zero chunks for that file.
+func TestGitChunk_LongLine(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	repoPath := setupTestRepo(t, "long-line-repo")
+
+	// Build a single line that is 100 KB — well above the old 64 KB cap.
+	longLine := strings.Repeat("a", 100*1024)
+	addTestFileAndCommit(t, repoPath, "long_line.txt", longLine)
+
+	conn, err := anypb.New(&sourcespb.Git{
+		Credential: &sourcespb.Git_Unauthenticated{
+			Unauthenticated: &credentialspb.Unauthenticated{},
+		},
+		Repositories: []string{"file://" + repoPath},
+	})
+	assert.NoError(t, err)
+
+	s := Source{}
+	assert.NoError(t, s.Init(ctx, "test long line", 0, 0, false, conn, 1))
+
+	chunksCh := make(chan *sources.Chunk, 64)
+	var count int
+	go func() {
+		for range chunksCh {
+			count++
+		}
+	}()
+
+	assert.NoError(t, s.Chunks(ctx, chunksCh))
+	close(chunksCh)
+	// one chunk for the commit/file metadata, and at least one chunk for the file content
+	assert.Equal(t, 2, count, "expected at least two chunk from a file with a 100 KB line")
+}

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1191,7 +1192,10 @@ func TestGitChunk_LongLine(t *testing.T) {
 
 	chunksCh := make(chan *sources.Chunk, 64)
 	var count int
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
 		for range chunksCh {
 			count++
 		}
@@ -1199,6 +1203,8 @@ func TestGitChunk_LongLine(t *testing.T) {
 
 	assert.NoError(t, s.Chunks(ctx, chunksCh))
 	close(chunksCh)
+	wg.Wait()
+	// ensure the goroutine has finished writing to count before we read it
 	// one chunk for the commit/file metadata, and at least one chunk for the file content
 	assert.Equal(t, 2, count, "expected at least two chunk from a file with a 100 KB line")
 }

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -1206,5 +1206,5 @@ func TestGitChunk_LongLine(t *testing.T) {
 	wg.Wait()
 	// ensure the goroutine has finished writing to count before we read it
 	// one chunk for the commit/file metadata, and at least one chunk for the file content
-	assert.Equal(t, 2, count, "expected at least two chunk from a file with a 100 KB line")
+	assert.Equal(t, 2, count, "expected two chunks from a file with a 100 KB line")
 }


### PR DESCRIPTION
### Description:
- Raise `bufio.Scanner` max token size from 64 KB to 10 MB in `gitChunk` so files with long lines (minified JS, base64 blobs, etc.) are fully scanned
- Keep the initial buffer at 4 KB (bufio default) to avoid unnecessary allocations on the common case of small diffs
- Add `Scanner.Err()` check after the scan loop to surface scanner failures as logged errors instead of silent no-ops

### Root Cause
`gitChunk` used `bufio.NewScanner` with the default 64 KB max token size. Any line exceeding that limit caused `Scan()` to return `false` with `bufio.Scanner: token too long` — but since `Err()` was never checked, the function exited silently as if it had reached EOF. No secrets were scanned, no error was reported.

### Test Changes
- Added `TestGitChunk_LongLine` — creates a local git repo with a single 100 KB line (well above the old 64 KB cap), scans it, and asserts at least one chunk is produced. This test would have hung/failed before the fix.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core git chunking for large diffs and allows up to 10 MB per scanned line, which can increase memory use on pathological files but fixes missed secret detection.
> 
> **Overview**
> Fixes a **silent scan gap** in large git diffs: `gitChunk` no longer stops at the first line over bufio’s default **64 KB** token limit.
> 
> **`gitChunk`** now configures `bufio.Scanner` with a **10 MB** max token and a **4 KB** starting buffer so long single-line files (minified JS, base64, etc.) are read fully and still flow through the existing oversize-line chunking. After the scan loop, **`Scanner.Err()`** is checked and failures are logged instead of treating them like EOF.
> 
> Adds **`TestGitChunk_LongLine`**, which commits a **100 KB** one-line file and asserts the git source emits the expected chunks (behavior that failed before the fix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a715feff498d057b0a54fcd3cbf2bc12291a3f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->