### PR TITLE
Re-host pkg/handlers JSON test fixtures under the org

### DIFF
--- a/pkg/handlers/handlers_test.go
+++ b/pkg/handlers/handlers_test.go
@@ -54,7 +54,7 @@ func TestHandleFile(t *testing.T) {
 }
 
 func TestHandleHTTPJson(t *testing.T) {
-	resp, err := http.Get("https://raw.githubusercontent.com/ahrav/nothing-to-see-here/main/sm_random_data.json")
+	resp, err := http.Get("https://raw.githubusercontent.com/trufflesecurity/trufflehog-test-assets/main/sm_random_data.json")
 	assert.NoError(t, err)
 	defer func() {
 		if resp != nil && resp.Body != nil {
@@ -425,7 +425,7 @@ func BenchmarkHandleTar(b *testing.B) {
 }
 
 func TestHandleLargeHTTPJson(t *testing.T) {
-	resp, err := http.Get("https://raw.githubusercontent.com/ahrav/nothing-to-see-here/main/md_random_data.json.zip")
+	resp, err := http.Get("https://raw.githubusercontent.com/trufflesecurity/trufflehog-test-assets/main/md_random_data.json.zip")
 	if !assert.NoError(t, err) {
 		return
 	}


### PR DESCRIPTION
Follow-up to review feedback on #5001. Repoints the two remaining HTTP-fetched fixtures in `pkg/handlers/handlers_test.go` (`TestHandleHTTPJson`, `TestHandleLargeHTTPJson`) from `ahrav/nothing-to-see-here` to `trufflesecurity/trufflehog-test-assets`, so they no longer depend on a personal repo.

Depends on trufflesecurity/trufflehog-test-assets#1 (adds the fixtures). **CI will be red until that PR merges**, since the new URLs 404 until then. Re-run CI once it's in.

Scope: the two small fixtures from #5001 are embedded, not affected here; `sm.zip` (lines 81/108) is handled by #5001's embed work.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only URL updates with no production or security logic changes; CI may be red until the upstream assets repo is populated.
> 
> **Overview**
> Repoints two HTTP integration tests in `pkg/handlers/handlers_test.go` from the personal repo `ahrav/nothing-to-see-here` to **`trufflesecurity/trufflehog-test-assets`**: `TestHandleHTTPJson` now fetches `sm_random_data.json`, and `TestHandleLargeHTTPJson` fetches `md_random_data.json.zip`. Test behavior and assertions are unchanged; only the raw GitHub URLs move to an org-owned fixture repo.
> 
> **Note:** These tests will fail until the assets exist at the new URLs (per dependent PR on `trufflehog-test-assets`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1373da1e6fe43ab4401972fcf355f6494c7c39a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->