### PR TITLE
Add Octopus Deploy API Key detector

### DIFF
--- a/pkg/detectors/octopusapikey/octopus_api_key.go
+++ b/pkg/detectors/octopusapikey/octopus_api_key.go
@@ -1,0 +1,66 @@
+package octopusapikey
+
+import (
+	"context"
+	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+type Scanner struct {
+	detectors.DefaultMultiPartCredentialProvider
+}
+
+var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.CustomFalsePositiveChecker = (*Scanner)(nil)
+
+var (
+	// Keep the provider keyword close to the secret pattern to reduce false positives.
+	// Octopus Deploy API keys are commonly represented as API- followed by 26 uppercase alphanumerics.
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"octopus", "x-octopus-apikey"}) + `\b(API-[A-Z0-9]{26})(?:['"|\n\r\s\x60;]|$)`)
+)
+
+func (s Scanner) Keywords() []string {
+	return []string{"octopus", "X-Octopus-ApiKey"}
+}
+
+func (s Scanner) Type() detector_typepb.DetectorType {
+	return detector_typepb.DetectorType_OctopusApiKey
+}
+
+func (s Scanner) Description() string {
+	return "Octopus Deploy API keys authenticate requests to Octopus REST API endpoints."
+}
+
+func (s Scanner) FromData(_ context.Context, _ bool, data []byte) ([]detectors.Result, error) {
+	dataStr := string(data)
+
+	uniqueMatches := make(map[string]struct{})
+	for _, match := range keyPat.FindAllStringSubmatch(dataStr, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		uniqueMatches[strings.TrimSpace(match[1])] = struct{}{}
+	}
+
+	results := make([]detectors.Result, 0, len(uniqueMatches))
+	for key := range uniqueMatches {
+		results = append(results, detectors.Result{
+			DetectorType: detector_typepb.DetectorType_OctopusApiKey,
+			Raw:          []byte(key),
+			ExtraData: map[string]string{
+				"rotation_guide": "https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key",
+			},
+			SecretParts: map[string]string{"key": key},
+		})
+	}
+
+	return results, nil
+}
+
+func (s Scanner) IsFalsePositive(result detectors.Result) (bool, string) {
+	return detectors.IsKnownFalsePositive(string(result.Raw), detectors.DefaultFalsePositives, true)
+}

--- a/pkg/detectors/octopusapikey/octopus_api_key_test.go
+++ b/pkg/detectors/octopusapikey/octopus_api_key_test.go
@@ -1,0 +1,111 @@
+package octopusapikey
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+func TestOctopusApiKey_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "valid pattern - header usage",
+			input: `X-Octopus-ApiKey: API-ZNRMR7SL6L3ATMOIK7GKJDKLPY`,
+			want:  []string{"API-ZNRMR7SL6L3ATMOIK7GKJDKLPY"},
+		},
+		{
+			name:  "valid pattern - env assignment",
+			input: `OCTOPUS_API_KEY="API-7F1M9T3D5P7Q2W4R6Y8U0I2O4A"`,
+			want:  []string{"API-7F1M9T3D5P7Q2W4R6Y8U0I2O4A"},
+		},
+		{
+			name: "valid pattern - multiple keys",
+			input: `octopus primary=API-ZNRMR7SL6L3ATMOIK7GKJDKLPY
+octopus backup=API-1A2B3C4D5E6F7G8H9I0J1K2L3M`,
+			want: []string{
+				"API-ZNRMR7SL6L3ATMOIK7GKJDKLPY",
+				"API-1A2B3C4D5E6F7G8H9I0J1K2L3M",
+			},
+		},
+		{
+			name:  "deduplication - repeated key",
+			input: `octopus API-ZNRMR7SL6L3ATMOIK7GKJDKLPY octopus API-ZNRMR7SL6L3ATMOIK7GKJDKLPY`,
+			want:  []string{"API-ZNRMR7SL6L3ATMOIK7GKJDKLPY"},
+		},
+		{
+			name:  "invalid pattern - too short",
+			input: `key = "API-ABC123"`,
+			want:  nil,
+		},
+		{
+			name:  "invalid pattern - lowercase characters",
+			input: `key = "API-ZNRMR7SL6L3ATMOIK7GkJDKLPY"`,
+			want:  nil,
+		},
+		{
+			name:  "invalid pattern - wrong prefix",
+			input: `key = "AP1-ZNRMR7SL6L3ATMOIK7GKJDKLPY"`,
+			want:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(test.want) > 0 && len(matchedDetectors) == 0 {
+				t.Errorf("keywords %v not found in input", d.Keywords())
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			require.NoError(t, err)
+
+			if len(results) != len(test.want) {
+				t.Errorf("expected %d results, got %d", len(test.want), len(results))
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.RawV2) > 0 {
+					actual[string(r.RawV2)] = struct{}{}
+				} else {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}
+
+func TestOctopusApiKey_Type(t *testing.T) {
+	s := Scanner{}
+	require.Equal(t, detector_typepb.DetectorType_OctopusApiKey, s.Type())
+}
+
+func TestOctopusApiKey_Keywords(t *testing.T) {
+	s := Scanner{}
+	require.NotEmpty(t, s.Keywords())
+	require.Contains(t, s.Keywords(), "octopus")
+	require.Contains(t, s.Keywords(), "X-Octopus-ApiKey")
+}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -521,6 +521,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/nvapi"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/nylas"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/oanda"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/octopusapikey"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/okta"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/omnisend"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/onedesk"
@@ -1413,6 +1414,7 @@ func buildDetectorList() []detectors.Detector {
 		&nvapi.Scanner{},
 		&nylas.Scanner{},
 		&oanda.Scanner{},
+		&octopusapikey.Scanner{},
 		&okta.Scanner{},
 		&omnisend.Scanner{},
 		&onedesk.Scanner{},

--- a/pkg/pb/detector_typepb/detector_type.pb.go
+++ b/pkg/pb/detector_typepb/detector_type.pb.go
@@ -1106,6 +1106,7 @@ const (
 	DetectorType_GitLabOauth2                            DetectorType = 1050
 	DetectorType_SpectralOps                             DetectorType = 1051
 	DetectorType_AWSAppSync                              DetectorType = 1052
+	DetectorType_OctopusApiKey                           DetectorType = 1053
 )
 
 // Enum value maps for DetectorType.
@@ -2160,6 +2161,7 @@ var (
 		1050: "GitLabOauth2",
 		1051: "SpectralOps",
 		1052: "AWSAppSync",
+		1053: "OctopusApiKey",
 	}
 	DetectorType_value = map[string]int32{
 		"Alibaba":                               0,
@@ -3211,6 +3213,7 @@ var (
 		"GitLabOauth2":                      1050,
 		"SpectralOps":                       1051,
 		"AWSAppSync":                        1052,
+		"OctopusApiKey":                     1053,
 	}
 )
 

--- a/proto/detector_type.proto
+++ b/proto/detector_type.proto
@@ -1054,4 +1054,5 @@ enum DetectorType {
   GitLabOauth2 = 1050;
   SpectralOps = 1051;
   AWSAppSync = 1052;
+  OctopusApiKey = 1053;
 }


### PR DESCRIPTION
## Summary
This PR adds a detector for Octopus Deploy API keys used to authenticate requests to Octopus REST API endpoints.

Key features:
- Detects API keys with the `API-` prefix followed by exactly 26 uppercase alphanumerics
- Context-aware matching requiring "octopus" or "X-Octopus-ApiKey" nearby
- Implements `CustomFalsePositiveChecker` interface for additional validation
- Non-verifying detector (API keys require server URL for verification)
- Includes comprehensive test coverage

## Changes
- Added `OctopusApiKey` (ID 1053) to `proto/detector_type.proto`
- Created detector implementation at `pkg/detectors/octopusapikey/`
- Integrated detector into default detector list in `pkg/engine/defaults/defaults.go`
- Updated proto-generated files with new detector type
- Added comprehensive unit tests with 100% pass rate

## Pattern Details
The detector uses a context-aware regex pattern:
```regex
(octopus|x-octopus-apikey).*\b(API-[A-Z0-9]{26})(?:['"|\n\r\s\x60;]|$)
```

This requires either "octopus" or "x-octopus-apikey" to appear before the token to avoid false positives. The API key format is highly specific:
- Must start with `API-` prefix
- Followed by exactly 26 uppercase letters and digits
- No lowercase letters, special characters, or hyphens in the key portion

## Testing
All tests pass successfully:
```
go test ./pkg/detectors/octopusapikey -tags=detectors -v
```

Test coverage includes:
- Valid pattern detection in HTTP header context (`X-Octopus-ApiKey` header)
- Environment variable assignments
- Multiple tokens in the same file
- Deduplication of repeated tokens
- Rejection of invalid patterns:
  - Keys that are too short
  - Keys with lowercase characters (strict uppercase validation)
  - Keys with wrong prefix format
- Proper detector type and keyword registration

## Design Rationale

**Why context-aware matching?**
While the `API-[A-Z0-9]{26}` format is specific, it could still match other API key formats. Requiring "octopus" or the standard HTTP header name "X-Octopus-ApiKey" in nearby context ensures high precision while maintaining excellent recall for actual Octopus Deploy keys.

**Why support both keywords?**
- `"octopus"` catches environment variables, config files, and code comments
- `"X-Octopus-ApiKey"` catches HTTP header usage, which is the standard way to use these keys in API requests

**Why no verification?**
Octopus Deploy API keys require both the API key AND the Octopus Server URL to verify. Since the detector only extracts the key (not the associated server URL), verification is not possible without additional context. The key format itself is sufficiently distinctive to provide high-confidence detection.

## SecretParts Population
The detector properly populates `SecretParts` with:
```go
SecretParts: map[string]string{"key": key}
```

And includes a rotation guide in `ExtraData`:
```go
ExtraData: map[string]string{
    "rotation_guide": "https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key",
}
```

## Example Matches
✅ Will detect:
```
X-Octopus-ApiKey: API-ZNRMR7SL6L3ATMOIK7GKJDKLPY
OCTOPUS_API_KEY="API-7F1M9T3D5P7Q2W4R6Y8U0I2O4A"
octopus_key: API-1A2B3C4D5E6F7G8H9I0J1K2L3M
```

❌ Will NOT detect (reducing false positives):
```
# Missing context
API_KEY="API-ZNRMR7SL6L3ATMOIK7GKJDKLPY"

# Wrong format
octopus key="API-ZNRMR7SL6L3ATMOIK7GkJDKLPY"  # lowercase 'k'
octopus key="AP1-ZNRMR7SL6L3ATMOIK7GKJDKLPY"  # wrong prefix
octopus key="API-ABC123"  # too short
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive secret-detection only; no changes to auth, verification, or core scan pipeline beyond registering one more default detector.
> 
> **Overview**
> Adds **Octopus Deploy API key** scanning as detector type `OctopusApiKey` (ID **1053**), wired into the default engine and protobuf enum.
> 
> The new scanner matches `API-` plus **26 uppercase alphanumerics** only when nearby context includes `octopus` or `X-Octopus-ApiKey`, deduplicates hits, fills `SecretParts` and a rotation-guide link, and uses the shared false-positive checker. There is **no live verification** (keys need a server URL). Unit tests cover headers, env vars, multi-key/dedup, and invalid formats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db92812a81dc698ce2a210e971d896ea2cf20af4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->