### PR TITLE
set redacted value to last 4 characters of secret, to match how the secret type admin interface displays it

### DIFF
--- a/pkg/detectors/contentfulpersonalaccesstoken/contentfulpersonalaccesstoken.go
+++ b/pkg/detectors/contentfulpersonalaccesstoken/contentfulpersonalaccesstoken.go
@@ -41,6 +41,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_ContentfulPersonalAccessToken,
 			Raw:          []byte(keyRes),
+			Redacted:     "..." + keyRes[len(keyRes)-4:],
 			SecretParts:  map[string]string{"key": keyRes},
 		}
 

--- a/pkg/detectors/contentfulpersonalaccesstoken/contentfulpersonalaccesstoken_test.go
+++ b/pkg/detectors/contentfulpersonalaccesstoken/contentfulpersonalaccesstoken_test.go
@@ -2,6 +2,7 @@ package contentfulpersonalaccesstoken
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -9,6 +10,8 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 )
+
+const validToken = "CFPAT-fakeabcdefghijklmnopqrstuvwxyz0123456789xyz"
 
 var (
 	validPattern = `
@@ -29,6 +32,12 @@ var (
 		# - Remember to rotate the secret every 90 days.
 		# - The above credentials should only be used in a secure environment.
 	`
+
+	validPatternWithToken = fmt.Sprintf(`
+		api:
+			auth_type: "Bearer"
+			contentful_access_token: "%s"
+	`, validToken)
 )
 
 func TestContentfulPersonalAccessToken_Pattern(t *testing.T) {
@@ -44,6 +53,11 @@ func TestContentfulPersonalAccessToken_Pattern(t *testing.T) {
 			name:  "valid pattern - not found",
 			input: validPattern,
 			want:  nil,
+		},
+		{
+			name:  "valid pattern with token - found",
+			input: validPatternWithToken,
+			want:  []string{validToken},
 		},
 	}
 
@@ -87,5 +101,24 @@ func TestContentfulPersonalAccessToken_Pattern(t *testing.T) {
 				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
 			}
 		})
+	}
+}
+
+func TestContentfulPersonalAccessToken_SecretRedacted(t *testing.T) {
+	d := Scanner{}
+
+	results, err := d.FromData(context.Background(), false, []byte(validPatternWithToken))
+	if err != nil {
+		t.Errorf("error = %v", err)
+		return
+	}
+
+	if len(results) == 0 {
+		t.Fatal("did not receive result")
+	}
+
+	want := "..." + validToken[len(validToken)-4:]
+	if results[0].Redacted != want {
+		t.Errorf("expected redacted secret to be '%s', got '%s'", want, results[0].Redacted)
 	}
 }


### PR DESCRIPTION
This detector's admin interface shows the last 4 characters of the secret, rather than the prefix that we default to. This PR sets the redacted value to the last 4 in order to better display helpful information.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes how detected secrets are displayed in `Redacted`; detection and verification logic are unchanged.
> 
> **Overview**
> **Contentful personal access token** findings now set an explicit `Redacted` value of `...` plus the **last four characters** of the token, instead of the scanner’s default prefix-style redaction. That aligns TruffleHog output with how Contentful’s admin UI surfaces PATs.
> 
> Tests add a fixture with a full `CFPAT-` token (pattern “found” case) and **`TestContentfulPersonalAccessToken_SecretRedacted`** to lock in the suffix redaction behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d233b1ab80fc441d54c818dcf5f4fa7a941cb93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->