### PR TITLE
fixed regex typo that was causing conf uuid's to be surfaced as non-live atlassian secrets.

### DIFF
--- a/pkg/detectors/atlassian/v1/atlassian.go
+++ b/pkg/detectors/atlassian/v1/atlassian.go
@@ -35,7 +35,7 @@ var _ detectors.Versioner = (*Scanner)(nil)
 var (
 	defaultClient = common.SaneHttpClient()
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"atlassian"}) + `\b([a-zA-Z-0-9]{24})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"atlassian"}) + `\b([a-zA-Z0-9]{24})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/atlassian/v1/atlassian_test.go
+++ b/pkg/detectors/atlassian/v1/atlassian_test.go
@@ -41,6 +41,15 @@ func TestAtlassian_Pattern(t *testing.T) {
 			`,
 			want: []string{"r6RkiQao3PgqY9MOKtonpJdU"},
 		},
+		{
+			name: "confluence macro-id near atlassian url - no match",
+			input: `
+				<a href="https://example.atlassian.net/wiki/spaces/X">link</a>
+				<ac:structured-macro ac:name="jira" ac:schema-version="1" ac:macro-id="451a36ca-3009-404c-a6b2-63cb71b229ce">
+				<ac:structured-macro ac:name="roadmap" ac:schema-version="1" ac:macro-id="73067429-8398-407c-a8a4-e5cb1049c840">
+			`,
+			want: nil,
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/detectors/atlassian/v1/atlassian_test.go
+++ b/pkg/detectors/atlassian/v1/atlassian_test.go
@@ -45,8 +45,8 @@ func TestAtlassian_Pattern(t *testing.T) {
 			name: "confluence macro-id near atlassian url - no match",
 			input: `
 				<a href="https://example.atlassian.net/wiki/spaces/X">link</a>
-				<ac:structured-macro ac:name="jira" ac:schema-version="1" ac:macro-id="451a36ca-3009-404c-a6b2-63cb71b229ce">
-				<ac:structured-macro ac:name="roadmap" ac:schema-version="1" ac:macro-id="73067429-8398-407c-a8a4-e5cb1049c840">
+				<ac:structured-macro ac:name="jira" ac:schema-version="1" ac:macro-id="11112222-3333-4444-5555-666677778888">
+				<ac:structured-macro ac:name="roadmap" ac:schema-version="1" ac:macro-id="aaaabbbb-cccc-dddd-eeee-ffff00001111">
 			`,
 			want: nil,
 		},


### PR DESCRIPTION
Fix(atlassian/v1): removes stray dash from keyPat character class
The character class `[a-zA-Z-0-9]` accidentally admitted `-` as a
literal, allowing the detector to carve a 24-char slice out of UUID-
shaped strings (e.g. Confluence `ac:macro-id="451a36ca-3009-404c-a6b2-
63cb71b229ce"`) when the keyword "atlassian" appeared within 40 chars.
Real classic Atlassian API tokens are 24 alphanumeric characters with
no dashes, this tightens the class to `[a-zA-Z0-9]` and adds a regression
test.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4246f151995d71591315af095f90b73186fd8460. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->