### PR TITLE
Skipped git test failing consistently in CI

### DIFF
--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -811,6 +811,7 @@ func TestGitConfigSecurityIsolation(t *testing.T) {
 }
 
 func TestGitConfigSanitizationWithStagedChanges(t *testing.T) {
+	t.Skip("failing in CI - INS-516")
 	t.Parallel()
 	ctx := context.Background()
 


### PR DESCRIPTION
### Description:
Skips the `TestGitConfigSanitizationWithStagedChanges` test because it is currently failing in CI.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; reduces CI coverage for staged-changes sanitization until INS-516 is resolved.
> 
> **Overview**
> Adds **`t.Skip("failing in CI - INS-516")`** at the top of **`TestGitConfigSanitizationWithStagedChanges`** in `git_test.go` so CI no longer runs this test while the failure is tracked under INS-516.
> 
> No production or git-source behavior changes—only test execution is affected. The skipped test still exercises staged-index behavior when **`PrepareRepo`** sanitizes a local repo with malicious git config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83dd608fbad66e49a4b21984010b148138e351f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->