### PR TITLE
feat: shell completion value hints + docs (bash/zsh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,35 @@ Replace `{version}` with the downloaded files version
 Alternatively, if you are using the installation script, pass `-v` option to perform signature verification.
 This requires Cosign binary to be installed prior to running the installation script.
 
+# :keyboard: Shell completion
+
+TruffleHog can generate tab-completion scripts for `bash` and `zsh`. Completion
+covers subcommands (e.g. `git`, `github`, `s3`), flags, and value hints for
+flags with a fixed set of options (e.g. `--results`, `--protocol`, `--format`).
+
+### Bash
+
+```bash
+# Try it out in the current shell:
+source <(trufflehog --completion-script-bash)
+
+# Or install it persistently:
+trufflehog --completion-script-bash > /etc/bash_completion.d/trufflehog
+```
+
+### Zsh
+
+```zsh
+# Try it out in the current shell:
+source <(trufflehog --completion-script-zsh)
+
+# Or install it persistently to a directory on your $fpath, e.g.:
+trufflehog --completion-script-zsh > "${fpath[1]}/_trufflehog"
+```
+
+After installing persistently, restart your shell (or re-run `compinit` on zsh)
+to pick up the completions.
+
 # :rocket: Quick Start
 
 ## 1: Scan a repo for only verified secrets

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ var (
 	concurrency         = cli.Flag("concurrency", "Number of concurrent workers.").PlaceHolder("N").Int()
 	noVerification      = cli.Flag("no-verification", "Don't verify the results.").Bool()
 	onlyVerified        = cli.Flag("only-verified", "Only output verified results.").Hidden().Bool()
-	results             = cli.Flag("results", "Specifies which type(s) of results to output: verified (confirmed valid by API), unknown (verification failed due to error), unverified (detected but not verified), filtered_unverified (unverified but would have been filtered out). Defaults to verified,unverified,unknown.").String()
+	results             = cli.Flag("results", "Specifies which type(s) of results to output: verified (confirmed valid by API), unknown (verification failed due to error), unverified (detected but not verified), filtered_unverified (unverified but would have been filtered out). Defaults to verified,unverified,unknown.").HintOptions("verified", "unverified", "unknown", "filtered_unverified").String()
 	noColor             = cli.Flag("no-color", "Disable colorized output").Bool()
 	noColour            = cli.Flag("no-colour", "Alias for --no-color").Hidden().Bool()
 
@@ -188,10 +188,10 @@ var (
 
 	syslogScan     = cli.Command("syslog", "Scan syslog")
 	syslogAddress  = syslogScan.Flag("address", "Address and port to listen on for syslog. Example: 127.0.0.1:514").String()
-	syslogProtocol = syslogScan.Flag("protocol", "Protocol to listen on. udp or tcp").String()
+	syslogProtocol = syslogScan.Flag("protocol", "Protocol to listen on. udp or tcp").HintOptions("udp", "tcp").String()
 	syslogTLSCert  = syslogScan.Flag("cert", "Path to TLS cert.").String()
 	syslogTLSKey   = syslogScan.Flag("key", "Path to TLS key.").String()
-	syslogFormat   = syslogScan.Flag("format", "Log format. Can be rfc3164 or rfc5424").Required().String()
+	syslogFormat   = syslogScan.Flag("format", "Log format. Can be rfc3164 or rfc5424").HintOptions("rfc3164", "rfc5424").Required().String()
 
 	circleCiScan      = cli.Command("circleci", "Scan CircleCI")
 	circleCiScanToken = circleCiScan.Flag("token", "CircleCI token. Can also be provided with environment variable").Envar("CIRCLECI_TOKEN").Required().String()


### PR DESCRIPTION
### Description:

Closes #4923.

`trufflehog` is built on `kingpin/v2`, which already auto-registers hidden `--completion-script-bash` and `--completion-script-zsh` flags, so subcommand and flag-name completion already worked — it was just undocumented, and flags with a fixed set of values gave no value suggestions (the `--results` example called out in the issue).

This PR:

- Adds `HintOptions` to the flags that accept a fixed set of values, so tab-completion suggests them:
  - `--results` → `verified`, `unverified`, `unknown`, `filtered_unverified`
  - `--protocol` (syslog) → `udp`, `tcp`
  - `--format` (syslog) → `rfc3164`, `rfc5424`
  
  Parsing is unchanged; only completion hints are added.
- Documents how to generate/install the bash and zsh completion scripts in the README.

Verified locally:

```
$ trufflehog --completion-bash --results
verified
unverified
unknown
filtered_unverified
```

`go build`, `go vet`, and `gofmt -l` are clean.

### Checklist:
* [x] Tests passing (`go build` / `go vet` / `gofmt` clean; no test files in the affected package). `make test-community` unaffected.
* [ ] Lint passing — `golangci-lint` not installed in my environment; `go vet` and `gofmt` are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and completion-metadata only; no changes to scan logic or flag parsing behavior.
> 
> **Overview**
> Improves **tab completion** for flags with fixed choices by adding kingpin **`HintOptions`** on **`--results`** (`verified`, `unverified`, `unknown`, `filtered_unverified`) and on syslog **`--protocol`** / **`--format`**. Flag parsing and validation are unchanged; only completion suggestions are new.
> 
> Adds a **README** section on generating and installing **bash** and **zsh** completion scripts via the existing **`--completion-script-bash`** / **`--completion-script-zsh`** flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fed28989a026e432f14b172a7260fc5c8df66af7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->