### PR TITLE
fix(sources/filesystem): order resume comparison by path component

### DIFF
--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/go-errors/errors"
@@ -239,25 +240,13 @@ func (s *Source) scanSymlink(
 // component matches os.ReadDir's ordering, where "blue-team" sorts before
 // "blue-team-deprecated". Returns -1, 0, or 1.
 func comparePathsForResume(a, b string) int {
-	aParts := strings.Split(a, string(filepath.Separator))
-	bParts := strings.Split(b, string(filepath.Separator))
-	for i := 0; i < len(aParts) && i < len(bParts); i++ {
-		if aParts[i] != bParts[i] {
-			if aParts[i] < bParts[i] {
-				return -1
-			}
-			return 1
-		}
-	}
-	// All shared components are equal; the shorter path (the ancestor) comes first.
-	switch {
-	case len(aParts) < len(bParts):
-		return -1
-	case len(aParts) > len(bParts):
-		return 1
-	default:
-		return 0
-	}
+	// slices.Compare walks the components lexicographically and, when one path is
+	// a prefix of the other, orders the shorter (ancestor) path first — matching
+	// the depth-first walk order described above.
+	return slices.Compare(
+		strings.Split(a, string(filepath.Separator)),
+		strings.Split(b, string(filepath.Separator)),
+	)
 }
 
 func (s *Source) scanDir(

--- a/pkg/sources/filesystem/filesystem.go
+++ b/pkg/sources/filesystem/filesystem.go
@@ -229,6 +229,37 @@ func (s *Source) scanSymlink(
 	return nil
 }
 
+// comparePathsForResume orders two cleaned paths the way a depth-first walk over
+// os.ReadDir-sorted entries does: component by component. A raw string comparison
+// is wrong here because the separator '/' (0x2F) sorts after characters that are
+// valid in a path component, such as '-' (0x2D) or '.' (0x2E). For example, as raw
+// strings "/root/blue-team-deprecated" < "/root/blue-team/file.txt" (the '-' after
+// "blue-team" sorts before '/'), which would make scanDir wrongly skip the sibling
+// directory "blue-team-deprecated" when resuming inside "blue-team". Comparing per
+// component matches os.ReadDir's ordering, where "blue-team" sorts before
+// "blue-team-deprecated". Returns -1, 0, or 1.
+func comparePathsForResume(a, b string) int {
+	aParts := strings.Split(a, string(filepath.Separator))
+	bParts := strings.Split(b, string(filepath.Separator))
+	for i := 0; i < len(aParts) && i < len(bParts); i++ {
+		if aParts[i] != bParts[i] {
+			if aParts[i] < bParts[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	// All shared components are equal; the shorter path (the ancestor) comes first.
+	switch {
+	case len(aParts) < len(bParts):
+		return -1
+	case len(aParts) > len(bParts):
+		return 1
+	default:
+		return 0
+	}
+}
+
 func (s *Source) scanDir(
 	ctx trContext.Context,
 	chunksChan chan *sources.Chunk,
@@ -258,8 +289,8 @@ func (s *Source) scanDir(
 	if resumeAfter != "" && !strings.HasPrefix(resumeAfter, path+string(filepath.Separator)) && resumeAfter != path {
 		// Resume point is not in this subtree. Compare paths to determine if we
 		// should skip this directory (already scanned) or process it (already passed).
-		if path < resumeAfter {
-			// This directory comes before the resume point lexicographically,
+		if comparePathsForResume(path, resumeAfter) < 0 {
+			// This directory comes before the resume point in traversal order,
 			// meaning it was already fully scanned. Skip it entirely.
 			return nil
 		}

--- a/pkg/sources/filesystem/filesystem_test.go
+++ b/pkg/sources/filesystem/filesystem_test.go
@@ -679,6 +679,88 @@ func TestResumptionWithNestedDirectories(t *testing.T) {
 	assert.Equal(t, 1, len(reporter.Chunks), "expected exactly 1 file to be scanned")
 }
 
+func TestResumptionWithPrefixSiblingDirectories(t *testing.T) {
+	ctx := trContext.Background()
+
+	// Create sibling directories where one name is a prefix of the other:
+	// root/
+	//   blue-team/
+	//     project-notes.txt
+	//   blue-team-deprecated/
+	//     AWSCredentials.txt
+	//
+	// os.ReadDir sorts "blue-team" before "blue-team-deprecated", so a scan that
+	// resumes inside blue-team must still descend into blue-team-deprecated. A raw
+	// string comparison of the directory path against the resume point would skip
+	// blue-team-deprecated, because '-' (0x2D) sorts before the separator '/' (0x2F).
+	rootDir, err := os.MkdirTemp("", "trufflehog-resumption-prefix-test")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(rootDir) })
+
+	dirs := map[string]string{
+		"blue-team":            "project-notes.txt",
+		"blue-team-deprecated": "AWSCredentials.txt",
+	}
+	for dir, file := range dirs {
+		dirPath := filepath.Join(rootDir, dir)
+		require.NoError(t, os.Mkdir(dirPath, 0755))
+		require.NoError(t, os.WriteFile(filepath.Join(dirPath, file), []byte("content of "+file), 0644))
+	}
+
+	conn, err := anypb.New(&sourcespb.Filesystem{})
+	require.NoError(t, err)
+
+	s := Source{}
+	err = s.Init(ctx, "test resumption prefix sibling", 0, 0, true, conn, 1)
+	require.NoError(t, err)
+
+	// Resume inside blue-team. project-notes.txt is the resume point (already
+	// scanned); AWSCredentials.txt in the sibling blue-team-deprecated comes after
+	// it in traversal order and must still be scanned.
+	resumePoint := filepath.Join(rootDir, "blue-team", "project-notes.txt")
+	s.SetEncodedResumeInfoFor(rootDir, resumePoint)
+
+	reporter := sourcestest.TestReporter{}
+	err = s.ChunkUnit(ctx, sources.CommonSourceUnit{ID: rootDir}, &reporter)
+	require.NoError(t, err)
+
+	scannedFiles := make(map[string]bool)
+	for _, chunk := range reporter.Chunks {
+		scannedFiles[filepath.Base(chunk.SourceMetadata.GetFilesystem().GetFile())] = true
+	}
+
+	assert.False(t, scannedFiles["project-notes.txt"], "project-notes.txt should have been skipped (the resume point itself)")
+	assert.True(t, scannedFiles["AWSCredentials.txt"], "AWSCredentials.txt should have been scanned (sibling dir after the resume point)")
+	assert.Equal(t, 1, len(reporter.Chunks), "expected exactly 1 file to be scanned")
+}
+
+func TestComparePathsForResume(t *testing.T) {
+	sep := string(filepath.Separator)
+	p := func(parts ...string) string { return sep + filepath.Join(parts...) }
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want int
+	}{
+		{"equal", p("root", "aaa"), p("root", "aaa"), 0},
+		{"before sibling", p("root", "aaa"), p("root", "bbb", "file.txt"), -1},
+		{"after sibling", p("root", "ccc"), p("root", "bbb", "file.txt"), 1},
+		{"ancestor before descendant", p("root", "aaa"), p("root", "aaa", "file.txt"), -1},
+		// Prefix-sibling: "blue-team-deprecated" must sort AFTER a resume point
+		// inside "blue-team", matching os.ReadDir order (regression for the raw
+		// string comparison where '-' < '/').
+		{"prefix sibling sorts after", p("root", "blue-team-deprecated"), p("root", "blue-team", "notes.txt"), 1},
+		{"prefix sibling reverse", p("root", "blue-team", "notes.txt"), p("root", "blue-team-deprecated"), -1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, comparePathsForResume(tt.a, tt.b))
+		})
+	}
+}
+
 func TestResumptionWithOutOfSubtreeResumePoint(t *testing.T) {
 	ctx := trContext.Background()
 


### PR DESCRIPTION
### Description:

Resuming a filesystem scan could silently skip an entire sibling directory when one directory name is a prefix of another (e.g. `blue-team` and `blue-team-deprecated`).

`scanDir` decided whether a directory was already scanned by comparing its path against the stored resume point with a raw string comparison (`path < resumeAfter`). Raw string order does not match the depth-first order `os.ReadDir` produces, because the separator `/` (0x2F) sorts *after* characters that are valid inside a path component such as `-` (0x2D) and `.` (0x2E).

So when resuming inside `blue-team` with resume point `/root/blue-team/project-notes.txt`, the check evaluated:

```
"/root/blue-team-deprecated" < "/root/blue-team/project-notes.txt"  // true: '-' < '/'
```

and skipped `blue-team-deprecated` entirely — every file beneath it (e.g. `AWSCredentials.txt`) was never enumerated or scanned. Renaming `blue-team` to `blue-team2` made the problem disappear, matching the report.

The fix compares the two paths component by component, which matches `os.ReadDir`'s ordering (`blue-team` sorts before `blue-team-deprecated`). The in-subtree `HasPrefix` checks and the per-entry loop were already correct and are unchanged.

Closes #5039

Tests:
- `TestResumptionWithPrefixSiblingDirectories` — integration test reproducing the report (resume inside `blue-team`, assert the sibling `blue-team-deprecated/AWSCredentials.txt` is still scanned).
- `TestComparePathsForResume` — unit test for the comparison helper, including the prefix-sibling case and the existing before/after/ancestor cases.
- Existing `TestResumption*` tests still pass.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint`)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Incorrect resume ordering could miss files during interrupted scans; the change is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes **filesystem scan resumption** skipping whole sibling directories when one directory name is a prefix of another (e.g. `blue-team` vs `blue-team-deprecated`).
> 
> `scanDir` used to treat a directory as already scanned when `path < resumeAfter` as **raw strings**. That order disagrees with `os.ReadDir` because `/` sorts after characters like `-` inside a name, so `blue-team-deprecated` could look “before” a resume point under `blue-team/` and never be visited.
> 
> The PR adds **`comparePathsForResume`** (path components via `slices.Compare`) and uses it for the out-of-subtree skip decision. **Integration and unit tests** cover the prefix-sibling regression and comparison cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4064b9b61bcbadf61193283dba51c2771b725488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->