### PR TITLE
chore(renovate): bump shared config to v1.0.3

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>trufflesecurity/.github:renovate-config#v1.0.2"]
+  "extends": ["github>trufflesecurity/.github:renovate-config#v1.0.3"]
 }


### PR DESCRIPTION
Bumps the shared Renovate preset pin from `renovate-config#v1.0.2` to `#v1.0.3`.

v1.0.3 adds a packageRule exempting `pin`, `pinDigest`, and `digest` update types from `minimumReleaseAge`.

### Impact of v1.0.3

**What we gain**
- Unblocks `pin`/`pinDigest`/`digest` PRs that sat permanently pending on `renovate/stability-days` — Renovate can't reliably age digest updates, so the cooldown never cleared.
- Keeps SHA-pinned GitHub Actions (and Go-module digests) current instead of frozen, which is the point of pinning in the first place.
- Removes the recurring manual toil of rebasing/force-clearing these stuck PRs.

**What we lose**
- The 3-day `minimumReleaseAge` soak no longer applies to `pin`/`pinDigest`/`digest`. In the worst case a maliciously published digest could be adopted without the delay. This is bounded: normal version bumps still soak 3 days, and — because this is a high-risk repo where automerge is **not** enabled — every such update still requires human review before it can merge (the cooldown was never the only gate here).

Tracking: PLAT-260
