### PR TITLE
fix(release): produce .zip archives for Windows builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,10 @@ archives:
       - LICENSE
       - README.md
       - docs/man/trufflehog.1
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
 dockers:
   - image_templates: ["trufflesecurity/{{ .ProjectName }}:{{ .Version }}-amd64"]
     dockerfile: Dockerfile.goreleaser

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -44,6 +44,7 @@ archives:
       - goos: windows
         formats:
           - zip
+          - tar.gz
 dockers:
   - image_templates: ["trufflesecurity/{{ .ProjectName }}:{{ .Version }}-amd64"]
     dockerfile: Dockerfile.goreleaser


### PR DESCRIPTION
### Changes

Adds a `format_overrides` entry to `.goreleaser.yml` so Windows builds are packaged as `.zip` instead of `.tar.gz`. All other platforms (linux, darwin) are unaffected.

```yaml
format_overrides:
  - goos: windows
    formats:
      - zip
```

### Why

WinGet (Microsoft's official package manager) does not support `.tar.gz` for portable packages. The `.zip` format is required to submit TruffleHog to the official WinGet repository, which would give Windows users a native `winget install TruffleHog` path.

The issue reporter (#5010) offered to submit the WinGet manifest PR themselves once the release pipeline produces `.zip` files.

### Impact

- Windows: `trufflehog_<version>_windows_<arch>.zip` (new)
- Linux/macOS: unchanged, still `.tar.gz`
- No build matrix changes, no code changes

Closes #5010

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only `.goreleaser.yml` tweak with no runtime or security impact; Windows users may see new or duplicate archive filenames on GitHub releases.
> 
> **Overview**
> **GoReleaser** now uses `archives.format_overrides` for `goos: windows`, so Windows release assets are published as **`.zip`** (and **`.tar.gz`** per the configured `formats` list) instead of relying on the default archive format alone.
> 
> Linux and macOS packaging is unchanged. No application code or build matrix changes—only release artifact layout on GitHub, aimed at **WinGet** portable package requirements (#5010).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8a5f73736060bf142e595d46c340374db894100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->