### PR TITLE
feat(detectors): add Shippo Live Token detector

### DIFF
--- a/pkg/detectors/shippolivetoken/shippo_live_token.go
+++ b/pkg/detectors/shippolivetoken/shippo_live_token.go
@@ -1,0 +1,135 @@
+package shippolivetoken
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+type Scanner struct {
+	client *http.Client
+	// apiBaseURL exists for deterministic local verification tests.
+	apiBaseURL string
+	detectors.DefaultMultiPartCredentialProvider
+}
+
+var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.CustomFalsePositiveChecker = (*Scanner)(nil)
+
+const defaultShippoAPIBaseURL = "https://api.goshippo.com"
+
+var (
+	defaultClient = common.SaneHttpClient()
+
+	tokenPat = regexp.MustCompile(`\b(shippo_live_[a-f0-9]{40})(?:['"|\n\r\s\x60;]|$)`)
+)
+
+func (s Scanner) Keywords() []string {
+	return []string{"shippo_live_", "ShippoToken", "shippo"}
+}
+
+func (s Scanner) Type() detector_typepb.DetectorType {
+	return detector_typepb.DetectorType_ShippoLiveToken
+}
+
+func (s Scanner) Description() string {
+	return "Shippo live API tokens authorize shipping operations and label purchases in production Shippo accounts."
+}
+
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	uniqueMatches := make(map[string]struct{})
+	for _, match := range tokenPat.FindAllStringSubmatch(dataStr, -1) {
+		if len(match) < 2 {
+			continue
+		}
+		uniqueMatches[strings.TrimSpace(match[1])] = struct{}{}
+	}
+
+	client := s.getClient()
+	for token := range uniqueMatches {
+		r := detectors.Result{
+			DetectorType: s.Type(),
+			Raw:          []byte(token),
+			SecretParts:  map[string]string{"key": token},
+			ExtraData: map[string]string{
+				"rotation_guide": "https://support.goshippo.com/hc/en-us/articles/360026412791-Managing-Your-API-Tokens-in-Shippo",
+			},
+		}
+
+		if verify {
+			isVerified, verificationErr := verifyToken(ctx, client, s.getAPIBaseURL(), token)
+			r.Verified = isVerified
+			r.SetVerificationError(verificationErr, token)
+		}
+
+		results = append(results, r)
+	}
+
+	return results, nil
+}
+
+func (s Scanner) IsFalsePositive(result detectors.Result) (bool, string) {
+	return detectors.IsKnownFalsePositive(string(result.Raw), detectors.DefaultFalsePositives, true)
+}
+
+func (s Scanner) getClient() *http.Client {
+	if s.client != nil {
+		return s.client
+	}
+	return defaultClient
+}
+
+func (s Scanner) getAPIBaseURL() string {
+	if strings.TrimSpace(s.apiBaseURL) != "" {
+		return strings.TrimSpace(s.apiBaseURL)
+	}
+	return defaultShippoAPIBaseURL
+}
+
+func verifyToken(ctx context.Context, client *http.Client, apiBaseURL, token string) (bool, error) {
+	base, err := url.Parse(apiBaseURL)
+	if err != nil {
+		return false, err
+	}
+	base.Path = path.Join(base.Path, "addresses")
+	q := base.Query()
+	q.Set("results", "1")
+	base.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base.String(), http.NoBody)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Authorization", "ShippoToken "+token)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected HTTP response status %d", resp.StatusCode)
+	}
+}

--- a/pkg/detectors/shippolivetoken/shippo_live_token_test.go
+++ b/pkg/detectors/shippolivetoken/shippo_live_token_test.go
@@ -1,0 +1,191 @@
+package shippolivetoken
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+func TestShippoLiveToken_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+
+	validTokenA := "shippo_live_0123456789abcdef0123456789abcdef01234567"
+	validTokenB := "shippo_live_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "valid pattern - auth header style",
+			input: `Authorization: ShippoToken ` + validTokenA,
+			want:  []string{validTokenA},
+		},
+		{
+			name:  "valid pattern - env var",
+			input: `SHIPPO_LIVE_TOKEN="` + validTokenA + `"`,
+			want:  []string{validTokenA},
+		},
+		{
+			name: "valid pattern - multiple keys",
+			input: `shippo live key1=` + validTokenA + `
+shippo live key2=` + validTokenB,
+			want: []string{validTokenA, validTokenB},
+		},
+		{
+			name:  "deduplication - repeated key",
+			input: `ShippoToken ` + validTokenA + ` ShippoToken ` + validTokenA,
+			want:  []string{validTokenA},
+		},
+		{
+			name:  "invalid pattern - wrong prefix",
+			input: `Authorization: ShippoToken shippo_test_0123456789abcdef0123456789abcdef01234567`,
+			want:  nil,
+		},
+		{
+			name:  "invalid pattern - uppercase hex suffix",
+			input: `shippo_live_0123456789ABCDEF0123456789ABCDEF01234567`,
+			want:  nil,
+		},
+		{
+			name:  "invalid pattern - too short",
+			input: `shippo_live_0123456789abcdef0123456789abcdef`,
+			want:  nil,
+		},
+		{
+			name:  "invalid pattern - invalid character",
+			input: `shippo_live_0123456789abcdef0123456789abcdef0123456z`,
+			want:  nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(test.want) > 0 && len(matchedDetectors) == 0 {
+				t.Errorf("keywords %v not found in input", d.Keywords())
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			require.NoError(t, err)
+
+			if len(results) != len(test.want) {
+				t.Errorf("expected %d results, got %d", len(test.want), len(results))
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.RawV2) > 0 {
+					actual[string(r.RawV2)] = struct{}{}
+				} else {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}
+
+func TestShippoLiveToken_Verify(t *testing.T) {
+	validToken := "shippo_live_0123456789abcdef0123456789abcdef01234567"
+	invalidToken := "shippo_live_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := strings.TrimSpace(r.Header.Get("Authorization"))
+		expected := "ShippoToken " + validToken
+		switch auth {
+		case expected:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"results":[]}`))
+		default:
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"detail":"invalid token"}`))
+		}
+	}))
+	defer mockServer.Close()
+
+	tests := []struct {
+		name       string
+		input      string
+		wantResult []detectors.Result
+	}{
+		{
+			name:  "verified token",
+			input: `Authorization: ShippoToken ` + validToken,
+			wantResult: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_ShippoLiveToken,
+					Raw:          []byte(validToken),
+					Verified:     true,
+				},
+			},
+		},
+		{
+			name:  "unverified token",
+			input: `Authorization: ShippoToken ` + invalidToken,
+			wantResult: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_ShippoLiveToken,
+					Raw:          []byte(invalidToken),
+					Verified:     false,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			s := Scanner{
+				client:     mockServer.Client(),
+				apiBaseURL: mockServer.URL,
+			}
+			got, err := s.FromData(context.Background(), true, []byte(test.input))
+			require.NoError(t, err)
+			for _, r := range got {
+				t.Logf("raw=%s verified=%t verification_error=%v", string(r.Raw), r.Verified, r.VerificationError())
+			}
+
+			if diff := cmp.Diff(
+				test.wantResult,
+				got,
+				cmpopts.IgnoreFields(detectors.Result{}, "ExtraData", "SecretParts"),
+				cmpopts.IgnoreUnexported(detectors.Result{}),
+			); diff != "" {
+				t.Errorf("FromData() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestShippoLiveToken_Type(t *testing.T) {
+	s := Scanner{}
+	require.Equal(t, detector_typepb.DetectorType_ShippoLiveToken, s.Type())
+}
+
+func TestShippoLiveToken_Keywords(t *testing.T) {
+	s := Scanner{}
+	require.NotEmpty(t, s.Keywords())
+	require.Contains(t, s.Keywords(), "shippo_live_")
+	require.Contains(t, s.Keywords(), "ShippoToken")
+}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -679,6 +679,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/sheety"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/sherpadesk"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/shipday"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/shippolivetoken"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/shodankey"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/shopify"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/shopifyoauth"
@@ -1579,6 +1580,7 @@ func buildDetectorList() []detectors.Detector {
 		&sheety.Scanner{},
 		&sherpadesk.Scanner{},
 		&shipday.Scanner{},
+		&shippolivetoken.Scanner{},
 		&shodankey.Scanner{},
 		&shopify.Scanner{},
 		&shopifyoauth.Scanner{},

--- a/pkg/pb/detector_typepb/detector_type.pb.go
+++ b/pkg/pb/detector_typepb/detector_type.pb.go
@@ -1106,6 +1106,7 @@ const (
 	DetectorType_GitLabOauth2                            DetectorType = 1050
 	DetectorType_SpectralOps                             DetectorType = 1051
 	DetectorType_AWSAppSync                              DetectorType = 1052
+	DetectorType_ShippoLiveToken                         DetectorType = 1054
 )
 
 // Enum value maps for DetectorType.
@@ -2160,6 +2161,7 @@ var (
 		1050: "GitLabOauth2",
 		1051: "SpectralOps",
 		1052: "AWSAppSync",
+		1054: "ShippoLiveToken",
 	}
 	DetectorType_value = map[string]int32{
 		"Alibaba":                               0,
@@ -3211,6 +3213,7 @@ var (
 		"GitLabOauth2":                      1050,
 		"SpectralOps":                       1051,
 		"AWSAppSync":                        1052,
+		"ShippoLiveToken":                   1054,
 	}
 )
 

--- a/proto/detector_type.proto
+++ b/proto/detector_type.proto
@@ -1054,4 +1054,5 @@ enum DetectorType {
   GitLabOauth2 = 1050;
   SpectralOps = 1051;
   AWSAppSync = 1052;
+  ShippoLiveToken = 1054;
 }


### PR DESCRIPTION
## Summary
- Adds a detector for Shippo live API tokens (`shippo_live_` + 40 hex chars).
- Verifier issues `GET /addresses?results=1` with the `ShippoToken` auth scheme; treats `200` as verified, `401`/`403` as determinately invalid, any other status as indeterminate (returns an error per CONTRIBUTING.md).
- Adds `ShippoLiveToken = 1054` to `proto/detector_type.proto`, regenerated `pb.go`, and registers the scanner in `pkg/engine/defaults/defaults.go`.
- Populates `SecretParts` with `key`, includes a `rotation_guide` in `ExtraData`, and implements `CustomFalsePositiveChecker`.

## Test plan
- [x] `go test ./pkg/detectors/shippolivetoken -tags=detectors -v` — all pattern + verify cases pass
- [x] `go build ./...` succeeds
- [x] `go vet` clean on touched packages
- [ ] Reviewer to validate against a real Shippo live token in CI/secret store

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated new detector package following existing patterns; verification is read-only against Shippo’s API with no changes to core scan engine logic.
> 
> **Overview**
> Adds a **Shippo live API token** detector so scans can find production `shippo_live_` credentials (40 lowercase hex chars after the prefix).
> 
> When verification is enabled, it calls Shippo’s `GET /addresses?results=1` with `Authorization: ShippoToken <token>`, marks **200** as verified and **401/403** as invalid, and treats other statuses as indeterminate errors. Results include `SecretParts`, a rotation guide link, and the shared default false-positive checker.
> 
> **`ShippoLiveToken` (1054)** is added in `proto/detector_type.proto` with regenerated protobufs, and the scanner is registered in default engine detectors. Unit tests cover regex/keyword behavior and mock HTTP verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d6dc9e9b433e8e49a55cc9b6399493d3727272. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->