### PR TITLE
test(handlers): point APK test fixture at trufflehog-test-assets

### DIFF
--- a/pkg/handlers/apk_test.go
+++ b/pkg/handlers/apk_test.go
@@ -21,7 +21,7 @@ func TestAPKHandler(t *testing.T) {
 		matchString     string
 	}{
 		"apk_with_3_leaked_keys": {
-			archiveURL:     "https://raw.githubusercontent.com/trufflesecurity/leakyAPK/main/aws_leak.apk",
+			archiveURL:     "https://raw.githubusercontent.com/trufflesecurity/trufflehog-test-assets/main/aws_leak.apk",
 			expectedChunks: 942,
 			// Note: the secret count is 4 instead of 3 b/c we're not actually running the secret detection engine,
 			// we're just looking for a string match. There is one extra string match in the APK (but only 3 detected secrets).


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Updates the `TestAPKHandler` fixture URL to source `aws_leak.apk` from `trufflesecurity/trufflehog-test-assets` instead of the standalone `trufflesecurity/leakyAPK` repo.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only URL change with no production or handler logic impact.
> 
> **Overview**
> **`TestAPKHandler`** now downloads `aws_leak.apk` from **`trufflesecurity/trufflehog-test-assets`** (`main/aws_leak.apk`) instead of **`trufflesecurity/leakyAPK`**.
> 
> Test expectations (chunk count, secret count, match string) are unchanged; only the remote fixture URL moved to the consolidated test-assets repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64254ce6b19e8efff91ac21e17ace57e6d1787e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->