### PR TITLE
Fix/readme install command linebreak

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Download and unpack from https://github.com/trufflesecurity/trufflehog/releases
 
 ```bash
 git clone https://github.com/trufflesecurity/trufflehog.git
-cd trufflehog;
+cd trufflehog
 go install
 ```
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,8 @@ Download and unpack from https://github.com/trufflesecurity/trufflehog/releases
 
 ```bash
 git clone https://github.com/trufflesecurity/trufflehog.git
-cd trufflehog; go install
+cd trufflehog;
+go install
 ```
 
 ### Using installation script


### PR DESCRIPTION
### Description:
Fix the "From source" installation section in README.md where both commands
were on a single line, making them appear as one command instead of two.

Before:
```bash
git clone https://github.com/trufflesecurity/trufflehog.git
cd trufflehog; go install
```


After:
```bash
git clone https://github.com/trufflesecurity/trufflehog.git
cd trufflehog
go install
```

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires golangci-lint)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only formatting change with no runtime or security impact.
> 
> **Overview**
> **README “Compile from source”** now shows three separate shell lines instead of folding `cd` and `go install` onto one line with a semicolon.
> 
> Readers copying the fenced block get distinct `git clone`, `cd trufflehog`, and `go install` steps, which matches how the commands are meant to be run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fcb0321bccac9d7d0eda153be454189e012f714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->