### PR TITLE
github: scan a user's public repos when --org names a non-owner

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -609,7 +609,13 @@ func (s *Source) enumerateWithToken(ctx context.Context, isGithubEnterprise bool
 	if len(s.orgsCache.Keys()) > 0 {
 		for _, org := range s.orgsCache.Keys() {
 			orgCtx := context.WithValue(ctx, "account", org)
-			userType, err := s.getReposByOrgOrUser(ctx, org, true, reporter)
+			// The authenticated /user/repos endpoint ignores the requested account
+			// and returns the token owner's repos, so only use it when org is the
+			// token owner. For any other user passed via --org, fall back to the
+			// public listing instead of silently scanning the token owner's repos.
+			// https://github.com/trufflesecurity/trufflehog/issues/4517
+			authenticated := strings.EqualFold(org, ghUser.GetLogin())
+			userType, err := s.getReposByOrgOrUser(ctx, org, authenticated, reporter)
 			if err != nil {
 				orgCtx.Logger().Error(err, "Unable to fetch repos for org or user")
 				continue

--- a/pkg/sources/github/github_test.go
+++ b/pkg/sources/github/github_test.go
@@ -624,6 +624,90 @@ func TestEnumerateWithToken(t *testing.T) {
 	assert.True(t, gock.IsDone())
 }
 
+// Passing a username via --org that isn't the token owner should list that
+// user's public repos via /users/{user}/repos, not the token owner's repos
+// via /user/repos. Regression test for issue #4517.
+func TestEnumerateWithToken_DifferentUserListsPublicRepos(t *testing.T) {
+	defer gock.Off()
+
+	// The token owner is "token-owner", but we scan "super-secret-user".
+	gock.New("https://api.github.com").
+		Get("/user").
+		Reply(200).
+		JSON(map[string]string{"login": "token-owner"})
+
+	// The requested account is not an org.
+	gock.New("https://api.github.com").
+		Get("/orgs/super-secret-user/repos").
+		Reply(404).
+		JSON(map[string]string{"message": "Not Found"})
+
+	// It must be resolved as a user and listed via the public endpoint.
+	gock.New("https://api.github.com").
+		Get("/users/super-secret-user/repos").
+		Reply(200).
+		JSON([]map[string]string{{"full_name": "super-secret-user/super-secret-repo", "clone_url": "https://github.com/super-secret-user/super-secret-repo.git"}})
+
+	gock.New("https://api.github.com").
+		Get("/users/super-secret-user/gists").
+		Reply(200).
+		JSON([]map[string]string{{"id": "super-secret-gist", "git_pull_url": "https://gist.github.com/super-secret-gist.git"}})
+
+	s := initTestSource(&sourcespb.GitHub{
+		Endpoint:      "https://api.github.com",
+		Organizations: []string{"super-secret-user"},
+		Credential: &sourcespb.GitHub_Token{
+			Token: "token",
+		},
+	})
+	err := s.enumerateWithToken(context.Background(), false, noopReporter())
+	assert.Nil(t, err)
+	assert.True(t, s.filteredRepoCache.Exists("super-secret-user/super-secret-repo"))
+	// /user/repos must not be hit for a different user; all mocks consumed once.
+	assert.False(t, gock.HasUnmatchedRequest())
+	assert.True(t, gock.IsDone())
+}
+
+// When the account is the token owner, keep using the authenticated
+// /user/repos listing so private repos are still scanned (see #4426).
+func TestEnumerateWithToken_OwnerListsAuthenticatedRepos(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://api.github.com").
+		Get("/user").
+		Reply(200).
+		JSON(map[string]string{"login": "super-secret-user"})
+
+	gock.New("https://api.github.com").
+		Get("/orgs/super-secret-user/repos").
+		Reply(404).
+		JSON(map[string]string{"message": "Not Found"})
+
+	// Token owner: private + public repositories via the authenticated endpoint.
+	gock.New("https://api.github.com").
+		Get("/user/repos").
+		Reply(200).
+		JSON([]map[string]string{{"full_name": "super-secret-user/private-repo", "clone_url": "https://github.com/super-secret-user/private-repo.git"}})
+
+	gock.New("https://api.github.com").
+		Get("/users/super-secret-user/gists").
+		Reply(200).
+		JSON([]map[string]string{{"id": "super-secret-gist", "git_pull_url": "https://gist.github.com/super-secret-gist.git"}})
+
+	s := initTestSource(&sourcespb.GitHub{
+		Endpoint:      "https://api.github.com",
+		Organizations: []string{"super-secret-user"},
+		Credential: &sourcespb.GitHub_Token{
+			Token: "token",
+		},
+	})
+	err := s.enumerateWithToken(context.Background(), false, noopReporter())
+	assert.Nil(t, err)
+	assert.True(t, s.filteredRepoCache.Exists("super-secret-user/private-repo"))
+	assert.False(t, gock.HasUnmatchedRequest())
+	assert.True(t, gock.IsDone())
+}
+
 func BenchmarkEnumerateWithToken(b *testing.B) {
 	defer gock.Off()
 


### PR DESCRIPTION
### Description:
Fixes #4517.

When a username is passed via `--org` together with a token, `enumerateWithToken` listed repositories through the authenticated `/user/repos` endpoint. That endpoint ignores the requested account and always returns the *token owner's* repositories, so `trufflehog github --org someuser --token ...` silently scanned the token owner instead of `someuser`.

The fix only uses the authenticated listing when the requested account matches the token owner; for any other user it falls back to the public `/users/{user}/repos` endpoint. This keeps the token owner's private repos in scope (the behaviour added in #4426) while scanning the right account for everyone else.

Scoped to the token enumeration path. Added two regression tests covering both branches: a different user resolves to the public endpoint, and the token owner still uses the authenticated one.

### Checklist:
* [x] Tests passing (`make test-community`)? — ran the affected package (`go test ./pkg/sources/github/...`), plus `gofmt` and `go vet`, all clean on Windows.
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))? — golangci-lint not installed locally; `gofmt`/`go vet` clean, relying on CI for the full lint.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which repositories are enumerated for a common CLI pattern; wrong behavior previously caused silent mis-scans, but the fix may reduce private-repo coverage when scanning another user's account by name.
> 
> **Overview**
> Fixes incorrect scan targets when **`--org`** names a GitHub user that is not the token owner during token-based enumeration.
> 
> **`enumerateWithToken`** no longer always passes **`authenticated: true`** into **`getReposByOrgOrUser`**. It now sets **`authenticated`** only when the org/account name matches the token owner (case-insensitive), so **`/user/repos`** is used for the owner (including private repos, per #4426) and **`/users/{user}/repos`** is used for other users instead of silently enumerating the token owner's repos (#4517).
> 
> Adds two HTTP-mocked regression tests for the non-owner public path and the owner authenticated path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6b58e51b039a0b6905785c7baff385e18ca7dd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->