### PR TITLE
fix(git): avoid panic when parsing non-standard git version output

### DIFF
--- a/pkg/sources/git/cmd_check.go
+++ b/pkg/sources/git/cmd_check.go
@@ -10,8 +10,11 @@ import (
 	"github.com/go-errors/errors"
 )
 
-// Extract the version string using a regex to find the version numbers
-var regex = regexp.MustCompile(`\d+\.\d+\.\d+`)
+// Extract the version string using a regex to find the major and minor numbers.
+// Only the major and minor components are needed for the version check, and some
+// builds report a non-numeric patch component (for example "2.52.gaea8cc3"), so
+// matching the full "x.y.z" form here would fail to find a match for them.
+var regex = regexp.MustCompile(`\d+\.\d+`)
 
 // CmdCheck checks if git is installed and meets 2.20.0<=x<3.0.0 version requirements.
 func CmdCheck() error {
@@ -25,8 +28,17 @@ func CmdCheck() error {
 		return fmt.Errorf("failed to check git version: %w", err)
 	}
 
-	versionStr := regex.FindString(string(out))
+	return checkGitVersion(string(out))
+}
+
+// checkGitVersion verifies that the output of `git --version` reports a version
+// in the range 2.20.0 <= x < 3.0.0.
+func checkGitVersion(version string) error {
+	versionStr := regex.FindString(version)
 	versionParts := strings.Split(versionStr, ".")
+	if len(versionParts) < 2 {
+		return fmt.Errorf("could not parse git version from %q", strings.TrimSpace(version))
+	}
 
 	// Parse version numbers
 	major, _ := strconv.Atoi(versionParts[0])

--- a/pkg/sources/git/cmd_check_test.go
+++ b/pkg/sources/git/cmd_check_test.go
@@ -1,0 +1,31 @@
+package git
+
+import "testing"
+
+func TestCheckGitVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		wantErr bool
+	}{
+		{name: "supported version", version: "git version 2.39.5\n", wantErr: false},
+		{name: "minimum supported version", version: "git version 2.20.0\n", wantErr: false},
+		{name: "apple git suffix", version: "git version 2.39.5 (Apple Git-154)\n", wantErr: false},
+		// Dev builds report a non-numeric patch component; this previously panicked
+		// with "index out of range [1] with length 1". See issue #4801.
+		{name: "non-numeric patch component", version: "git version 2.52.gaea8cc3\n", wantErr: false},
+		{name: "too old", version: "git version 2.19.1\n", wantErr: true},
+		{name: "major too new", version: "git version 3.0.0\n", wantErr: true},
+		{name: "unparseable output", version: "git version unknown\n", wantErr: true},
+		{name: "empty output", version: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkGitVersion(tt.version)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkGitVersion(%q) error = %v, wantErr %v", tt.version, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #4801.

### Problem
`CmdCheck` extracts the git version with the regex `\d+\.\d+\.\d+` and then indexes `versionParts[0]` and `versionParts[1]` without checking the length:

```go
versionStr := regex.FindString(string(out))       // "" when no x.y.z match
versionParts := strings.Split(versionStr, ".")     // [""] -> len 1
major, _ := strconv.Atoi(versionParts[0])
minor, _ := strconv.Atoi(versionParts[1])          // panic: index out of range [1] with length 1
```

Some git builds report a **non-numeric patch component**, e.g. `git version 2.52.gaea8cc3` (reported in the issue). The `x.y.z` regex finds no match, `FindString` returns `""`, and `strings.Split("", ".")` returns a one-element slice — so `versionParts[1]` panics with exactly:

```
panic: runtime error: index out of range [1] with length 1
.../pkg/sources/git/cmd_check.go:33
```

### Fix
- Match only the **major and minor** components (`\d+\.\d+`). Those are the only parts the check uses, and this makes versions like `2.52.gaea8cc3` parse correctly (major 2, minor 52 → valid) instead of failing to match.
- **Guard** against output with no parseable version (return an error rather than indexing blindly).
- Extract the parsing/comparison into `checkGitVersion(string) error` so it can be unit tested.

No new dependencies (stdlib only).

### Test
Adds `cmd_check_test.go` covering the previously-panicking dev-build string, the supported/boundary versions (2.20, 2.39, Apple suffix), out-of-range versions, and unparseable/empty output. Verified the dev-build case panics on `main` and passes with this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to startup git version validation with added tests; no auth, data, or API behavior changes beyond failing safely instead of panicking.
> 
> **Overview**
> Fixes a **panic** in `CmdCheck` when `git --version` reports a non-numeric patch (e.g. `2.52.gaea8cc3`): the old `x.y.z` regex could return no match, leaving too few split segments and indexing `versionParts[1]` unsafely.
> 
> Version parsing now uses **major.minor only** (`\d+\.\d+`), returns a clear error when nothing parseable is found, and moves comparison into **`checkGitVersion`** for unit tests. **`cmd_check_test.go`** covers the dev-build case, supported bounds, Apple suffixes, rejections, and bad/empty output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbf210f6696bcffca7c67ab67835fde282390e1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->