### PR TITLE
feat: implement RancherToken detector to fix #4622

### DIFF
--- a/pkg/detectors/ranchertoken/ranchertoken.go
+++ b/pkg/detectors/ranchertoken/ranchertoken.go
@@ -31,7 +31,7 @@ var (
 
 // Keywords are used for efficiently pre-filtering chunks.
 func (s Scanner) Keywords() []string {
-	return []string{"cattle_token", "rancher_token", "cattle_bootstrap_password", "rancher_api_token", "rancher_secret_key"}
+	return []string{"cattle", "rancher"}
 }
 
 // FromData will find and optionally verify RancherToken secrets in a given set of bytes.

--- a/pkg/detectors/ranchertoken/ranchertoken.go
+++ b/pkg/detectors/ranchertoken/ranchertoken.go
@@ -9,7 +9,6 @@ import (
 
 	regexp "github.com/wasilibs/go-re2"
 
-	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
 )
@@ -24,7 +23,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 var _ detectors.EndpointCustomizer = (*Scanner)(nil)
 
 var (
-	defaultClient = common.SaneHttpClient()
+	defaultClient = detectors.DetectorHttpClientWithNoLocalAddresses
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"cattle", "rancher"}) + `\b([a-z0-9]{54,64})\b`)
 )

--- a/pkg/detectors/ranchertoken/ranchertoken.go
+++ b/pkg/detectors/ranchertoken/ranchertoken.go
@@ -1,0 +1,135 @@
+package ranchertoken
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+type Scanner struct {
+	detectors.EndpointSetter
+	client *http.Client
+}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+var _ detectors.EndpointCustomizer = (*Scanner)(nil)
+
+var (
+	defaultClient = common.SaneHttpClient()
+	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"cattle", "rancher"}) + `\b([a-z0-9]{54,64})\b`)
+)
+
+// Keywords are used for efficiently pre-filtering chunks.
+func (s Scanner) Keywords() []string {
+	return []string{"cattle_token", "rancher_token", "cattle_bootstrap_password", "rancher_api_token", "rancher_secret_key"}
+}
+
+// FromData will find and optionally verify RancherToken secrets in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	uniqueMatches := make(map[string]struct{})
+	for _, match := range keyPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueMatches[match[1]] = struct{}{}
+	}
+
+	for match := range uniqueMatches {
+		s1 := detectors.Result{
+			DetectorType: detector_typepb.DetectorType_RancherToken,
+			Raw:          []byte(match),
+			SecretParts:  map[string]string{"token": match},
+		}
+
+		if verify {
+			client := s.client
+			if client == nil {
+				client = defaultClient
+			}
+			
+			endpoints := s.Endpoints()
+			if len(endpoints) == 0 {
+				s1.Verified = false
+				s1.SetVerificationError(fmt.Errorf("requires endpoint configuration"), match)
+				results = append(results, s1)
+				continue
+			}
+
+			var anyVerified bool
+			var lastErr error
+			for _, endpoint := range endpoints {
+				endpointURL := strings.TrimSuffix(endpoint, "/")
+				isVerified, extraData, verificationErr := verifyMatch(ctx, client, endpointURL, match)
+				if isVerified {
+					s1.Verified = true
+					s1.ExtraData = extraData
+					anyVerified = true
+					break
+				}
+				if verificationErr != nil {
+					lastErr = verificationErr
+				}
+			}
+
+			if !anyVerified {
+				s1.Verified = false
+				s1.SetVerificationError(lastErr, match)
+			}
+		}
+
+		results = append(results, s1)
+	}
+
+	return
+}
+
+func verifyMatch(ctx context.Context, client *http.Client, endpoint, token string) (bool, map[string]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/v3", nil)
+	if err != nil {
+		return false, nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, nil, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		bodyBytes, err := io.ReadAll(res.Body)
+		if err != nil {
+			return false, nil, err
+		}
+		if strings.Contains(string(bodyBytes), "apiVersion") {
+			return true, nil, nil
+		}
+		return false, nil, nil
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return false, nil, nil
+	default:
+		return false, nil, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
+}
+
+func (s Scanner) Type() detector_typepb.DetectorType {
+	return detector_typepb.DetectorType_RancherToken
+}
+
+func (s Scanner) Description() string {
+	return "Rancher is a Kubernetes management platform. Rancher tokens can provide full cluster admin access."
+}

--- a/pkg/detectors/ranchertoken/ranchertoken_test.go
+++ b/pkg/detectors/ranchertoken/ranchertoken_test.go
@@ -1,0 +1,79 @@
+package ranchertoken
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+)
+
+var (
+	validPattern   = "CATTLE_TOKEN=jswpl27hs8pd88rmw2mgfgrjtpljp85fd5v7rhdwr2s6z22hvt6vjt"
+	invalidPattern = "CATTLE_TOKEN=abcdefghijklmnopqrstuvwxyz0123456789abcdefghijkl" // only 52 chars
+	validToken     = "jswpl27hs8pd88rmw2mgfgrjtpljp85fd5v7rhdwr2s6z22hvt6vjt"
+)
+
+func TestRancherToken_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "valid pattern",
+			input: fmt.Sprintf("%s", validPattern),
+			want:  []string{validToken},
+		},
+		{
+			name:  "invalid pattern - too short",
+			input: fmt.Sprintf("%s", invalidPattern),
+			want:  []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(matchedDetectors) == 0 {
+				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			if err != nil {
+				t.Errorf("error = %v", err)
+				return
+			}
+
+			if len(results) != len(test.want) {
+				if len(results) == 0 {
+					t.Errorf("did not receive result")
+				} else {
+					t.Errorf("expected %d results, only received %d", len(test.want), len(results))
+				}
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.Raw) > 0 {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -21,6 +21,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/airvisual"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/aiven"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/alchemy"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/ranchertoken"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/alegra"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/aletheiaapi"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/algoliaadminkey"
@@ -899,6 +900,7 @@ func buildDetectorList() []detectors.Detector {
 		&airvisual.Scanner{},
 		&aiven.Scanner{},
 		&alchemy.Scanner{},
+		&ranchertoken.Scanner{},
 		// The service currently has blocked requests with a "TruffleHog" UserAgent.
 		// &alconost.Scanner{},
 		&alegra.Scanner{},

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -21,7 +21,6 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/airvisual"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/aiven"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/alchemy"
-	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/ranchertoken"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/alegra"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/aletheiaapi"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/algoliaadminkey"
@@ -612,6 +611,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/rabbitmq"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/railwayapp"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/ramp"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/ranchertoken"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/rapidapi"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/rawg"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/razorpay"
@@ -900,7 +900,6 @@ func buildDetectorList() []detectors.Detector {
 		&airvisual.Scanner{},
 		&aiven.Scanner{},
 		&alchemy.Scanner{},
-		&ranchertoken.Scanner{},
 		// The service currently has blocked requests with a "TruffleHog" UserAgent.
 		// &alconost.Scanner{},
 		&alegra.Scanner{},
@@ -1511,6 +1510,7 @@ func buildDetectorList() []detectors.Detector {
 		&rabbitmq.Scanner{},
 		&railwayapp.Scanner{},
 		&ramp.Scanner{},
+		&ranchertoken.Scanner{},
 		&rapidapi.Scanner{},
 		// &raven.Scanner{},
 		&rawg.Scanner{},

--- a/pkg/pb/detector_typepb/detector_type.pb.go
+++ b/pkg/pb/detector_typepb/detector_type.pb.go
@@ -1107,6 +1107,7 @@ const (
 	DetectorType_SpectralOps                             DetectorType = 1051
 	DetectorType_AWSAppSync                              DetectorType = 1052
 	DetectorType_BrainTrustApiKey                        DetectorType = 1053
+	DetectorType_RancherToken                            DetectorType = 1054
 )
 
 // Enum value maps for DetectorType.
@@ -2162,6 +2163,7 @@ var (
 		1051: "SpectralOps",
 		1052: "AWSAppSync",
 		1053: "BrainTrustApiKey",
+		1054: "RancherToken",
 	}
 	DetectorType_value = map[string]int32{
 		"Alibaba":                               0,
@@ -3214,6 +3216,7 @@ var (
 		"SpectralOps":                       1051,
 		"AWSAppSync":                        1052,
 		"BrainTrustApiKey":                  1053,
+		"RancherToken":                      1054,
 	}
 )
 

--- a/proto/detector_type.proto
+++ b/proto/detector_type.proto
@@ -1055,4 +1055,5 @@ enum DetectorType {
   SpectralOps = 1051;
   AWSAppSync = 1052;
   BrainTrustApiKey = 1053;
+  RancherToken = 1054;
 }


### PR DESCRIPTION
Fixes #4622 by adding a new credential detector for Rancher Tokens, complete with PrefixRegex extraction, API verification via the `/v3` endpoint, and unit tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Verification sends discovered bearer tokens to configured Rancher URLs (high-privilege credentials), though it follows the same endpoint-customizer pattern as other infra detectors and does not change TruffleHog core auth.
> 
> **Overview**
> Adds a **RancherToken** detector so TruffleHog can find Rancher/Cattle API tokens in scanned content and optionally confirm them against a Rancher server.
> 
> Detection uses `PrefixRegex` on keywords `cattle` and `rancher`, then matches **54–64** lowercase alphanumeric token strings. Results are tagged as `DetectorType_RancherToken` with a `token` secret part.
> 
> When verification is enabled, the scanner requires **user-configured Rancher base URLs** (`EndpointCustomizer`); without endpoints it reports an unverified result with a configuration error. It tries each endpoint with `GET {base}/v3` and a `Bearer` token, marking verified on HTTP 200 when the body contains `apiVersion`.
> 
> The new scanner is wired into the default detector list and the `RancherToken = 1054` enum in `detector_type.proto` (plus generated Go). Unit tests cover keyword prefiltering and valid vs too-short token patterns (no live HTTP tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 962cf82df209c151214cc4396848080f858df23c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->