### PR TITLE
fix(detectors/datadogtoken): report verification endpoint failures

### DIFF
--- a/pkg/detectors/datadogtoken/datadogtoken.go
+++ b/pkg/detectors/datadogtoken/datadogtoken.go
@@ -14,6 +14,7 @@ import (
 )
 
 type Scanner struct {
+	client *http.Client
 	detectors.EndpointSetter
 	detectors.DefaultMultiPartCredentialProvider
 }
@@ -24,6 +25,13 @@ var _ detectors.EndpointCustomizer = (*Scanner)(nil)
 var _ detectors.CloudProvider = (*Scanner)(nil)
 
 func (Scanner) CloudEndpoint() string { return "https://api.datadoghq.com" }
+
+func (s Scanner) getClient() *http.Client {
+	if s.client != nil {
+		return s.client
+	}
+	return client
+}
 
 var (
 	client = common.SaneHttpClient()
@@ -130,6 +138,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
+				client := s.getClient()
+				var verificationErr error
 				for _, baseURL := range s.Endpoints(endpoints...) {
 					req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/api/v2/users", nil)
 					if err != nil {
@@ -139,26 +149,34 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					req.Header.Add("DD-API-KEY", resApiMatch)
 					req.Header.Add("DD-APPLICATION-KEY", resAppMatch)
 					res, err := client.Do(req)
-					if err == nil {
-						defer func() { _ = res.Body.Close() }()
-						if res.StatusCode >= 200 && res.StatusCode < 300 {
-							s1.Verified = true
-							s1.SecretParts["endpoint"] = baseURL
-							var serviceResponse userServiceResponse
-							if err := json.NewDecoder(res.Body).Decode(&serviceResponse); err == nil {
-								// setup emails
-								if len(serviceResponse.Data) > 0 {
-									setUserEmails(serviceResponse.Data, &s1)
-								}
-								// setup organizations
-								if len(serviceResponse.Included) > 0 {
-									setOrganizationInfo(serviceResponse.Included, &s1)
-								}
-							}
-							// break the loop once we've successfully validated the token against a baseURL
-							break
-						}
+					if err != nil {
+						// An unreachable endpoint is a verification issue, not an
+						// invalid credential. Remember the error and surface it
+						// below if no endpoint ends up verifying the token.
+						verificationErr = err
+						continue
 					}
+					defer func() { _ = res.Body.Close() }()
+					if res.StatusCode >= 200 && res.StatusCode < 300 {
+						s1.Verified = true
+						s1.SecretParts["endpoint"] = baseURL
+						var serviceResponse userServiceResponse
+						if err := json.NewDecoder(res.Body).Decode(&serviceResponse); err == nil {
+							// setup emails
+							if len(serviceResponse.Data) > 0 {
+								setUserEmails(serviceResponse.Data, &s1)
+							}
+							// setup organizations
+							if len(serviceResponse.Included) > 0 {
+								setOrganizationInfo(serviceResponse.Included, &s1)
+							}
+						}
+						// break the loop once we've successfully validated the token against a baseURL
+						break
+					}
+				}
+				if !s1.Verified && verificationErr != nil {
+					s1.SetVerificationError(verificationErr, resApiMatch)
 				}
 			}
 			results = append(results, s1)

--- a/pkg/detectors/datadogtoken/datadogtoken_test.go
+++ b/pkg/detectors/datadogtoken/datadogtoken_test.go
@@ -2,6 +2,8 @@ package datadogtoken
 
 import (
 	"context"
+	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -9,6 +11,12 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestDataDogToken_Pattern_WithValidAPIandAppKey(t *testing.T) {
 	d := Scanner{}
@@ -84,6 +92,45 @@ func TestDataDogToken_Pattern_WithAPIKeyOnly(t *testing.T) {
 
 	if len(results) != 0 {
 		t.Errorf("expected 0 results, received %d", len(results))
+	}
+}
+
+// TestDataDogToken_FromData_VerificationEndpointFailure ensures that when the
+// Datadog verification endpoint is unreachable, the result reports a
+// verification error (surfaced as "unknown" under --results=verified,unknown)
+// instead of silently swallowing the failure. See issue #4541.
+func TestDataDogToken_FromData_VerificationEndpointFailure(t *testing.T) {
+	wantErr := errors.New("simulated endpoint unreachable")
+	scanner := Scanner{
+		client: &http.Client{
+			Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+				return nil, wantErr
+			}),
+		},
+	}
+	// The engine enables these at runtime; do the same so the verification
+	// request is actually attempted against the discovered endpoint.
+	scanner.UseFoundEndpoints(true)
+	scanner.UseCloudEndpoint(true)
+
+	input := `
+			dd_api_secret: "FKNwdbyfYTmGUm5DK3yHEuK-BBQf0fVG"
+			dd_app: "iHxNanzZ8vjrmbjXK7NJLrwpGw2czdSh90PKH6VL"
+			base_url: "https://api.us5.datadoghq.com"
+	`
+
+	results, err := scanner.FromData(context.Background(), true, []byte(input))
+	if err != nil {
+		t.Fatalf("FromData returned error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Verified {
+		t.Error("result should not be verified when the endpoint is unreachable")
+	}
+	if results[0].VerificationError() == nil {
+		t.Error("expected a verification error when the endpoint is unreachable, got nil")
 	}
 }
 


### PR DESCRIPTION
### Description:

Closes #4541.

When the DatadogToken verifier could not reach the verification endpoint, the failure was silently dropped: the detector inlined the API call and only acted on the response inside an `if err == nil` branch, so a transport-level error (unreachable endpoint, DNS failure, timeout) left the result unverified with **no** verification error. Under `--results=verified,unknown` the secret was reported as `unknown` with no indication that verification had actually failed, unlike AWS (and unlike the sibling DatadogApiKey detector).

This change captures the request error and, when no endpoint verifies the token, surfaces it via `SetVerificationError`, so endpoint failures are reported as verification issues. The `DatadogApiKey` detector in this same package already follows this pattern, so this brings `DatadogToken` in line with it.

To keep the verifier testable the same way `DatadogApiKey` is, the scanner gains an optional injectable `client` (via `getClient()`); behavior is unchanged when it is nil.

### Checklist:
* [x] Tests passing (`make test-community`)? Added `TestDataDogToken_FromData_VerificationEndpointFailure`, which drives `FromData` with an error-returning transport and asserts a verification error is reported. It fails on the prior code (error swallowed) and passes with this fix.
* [x] Lint passing (`make lint`)? `golangci-lint run ./pkg/detectors/datadogtoken/...` reports 0 issues; `gofmt`/`go vet` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized detector verification and error-reporting behavior; no auth or data-path changes beyond clearer failure signaling.
> 
> **Overview**
> **DatadogToken** verification no longer drops transport failures (DNS, timeout, unreachable host). When `client.Do` fails across tried endpoints, the last error is recorded and, if nothing verifies, exposed via **`SetVerificationError`**—aligning with **DatadogApiKey** and other detectors so `--results=verified,unknown` can distinguish “couldn’t verify” from a plain unverified hit.
> 
> The scanner adds an optional injectable **`http.Client`** through **`getClient()`** (default behavior unchanged when nil), enabling the new **`TestDataDogToken_FromData_VerificationEndpointFailure`** test with a failing transport.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8062329ab13bf650950dd941c4ef1a708b4e4bda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->