### PR TITLE
Expose `SecretParts` in the JSON output

### DIFF
--- a/pkg/output/json.go
+++ b/pkg/output/json.go
@@ -55,6 +55,7 @@ func (p *JSONPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) 
 		Redacted       string
 		ExtraData      map[string]string
 		StructuredData *detectorspb.StructuredData
+		SecretParts    map[string]string
 	}{
 		SourceMetadata:        r.SourceMetadata,
 		SourceID:              r.SourceID,
@@ -72,6 +73,7 @@ func (p *JSONPrinter) Print(_ context.Context, r *detectors.ResultWithMetadata) 
 		Redacted:              r.Redacted,
 		ExtraData:             r.ExtraData,
 		StructuredData:        r.StructuredData,
+		SecretParts:           r.SecretParts,
 	}
 	out, err := json.Marshal(v)
 	if err != nil {


### PR DESCRIPTION
This PR exposes the recently-added `detectors.Result.SecretParts` map in its JSON representation.

Background:

In TruffleHog `detectors.Result`, there is the `RawV2` field that is _sometimes_ populated, particularly if the secret is a multi-part secret. However, `RawV2` is a single string, and in some cases (e.g., [Algolia Admin Keys](https://github.com/trufflesecurity/trufflehog/blob/ac0805e53b065e7188181fc80dce1800dfa51ab9/pkg/detectors/algoliaadminkey/algoliaadminkey.go#L84)), the multiple parts get concatenated with `:` as a separator. In other cases (like [Box OAuth](https://github.com/trufflesecurity/trufflehog/blob/48f31cb60dfc4f81655ed7a1db181f5945f92420/pkg/detectors/boxoauth/boxoauth.go#L86)), the multiple parts are simply concatenated. This makes it difficult to recover the exact parts from a multi-part secret.

`SecretParts` is a recent addition that represents the multiple parts more faithfully, as a `map[string]string` in Go. This PR exposes that field in the JSON output from TruffleHog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds one optional JSON field to stdout output; no change to detection, verification, or secret handling logic.
> 
> **Overview**
> JSON scan output now includes a **`secretParts`** field (from `detectors.Result.SecretParts`) alongside existing fields like `raw` and `rawV2`.
> 
> Consumers can read labeled multi-part secrets (e.g. separate key IDs and tokens) without parsing inconsistent `rawV2` concatenation. The change is limited to the anonymous struct used in `JSONPrinter.Print` in `pkg/output/json.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a82161e916fbe8e319ba4b25ec8392e7a9cc25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->