### PR TITLE
fix(detectors/hunter): surface indeterminate verification as a VerificationError

### DIFF
--- a/pkg/detectors/hunter/hunter.go
+++ b/pkg/detectors/hunter/hunter.go
@@ -2,6 +2,8 @@ package hunter
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -12,16 +14,25 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
 )
 
-type Scanner struct{}
+type Scanner struct {
+	client *http.Client
+}
 
 // Ensure the Scanner satisfies the interface at compile time.
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	client = common.SaneHttpClient()
+	defaultClient = common.SaneHttpClient()
 
 	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"hunter"}) + `\b([a-z0-9_-]{40})\b`)
 )
+
+func (s Scanner) getClient() *http.Client {
+	if s.client != nil {
+		return s.client
+	}
+	return defaultClient
+}
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
@@ -45,23 +56,46 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			req, err := http.NewRequestWithContext(ctx, "GET", "https://api.hunter.io/v2/leads_lists?api_key="+resMatch, nil)
-			if err != nil {
-				continue
-			}
-			res, err := client.Do(req)
-			if err == nil {
-				defer func() { _ = res.Body.Close() }()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
-					s1.Verified = true
-				}
-			}
+			verified, verErr := verifyMatch(ctx, s.getClient(), resMatch)
+			s1.Verified = verified
+			s1.SetVerificationError(verErr, resMatch)
 		}
 
 		results = append(results, s1)
 	}
 
 	return results, nil
+}
+
+// verifyMatch reports whether the key authenticates. A nil error with
+// verified=false means the key is definitively invalid; a non-nil error means
+// verification was indeterminate (a transport failure or an unexpected status
+// such as a 429 rate limit or a 5xx), so the finding must not be silently
+// treated as a non-secret.
+func verifyMatch(ctx context.Context, client *http.Client, key string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.hunter.io/v2/leads_lists?api_key="+key, nil)
+	if err != nil {
+		return false, err
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch {
+	case res.StatusCode >= 200 && res.StatusCode < 300:
+		return true, nil
+	case res.StatusCode == http.StatusUnauthorized || res.StatusCode == http.StatusForbidden:
+		// Definitive: the credentials were rejected.
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
 }
 
 func (s Scanner) Type() detector_typepb.DetectorType {

--- a/pkg/detectors/hunter/hunter_test.go
+++ b/pkg/detectors/hunter/hunter_test.go
@@ -2,6 +2,11 @@ package hunter
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -82,6 +87,79 @@ func TestHunter_Pattern(t *testing.T) {
 
 			if diff := cmp.Diff(expected, actual); diff != "" {
 				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}
+
+type roundTripFunc func(req *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func statusResponse(status int) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader("{}")),
+		Header:     make(http.Header),
+	}
+}
+
+// TestHunter_VerificationError asserts that an indeterminate verification
+// outcome (transport failure, rate limit, or other unexpected status) is
+// surfaced as a VerificationError rather than being silently reported as an
+// unverified, definitively-invalid key.
+func TestHunter_VerificationError(t *testing.T) {
+	input := fmt.Sprintf("hunter api key = %s", secret)
+
+	tests := []struct {
+		name         string
+		transport    roundTripFunc
+		wantVerified bool
+		wantErr      bool
+	}{
+		{
+			name:         "valid key (2xx)",
+			transport:    func(*http.Request) (*http.Response, error) { return statusResponse(http.StatusOK), nil },
+			wantVerified: true,
+			wantErr:      false,
+		},
+		{
+			name:         "invalid key (401) is definitive",
+			transport:    func(*http.Request) (*http.Response, error) { return statusResponse(http.StatusUnauthorized), nil },
+			wantVerified: false,
+			wantErr:      false,
+		},
+		{
+			name:         "rate limited (429) is indeterminate",
+			transport:    func(*http.Request) (*http.Response, error) { return statusResponse(http.StatusTooManyRequests), nil },
+			wantVerified: false,
+			wantErr:      true,
+		},
+		{
+			name:         "transport error is indeterminate",
+			transport:    func(*http.Request) (*http.Response, error) { return nil, errors.New("dial tcp: connection refused") },
+			wantVerified: false,
+			wantErr:      true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			d := Scanner{client: &http.Client{Transport: test.transport}}
+			results, err := d.FromData(context.Background(), true, []byte(input))
+			if err != nil {
+				t.Fatalf("FromData returned a fatal error: %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(results))
+			}
+
+			r := results[0]
+			if r.Verified != test.wantVerified {
+				t.Errorf("Verified = %v, want %v", r.Verified, test.wantVerified)
+			}
+			if gotErr := r.VerificationError() != nil; gotErr != test.wantErr {
+				t.Errorf("VerificationError present = %v (%v), want %v", gotErr, r.VerificationError(), test.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem
The Hunter verifier only set `Verified=true` on a 2xx response and silently ignored every other outcome. A transport failure (network blip), a `429` rate limit, or a `5xx` all left the result `Verified=false` with **no** `VerificationError`, making them indistinguishable from a definitively-rejected key. Under the default `--results=verified` filter a live key could be dropped with no signal that it was never actually checked.

This mirrors the verification-error convention already used across the detector suite (e.g. `SetVerificationError` on transport/indeterminate failures).

## Fix
Extract `verifyMatch` into a tri-state result:
- `2xx` -> verified;
- `401` / `403` -> definitively invalid (no error);
- transport failure or any other status (429, 5xx, ...) -> returned as an error and recorded via `SetVerificationError`.

Also adds an injectable client for testing and drains the response body before close.

## Tests
Added `TestHunter_VerificationError` covering the valid (2xx), invalid (401), rate-limited (429), and transport-error cases. The existing `TestHunter_Pattern` is unchanged.

`go test ./pkg/detectors/hunter/...`, `go vet`, `gofmt`, and `golangci-lint` are clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Hunter detector verification behavior and tests; aligns with existing detector conventions without changing auth or data paths.
> 
> **Overview**
> **Hunter API key verification** no longer treats every non-2xx or failed request as a quietly unverified finding. Verification is moved into `verifyMatch`, which returns a clear outcome: **2xx** marks the key verified; **401/403** mark it definitively invalid with no error; **transport failures, 429, 5xx, and other statuses** return an error and are recorded via **`SetVerificationError`**, matching other detectors.
> 
> The scanner gains an optional injectable **`http.Client`** (with a shared default) so tests can stub HTTP. Response bodies are drained before close.
> 
> **`TestHunter_VerificationError`** covers 2xx, 401, 429, and transport errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05ba949225ad03d751315f6b6d7e94d9362aaa59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->