### PR TITLE
fix(detectors): extend Azure App Config Id regex to allow hyphen and colon

### DIFF
--- a/pkg/detectors/azureappconfigconnectionstring/azureappconfigconnectionstring.go
+++ b/pkg/detectors/azureappconfigconnectionstring/azureappconfigconnectionstring.go
@@ -27,7 +27,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 
 var (
 	defaultClient       = common.SaneHttpClient()
-	connectionStringPat = regexp.MustCompile(`Endpoint=(https:\/\/[a-zA-Z0-9-]+\.azconfig\.io);Id=([a-zA-Z0-9+\/=]+);Secret=([a-zA-Z0-9+\/=]+)`)
+	connectionStringPat = regexp.MustCompile(`Endpoint=(https:\/\/[a-zA-Z0-9-]+\.azconfig\.io);Id=([a-zA-Z0-9+\/:=\-]+);Secret=([a-zA-Z0-9+\/=]+)`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/azureappconfigconnectionstring/azureappconfigconnectionstring_test.go
+++ b/pkg/detectors/azureappconfigconnectionstring/azureappconfigconnectionstring_test.go
@@ -40,6 +40,11 @@ func TestAzureAppConfigConnectionString_Pattern(t *testing.T) {
 			want: []string{"Endpoint=https://iTHzRfnepCddRiYoBbPj-drVzUjwTNduwb3EUOTsuSAgg1e83Q7bw.azconfig.io;Id=eO04L+/m9rYn;Secret=G4jQ3GmcsYqlLkkG8uoIVbx08PZIJSdfB/7"},
 		},
 		{
+			name:  "valid pattern - canonical Azure format with hyphenated prefix and colon",
+			input: `Endpoint=https://myappconfig001.azconfig.io;Id=aB1c-d2-e3:+XyZ12345AbCdEfGhIjKl;Secret=MnOpQrSt67UvWxYz89AbCdEf0123GhIjKlMnOpQrStUvWxYz1234=`,
+			want:  []string{"Endpoint=https://myappconfig001.azconfig.io;Id=aB1c-d2-e3:+XyZ12345AbCdEfGhIjKl;Secret=MnOpQrSt67UvWxYz89AbCdEf0123GhIjKlMnOpQrStUvWxYz1234="},
+		},
+		{
 			name:  "invalid pattern",
 			input: `Endpoint=https://trufflesecurity.azconfig.io;Secret=80DtxZkndXpMTmV2J3JjX2vL1x4gm1hHn8Y3KeFV4N0PPLSO5D70JQQJ79BBAC1i4FpRkb5wAAACAAZC26dr`,
 			want:  nil,


### PR DESCRIPTION
## Summary

The `AzureAppConfigConnectionString` detector silently misses **all** real-world Azure App Configuration access keys because the regex doesn't allow `-` and `:` in the `Id` field.

### Root Cause

Azure-issued connection strings use the canonical format:

```
Endpoint=https://<store>.azconfig.io;Id=<prefix>:<base64>;Secret=<base64>
```

Where `<prefix>` typically contains hyphens (e.g. `aB1c-d2-e3`) and the colon separates the prefix from the base64 body.

The detector regex only allowed base64 characters in `Id`:

```go
// Before: misses every real Azure key
Id=([a-zA-Z0-9+\/=]+)
```

### Fix

```go
// After: matches canonical Azure-issued format
Id=([a-zA-Z0-9+\/:=\-]+)
```

### Before / After

| Input | Before | After |
|-------|--------|-------|
| `Id=aB1c-d2-e3:+XyZ123...` (canonical Azure format) | ❌ no match | ✅ matched |
| `Id=eO04L+/m9rYn` (simple base64) | ✅ matched | ✅ matched |
| `Id=u+De` (short base64) | ✅ matched | ✅ matched |

### Test

Added test case `valid pattern - canonical Azure format with hyphenated prefix and colon` covering the real-world Azure key format that was previously missed.

All 4 tests pass:
- ✅ valid pattern (existing)
- ✅ valid pattern - xml (existing)
- ✅ valid pattern - canonical Azure format with hyphenated prefix and colon (NEW)
- ✅ invalid pattern (existing)

### Verification

- `go test`: 4/4 PASS
- `go vet`: clean
- `go build`: clean

### Closes

Closes #4955

### Checklist

- [x] Root cause identified (regex character class too narrow)
- [x] Minimal fix (2 chars added to character class)
- [x] Backward compatible (existing test patterns still match)
- [x] New test covering the real-world format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow regex tweak in a secret detector plus a unit test; no auth, verification, or API behavior changes.
> 
> **Overview**
> The **Azure App Configuration connection string** detector was failing to match real Azure-issued keys because the `Id` capture group only allowed base64 characters. Azure’s canonical `Id` values include **hyphens** in the prefix and a **colon** before the base64 segment (e.g. `aB1c-d2-e3:+XyZ...`), so those strings were never detected.
> 
> The fix widens the `Id` regex class to `[a-zA-Z0-9+\/:=\-]+` while leaving endpoint and `Secret` matching unchanged. A pattern test was added for the hyphenated-prefix-and-colon format so the previously missed case is covered without breaking existing valid/invalid cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa13ec1ccfce145a5e3a66750e3fe9891015db4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->