### PR TITLE
fix(detectors/jdbc): do not dial local hosts during verification

### DIFF
--- a/pkg/detectors/jdbc/jdbc.go
+++ b/pkg/detectors/jdbc/jdbc.go
@@ -5,7 +5,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -257,6 +259,52 @@ func ping(ctx context.Context, driverName string, isDeterminate func(error) bool
 		indeterminateErrors = append(indeterminateErrors, err)
 	}
 	return pingResult{errors.Join(indeterminateErrors...), false}
+}
+
+// errNoLocalIP mirrors detectors.ErrNoLocalIP used by the URI detector. Returning
+// it from a ping is a determinate result, which stops the candidate-connection
+// waterfall so we never actually dial the local address.
+var errNoLocalIP = errors.New("dialing local IP addresses is not allowed")
+
+// isLocalIP reports whether ip points at the local machine or an internal
+// network. It mirrors the check used by the URI detector in
+// detectors.DetectorHttpClientWithNoLocalAddresses (see pkg/detectors/http.go).
+func isLocalIP(ip net.IP) bool {
+	return ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsPrivate() ||
+		ip.IsUnspecified()
+}
+
+// hostIsLocal reports whether host resolves to a local/loopback/link-local/
+// private/unspecified address. host is the value stored on a parsed JDBC
+// connection, which may carry the MySQL driver's tcp(...)/unix(...) wrapper and
+// an optional ":port" suffix, so both are stripped before the check. If the host
+// is a name rather than a literal IP it is resolved with net.LookupIP and treated
+// as local when any resolved address is local.
+func hostIsLocal(host string) bool {
+	// Strip the MySQL driver's network wrapper, e.g. tcp(127.0.0.1:3306) or
+	// unix(/var/run/mysqld.sock).
+	if i := strings.IndexByte(host, '('); i >= 0 && strings.HasSuffix(host, ")") {
+		host = host[i+1 : len(host)-1]
+	}
+
+	// Drop an optional port. SplitHostPort fails when there is no port, in which
+	// case host is already bare.
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		return isLocalIP(ip)
+	}
+
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return false
+	}
+	return slices.ContainsFunc(ips, isLocalIP)
 }
 
 func pingErr(ctx context.Context, driverName, conn string) error {

--- a/pkg/detectors/jdbc/jdbc.go
+++ b/pkg/detectors/jdbc/jdbc.go
@@ -261,14 +261,10 @@ func ping(ctx context.Context, driverName string, isDeterminate func(error) bool
 	return pingResult{errors.Join(indeterminateErrors...), false}
 }
 
-// errNoLocalIP mirrors detectors.ErrNoLocalIP used by the URI detector. Returning
-// it from a ping is a determinate result, which stops the candidate-connection
-// waterfall so we never actually dial the local address.
-var errNoLocalIP = errors.New("dialing local IP addresses is not allowed")
-
 // isLocalIP reports whether ip points at the local machine or an internal
 // network. It mirrors the check used by the URI detector in
-// detectors.DetectorHttpClientWithNoLocalAddresses (see pkg/detectors/http.go).
+// detectors.DetectorHttpClientWithNoLocalAddresses (see pkg/detectors/http.go),
+// which is unexported there so it cannot be shared.
 func isLocalIP(ip net.IP) bool {
 	return ip.IsLoopback() ||
 		ip.IsLinkLocalUnicast() ||
@@ -294,6 +290,13 @@ func hostIsLocal(host string) bool {
 	// case host is already bare.
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
+	}
+
+	// Drop a SQL Server named-instance suffix. parseSqlServer keeps the instance
+	// on the host, so localhost\SQLEXPRESS would otherwise parse as neither an IP
+	// nor a resolvable name and slip past the check.
+	if i := strings.IndexByte(host, '\\'); i >= 0 {
+		host = host[:i]
 	}
 
 	if ip := net.ParseIP(host); ip != nil {

--- a/pkg/detectors/jdbc/jdbc_local_test.go
+++ b/pkg/detectors/jdbc/jdbc_local_test.go
@@ -1,0 +1,62 @@
+package jdbc
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestHostIsLocal(t *testing.T) {
+	cases := []struct {
+		host string
+		want bool
+	}{
+		// Loopback and unspecified.
+		{"127.0.0.1", true},
+		{"127.0.0.1:5432", true},
+		{"localhost", true},
+		{"[::1]:1433", true},
+		{"::1", true},
+		{"0.0.0.0", true},
+		// MySQL driver tcp(...) wrapper.
+		{"tcp(127.0.0.1:3306)", true},
+		{"tcp(localhost:3306)", true},
+		// Private and link-local ranges.
+		{"10.0.0.5", true},
+		{"192.168.1.1", true},
+		{"169.254.1.1", true},
+		// Public hosts must not be refused.
+		{"db.example.com:5432", false},
+		{"8.8.8.8", false},
+		{"tcp(8.8.8.8:3306)", false},
+		{"example.org", false},
+	}
+
+	for _, c := range cases {
+		if got := hostIsLocal(c.host); got != c.want {
+			t.Errorf("hostIsLocal(%q) = %v, want %v", c.host, got, c.want)
+		}
+	}
+}
+
+// TestJdbcPingRefusesLocalHosts ensures every supported sub-protocol refuses to
+// dial a local host during verification, matching the URI detector's existing
+// local-address refusal (see issue #3679).
+func TestJdbcPingRefusesLocalHosts(t *testing.T) {
+	ctx := context.Background()
+	pingers := map[string]jdbcPinger{
+		"postgres":  &PostgresJDBC{ConnectionInfo: ConnectionInfo{Host: "127.0.0.1:5432", User: "u", Password: "p"}},
+		"mysql":     &MysqlJDBC{ConnectionInfo: ConnectionInfo{Host: "tcp(localhost:3306)", User: "u", Password: "p"}},
+		"sqlserver": &SqlServerJDBC{ConnectionInfo: ConnectionInfo{Host: "[::1]:1433", User: "u", Password: "p"}},
+	}
+
+	for name, p := range pingers {
+		res := p.ping(ctx)
+		if !res.determinate {
+			t.Errorf("%s: expected determinate result for local host, got indeterminate", name)
+		}
+		if !errors.Is(res.err, errNoLocalIP) {
+			t.Errorf("%s: expected errNoLocalIP, got %v", name, res.err)
+		}
+	}
+}

--- a/pkg/detectors/jdbc/jdbc_local_test.go
+++ b/pkg/detectors/jdbc/jdbc_local_test.go
@@ -3,6 +3,7 @@ package jdbc
 import (
 	"context"
 	"errors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"testing"
 )
 
@@ -25,7 +26,15 @@ func TestHostIsLocal(t *testing.T) {
 		{"10.0.0.5", true},
 		{"192.168.1.1", true},
 		{"169.254.1.1", true},
+		// SQL Server named instances: parseSqlServer leaves the instance on the
+		// host, and it used to hide the address from the check completely.
+		{`localhost\SQLEXPRESS`, true},
+		{`127.0.0.1\SQLEXPRESS`, true},
+		{`localhost\SQLEXPRESS:1433`, true},
+		{`127.0.0.1\SQLEXPRESS:1433`, true},
+		{`10.0.0.5\SQLEXPRESS`, true},
 		// Public hosts must not be refused.
+		{`db.example.com\SQLEXPRESS`, false},
 		{"db.example.com:5432", false},
 		{"8.8.8.8", false},
 		{"tcp(8.8.8.8:3306)", false},
@@ -48,6 +57,10 @@ func TestJdbcPingRefusesLocalHosts(t *testing.T) {
 		"postgres":  &PostgresJDBC{ConnectionInfo: ConnectionInfo{Host: "127.0.0.1:5432", User: "u", Password: "p"}},
 		"mysql":     &MysqlJDBC{ConnectionInfo: ConnectionInfo{Host: "tcp(localhost:3306)", User: "u", Password: "p"}},
 		"sqlserver": &SqlServerJDBC{ConnectionInfo: ConnectionInfo{Host: "[::1]:1433", User: "u", Password: "p"}},
+		// parseSqlServer keeps the named instance on the host, and it used to hide
+		// the address from the check entirely
+		"sqlserver-named-instance":    &SqlServerJDBC{ConnectionInfo: ConnectionInfo{Host: `localhost\SQLEXPRESS`, User: "u", Password: "p"}},
+		"sqlserver-named-instance-ip": &SqlServerJDBC{ConnectionInfo: ConnectionInfo{Host: `127.0.0.1\SQLEXPRESS:1433`, User: "u", Password: "p"}},
 	}
 
 	for name, p := range pingers {
@@ -55,8 +68,8 @@ func TestJdbcPingRefusesLocalHosts(t *testing.T) {
 		if !res.determinate {
 			t.Errorf("%s: expected determinate result for local host, got indeterminate", name)
 		}
-		if !errors.Is(res.err, errNoLocalIP) {
-			t.Errorf("%s: expected errNoLocalIP, got %v", name, res.err)
+		if !errors.Is(res.err, detectors.ErrNoLocalIP) {
+			t.Errorf("%s: expected detectors.ErrNoLocalIP, got %v", name, res.err)
 		}
 	}
 }

--- a/pkg/detectors/jdbc/jdbc_test.go
+++ b/pkg/detectors/jdbc/jdbc_test.go
@@ -84,7 +84,7 @@ func TestJdbc_Pattern(t *testing.T) {
 			},
 		},
 		{
-			name: "trailing non-alphanumeric characters in password",
+			name:  "trailing non-alphanumeric characters in password",
 			input: `jdbc:hive9://foo.example.com:10191/default;user=MyRoleUser;password=MyPa$$w0rd...`,
 			want: []string{
 				"jdbc:hive9://foo.example.com:10191/default;user=MyRoleUser;password=MyPa$$w0rd...",

--- a/pkg/detectors/jdbc/mysql.go
+++ b/pkg/detectors/jdbc/mysql.go
@@ -19,6 +19,9 @@ type MysqlJDBC struct {
 var _ JDBC = (*MysqlJDBC)(nil)
 
 func (s *MysqlJDBC) ping(ctx context.Context) pingResult {
+	if hostIsLocal(s.Host) {
+		return pingResult{errNoLocalIP, true}
+	}
 	return ping(ctx, "mysql", isMySQLErrorDeterminate,
 		buildMySQLConnectionString(s.Host, "", s.User, s.Password, s.Params))
 }

--- a/pkg/detectors/jdbc/mysql.go
+++ b/pkg/detectors/jdbc/mysql.go
@@ -10,6 +10,7 @@ import (
 	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 )
 
 type MysqlJDBC struct {
@@ -20,7 +21,7 @@ var _ JDBC = (*MysqlJDBC)(nil)
 
 func (s *MysqlJDBC) ping(ctx context.Context) pingResult {
 	if hostIsLocal(s.Host) {
-		return pingResult{errNoLocalIP, true}
+		return pingResult{detectors.ErrNoLocalIP, true}
 	}
 	return ping(ctx, "mysql", isMySQLErrorDeterminate,
 		buildMySQLConnectionString(s.Host, "", s.User, s.Password, s.Params))

--- a/pkg/detectors/jdbc/postgres.go
+++ b/pkg/detectors/jdbc/postgres.go
@@ -19,6 +19,9 @@ type PostgresJDBC struct {
 var _ JDBC = (*PostgresJDBC)(nil)
 
 func (s *PostgresJDBC) ping(ctx context.Context) pingResult {
+	if hostIsLocal(s.Host) {
+		return pingResult{errNoLocalIP, true}
+	}
 	// It is crucial that we try to build a connection string ourselves before using the one we found. This is because
 	// if the found connection string doesn't include a username, the driver will attempt to connect using the current
 	// user's name, which will fail in a way that looks like a determinate failure, thus terminating the waterfall. In

--- a/pkg/detectors/jdbc/postgres.go
+++ b/pkg/detectors/jdbc/postgres.go
@@ -10,6 +10,7 @@ import (
 	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 
 	"github.com/lib/pq"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 )
 
 type PostgresJDBC struct {
@@ -20,7 +21,7 @@ var _ JDBC = (*PostgresJDBC)(nil)
 
 func (s *PostgresJDBC) ping(ctx context.Context) pingResult {
 	if hostIsLocal(s.Host) {
-		return pingResult{errNoLocalIP, true}
+		return pingResult{detectors.ErrNoLocalIP, true}
 	}
 	// It is crucial that we try to build a connection string ourselves before using the one we found. This is because
 	// if the found connection string doesn't include a username, the driver will attempt to connect using the current

--- a/pkg/detectors/jdbc/sqlserver.go
+++ b/pkg/detectors/jdbc/sqlserver.go
@@ -18,6 +18,9 @@ type SqlServerJDBC struct {
 var _ JDBC = (*SqlServerJDBC)(nil)
 
 func (s *SqlServerJDBC) ping(ctx context.Context) pingResult {
+	if hostIsLocal(s.Host) {
+		return pingResult{errNoLocalIP, true}
+	}
 	return ping(ctx, "mssql", isSqlServerErrorDeterminate,
 		buildSQLServerConnectionString(s.Host, s.User, s.Password, "master", map[string]string{"connection+timeout": "5"}))
 }

--- a/pkg/detectors/jdbc/sqlserver.go
+++ b/pkg/detectors/jdbc/sqlserver.go
@@ -9,6 +9,7 @@ import (
 	logContext "github.com/trufflesecurity/trufflehog/v3/pkg/context"
 
 	mssql "github.com/microsoft/go-mssqldb"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 )
 
 type SqlServerJDBC struct {
@@ -19,7 +20,7 @@ var _ JDBC = (*SqlServerJDBC)(nil)
 
 func (s *SqlServerJDBC) ping(ctx context.Context) pingResult {
 	if hostIsLocal(s.Host) {
-		return pingResult{errNoLocalIP, true}
+		return pingResult{detectors.ErrNoLocalIP, true}
 	}
 	return ping(ctx, "mssql", isSqlServerErrorDeterminate,
 		buildSQLServerConnectionString(s.Host, s.User, s.Password, "master", map[string]string{"connection+timeout": "5"}))


### PR DESCRIPTION
Fixes #3679. The JDBC detector opens real database connections to local hosts during verification, so scanning something like `jdbc:postgresql://127.0.0.1:5432/db` or `jdbc:mysql://user:pass@localhost:3306/db` makes TruffleHog dial loopback/private addresses. The URI detector already refuses this through DetectorHttpClientWithNoLocalAddresses; this brings JDBC to the same behavior. It's the noisy verification error from the issue and also a small SSRF-adjacent surface, since scanned content drives the outbound connection.

The change adds a local-host guard in the jdbc package that mirrors the isLocalIP check in pkg/detectors/http.go (loopback, link-local, private, unspecified), and bails out before any dial for the postgres, mysql, and sqlserver sub-protocols. It strips the MySQL `tcp(...)` wrapper and optional port and resolves names with net.LookupIP so `localhost` is caught too. Detection is unchanged; the finding just comes back unverified instead of dialing.

Tests cover host classification and a per-protocol refusal for each of the three sub-protocols. `go test ./pkg/detectors/jdbc/` and `go vet` pass.

Two notes for review:
- I kept this to JDBC to keep it small. The issue mentions other database detectors, and I'm happy to extend the same guard in a follow-up.
- I duplicated a small isLocalIP helper in the jdbc package rather than reach for the unexported one in pkg/detectors. If you'd rather I export and reuse it, just say so.

I've signed the CLA. Thanks for taking a look.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes outbound connection behavior during secret verification (SSRF-adjacent hardening); scoped to JDBC ping paths with tests, but DNS resolution for hostnames is new behavior on the verification path.
> 
> **Overview**
> Stops JDBC **verification** from opening real DB connections to loopback, private, link-local, or unspecified hosts—aligning with the URI detector’s local-address refusal (fixes #3679).
> 
> Adds `isLocalIP` / `hostIsLocal` in the JDBC package (with MySQL `tcp(...)`, port, and SQL Server `host\INSTANCE` normalization plus DNS lookup for names like `localhost`). **Postgres, MySQL, and SQL Server** `ping` paths now return a determinate `detectors.ErrNoLocalIP` before `sql.Open`/`Ping`; detection and redaction are unchanged, so local URLs still surface as **unverified** findings.
> 
> New tests cover host classification and per-protocol refusal for named-instance SQL Server cases that previously bypassed the check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aab4bacf12583def1a2dd55e1faf7a9c2607736. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->