### PR TITLE
feat(detectors): add AnypointClientSecret detector

### DIFF
--- a/pkg/detectors/anypointclientsecret/anypointclientsecret.go
+++ b/pkg/detectors/anypointclientsecret/anypointclientsecret.go
@@ -1,0 +1,135 @@
+package anypointclientsecret
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+type Scanner struct {
+	client *http.Client
+	detectors.DefaultMultiPartCredentialProvider
+}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	defaultClient = common.SaneHttpClient()
+
+	// Anypoint Client ID/Secret patterns - 32 character hex strings
+	// Client IDs and Secrets are 32-character hexadecimal strings
+	clientIdPat     = regexp.MustCompile(detectors.PrefixRegex([]string{"anypoint", "client", "id"}) + `\b([0-9a-f]{32})\b`)
+	clientSecretPat = regexp.MustCompile(detectors.PrefixRegex([]string{"anypoint", "client", "secret"}) + `\b([0-9a-fA-F]{32})\b`)
+
+	verificationUrl = "https://anypoint.mulesoft.com/accounts/oauth2/token"
+)
+
+// Keywords are used for efficiently pre-filtering chunks.
+// Use identifiers in the secret preferably, or the provider name.
+func (s Scanner) Keywords() []string {
+	return []string{"anypoint"}
+}
+
+func (s Scanner) getClient() *http.Client {
+	if s.client != nil {
+		return s.client
+	}
+	return defaultClient
+}
+
+// FromData will find and optionally verify Anypoint Client ID/Secret pairs in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	var uniqueClientIDs, uniqueClientSecrets = make(map[string]struct{}), make(map[string]struct{})
+
+	for _, matches := range clientIdPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueClientIDs[matches[1]] = struct{}{}
+	}
+
+	for _, matches := range clientSecretPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueClientSecrets[matches[1]] = struct{}{}
+	}
+
+	for clientId := range uniqueClientIDs {
+		for clientSecret := range uniqueClientSecrets {
+			if clientId == clientSecret {
+				// Avoid processing the same string for both client ID and secret.
+				continue
+			}
+
+			s1 := detectors.Result{
+				DetectorType: detector_typepb.DetectorType_AnypointClientSecret,
+				Raw:          []byte(clientSecret),
+				RawV2:        []byte(fmt.Sprintf("%s:%s", clientId, clientSecret)),
+				SecretParts: map[string]string{
+					"client_id":     clientId,
+					"client_secret": clientSecret,
+				},
+			}
+
+			if verify {
+				client := s.getClient()
+				isVerified, verificationErr := verifyMatch(ctx, client, clientId, clientSecret)
+				s1.Verified = isVerified
+				s1.SetVerificationError(verificationErr)
+			}
+
+			results = append(results, s1)
+
+			if s1.Verified {
+				// Anypoint client IDs and secrets are mapped one-to-one, so if a pair
+				// is verified, we can remove that secret from the uniqueClientSecrets map.
+				delete(uniqueClientSecrets, clientSecret)
+				break
+			}
+		}
+	}
+
+	return
+}
+
+func verifyMatch(ctx context.Context, client *http.Client, clientId, clientSecret string) (bool, error) {
+	payload := strings.NewReader(`{"grant_type":"client_credentials","client_id":"` + clientId + `","client_secret":"` + clientSecret + `"}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, verificationUrl, payload)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	// The endpoint responds with status 200 for valid Organization credentials and 422 for Client credentials.
+	case http.StatusOK, http.StatusUnprocessableEntity:
+		return true, nil
+	case http.StatusUnauthorized:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected status code: %d", res.StatusCode)
+	}
+}
+
+func (s Scanner) Type() detector_typepb.DetectorType {
+	return detector_typepb.DetectorType_AnypointClientSecret
+}
+
+func (s Scanner) Description() string {
+	return "Anypoint is a unified platform for building and managing APIs and integrations. Anypoint Client ID and Secret credentials can be used to authenticate applications and access API resources."
+}

--- a/pkg/detectors/anypointclientsecret/anypointclientsecret_test.go
+++ b/pkg/detectors/anypointclientsecret/anypointclientsecret_test.go
@@ -1,0 +1,98 @@
+package anypointclientsecret
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+)
+
+func TestAnypointClientSecret_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name: "valid pattern with prefix",
+			input: `
+anypoint_client_id: a1b2c3d4e5f67890abcdef1234567890
+anypoint_client_secret: A1B2C3D4E5F67890ABCDEF1234567890
+`,
+			want: []string{"a1b2c3d4e5f67890abcdef1234567890:A1B2C3D4E5F67890ABCDEF1234567890"},
+		},
+		{
+			name: "valid pattern - config file format",
+			input: `
+ANYPOINT_CLIENT_ID=a1b2c3d4e5f67890abcdef1234567890
+ANYPOINT_CLIENT_SECRET=A1B2C3D4E5F67890ABCDEF1234567890
+`,
+			want: []string{"a1b2c3d4e5f67890abcdef1234567890:A1B2C3D4E5F67890ABCDEF1234567890"},
+		},
+		{
+			name: "invalid pattern - too short",
+			input: `
+anypoint_client_id: a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5
+anypoint_client_secret: A1B2C3D4E5F6G7H8I9J0K1L2M3N4O5
+`,
+			want: []string{},
+		},
+		{
+			name: "invalid pattern - non-hex characters",
+			input: `
+anypoint_client_id: g1h2i3j4k5l6m7n8o9p0q1r2s3t4u5v6
+anypoint_client_secret: G1H2I3J4K5L6M7N8O9P0Q1R2S3T4U5V6
+`,
+			want: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(matchedDetectors) == 0 {
+				if len(test.want) > 0 {
+					t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
+				}
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			if err != nil {
+				t.Errorf("error = %v", err)
+				return
+			}
+
+			if len(results) != len(test.want) {
+				if len(results) == 0 {
+					t.Errorf("did not receive any results")
+				} else {
+					t.Errorf("expected %d results, got %d", len(test.want), len(results))
+				}
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.RawV2) > 0 {
+					actual[string(r.RawV2)] = struct{}{}
+				} else {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -32,6 +32,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/amplitudeapikey"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/anthropic"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/anypoint"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/anypointclientsecret"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/anypointoauth2"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/apacta"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/api2cart"
@@ -914,6 +915,7 @@ func buildDetectorList() []detectors.Detector {
 		&amplitudeapikey.Scanner{},
 		&anthropic.Scanner{},
 		&anypoint.Scanner{},
+		&anypointclientsecret.Scanner{},
 		&anypointoauth2.Scanner{},
 		&apacta.Scanner{},
 		&api2cart.Scanner{},

--- a/pkg/pb/detector_typepb/detector_type.pb.go
+++ b/pkg/pb/detector_typepb/detector_type.pb.go
@@ -1109,6 +1109,7 @@ const (
 	DetectorType_BrainTrustApiKey                        DetectorType = 1053
 	DetectorType_PgAnalyzeReadKey                        DetectorType = 1054
 	DetectorType_RedHatPyxis                             DetectorType = 1055
+	DetectorType_AnypointClientSecret                    DetectorType = 1056
 )
 
 // Enum value maps for DetectorType.
@@ -2166,6 +2167,7 @@ var (
 		1053: "BrainTrustApiKey",
 		1054: "PgAnalyzeReadKey",
 		1055: "RedHatPyxis",
+		1056: "AnypointClientSecret",
 	}
 	DetectorType_value = map[string]int32{
 		"Alibaba":                               0,
@@ -3220,6 +3222,7 @@ var (
 		"BrainTrustApiKey":                  1053,
 		"PgAnalyzeReadKey":                  1054,
 		"RedHatPyxis":                       1055,
+		"AnypointClientSecret":              1056,
 	}
 )
 

--- a/proto/detector_type.proto
+++ b/proto/detector_type.proto
@@ -1057,4 +1057,5 @@ enum DetectorType {
   BrainTrustApiKey = 1053;
   PgAnalyzeReadKey = 1054;
   RedHatPyxis = 1055;
+  AnypointClientSecret = 1056;
 }


### PR DESCRIPTION
Add detector for MuleSoft Anypoint Client ID/Secret pairs (ANIPNT001).

Detects 32-character hexadecimal client_id and client_secret combinations used to authenticate with the Anypoint Platform API.

## Details
- Pattern: 32-character hex strings with anypoint/client/id or anypoint/client/secret prefixes
- Verification: POST to OAuth2 token endpoint
- Status codes: 200/422 for valid, 401 for invalid credentials

## Testing
- Pattern detection tests included
- Verification tested against Anypoint Platform

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Verification sends discovered credentials to Anypoint’s live OAuth endpoint and treats 422 as “verified,” which could mark some non-token scenarios as valid; otherwise this is a standard additive detector with limited blast radius.
> 
> **Overview**
> Adds a new **AnypointClientSecret** detector for MuleSoft Anypoint **client ID / client secret** pairs (32-character hex values with `anypoint`/`client`/`id` or `secret` context), separate from the existing Anypoint UUID key + org detector.
> 
> Detection pairs all found IDs and secrets (skipping identical strings), optionally **verifies** via `POST` to `https://anypoint.mulesoft.com/accounts/oauth2/token` with `client_credentials`, treating **200** and **422** as valid and **401** as invalid. On a verified match it stops reusing that secret for other ID pairings.
> 
> Wires the scanner into **default detectors** and registers **`DetectorType_AnypointClientSecret = 1056`** in proto and generated Go. Includes pattern unit tests (no live verification tests in the diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf329b172cedc876428c264aa30e48b061df5b58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->