### PR TITLE
fix(detectors): disable verification for decommissioned blocknative API

### DIFF
--- a/pkg/detectors/blocknative/blocknative.go
+++ b/pkg/detectors/blocknative/blocknative.go
@@ -67,14 +67,16 @@ func (s Scanner) Description() string {
 	return "Blocknative is a platform that provides real-time blockchain transaction monitoring and notification services. Blocknative API keys can be used to access and interact with these services."
 }
 
-// docs: https://docs.blocknative.com/gas-prediction/gas-platform#api-endpoint
+// docs: https://logicnodes.io/blocknative
 func verifyBlocknative(ctx context.Context, client *http.Client, key string) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", "https://api.blocknative.com/gasprices/blockprices", nil)
+	payload := strings.NewReader(`{"chain": "base", "speed": "fast"}`)
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://logicnodes.io/call/eip1559_gas_estimator", payload)
 	if err != nil {
 		return false, err
 	}
 
-	req.Header.Add("Authorization", key)
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("X-API-Key", key)
 
 	resp, err := client.Do(req)
 	if err != nil {
@@ -86,11 +88,10 @@ func verifyBlocknative(ctx context.Context, client *http.Client, key string) (bo
 		_ = resp.Body.Close()
 	}()
 
-	// Right now the blocknative API logic is broken and return 200 for invalid key as well
 	switch resp.StatusCode {
 	case http.StatusOK:
 		return true, nil
-	case http.StatusUnauthorized, http.StatusTooManyRequests:
+	case http.StatusPaymentRequired, http.StatusUnauthorized, http.StatusForbidden, http.StatusTooManyRequests:
 		return false, nil
 	default:
 		return false, fmt.Errorf("unexpected status code: %d", resp.StatusCode)

--- a/pkg/detectors/blocknative/blocknative.go
+++ b/pkg/detectors/blocknative/blocknative.go
@@ -2,8 +2,6 @@ package blocknative
 
 import (
 	"context"
-	"fmt"
-	"io"
 	"net/http"
 	"strings"
 
@@ -67,33 +65,9 @@ func (s Scanner) Description() string {
 	return "Blocknative is a platform that provides real-time blockchain transaction monitoring and notification services. Blocknative API keys can be used to access and interact with these services."
 }
 
-// docs: https://logicnodes.io/blocknative
+// docs: API decommissioned on June 19, 2026.
 func verifyBlocknative(ctx context.Context, client *http.Client, key string) (bool, error) {
-	payload := strings.NewReader(`{"chain": "base", "speed": "fast"}`)
-	req, err := http.NewRequestWithContext(ctx, "POST", "https://logicnodes.io/call/eip1559_gas_estimator", payload)
-	if err != nil {
-		return false, err
-	}
-
-	req.Header.Add("Content-Type", "application/json")
-	req.Header.Add("X-API-Key", key)
-
-	resp, err := client.Do(req)
-	if err != nil {
-		return false, err
-	}
-
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}()
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		return true, nil
-	case http.StatusPaymentRequired, http.StatusUnauthorized, http.StatusForbidden, http.StatusTooManyRequests:
-		return false, nil
-	default:
-		return false, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-	}
+	// The Blocknative gas estimation API was shut down on June 19, 2026.
+	// We no longer attempt to verify these credentials as the issuer endpoint is dead.
+	return false, nil
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The Blocknative gas estimation API was shut down on June 19, 2026. This PR disables the Blocknative credential verification logic in `pkg/detectors/blocknative/blocknative.go` since verification against the original issuer is no longer possible. 

The original issue suggested migrating to a third-party LogicNodes endpoint as a drop-in replacement, but we explicitly rejected that approach because sending detected secrets to an unaffiliated third party introduces a severe security risk and changes the trust model of the scanner. Therefore, the detector now safely returns unverified (`false, nil`) for all detected Blocknative keys without making any network requests.

Closes #4982.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?