### PR TITLE
Fix PubNub subscription key verification: handle App Context disabled response

### DIFF
--- a/pkg/detectors/pubnubsubscriptionkey/pubnubsubscriptionkey.go
+++ b/pkg/detectors/pubnubsubscriptionkey/pubnubsubscriptionkey.go
@@ -24,6 +24,8 @@ var (
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(`\b(sub-c-[0-9a-z]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\b`)
+
+	verifyBaseURL = "https://ps.pndsn.com"
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -48,9 +50,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			isVerified, verificationErr := verifyKey(ctx, client, resMatch)
+			isVerified, verificationErr := verifyKey(ctx, client, verifyBaseURL, resMatch)
 			s1.Verified = isVerified
-			s1.SetVerificationError(verificationErr)
+			s1.SetVerificationError(verificationErr, resMatch)
 		}
 
 		results = append(results, s1)
@@ -67,8 +69,8 @@ func (s Scanner) Description() string {
 	return "PubNub is a real-time communication platform. A PubNub Subscription Key allows access to the PubNub API for subscribing to channels and receiving messages."
 }
 
-func verifyKey(ctx context.Context, client *http.Client, key string) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://ps.pndsn.com/v2/objects/"+key+"/uuids", nil)
+func verifyKey(ctx context.Context, client *http.Client, baseURL, key string) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/v2/objects/"+key+"/uuids", nil)
 	if err != nil {
 		return false, err
 	}
@@ -92,7 +94,8 @@ func verifyKey(ctx context.Context, client *http.Client, key string) (bool, erro
 			return false, err
 		}
 
-		if strings.Contains(string(bodyBytes), "Objects not enabled for this subscriber key.") {
+		if strings.Contains(string(bodyBytes), "Objects not enabled for this subscriber key.") ||
+			strings.Contains(string(bodyBytes), "App Context is not enabled for this subscribe key.") {
 			return true, nil
 		}
 

--- a/pkg/detectors/pubnubsubscriptionkey/pubnubsubscriptionkey_test.go
+++ b/pkg/detectors/pubnubsubscriptionkey/pubnubsubscriptionkey_test.go
@@ -3,6 +3,8 @@ package pubnubsubscriptionkey
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -16,6 +18,75 @@ var (
 	invalidPattern = "sub-c-sy4te40h-w1oc-z?yq-zlrw-w6ehv0y0y78c"
 	keyword        = "pubnubsubscriptionkey"
 )
+
+// TestPubNubSubscriptionKey_VerifyKey tests the 403 body-parsing logic that
+// determines whether a key is valid even when the Objects/App Context feature
+// is disabled on the PubNub account.
+func TestPubNubSubscriptionKey_VerifyKey(t *testing.T) {
+	tests := []struct {
+		name           string
+		statusCode     int
+		responseBody   string
+		wantVerified   bool
+		wantErrPresent bool
+	}{
+		{
+			name:         "200 OK - key is valid",
+			statusCode:   http.StatusOK,
+			responseBody: `{"status":200,"data":[]}`,
+			wantVerified: true,
+		},
+		{
+			name:         "403 with 'Objects not enabled' - key is valid, feature disabled",
+			statusCode:   http.StatusForbidden,
+			responseBody: `{"status":403,"error":true,"message":"Objects not enabled for this subscriber key."}`,
+			wantVerified: true,
+		},
+		{
+			name:         "403 with 'App Context is not enabled' - key is valid, feature disabled",
+			statusCode:   http.StatusForbidden,
+			responseBody: `{"status":403,"error":true,"message":"App Context is not enabled for this subscribe key."}`,
+			wantVerified: true,
+		},
+		{
+			name:         "403 with other body - key is invalid",
+			statusCode:   http.StatusForbidden,
+			responseBody: `{"status":403,"error":true,"message":"Invalid subscribe key"}`,
+			wantVerified: false,
+		},
+		{
+			name:         "401 Unauthorized - key is invalid",
+			statusCode:   http.StatusUnauthorized,
+			responseBody: `{"status":401,"error":true}`,
+			wantVerified: false,
+		},
+		{
+			name:           "unexpected status code - returns error",
+			statusCode:     http.StatusInternalServerError,
+			responseBody:   `internal error`,
+			wantVerified:   false,
+			wantErrPresent: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(test.statusCode)
+				_, _ = w.Write([]byte(test.responseBody))
+			}))
+			defer srv.Close()
+
+			verified, err := verifyKey(context.Background(), srv.Client(), srv.URL, "test-key")
+			if (err != nil) != test.wantErrPresent {
+				t.Errorf("wantErr=%v, got err=%v", test.wantErrPresent, err)
+			}
+			if verified != test.wantVerified {
+				t.Errorf("wantVerified=%v, got=%v", test.wantVerified, verified)
+			}
+		})
+	}
+}
 
 func TestPubNubSubscriptionKey_Pattern(t *testing.T) {
 	d := Scanner{}


### PR DESCRIPTION
Fixes #5099

### Description:

The subscription key detector verifies keys by calling:

```
GET https://ps.pndsn.com/v2/objects/<sub-key>/uuids
```

A valid key whose account has the App Context feature disabled returns `403 Forbidden`. The detector already handled one such response body:

```
"Objects not enabled for this subscriber key."
```

However, some PubNub accounts return a different message for the same condition:

```
"App Context is not enabled for this subscribe key."
```

Both messages mean the key is valid - the feature is simply not enabled. Without this fix, keys returning the second message were incorrectly reported as unverified.

**Additional changes:**

- Extracted the endpoint as a `verifyBaseURL` package variable and threaded it through `verifyKey` to make the 403 body-parsing logic unit testable via `httptest.Server`. Without this, the only coverage for the new string match would be the integration test, which requires live credentials.
- Added the raw secret to `SetVerificationError` for consistent error redaction (aligns with `PubNubPublishKey`).

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint`)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to PubNub subscription key verification logic and tests; no auth or data-path changes beyond fewer false unverified results.
> 
> **Overview**
> **PubNub subscription key verification** now treats a second `403 Forbidden` response as proof the key is valid when App Context is off: bodies containing `"App Context is not enabled for this subscribe key."` are handled like the existing `"Objects not enabled for this subscriber key."` case, so those keys are no longer marked unverified.
> 
> To support testing without live API calls, verification uses a package-level `verifyBaseURL` and `verifyKey` accepts a `baseURL` argument (production still uses `https://ps.pndsn.com`). Verification errors now pass the raw key into `SetVerificationError` for consistent redaction, matching other PubNub detectors.
> 
> New `TestPubNubSubscriptionKey_VerifyKey` covers 200, both 403 “feature disabled” messages, invalid 403/401, and unexpected status codes via `httptest.Server`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b4e6a49323dbc64d1517a5765495beea213e4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->