### PR TITLE
fix(sentryorgtoken): match variable-length org auth tokens

### DIFF
--- a/pkg/detectors/sentryorgtoken/sentryorgtoken.go
+++ b/pkg/detectors/sentryorgtoken/sentryorgtoken.go
@@ -22,7 +22,11 @@ var _ detectors.Detector = (*Scanner)(nil)
 
 var (
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	orgAuthTokenPat = regexp.MustCompile(`\b(sntrys_eyJ[a-zA-Z0-9=_+/]{197})\b`)
+	// The base64 payload encodes the org slug plus url/region_url, which vary
+	// per organization/region, so the token length is not fixed. Match a range
+	// rather than the single hardcoded length that only matched tokens which
+	// happened to total 197 characters.
+	orgAuthTokenPat = regexp.MustCompile(`\b(sntrys_eyJ[a-zA-Z0-9=_+/]{130,300})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/sentryorgtoken/sentryorgtoken_test.go
+++ b/pkg/detectors/sentryorgtoken/sentryorgtoken_test.go
@@ -3,6 +3,7 @@ package sentryorgtoken
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -18,6 +19,14 @@ var (
 	`
 	invalidPattern = "sntrys_eyJFAKE-OjE3NDIzNjM1NTIuNTAzMzA5LCJ1cmwiOiJodHRwczovL3NlbnRyeS5pbyIsInJlZ2lvbl91cmwiOiJodHRwczovL3VzLnNlbnRyeS5pbfakem9yZyI6InRydWZmbGUtc2VjdXJpdHktamQifQ==_+zqSnKjs87cicc3FAK08vmZs5cWx9C5EARKHFtW5lqI"
 	token          = "sntrys_eyJFAKEiOjE3NDIzNjM1NTIuNTAzMzA5LCJ1cmwiOiJodHRwczovL3NlbnRyeS5pbyIsInJlZ2lvbl91cmwiOiJodHRwczovL3VzLnNlbnRyeS5pbfakem9yZyI6InRydWZmbGUtc2VjdXJpdHktamQifQ==_+zqSnKjs87cicc3FAK08vmZs5cWx9C5EARKHFtW5lqI"
+	// Org auth tokens are variable length (the org slug and region URLs differ
+	// per organization/region). Build a shorter- and longer-than-fixture token at
+	// runtime from the `sntrys_eyJ` prefix plus filler, so these fixtures do not
+	// trip push-protection secret scanners; the detector only requires
+	// `sntrys_eyJ` followed by base64 characters. Post-`eyJ` lengths 177 and 225
+	// bracket the fixture's 197 -- both were dropped by the old fixed pattern.
+	shortOrgToken = "sntrys_eyJ" + strings.Repeat("A", 177)
+	longOrgToken  = "sntrys_eyJ" + strings.Repeat("A", 225)
 )
 
 func TestSentryToken_Pattern(t *testing.T) {
@@ -37,6 +46,16 @@ func TestSentryToken_Pattern(t *testing.T) {
 			name:  "valid pattern - ignore duplicate",
 			input: fmt.Sprintf("token = '%s' | '%s'", validPattern, validPattern),
 			want:  []string{token},
+		},
+		{
+			name:  "valid pattern - short org slug",
+			input: fmt.Sprintf("sentry_token := %s", shortOrgToken),
+			want:  []string{shortOrgToken},
+		},
+		{
+			name:  "valid pattern - long org slug",
+			input: fmt.Sprintf("sentry_token := %s", longOrgToken),
+			want:  []string{longOrgToken},
 		},
 		{
 			name:  "invalid pattern",


### PR DESCRIPTION
## Summary

The `sentryorgtoken` detector hardcodes exactly 197 characters after `sntrys_eyJ`, so it silently misses most real Sentry organization auth tokens — a false negative on valid secrets.

## Root cause

A Sentry org auth token is `sntrys_` + base64(JSON payload) + `_` + secret, where the JSON encodes `iat`, `url`, `region_url`, and `org`. The org slug and the url/region_url vary per organization and region, so the base64 payload — and therefore the total token length — is not fixed. The pattern `\b(sntrys_eyJ[a-zA-Z0-9=_+/]{197})\b` only matches tokens that happen to total 197 characters. The single existing fixture (org slug `truffle-security-jd`) coincidentally hits 197, so the gap was never caught, and the detector has no fallback pattern — so any other length is dropped.

Using the real token structure: an org slug of `acme` yields 177 characters after `sntrys_eyJ`, and a longer slug yields 225 — both valid tokens the old pattern misses.

## Fix

Widen the quantifier to `{130,300}` to bracket real payload/secret length variance. The highly specific `sntrys_eyJ` prefix keeps false positives negligible.

## Tests

Added short- and long-length regression cases to `TestSentryToken_Pattern` (built at runtime so the fixtures don't trip push-protection secret scanning). Both fail against the old `{197}` pattern and pass with the fix. `go test ./pkg/detectors/sentryorgtoken/` passes; `gofmt` and `go vet` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped regex and test changes in one detector; no auth or verification logic changes, with low false-positive risk due to the specific `sntrys_eyJ` prefix.
> 
> **Overview**
> Fixes a **false-negative** in the Sentry org auth token detector: the regex required exactly **197** characters after `sntrys_eyJ`, so most real tokens (length varies with org slug and region URLs) were never reported.
> 
> The pattern now allows **`{130,300}`** characters after the prefix, with a short comment explaining why length is not fixed. **`TestSentryToken_Pattern`** adds runtime-built short (177) and long (225) fixtures that the old rule missed, without embedding secrets that would trigger push protection.
> 
> Verification (`verifySentryOrgToken`) is unchanged; only extraction breadth improves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 899baed10d68aa71f1655f8f8a3af1977ab07652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->