### PR TITLE
Integrations fully codeowns detectors

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,3 +11,7 @@ pkg/writers/ @trufflesecurity/scanning
 
 # Contracts -- co-owned, changes affect both teams
 proto/ @trufflesecurity/integrations @trufflesecurity/scanning
+
+# Detectors are fully owned by integrations
+proto/detector_type.proto @trufflesecurity/integrations
+pkg/engine/defaults/ @trufflesecurity/integrations


### PR DESCRIPTION
This includes the injection points of detectors into the rest of the systems. Specifically the detector_type.proto, which is a list of all detectors, and the defaults.go and defaults_test.go (the only contents of pkg/engine/defaults), which are also a list of all detectors.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Right now adding a new detector requires approvals from two teams, and it should really only be one. The integrations teams own detectors, so the attachment points should also be owned by us.

### Checklist:
Unrelated to this change, so removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Governance-only change to GitHub review routing; no runtime or application code is modified.
> 
> **Overview**
> **CODEOWNERS** now routes detector “registry” touchpoints to **@trufflesecurity/integrations** alone, so new detectors don’t need **scanning** review on those paths.
> 
> Specifically, **`proto/detector_type.proto`** and **`pkg/engine/defaults/`** are owned only by integrations. That overrides the broader **`proto/`** co-ownership and the **`pkg/engine/`** scanning rule for those entries—the paths called out in the PR as where detectors are wired into the system (`DetectorType` enum and `DefaultDetectors` registration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33e85abf342cdefc164da66d9764fc8448a02986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->