### PR TITLE
fix: resolve committed merge-conflict markers breaking the build in feature.go

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -28,11 +28,8 @@ var (
 	BraintrustDetectorEnabled       atomic.Bool
 	PgAnalyzeReadKeyDetectorEnabled atomic.Bool
 	RedHatPyxisDetectorEnabled      atomic.Bool
-<<<<<<< oct-deploy-detector
 	OctopusDeployDetectorEnabled    atomic.Bool
-=======
-  DropUnverifiedJWTResults        atomic.Bool
->>>>>>> main
+	DropUnverifiedJWTResults        atomic.Bool
 )
 
 type AtomicString struct {


### PR DESCRIPTION
## Summary

The current `main` HEAD (the Octopus Deploy detector merge, #4787) left **unresolved git conflict markers committed** in `pkg/feature/feature.go`:

```go
<<<<<<< oct-deploy-detector
	OctopusDeployDetectorEnabled    atomic.Bool
=======
	DropUnverifiedJWTResults        atomic.Bool
>>>>>>> main
```

This makes the whole module fail to compile — `go build ./...` errors on `main` for every contributor.

## Fix

Remove the markers and keep **both** fields, since each was added by a different side of the merge and both are referenced elsewhere in the tree:

- `OctopusDeployDetectorEnabled` — used in `main.go` and `pkg/engine/defaults/defaults.go`
- `DropUnverifiedJWTResults` — used in `main.go` and `pkg/detectors/jwt/jwt.go`

## Verification

- No conflict markers remain anywhere (`git grep` for `<<<<<<<`/`=======`/`>>>>>>>` in `*.go` is clean).
- `gofmt` clean.
- `go build ./...` now succeeds for the entire module (was broken on `main`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Syntax-only merge cleanup with no logic changes beyond restoring two existing feature flags.
> 
> **Overview**
> **Restores compilation** by removing committed git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) from `pkg/feature/feature.go` that were left on `main` after merging the Octopus Deploy detector work.
> 
> The resolved block now declares **both** feature flags that each branch had added: `OctopusDeployDetectorEnabled` and `DropUnverifiedJWTResults`. No new behavior is introduced beyond what those two merges intended—only the invalid syntax is fixed so `go build ./...` succeeds again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9384c89a15246c576d2a9e26913e7ce192045910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->