### PR TITLE
Fix Syntax error in feature.go

### DIFF
--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -28,11 +28,8 @@ var (
 	BraintrustDetectorEnabled       atomic.Bool
 	PgAnalyzeReadKeyDetectorEnabled atomic.Bool
 	RedHatPyxisDetectorEnabled      atomic.Bool
-<<<<<<< oct-deploy-detector
 	OctopusDeployDetectorEnabled    atomic.Bool
-=======
-  DropUnverifiedJWTResults        atomic.Bool
->>>>>>> main
+	DropUnverifiedJWTResults        atomic.Bool
 )
 
 type AtomicString struct {


### PR DESCRIPTION
### Description:
Fixes a syntax error that was introduced while merging octopus deploy detector

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file syntax fix with no behavior change beyond restoring two intended feature flag declarations.
> 
> **Overview**
> Resolves an incomplete merge in `pkg/feature/feature.go` that left Git conflict markers and would not compile.
> 
> The fix keeps **both** feature flags from the conflicting branches: `OctopusDeployDetectorEnabled` and `DropUnverifiedJWTResults`, each as its own `atomic.Bool` in the shared `var` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c283b8da154dc1dcbe2b6d5aa94d0a5ee9fca4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->