### PR TITLE
fix: reject --include-repos/--exclude-repos with --repo in github scan

### DIFF
--- a/main.go
+++ b/main.go
@@ -878,6 +878,13 @@ func runSingleScan(ctx context.Context, cmd string, cfg engine.Config) (metrics,
 		if len(*githubScanOrgs) > 0 && len(*githubScanRepos) > 0 {
 			return scanMetrics, fmt.Errorf("invalid config: you cannot specify both organizations and repositories at the same time")
 		}
+		// --include-repos/--exclude-repos only filter repos enumerated from an org/user scan;
+		// explicit --repo entries bypass that filtering step entirely (see enumerate() in
+		// pkg/sources/github/github.go), so combining them with --repo would silently no-op
+		// the filters instead of erroring.
+		if len(*githubScanRepos) > 0 && (len(*githubIncludeRepos) > 0 || len(*githubExcludeRepos) > 0) {
+			return scanMetrics, fmt.Errorf("invalid config: --include-repos and --exclude-repos only apply to organization or user scans and cannot be used with --repo")
+		}
 
 		if err := validateClonePath(*githubClonePath, *githubNoCleanup); err != nil {
 			return scanMetrics, err

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -309,9 +309,13 @@ type GithubConfig struct {
 	Repos []string
 	// Orgs is the list of organizations to scan.
 	Orgs []string
-	// ExcludeRepos is a list of repositories to exclude from the scan.
+	// ExcludeRepos is a list of repositories to exclude from an org/user scan.
+	// It only filters repos enumerated via Orgs; it has no effect when Repos is set
+	// explicitly, since explicit repos bypass the filtering step entirely.
 	ExcludeRepos []string
-	// IncludeRepos is a list of repositories to include in the scan.
+	// IncludeRepos is a list of repositories to include in an org/user scan.
+	// It only filters repos enumerated via Orgs; it has no effect when Repos is set
+	// explicitly, since explicit repos bypass the filtering step entirely.
 	IncludeRepos []string
 	// Filter is the filter to use to scan the source.
 	Filter *common.Filter


### PR DESCRIPTION
Explicit --repo entries bypass org-scan filtering entirely, so combining with --include-repos/--exclude-repos silently ignored patterns instead of erroring. Add validation + doc comments explaining the bypass.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI/config validation and documentation only; no change to GitHub enumeration or scanning behavior when flags are used correctly.
> 
> **Overview**
> GitHub scans now **fail fast** when `--repo` is used together with `--include-repos` or `--exclude-repos`, instead of accepting a config where those filters are silently ignored.
> 
> Those include/exclude flags only apply to repositories discovered from an org/user scan; explicit `--repo` URLs skip that filtering path. The CLI returns a clear `invalid config` error, and `GithubConfig` comments document that `IncludeRepos` / `ExcludeRepos` have no effect when `Repos` is set explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 550e3f105ab2e2e6eb54f4def0cac407a53763ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->