### PR TITLE
feat(git): expose clone timeout flag and record clone duration on all paths

### DIFF
--- a/docs/man/trufflehog.1
+++ b/docs/man/trufflehog.1
@@ -110,6 +110,9 @@ Force skipping binaries.
 \fB--force-skip-archives\fR
 Force skipping archives.
 .TP
+\fB--git-clone-timeout=GIT-CLONE-TIMEOUT\fR
+Maximum time to spend cloning a repository, as a duration.
+.TP
 \fB--skip-additional-refs\fR
 Skip additional references.
 .TP

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ var (
 	// Add feature flags
 	forceSkipBinaries        = cli.Flag("force-skip-binaries", "Force skipping binaries.").Bool()
 	forceSkipArchives        = cli.Flag("force-skip-archives", "Force skipping archives.").Bool()
-	gitCloneTimeout          = cli.Flag("git-clone-timeout", "Maximum time to spend cloning a repository, as a duration.").Hidden().Duration()
+	gitCloneTimeout          = cli.Flag("git-clone-timeout", "Maximum time to spend cloning a repository, as a duration.").Duration()
 	skipAdditionalRefs       = cli.Flag("skip-additional-refs", "Skip additional references.").Bool()
 	userAgentSuffix          = cli.Flag("user-agent-suffix", "Suffix to add to User-Agent.").String()
 	dropUnverifiedJWTResults = cli.Flag("drop-unverified-jwt-results", "Drop unverified results without any verification errors from the JWT detector.").Bool()

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -587,14 +587,17 @@ func executeClone(ctx context.Context, params cloneParams) (*git.Repository, err
 	logger.V(3).Info("git subcommand finished", "output", output)
 
 	if common.IsDone(ctx) {
-		return nil, fmt.Errorf("git clone timed out (after %s)", time.Since(start))
+		elapsed := time.Since(start)
+		logger.V(1).Info("git clone timed out", "time_seconds", elapsed.Seconds())
+		metricsInstance.RecordCloneOperation(statusFailure, cloneFailureTimeout, elapsed)
+		return nil, fmt.Errorf("git clone timed out (after %s)", elapsed)
 	} else if cloneCmd.ProcessState == nil {
 		return nil, fmt.Errorf("clone command exited with no output")
 	} else if cloneCmd.ProcessState.ExitCode() != 0 {
-		logger.V(1).Info("git clone failed", "error", err)
+		elapsed := time.Since(start)
+		logger.V(1).Info("git clone failed", "error", err, "time_seconds", elapsed.Seconds(), "exit_code", cloneCmd.ProcessState.ExitCode())
 		failureReason := ClassifyCloneError(output)
-		exitCode := cloneCmd.ProcessState.ExitCode()
-		metricsInstance.RecordCloneOperation(statusFailure, failureReason, exitCode)
+		metricsInstance.RecordCloneOperation(statusFailure, failureReason, elapsed)
 		return nil, fmt.Errorf("could not clone repo: %s, %w", safeURL, err)
 	}
 
@@ -602,9 +605,10 @@ func executeClone(ctx context.Context, params cloneParams) (*git.Repository, err
 	if err != nil {
 		return nil, fmt.Errorf("could not open cloned repo: %w", err)
 	}
-	logger.V(1).Info("successfully cloned repo", "time_seconds", time.Since(start).Seconds())
+	elapsed := time.Since(start)
+	logger.V(1).Info("successfully cloned repo", "time_seconds", elapsed.Seconds())
 
-	metricsInstance.RecordCloneOperation(statusSuccess, cloneSuccess, 0)
+	metricsInstance.RecordCloneOperation(statusSuccess, cloneSuccess, elapsed)
 
 	return repo, nil
 }
@@ -631,16 +635,13 @@ func PingRepoUsingToken(ctx context.Context, token, gitUrl, user string) error {
 	fakeRef := "TRUFFLEHOG_CHECK_GIT_REMOTE_URL_REACHABILITY"
 	gitArgs := []string{"ls-remote", lsUrl.String(), "--quiet", fakeRef}
 	cmd := exec.Command("git", gitArgs...)
+	start := time.Now()
 	output, err := cmd.CombinedOutput()
 
 	if err != nil {
-		// Record the ping failure with the appropriate reason and exit code
+		// Record the ping failure with the appropriate reason
 		failureReason := ClassifyCloneError(string(output))
-		exitCode := 0
-		if cmd.ProcessState != nil {
-			exitCode = cmd.ProcessState.ExitCode()
-		}
-		metricsInstance.RecordCloneOperation(statusFailure, failureReason, exitCode)
+		metricsInstance.RecordCloneOperation(statusFailure, failureReason, time.Since(start))
 	}
 
 	return err

--- a/pkg/sources/git/metrics.go
+++ b/pkg/sources/git/metrics.go
@@ -1,8 +1,8 @@
 package git
 
 import (
-	"fmt"
 	"strings"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -13,7 +13,7 @@ import (
 // metricsCollector defines the interface for recording Git scan metrics.
 type metricsCollector interface {
 	// Clone metrics
-	RecordCloneOperation(status string, reason string, exitCode int)
+	RecordCloneOperation(status string, reason string, duration time.Duration)
 
 	// Scan metrics
 	RecordCommitScanned()
@@ -50,10 +50,13 @@ const (
 
 	// Other/unknown errors
 	cloneFailureOther = "other_error"
+
+	// Clone exceeded the configured timeout
+	cloneFailureTimeout = "timeout"
 )
 
 type collector struct {
-	cloneOperations *prometheus.CounterVec
+	cloneOperations *prometheus.HistogramVec
 	commitsScanned  prometheus.Counter
 	reposScanned    *prometheus.CounterVec
 }
@@ -61,14 +64,17 @@ type collector struct {
 var metricsInstance metricsCollector
 
 func init() {
-	// These are package-level metrics that are incremented by all git scans across the lifetime of the process.
+	// These are package-level metrics that are recorded by all git scans across the lifetime of the process.
 	metricsInstance = &collector{
-		cloneOperations: promauto.NewCounterVec(prometheus.CounterOpts{
+		// Labeled by status/reason only (not exit_code) to keep series count bounded -
+		// reason is already a small fixed set (see ClassifyCloneError), exit_code is not.
+		cloneOperations: promauto.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: common.MetricsNamespace,
 			Subsystem: common.MetricsSubsystem,
-			Name:      "git_clone_operations_total",
-			Help:      "Total number of git clone operations by status, reason, and exit code",
-		}, []string{"status", "reason", "exit_code"}),
+			Name:      "git_clone_operations_duration_seconds",
+			Help:      "Duration in seconds of git clone operations by status and reason",
+			Buckets:   []float64{1, 5, 15, 30, 60, 120, 300, 600, 1200, 1800, 3600, 7200},
+		}, []string{"status", "reason"}),
 
 		commitsScanned: promauto.NewCounter(prometheus.CounterOpts{
 			Namespace: common.MetricsNamespace,
@@ -86,8 +92,8 @@ func init() {
 	}
 }
 
-func (c *collector) RecordCloneOperation(status string, reason string, exitCode int) {
-	c.cloneOperations.WithLabelValues(status, reason, fmt.Sprintf("%d", exitCode)).Inc()
+func (c *collector) RecordCloneOperation(status string, reason string, duration time.Duration) {
+	c.cloneOperations.WithLabelValues(status, reason).Observe(duration.Seconds())
 }
 
 func (c *collector) RecordCommitScanned() {


### PR DESCRIPTION
Un-hides --git-clone-timeout and logs/records clone duration (success, failure, and timeout) so slow clones on huge repos are visible instead of silently hanging. Converts git_clone_operations_total counter to a duration histogram.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Prometheus metric name and labels change (breaking for dashboards/alerts on `git_clone_operations_total`); clone behavior and timeout wiring affect all git/GitHub/GitLab clone paths.
> 
> **Overview**
> **`--git-clone-timeout`** is now a public CLI flag (documented in the man page) so operators can cap how long a clone may run on large repos.
> 
> Clone **observability** is expanded: timeout paths log elapsed time and record metrics with reason **`timeout`**; success and failure paths also log duration (and exit code on failure). Prometheus **`git_clone_operations_total`** (counter labeled by status, reason, and exit code) is replaced by **`git_clone_operations_duration_seconds`**, a histogram labeled only by **status** and **reason** to limit cardinality. **`RecordCloneOperation`** now takes **`time.Duration`** instead of exit code; **`PingRepoUsingToken`** failures use the same duration-based recording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6e2bcd1302a3353961f16defb0e18cb539228e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->