### PR TITLE
[INT-715] Retry transient failures when verifying OpenAI keys

### DIFF
--- a/pkg/detectors/openai/openai.go
+++ b/pkg/detectors/openai/openai.go
@@ -25,7 +25,14 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 
 var (
-	defaultClient = common.SaneHttpClient()
+	// The OpenAI API can be slow to respond under load, so use a longer
+	// per-attempt timeout than the default 5s and retry transient failures
+	// (timeouts, connection errors, 429/5xx) so a single slow response does
+	// not record an indeterminate verification result.
+	defaultClient = common.RetryableHTTPClient(
+		common.WithTimeout(10*time.Second),
+		common.WithMaxRetries(2),
+	)
 
 	// The magic string T3BlbkFJ is the base64-encoded string: OpenAI
 	// Matches: legacy keys (sk-{alnum}T3BlbkFJ...), project keys (sk-proj-...),

--- a/pkg/detectors/openai/openai_test.go
+++ b/pkg/detectors/openai/openai_test.go
@@ -2,11 +2,47 @@ package openai
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
-	"testing"
 )
+
+// The default client must retry transient failures so a single slow or
+// failed OpenAI API response does not record an indeterminate verification
+// result (CSM-2131).
+func TestOpenAI_DefaultClientRetriesTransientErrors(t *testing.T) {
+	var requests atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	res, err := defaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("expected retries to reach a 200 response, got %d", res.StatusCode)
+	}
+	if got := requests.Load(); got != 3 {
+		t.Errorf("expected 3 attempts (initial + 2 retries), got %d", got)
+	}
+}
 
 func TestOpenAI_DoesNotMatchAdminKeys(t *testing.T) {
 	d := Scanner{}

--- a/pkg/detectors/openai/openai_test.go
+++ b/pkg/detectors/openai/openai_test.go
@@ -44,6 +44,34 @@ func TestOpenAI_DefaultClientRetriesTransientErrors(t *testing.T) {
 	}
 }
 
+// When the API never recovers, the client must give up after the configured
+// retry budget (initial attempt + 2 retries) and surface the failure rather
+// than retrying indefinitely.
+func TestOpenAI_DefaultClientGivesUpAfterRetryBudget(t *testing.T) {
+	var requests atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	res, err := defaultClient.Do(req)
+	if res != nil {
+		defer func() { _ = res.Body.Close() }()
+	}
+
+	if err == nil && res.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected exhausted retries to surface the failure, got status %d with no error", res.StatusCode)
+	}
+	if got := requests.Load(); got != 3 {
+		t.Errorf("expected 3 attempts (initial + 2 retries), got %d", got)
+	}
+}
+
 func TestOpenAI_DoesNotMatchAdminKeys(t *testing.T) {
 	d := Scanner{}
 	adminKey := `OPENAI_ADMIN_KEY = "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"`

--- a/pkg/detectors/openai/openai_test.go
+++ b/pkg/detectors/openai/openai_test.go
@@ -34,7 +34,7 @@ func TestOpenAI_DefaultClientRetriesTransientErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	defer res.Body.Close()
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != http.StatusOK {
 		t.Errorf("expected retries to reach a 200 response, got %d", res.StatusCode)


### PR DESCRIPTION
## Description

During bulk reverification, an OpenAI key verification failed with `context deadline exceeded (Client.Timeout exceeded while awaiting headers)` and was recorded as an indeterminate result. The detector's default client was `common.SaneHttpClient()`: a 5s timeout with no retries, so any single slow response from the OpenAI API becomes a permanent verification failure.

This switches the default client to `common.RetryableHTTPClient` (the same pattern already used by the `twilio` and `privatekey` detectors) with:

- 10s per-attempt timeout (the OpenAI API can be slow to respond under load)
- Up to 2 retries with exponential backoff on transient failures (timeouts, connection errors, 429/5xx)

The retryable client respects the parent context, so callers with their own deadlines still bound the total time. Scanners constructed with an explicit client are unaffected.

Adds a unit test asserting the default client retries transient errors (500, 500, then 200 → exactly 3 attempts, final 200).

## Checklist

- [x] Tests passing (`go test ./pkg/detectors/openai/`)
- [x] `go vet` and `gofmt` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to OpenAI detector verification HTTP behavior; may slightly increase verification latency on failures but reduces false indeterminate results.
> 
> **Overview**
> **OpenAI key verification** no longer treats a single slow or flaky API response as an indeterminate result during bulk reverification.
> 
> The detector’s default HTTP client is switched from `common.SaneHttpClient()` (5s timeout, no retries) to `common.RetryableHTTPClient` with a **10s per-attempt timeout** and **up to 2 retries** on transient failures (timeouts, connection errors, 429/5xx), matching patterns used by detectors such as Twilio and privatekey. Scanners that inject their own `client` are unchanged.
> 
> Unit tests assert the default client retries until success (500 → 500 → 200, three attempts) and stops after the retry budget when errors persist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84b316c22f9bbe9c72a3220331ec73b9bf2b43ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->