### PR TITLE
docs: clarify self-hosted git scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,15 @@ Run trufflehog from the parent directory (outside the git repo).
 trufflehog git file://test_keys --results=verified,unknown
 ```
 
+For self-hosted Git providers or private repositories that need custom
+authentication or TLS configuration, the safest pattern is to let your CI system
+or local Git client clone the repository first, then scan the local checkout
+with `file://` as shown above. This keeps credentials in your existing Git
+credential helper, SSH agent, CI secret store, or Docker secret workflow instead
+of embedding them in the TruffleHog command line. If the Git server uses a
+private certificate authority, configure trust for that CA in the environment
+that performs the clone and scan.
+
 To guard against malicious git configs in local scanning (see CVE-2025-41390), TruffleHog clones local git repositories to a temporary directory prior to scanning. This follows [Git's security best practices](https://git-scm.com/docs/git#_security). If you want to specify a custom path to clone the repository to (instead of tmp), you can use the `--clone-path` flag. If you'd like to skip the local cloning process and scan the repository directly (only do this for trusted repos), you can use the `--trust-local-git-config` flag.
 
 ## 11: Scan GCS buckets for only verified secrets


### PR DESCRIPTION
## Summary
- document a safe workflow for scanning private/self-hosted Git repositories by cloning with existing Git/CI authentication first
- point users at local `file://` scans so credentials do not need to be embedded in the TruffleHog command line

Fixes #3917

## Verification
- `git diff --check`
- `npx --yes markdownlint-cli2 README.md` (fails on existing README lint issues; no errors reported for the added lines)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security behavior changes in the product.
> 
> **Overview**
> Adds guidance in **Quick Start §10 (Scan a local git repo)** for private and self-hosted Git: clone with your normal Git/CI auth first, then scan with `trufflehog git file://…` so tokens and TLS settings stay in credential helpers, SSH agents, or CI secrets instead of on the TruffleHog CLI. It also notes trusting a private CA in the environment that does the clone and scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29ce49b04c341c35945891be5dd420047bccd8d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->