### PR TITLE
Tighten JiraToken v1 verification

### DIFF
--- a/pkg/detectors/jiratoken/v1/jiratoken.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken.go
@@ -178,7 +178,9 @@ func VerifyJiraToken(ctx context.Context, client *http.Client, email, domain, to
 			return false, nil // can't decode response in case of 200 OK = not valid JIRA domain
 		}
 
-		return true, nil
+		// A 200 on its own isn't enough - unrelated hosts can also return JSON and get flagged as verified.
+		// Only trust it when the body actually carries the authenticated user's name.
+		return jiraResp.Data.Me.User.Name != "", nil
 	case http.StatusUnauthorized:
 		return false, nil
 	default:

--- a/pkg/detectors/jiratoken/v1/jiratoken_integration_test.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken_integration_test.go
@@ -154,7 +154,7 @@ func TestJiraToken_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "RawV2", "verificationError", "primarySecret", "SecretParts", "chunkOffset", "chunkOffsetSet")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("JiraToken.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/jiratoken/v1/jiratoken_test.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 )
@@ -84,6 +85,48 @@ func TestJiraToken_Pattern(t *testing.T) {
 
 			if diff := cmp.Diff(expected, actual); diff != "" {
 				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}
+
+func TestJiraToken_Verify(t *testing.T) {
+	tests := []struct {
+		name         string
+		statusCode   int
+		body         string
+		wantVerified bool
+	}{
+		{
+			name:         "authenticated user in body is verified",
+			statusCode:   200,
+			body:         `{"data":{"me":{"user":{"name":"Jira User"}}}}`,
+			wantVerified: true,
+		},
+		{
+			// A non-Atlassian host can happily return 200 with unrelated JSON, so the status code alone can't be trusted.
+			name:         "200 without a jira user is not verified",
+			statusCode:   200,
+			body:         `{"method":"POST","host":"example.com"}`,
+			wantVerified: false,
+		},
+		{
+			name:         "unauthorized is not verified",
+			statusCode:   401,
+			body:         `{"code":401,"message":"Unauthorized"}`,
+			wantVerified: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := common.ConstantResponseHttpClient(test.statusCode, test.body)
+			verified, err := VerifyJiraToken(context.Background(), client, "user@example.com", "example.atlassian.net", validTokenPattern)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if verified != test.wantVerified {
+				t.Errorf("got verified = %v, want %v", verified, test.wantVerified)
 			}
 		})
 	}


### PR DESCRIPTION
### Problem
The verifier treated any HTTP 200 with a decodable JSON body as a valid token. Bad Atlassian credentials return **401**, not 200, so a 200 only ever came from a *non-Atlassian* host (an echo server, or an unrelated app on the guessed domain). Those bodies decoded fine into an empty struct, so the token was marked **verified**. This is verification fix only. The over-broad token regex (24-char hyphen class matching UUID fragments) is a separate, larger change and is **not** in this PR.

### Fix
Only verify when the response body actually carries the authenticated user (`data.me.user.name`). A real Atlassian success always populates it; echo/error bodies don't.

### Testing
- Added `TestJiraToken_Verify`: 
  - authenticated user present -> verified
  - 200 without a user -> unverified
  - 401 -> unverified
- Updated the integration test's `IgnoreFields` for the new `Result` fields so it runs again.


### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret verification semantics for JiraToken (v1 and shared v2 path), reducing false positives but altering which findings are marked verified.
> 
> **Overview**
> **JiraToken v1 verification** no longer treats HTTP 200 plus any decodable JSON as success. After a successful decode, `VerifyJiraToken` only marks a secret verified when `data.me.user.name` is present, so unrelated hosts that echo JSON are not falsely verified (invalid Atlassian creds still fail via 401).
> 
> Adds **`TestJiraToken_Verify`** with stubbed responses for a real user payload, a misleading 200 body, and 401. Updates the integration test **`cmpopts.IgnoreFields`** for newer `detectors.Result` fields. **JiraToken v2** calls the same `VerifyJiraToken`, so it inherits this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a7076067050038235ae5b6486b8da6245b5e2ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->