### PR TITLE
feat(detectors): add Cerebras API key detector

### DIFF
--- a/pkg/detectors/cerebras/cerebras.go
+++ b/pkg/detectors/cerebras/cerebras.go
@@ -1,0 +1,101 @@
+package cerebras
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+type Scanner struct {
+	client *http.Client
+}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	defaultClient = common.SaneHttpClient()
+	keyPat        = regexp.MustCompile(`\b(csk-[a-z0-9]{48})\b`)
+)
+
+func (s Scanner) Keywords() []string {
+	return []string{"csk-"}
+}
+
+// FromData will find and optionally verify Cerebras secrets in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	uniqueMatches := make(map[string]struct{})
+	for _, match := range keyPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueMatches[match[1]] = struct{}{}
+	}
+
+	for match := range uniqueMatches {
+		s1 := detectors.Result{
+			DetectorType: detector_typepb.DetectorType_Cerebras,
+			Raw:          []byte(match),
+			SecretParts:  map[string]string{"key": match},
+		}
+
+		if verify {
+			client := s.client
+			if client == nil {
+				client = defaultClient
+			}
+
+			isVerified, verificationErr := verifyMatch(ctx, client, match)
+			s1.Verified = isVerified
+			s1.SetVerificationError(verificationErr, match)
+		}
+
+		results = append(results, s1)
+	}
+
+	return
+}
+
+func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, error) {
+	// https://inference-docs.cerebras.ai/api-reference/models
+	// Listing models is a non-destructive, authenticated GET: it returns 200 for a
+	// valid key and 401 for an invalid one.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://api.cerebras.ai/v1/models", nil)
+	if err != nil {
+		return false, err
+	}
+	req.Header.Add("Authorization", "Bearer "+token)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusUnauthorized:
+		// The secret is determinately not verified (nothing to do)
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
+}
+
+func (s Scanner) Type() detector_typepb.DetectorType {
+	return detector_typepb.DetectorType_Cerebras
+}
+
+func (s Scanner) Description() string {
+	return "Cerebras provides fast AI inference through its cloud API. Cerebras API keys can be used to access these services."
+}

--- a/pkg/detectors/cerebras/cerebras_integration_test.go
+++ b/pkg/detectors/cerebras/cerebras_integration_test.go
@@ -1,0 +1,161 @@
+//go:build detectors
+// +build detectors
+
+package cerebras
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+func TestCerebras_FromChunk(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors5")
+	if err != nil {
+		t.Fatalf("could not get test secrets from GCP: %s", err)
+	}
+	secret := testSecrets.MustGetField("CEREBRAS")
+	inactiveSecret := testSecrets.MustGetField("CEREBRAS_INACTIVE")
+
+	type args struct {
+		ctx    context.Context
+		data   []byte
+		verify bool
+	}
+	tests := []struct {
+		name                string
+		s                   Scanner
+		args                args
+		want                []detectors.Result
+		wantErr             bool
+		wantVerificationErr bool
+	}{
+		{
+			name: "found, verified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a cerebras secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_Cerebras,
+					Verified:     true,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "found, unverified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a cerebras secret %s within but not valid", inactiveSecret)), // the secret would satisfy the regex but not pass validation
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_Cerebras,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "not found",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte("You cannot find the secret within"),
+				verify: true,
+			},
+			want:                nil,
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "found, would be verified if not for timeout",
+			s:    Scanner{client: common.SaneHttpClientTimeOut(1 * time.Microsecond)},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a cerebras secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_Cerebras,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+		{
+			name: "found, verified but unexpected api surface",
+			s:    Scanner{client: common.ConstantResponseHttpClient(404, "")},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a cerebras secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_Cerebras,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Cerebras.FromData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if len(got[i].Raw) == 0 {
+					t.Fatalf("no raw secret present: \n %+v", got[i])
+				}
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
+				}
+			}
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
+			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
+				t.Errorf("Cerebras.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			}
+		})
+	}
+}
+
+func BenchmarkFromData(benchmark *testing.B) {
+	ctx := context.Background()
+	s := Scanner{}
+	for name, data := range detectors.MustGetBenchmarkData() {
+		benchmark.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				_, err := s.FromData(ctx, false, data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/detectors/cerebras/cerebras_integration_test.go
+++ b/pkg/detectors/cerebras/cerebras_integration_test.go
@@ -136,7 +136,7 @@ func TestCerebras_FromChunk(t *testing.T) {
 					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
 				}
 			}
-			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError")
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{}, "Raw", "verificationError", "SecretParts")
 			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
 				t.Errorf("Cerebras.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
 			}

--- a/pkg/detectors/cerebras/cerebras_test.go
+++ b/pkg/detectors/cerebras/cerebras_test.go
@@ -1,0 +1,74 @@
+package cerebras
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+)
+
+func TestCerebras_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "typical pattern",
+			input: "cerebras_api_key = 'csk-0123456789abcdefghijklmnopqrstuvwxyz0123456789ab'",
+			want:  []string{"csk-0123456789abcdefghijklmnopqrstuvwxyz0123456789ab"},
+		},
+		{
+			name:  "key in url context",
+			input: "https://api.cerebras.ai/v1?key=csk-abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef",
+			want:  []string{"csk-abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdef"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			detectorMatches := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(detectorMatches) == 0 {
+				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			if err != nil {
+				t.Errorf("error = %v", err)
+				return
+			}
+
+			if len(results) != len(test.want) {
+				if len(results) == 0 {
+					t.Errorf("did not receive result")
+				} else {
+					t.Errorf("expected %d results, only received %d", len(test.want), len(results))
+				}
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.RawV2) > 0 {
+					actual[string(r.RawV2)] = struct{}{}
+				} else {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -144,6 +144,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/caspio"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/censys"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/centralstationcrm"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/cerebras"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/cexio"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/chartmogul"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/chatbot"
@@ -1038,6 +1039,7 @@ func buildDetectorList() []detectors.Detector {
 		&caspio.Scanner{},
 		&censys.Scanner{},
 		&centralstationcrm.Scanner{},
+		&cerebras.Scanner{},
 		&cexio.Scanner{},
 		&chartmogul.Scanner{},
 		&chatbot.Scanner{},

--- a/pkg/pb/detector_typepb/detector_type.pb.go
+++ b/pkg/pb/detector_typepb/detector_type.pb.go
@@ -1116,6 +1116,7 @@ const (
 	DetectorType_Shippo                                  DetectorType = 1060
 	DetectorType_HashiCorpVaultBatchToken                DetectorType = 1061
 	DetectorType_HashiCorpVaultToken                     DetectorType = 1062
+	DetectorType_Cerebras                                DetectorType = 1063
 )
 
 // Enum value maps for DetectorType.
@@ -2180,6 +2181,7 @@ var (
 		1060: "Shippo",
 		1061: "HashiCorpVaultBatchToken",
 		1062: "HashiCorpVaultToken",
+		1063: "Cerebras",
 	}
 	DetectorType_value = map[string]int32{
 		"Alibaba":                               0,
@@ -3241,6 +3243,7 @@ var (
 		"Shippo":                            1060,
 		"HashiCorpVaultBatchToken":          1061,
 		"HashiCorpVaultToken":               1062,
+		"Cerebras":                          1063,
 	}
 )
 

--- a/proto/detector_type.proto
+++ b/proto/detector_type.proto
@@ -1064,4 +1064,5 @@ enum DetectorType {
   Shippo = 1060;
   HashiCorpVaultBatchToken = 1061;
   HashiCorpVaultToken = 1062;
+  Cerebras = 1063;
 }


### PR DESCRIPTION
### Description:

Adds a new secret detector for **Cerebras Inference** API keys.

Cerebras runs a paid, hosted AI-inference API, so its keys fit the [sourcing guidelines](https://github.com/trufflesecurity/trufflehog/blob/main/hack/docs/Adding_Detectors_external.md#sourcing-guidelines) (paid service). Keys have the form `csk-` followed by **48 lowercase-alphanumeric** characters and are sent as `Authorization: Bearer <key>`.

**Verification** uses the OpenAI-compatible, non-destructive `GET https://api.cerebras.ai/v1/models` endpoint:

| Response | Result |
|---|---|
| `200 OK` | verified |
| `401 Unauthorized` | determinately unverified |
| anything else | indeterminate (returns a verification error) |

This mirrors the existing `groq` detector, which uses the same OpenAI-compatible verification shape.

**Changes**
- `proto/detector_type.proto`: add `Cerebras = 1063`; regenerated `pkg/pb/detector_typepb/detector_type.pb.go`.
- `pkg/detectors/cerebras/`: detector + pattern test + integration test.
- `pkg/engine/defaults/defaults.go`: register the detector in the default set.

The integration test reads `CEREBRAS` / `CEREBRAS_INACTIVE` from the `detectors5` GSM bucket (matching the convention used by other detectors).

### Checklist:
* [x] Tests passing? `go test ./pkg/detectors/cerebras/...` passes; `go build ./pkg/engine/defaults/...`, `gofmt`, and `go vet` are clean. (Couldn't run the full `make test-community` / `make lint` locally, but the detector is structurally identical to the merged `groq` detector.)
* [ ] Lint passing (`make lint`)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive detector-only change following established patterns; verification is a read-only models list call with no changes to core scan or auth paths.
> 
> **Overview**
> Adds **Cerebras Inference** API key detection and optional live verification to TruffleHog.
> 
> New `pkg/detectors/cerebras` matches `csk-` plus 48 lowercase alphanumeric characters (keyword `csk-`), deduplicates hits, and when verification is on calls `GET https://api.cerebras.ai/v1/models` with `Authorization: Bearer`—**200** marks verified, **401** unverified, other statuses surface a verification error (same OpenAI-style shape as `groq`).
> 
> `DetectorType_Cerebras` (**1063**) is added in `proto/detector_type.proto` with regenerated protobufs, and `&cerebras.Scanner{}` is wired into the default detector list. Pattern, integration (GCP `detectors5` secrets), and benchmark tests ship with the detector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51cfce41ae35efd4b9b048e1e67dd35492db2ab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->