### PR TITLE
Retry git clone on transient network errors

### DIFF
--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -38,7 +38,15 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
 )
 
-const SourceType = sourcespb.SourceType_SOURCE_TYPE_GIT
+const (
+	SourceType = sourcespb.SourceType_SOURCE_TYPE_GIT
+	// maxCloneAttempts is the total number of times a clone is attempted when
+	// each failure is classified as a transient network error.
+	maxCloneAttempts = 3
+	// cloneRetryBackoff is the base wait between clone attempts; it is
+	// multiplied by the number of failed attempts so far.
+	cloneRetryBackoff = 5 * time.Second
+)
 
 type Source struct {
 	name     string
@@ -474,38 +482,91 @@ type cloneParams struct {
 // infrastructure, ensuring that any encountered errors trigger a cleanup of resources.
 // The core cloning logic is delegated to a nested function, which returns errors to the
 // outer function for centralized error handling and cleanup.
+//
+// Failures classified as transient network errors (e.g. a connection reset
+// mid-transfer) are retried up to maxCloneAttempts times, each attempt
+// starting from a fresh clone directory. All other failures, including clone
+// timeouts (see feature.GitCloneTimeoutDuration), are returned immediately.
 func CloneRepo(ctx context.Context, userInfo *url.Userinfo, gitURL string, clonePath string, authInUrl bool, args ...string) (string, *git.Repository, error) {
-	var path string
-	var err error
-
-	// If --clone-path is set, create a subdirectory <clonePath>/trufflehog-<repo-name> with permissions 0755.
-	if clonePath != "" {
-		path = filepath.Join(clonePath, "trufflehog-"+strings.TrimSuffix(filepath.Base(gitURL), gitDirName))
-		if err = os.MkdirAll(path, 0755); err != nil {
-			return "", nil, fmt.Errorf("failed to create clone path %s: %w", clonePath, err)
-		}
-	} else {
-		// otherwise, create a temporary directory in the system temp path.
-		path, err = cleantemp.MkdirTemp()
-		if err != nil {
-			return "", nil, fmt.Errorf("failed to create temporary clone path: %w", err)
-		}
+	path, err := createClonePath(gitURL, clonePath)
+	if err != nil {
+		return "", nil, err
 	}
 
 	timeout := time.Duration(feature.GitCloneTimeoutDuration.Load())
 
-	repo, err := executeClone(ctx, cloneParams{userInfo, gitURL, args, path, authInUrl, timeout})
-	if err != nil {
-		// DO NOT FORGET TO CLEAN UP THE CLONE PATH HERE!!
-		// If we don't, we'll end up with a bunch of orphaned directories in the temp dir.
-		CleanOnError(&err, path)
+	var repo *git.Repository
+	for attempt := 1; ; attempt++ {
+		repo, err = executeClone(ctx, cloneParams{userInfo, gitURL, args, path, authInUrl, timeout})
+		if err == nil {
+			break
+		}
 
-		// Note: We don't need to record the clone failure here as it's already
-		// recorded in executeClone when the error occurs
-		return "", nil, err
+		if attempt >= maxCloneAttempts || !isRetryableCloneError(err) || common.IsDone(ctx) {
+			// DO NOT FORGET TO CLEAN UP THE CLONE PATH HERE!!
+			// If we don't, we'll end up with a bunch of orphaned directories in the temp dir.
+			CleanOnError(&err, path)
+
+			// Note: We don't need to record the clone failure here as it's already
+			// recorded in executeClone when the error occurs
+			return "", nil, err
+		}
+
+		// Discard the partial clone and start the next attempt from a fresh directory.
+		if rmErr := os.RemoveAll(path); rmErr != nil {
+			err = fmt.Errorf("failed to clean clone path for retry: %w (original clone error: %w)", rmErr, err)
+			return "", nil, err
+		}
+		newPath, mkErr := createClonePath(gitURL, clonePath)
+		if mkErr != nil {
+			err = fmt.Errorf("failed to recreate clone path for retry: %w (original clone error: %w)", mkErr, err)
+			return "", nil, err
+		}
+		path = newPath
+
+		ctx.Logger().Info("git clone interrupted by network error; retrying",
+			"attempt", attempt,
+			"max_attempts", maxCloneAttempts,
+			"error", err.Error(),
+		)
+		select {
+		case <-ctx.Done():
+			CleanOnError(&err, path)
+			return "", nil, err
+		case <-time.After(cloneRetryBackoff * time.Duration(attempt)):
+		}
 	}
 
 	return path, repo, nil
+}
+
+// isRetryableCloneError reports whether a clone failure looks like a
+// transient network interruption (e.g. a connection reset mid-transfer)
+// rather than a permanent condition like an auth or permission error.
+func isRetryableCloneError(err error) bool {
+	return err != nil && ClassifyCloneError(err.Error()) == cloneFailureNetwork
+}
+
+// createClonePath creates the directory a repository will be cloned into and
+// returns its path. When clonePath is set (the --clone-path flag), the
+// directory is <clonePath>/trufflehog-<repo-name> with permissions 0755;
+// otherwise a fresh temporary directory (0700, per os.MkdirTemp) is created
+// in the system temp path. It is called both before the first clone attempt
+// and to replace the directory between retries.
+func createClonePath(gitURL, clonePath string) (string, error) {
+	if clonePath == "" {
+		path, err := cleantemp.MkdirTemp()
+		if err != nil {
+			return "", fmt.Errorf("failed to create temporary clone path: %w", err)
+		}
+		return path, nil
+	}
+
+	path := filepath.Join(clonePath, "trufflehog-"+strings.TrimSuffix(filepath.Base(gitURL), gitDirName))
+	if err := os.MkdirAll(path, 0755); err != nil {
+		return "", fmt.Errorf("failed to create clone path %s: %w", clonePath, err)
+	}
+	return path, nil
 }
 
 // executeClone prepares the Git URL, constructs, and executes the git clone command using the provided

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -488,18 +488,21 @@ type cloneParams struct {
 // starting from a fresh clone directory. All other failures, including clone
 // timeouts (see feature.GitCloneTimeoutDuration), are returned immediately.
 func CloneRepo(ctx context.Context, userInfo *url.Userinfo, gitURL string, clonePath string, authInUrl bool, args ...string) (string, *git.Repository, error) {
-	path, err := createClonePath(gitURL, clonePath)
-	if err != nil {
-		return "", nil, err
-	}
-
 	timeout := time.Duration(feature.GitCloneTimeoutDuration.Load())
 
+	var path string
 	var repo *git.Repository
-	for attempt := 1; ; attempt++ {
+	var err error
+	for attempt := 1; attempt <= maxCloneAttempts; attempt++ {
+		// Each attempt starts from a fresh clone directory.
+		path, err = createClonePath(gitURL, clonePath)
+		if err != nil {
+			return "", nil, err
+		}
+
 		repo, err = executeClone(ctx, cloneParams{userInfo, gitURL, args, path, authInUrl, timeout})
 		if err == nil {
-			break
+			return path, repo, nil
 		}
 
 		if attempt >= maxCloneAttempts || !isRetryableCloneError(err) || common.IsDone(ctx) {
@@ -512,17 +515,10 @@ func CloneRepo(ctx context.Context, userInfo *url.Userinfo, gitURL string, clone
 			return "", nil, err
 		}
 
-		// Discard the partial clone and start the next attempt from a fresh directory.
+		// Discard the partial clone; the next iteration recreates a fresh directory.
 		if rmErr := os.RemoveAll(path); rmErr != nil {
-			err = fmt.Errorf("failed to clean clone path for retry: %w (original clone error: %w)", rmErr, err)
-			return "", nil, err
+			return "", nil, fmt.Errorf("failed to clean clone path for retry: %w (original clone error: %w)", rmErr, err)
 		}
-		newPath, mkErr := createClonePath(gitURL, clonePath)
-		if mkErr != nil {
-			err = fmt.Errorf("failed to recreate clone path for retry: %w (original clone error: %w)", mkErr, err)
-			return "", nil, err
-		}
-		path = newPath
 
 		ctx.Logger().Info("git clone interrupted by network error; retrying",
 			"attempt", attempt,
@@ -531,13 +527,12 @@ func CloneRepo(ctx context.Context, userInfo *url.Userinfo, gitURL string, clone
 		)
 		select {
 		case <-ctx.Done():
-			CleanOnError(&err, path)
-			return "", nil, err
+			return "", nil, ctx.Err()
 		case <-time.After(cloneRetryBackoff * time.Duration(attempt)):
 		}
 	}
 
-	return path, repo, nil
+	return "", nil, err
 }
 
 // isRetryableCloneError reports whether a clone failure looks like a

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -58,6 +59,131 @@ func TestClone_Timeout(t *testing.T) {
 		if assert.Error(t, err) {
 			assert.Contains(t, err.Error(), "timed out")
 		}
+	})
+}
+
+func TestIsRetryableCloneError(t *testing.T) {
+	retryable := []string{
+		// Connection reset mid-transfer.
+		`could not clone repo: https://github.com/org/repo.git, error executing git clone: exit status 128, error: RPC failed; curl 56 Recv failure: Connection reset by peer
+error: 7589 bytes of body are still expected
+fetch-pack: unexpected disconnect while reading sideband packet
+fatal: early EOF
+fatal: fetch-pack: invalid index-pack output`,
+		// HTTP/2 stream reset by the server.
+		`could not clone repo: https://github.com/org/repo.git, error executing git clone: exit status 128, error: RPC failed; curl 92 HTTP/2 stream 7 reset by server (error 0x8 CANCEL)
+error: 7457 bytes of body are still expected
+fetch-pack: unexpected disconnect while reading sideband packet
+fatal: early EOF
+fatal: fetch-pack: invalid index-pack output`,
+	}
+	for _, msg := range retryable {
+		assert.True(t, isRetryableCloneError(errors.New(msg)), "expected retryable: %q", msg)
+	}
+
+	notRetryable := []string{
+		"could not clone repo: https://github.com/org/repo.git, error executing git clone: exit status 128, remote: The requested URL returned error: 403",
+		"could not clone repo: https://github.com/org/repo.git, error executing git clone: exit status 128, The requested URL returned error: 429",
+		"git clone timed out (after 1h0m0s)",
+		"could not clone repo: https://github.com/org/repo.git, error executing git clone: exit status 128, fatal: repository 'https://github.com/org/repo.git/' not found",
+	}
+	for _, msg := range notRetryable {
+		assert.False(t, isRetryableCloneError(errors.New(msg)), "expected not retryable: %q", msg)
+	}
+	assert.False(t, isRetryableCloneError(nil))
+}
+
+func TestCreateClonePath(t *testing.T) {
+	t.Run("temp dir when clonePath is empty", func(t *testing.T) {
+		path, err := createClonePath("https://github.com/org/repo.git", "")
+		assert.NoError(t, err)
+		defer os.RemoveAll(path)
+
+		info, err := os.Stat(path)
+		assert.NoError(t, err)
+		assert.True(t, info.IsDir())
+		if runtime.GOOS != "windows" {
+			// os.MkdirTemp guarantees 0700 so private repo contents aren't
+			// exposed to other users on shared systems.
+			assert.Equal(t, os.FileMode(0700), info.Mode().Perm())
+		}
+	})
+
+	t.Run("temp dirs are unique across calls", func(t *testing.T) {
+		// A retry replaces the previous directory; a colliding name would
+		// mean cloning into a non-empty directory, which git refuses.
+		first, err := createClonePath("https://github.com/org/repo.git", "")
+		assert.NoError(t, err)
+		defer os.RemoveAll(first)
+
+		second, err := createClonePath("https://github.com/org/repo.git", "")
+		assert.NoError(t, err)
+		defer os.RemoveAll(second)
+
+		assert.NotEqual(t, first, second)
+	})
+
+	t.Run("clonePath set builds trufflehog-<repo> subdirectory", func(t *testing.T) {
+		base := t.TempDir()
+		path, err := createClonePath("https://github.com/org/repo.git", base)
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(base, "trufflehog-repo"), path)
+
+		info, err := os.Stat(path)
+		assert.NoError(t, err)
+		assert.True(t, info.IsDir())
+		if runtime.GOOS != "windows" {
+			assert.Equal(t, os.FileMode(0755), info.Mode().Perm())
+		}
+	})
+
+	t.Run("repo name without .git suffix", func(t *testing.T) {
+		base := t.TempDir()
+		path, err := createClonePath("https://github.com/org/repo", base)
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(base, "trufflehog-repo"), path)
+	})
+
+	t.Run("trailing slash in repo URL", func(t *testing.T) {
+		base := t.TempDir()
+		path, err := createClonePath("https://github.com/org/repo.git/", base)
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(base, "trufflehog-repo"), path)
+	})
+
+	t.Run("nonexistent clonePath parents are created", func(t *testing.T) {
+		base := filepath.Join(t.TempDir(), "a", "b", "c")
+		path, err := createClonePath("https://github.com/org/repo.git", base)
+		assert.NoError(t, err)
+		assert.Equal(t, filepath.Join(base, "trufflehog-repo"), path)
+
+		info, err := os.Stat(path)
+		assert.NoError(t, err)
+		assert.True(t, info.IsDir())
+	})
+
+	t.Run("second call with same arguments reuses the directory", func(t *testing.T) {
+		// The retry path calls this again after RemoveAll; it must also
+		// tolerate the directory already existing (MkdirAll semantics).
+		base := t.TempDir()
+		first, err := createClonePath("https://github.com/org/repo.git", base)
+		assert.NoError(t, err)
+
+		second, err := createClonePath("https://github.com/org/repo.git", base)
+		assert.NoError(t, err)
+		assert.Equal(t, first, second)
+	})
+
+	t.Run("error when clonePath location is not writable", func(t *testing.T) {
+		base := t.TempDir()
+		// Create a *file* where the subdirectory should go so MkdirAll fails.
+		blocker := filepath.Join(base, "trufflehog-repo")
+		assert.NoError(t, os.WriteFile(blocker, []byte("x"), 0644))
+
+		path, err := createClonePath("https://github.com/org/repo.git", base)
+		assert.Error(t, err)
+		assert.Empty(t, path)
+		assert.Contains(t, err.Error(), "failed to create clone path")
 	})
 }
 

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -97,7 +97,7 @@ func TestCreateClonePath(t *testing.T) {
 	t.Run("temp dir when clonePath is empty", func(t *testing.T) {
 		path, err := createClonePath("https://github.com/org/repo.git", "")
 		assert.NoError(t, err)
-		defer os.RemoveAll(path)
+		defer func() { _ = os.RemoveAll(path) }()
 
 		info, err := os.Stat(path)
 		assert.NoError(t, err)
@@ -114,11 +114,11 @@ func TestCreateClonePath(t *testing.T) {
 		// mean cloning into a non-empty directory, which git refuses.
 		first, err := createClonePath("https://github.com/org/repo.git", "")
 		assert.NoError(t, err)
-		defer os.RemoveAll(first)
+		defer func() { _ = os.RemoveAll(first) }()
 
 		second, err := createClonePath("https://github.com/org/repo.git", "")
 		assert.NoError(t, err)
-		defer os.RemoveAll(second)
+		defer func() { _ = os.RemoveAll(second) }()
 
 		assert.NotEqual(t, first, second)
 	})


### PR DESCRIPTION
### Issue
Currently a repo clone gets exactly one attempt. If the connection drops mid-transfer (`curl 56 Recv failure: Connection reset by peer`, `HTTP/2 stream reset by server`, `early EOF`, etc.), the whole scan of that repo fails, even though an immediate retry would almost certainly succeed. We've seen this repeatedly with large repos, where long transfer times make a transient network blip much more likely to hit.

### Solution
This PR makes `CloneRepo` retry when the failure is classified as a network error (using the existing `ClassifyCloneError`, which was previously only used for metrics). Up to 3 total attempts with a short backoff (5s, then 10s), each starting from a fresh clone directory. 
All other failure classes - auth, permissions, rate limits, not found, clone timeouts, still fail immediately, same as before.

Along the way, the directory setup logic was extracted into `createClonePath` so the initial attempt and retries share one code path. Temp directories keep their `os.MkdirTemp` 0700 permissions on retry, and `--clone-path` directories keep 0755.

### Notes:
* This applies to all git-based sources, not just GitHub, since they all clone through `CloneRepo`.
* Clone timeouts are deliberately not retried. Note that the timeout now applies per attempt, so a repo that repeatedly fails with network errors near the cap could take up to 3x the configured timeout in the worst case. Happy to make it a shared budget across attempts if that's preferred.
* Clone failure metrics are recorded per attempt, so failure counts may tick up slightly even as overall clone reliability improves.

### Tests: 
- Added unit tests for the `isRetryableCloneError` and for `createClonePath`. 
- Also verified the retry flow end-to-end with a stub git binary that fails the first attempt and succeeds on the second.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core clone behavior for all git-based sources; worst case can extend wall time (per-attempt timeout × retries) and slightly inflate clone-failure metrics per attempt.
> 
> **Overview**
> **`CloneRepo`** now retries up to **3** times when failures are classified as transient **network** errors (via existing **`ClassifyCloneError`** / **`cloneFailureNetwork`**), with linear backoff (**5s**, then **10s**) and a **fresh clone directory** on each attempt. **Auth**, **403/429**, **not found**, and **clone timeouts** still fail immediately without retry.
> 
> Clone directory setup is moved into **`createClonePath`** so the first attempt and retries share one path; partial clones are removed before retrying, with cleanup on final failure unchanged.
> 
> Unit tests cover **`isRetryableCloneError`** and **`createClonePath`** (temp vs **`--clone-path`**, permissions, uniqueness).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b845e62de03131be2d7fc3318b4cb4cb057c8c45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->