### PR TITLE
Posthog regex update

### DIFF
--- a/pkg/detectors/posthog/posthog.go
+++ b/pkg/detectors/posthog/posthog.go
@@ -21,7 +21,7 @@ var (
 	client = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(`\b(phx_[a-zA-Z0-9_]{43})\b`)
+	keyPat = regexp.MustCompile(`\b(phx_[a-zA-Z0-9_]{43,48})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/posthog/posthog_test.go
+++ b/pkg/detectors/posthog/posthog_test.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	validPattern   = "phx_C1rP9fnAtEFJvb0IYCFdeQhar2WdwUFBYHJym1F_Zqr"
+	validPattern48 = "phx_C1rP9fnAtEFJvb0IYCFdeQhar2WdwUFBYHJym1F_ZqrAbcde"
 	invalidPattern = "phx_C1rP9fnAtEFJvb0IYCF?eQhar2WdwUFBYHJym1F_Zqr"
 	keyword        = "posthog"
 )
@@ -29,6 +30,11 @@ func TestAppPosthog_Pattern(t *testing.T) {
 			name:  "valid pattern - with keyword posthog",
 			input: fmt.Sprintf("%s token = '%s'", keyword, validPattern),
 			want:  []string{validPattern},
+		},
+		{
+			name:  "valid pattern 48 chars - with keyword posthog",
+			input: fmt.Sprintf("%s token = '%s'", keyword, validPattern48),
+			want:  []string{validPattern48},
 		},
 		{
 			name:  "invalid pattern",


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:

As of today 7-16-26,  PostHog personal keys are phx_ + 48 chars (52 total), but the regex only allowed phx_ + 43 (47 total).

The range {43,48} is needed to cover both the legacy 47-char and current 52-char total lengths.

### Checklist:
* [ Yes ] Tests passing (`make test-community`)?
* [ Yes ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to PostHog detector pattern matching and tests; no auth, verification, or broader scanner behavior changes.
> 
> **Overview**
> Updates the PostHog personal API key detector so `phx_` tokens with **43–48** alphanumeric/underscore characters match, instead of requiring exactly 43. That aligns detection with current longer keys while still accepting the older 47-character total format.
> 
> Adds a pattern test that asserts a 48-character suffix example is extracted when the PostHog keyword is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc6a2a08b4e4ed0d6e0f672c744fac9a95eb7644. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->