### PR TITLE
fix(privatekey): report encrypted keys as unverified when passphrase is uncrackable

### DIFF
--- a/pkg/detectors/privatekey/privatekey.go
+++ b/pkg/detectors/privatekey/privatekey.go
@@ -81,7 +81,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			s1.ExtraData["encrypted"] = "true"
 			parsedKey, passphrase, err = Crack([]byte(token))
 			if err != nil {
+				// The key is encrypted and its passphrase is not in the built-in
+				// wordlist. An encrypted private key in a repo is still a real
+				// exposure (offline-crackable, weak legacy KDFs, passphrase often
+				// reused/committed nearby), so surface it as an unverified finding
+				// instead of silently dropping it.
 				s1.SetVerificationError(err, token)
+				results = append(results, s1)
 				continue
 			}
 			if passphrase != "" {

--- a/pkg/detectors/privatekey/privatekey_test.go
+++ b/pkg/detectors/privatekey/privatekey_test.go
@@ -2,8 +2,14 @@ package privatekey
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
 	"fmt"
+	"strings"
 	"testing"
+
+	"golang.org/x/crypto/ssh"
 
 	"github.com/google/go-cmp/cmp"
 
@@ -94,5 +100,61 @@ func TestPrivatekey_Pattern(t *testing.T) {
 				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
 			}
 		})
+	}
+}
+
+// generateEncryptedPrivateKey generates an ed25519 private key encrypted with a
+// passphrase that is not in the detector's built-in wordlist, so Crack() cannot
+// recover it.
+func generateEncryptedPrivateKey(t *testing.T, passphrase string) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	// MarshalPrivateKeyWithPassphrase produces an OpenSSH-format encrypted PEM
+	// block.
+	block, err := ssh.MarshalPrivateKeyWithPassphrase(priv, "", []byte(passphrase))
+	if err != nil {
+		t.Fatalf("marshal encrypted key: %v", err)
+	}
+	return string(pem.EncodeToMemory(block))
+}
+
+// TestPrivatekey_EncryptedUncrackable verifies that an encrypted private key
+// whose passphrase is not in the built-in wordlist is still surfaced as an
+// unverified finding (rather than silently dropped). See issue #5115.
+func TestPrivatekey_EncryptedUncrackable(t *testing.T) {
+	// Use a long, random-looking passphrase that the wordlist cannot guess.
+	const passphrase = "Zx9qK4mR7vW2pY8sT3nB6hJ5eL0cA1"
+
+	encKey := generateEncryptedPrivateKey(t, passphrase)
+	// Sanity check: the generated key must actually be encrypted, i.e.
+	// ssh.ParseRawPrivateKey rejects it as passphrase-protected.
+	if _, err := ssh.ParseRawPrivateKey([]byte(encKey)); err == nil ||
+		!strings.Contains(err.Error(), "passphrase protected") {
+		t.Fatalf("generated key is not passphrase-protected (err=%v)", err)
+	}
+
+	d := Scanner{}
+	data := []byte(fmt.Sprintf("privatekey = '%s'", encKey))
+	results, err := d.FromData(context.Background(), false, data)
+	if err != nil {
+		t.Fatalf("FromData error: %v", err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 unverified finding for encrypted-uncrackable key, got %d", len(results))
+	}
+
+	r := results[0]
+	if r.Verified {
+		t.Errorf("encrypted-uncrackable key should be unverified, got Verified=true")
+	}
+	if r.ExtraData["encrypted"] != "true" {
+		t.Errorf("expected ExtraData[encrypted]=true, got %q", r.ExtraData["encrypted"])
+	}
+	if r.VerificationError() == nil {
+		t.Errorf("expected a verification error describing the failed crack")
 	}
 }


### PR DESCRIPTION
When a private key is passphrase-protected and the built-in wordlist in Crack() can't recover the passphrase, the detector was discarding the finding entirely (continue without appending to results). An encrypted private key committed to a repo is still a real exposure — it's offline-crackable, often uses weak legacy KDFs, and the passphrase is frequently reused or committed nearby — so it should surface as an unverified finding rather than vanish.

The fix appends the result with encrypted="true" metadata and the crack error as the verification error before continuing, matching how other unverified findings are reported. Reported in #5115.

I added a regression test (TestPrivatekey_EncryptedUncrackable) that generates an ed25519 key encrypted with a random passphrase outside the wordlist and asserts exactly one unverified result with the encrypted flag and a verification error. Existing TestPrivatekey_Pattern still passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow detector behavior change that increases visibility of findings; no auth or data-path changes, covered by a focused regression test.
> 
> **Overview**
> **Fixes silent drops of passphrase-protected private keys** when `Crack()` cannot recover the passphrase from the built-in wordlist (#5115).
> 
> Previously, encrypted keys that failed cracking were skipped entirely. The detector now **returns an unverified finding** with `encrypted=true`, attaches the crack failure via `SetVerificationError`, and appends it to results—same pattern as other unverified secrets.
> 
> Adds **`TestPrivatekey_EncryptedUncrackable`**: generates an ed25519 key encrypted with a non-wordlist passphrase and asserts one unverified result with the encrypted flag and a verification error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ce6f216957fe8da1bc8f5a3d0b68ad3809c56aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->