### PR TITLE
fix(detectors): verify PubNub keys with 'App Context is not enabled' 403 body

### DIFF
--- a/pkg/detectors/pubnubsubscriptionkey/pubnubsubscriptionkey.go
+++ b/pkg/detectors/pubnubsubscriptionkey/pubnubsubscriptionkey.go
@@ -22,6 +22,11 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	client = common.SaneHttpClient()
 
+	// verifyURL is the PubNub App Context endpoint used to confirm a
+	// subscription key is live. It is a package variable (not a const) so the
+	// verification path can be exercised against a stub HTTP server in tests.
+	verifyURL = "https://ps.pndsn.com/v2/objects/%s/uuids"
+
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	keyPat = regexp.MustCompile(`\b(sub-c-[0-9a-z]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})\b`)
 )
@@ -68,7 +73,7 @@ func (s Scanner) Description() string {
 }
 
 func verifyKey(ctx context.Context, client *http.Client, key string) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://ps.pndsn.com/v2/objects/"+key+"/uuids", nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf(verifyURL, key), nil)
 	if err != nil {
 		return false, err
 	}
@@ -92,7 +97,11 @@ func verifyKey(ctx context.Context, client *http.Client, key string) (bool, erro
 			return false, err
 		}
 
-		if strings.Contains(string(bodyBytes), "Objects not enabled for this subscriber key.") {
+		// Both 403 bodies indicate the key is valid but the App Context
+		// (formerly "Objects") feature is not enabled for the subscribe key.
+		// PubNub renamed the feature, so either message confirms the key works.
+		if strings.Contains(string(bodyBytes), "Objects not enabled for this subscriber key.") ||
+			strings.Contains(string(bodyBytes), "App Context is not enabled for this subscribe key.") {
 			return true, nil
 		}
 

--- a/pkg/detectors/pubnubsubscriptionkey/pubnubsubscriptionkey_test.go
+++ b/pkg/detectors/pubnubsubscriptionkey/pubnubsubscriptionkey_test.go
@@ -3,6 +3,8 @@ package pubnubsubscriptionkey
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -77,5 +79,57 @@ func TestPubNubSubscriptionKey_Pattern(t *testing.T) {
 				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
 			}
 		})
+	}
+}
+
+// TestVerifyKey_AppContextDisabledBodies confirms that a valid subscription
+// key whose PubNub App Context feature is disabled is still reported as
+// verified. PubNub renamed "Objects" to "App Context", so a 403 may carry
+// either message — both must be treated as "key is valid, feature off".
+// Regression test for https://github.com/trufflesecurity/trufflehog/issues/5099.
+func TestVerifyKey_AppContextDisabledBodies(t *testing.T) {
+	bodies := []string{
+		"Objects not enabled for this subscriber key.",
+		"App Context is not enabled for this subscribe key.",
+	}
+	for _, body := range bodies {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(body))
+		}))
+		defer ts.Close()
+
+		prev := verifyURL
+		verifyURL = ts.URL + "/v2/objects/%s/uuids"
+		defer func() { verifyURL = prev }()
+
+		got, err := verifyKey(context.Background(), ts.Client(), "sub-c-sy4te40h-w1oc-zpyq-zlrw-w6ehv0y0y78c")
+		if err != nil {
+			t.Fatalf("body %q: unexpected error: %v", body, err)
+		}
+		if !got {
+			t.Errorf("body %q: expected key to be verified, got false", body)
+		}
+	}
+}
+
+// TestVerifyKey_UnauthorizedIsUnverified confirms a 401 is still treated as
+// an unverified key after the App Context handling change.
+func TestVerifyKey_UnauthorizedIsUnverified(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	prev := verifyURL
+	verifyURL = ts.URL + "/v2/objects/%s/uuids"
+	defer func() { verifyURL = prev }()
+
+	got, err := verifyKey(context.Background(), ts.Client(), "sub-c-sy4te40h-w1oc-zpyq-zlrw-w6ehv0y0y78c")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got {
+		t.Errorf("expected 401 to be unverified, got true")
 	}
 }


### PR DESCRIPTION
PubNub renamed the "Objects" feature to "App Context". When the feature is disabled on an otherwise valid subscription key, the App Context endpoint now returns 403 with body "App Context is not enabled for this subscribe key." instead of the legacy "Objects not enabled for this subscriber key.". The PubNub subscription key detector only matched the legacy string, so valid keys whose account had App Context off were reported as unverified.

This change treats both 403 bodies as "key is valid, feature disabled" so such keys are correctly verified. The verify endpoint URL is extracted into a package var so the verification path can be exercised against a stub HTTP server, and I added regression tests covering both 403 bodies and the 401 path.

Fixes #5099

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to PubNub subscription key verification heuristics with stubbed HTTP tests; no broader auth or data-path impact.
> 
> **Overview**
> Fixes false **unverified** results for valid PubNub subscription keys when PubNub returns **403** with the renamed App Context message instead of the legacy Objects wording.
> 
> `verifyKey` now treats both **403** response bodies as “key is valid, App Context/Objects feature off.” The verify endpoint is held in a package-level `verifyURL` so tests can stub HTTP. Regression tests cover both **403** bodies and unchanged **401** → unverified behavior (fixes #5099).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc567b427fe52bbca8d5420bc86d2ab9937e4138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->