### PR TITLE
fix(detectors/gitlab-v1): restrict keyword-to-secret gap to same line to stop Dockerfile false positives

### DIFF
--- a/pkg/detectors/gitlab/v1/gitlab.go
+++ b/pkg/detectors/gitlab/v1/gitlab.go
@@ -34,7 +34,16 @@ func (Scanner) CloudEndpoint() string { return "https://gitlab.com" }
 
 var (
 	defaultClient = common.SaneHttpClient()
-	keyPat        = regexp.MustCompile(detectors.PrefixRegex([]string{"gitlab"}) + `\b([a-zA-Z0-9][a-zA-Z0-9\-=_]{19,21})\b`)
+	// keyPat matches a `gitlab` keyword within 40 characters of the captured
+	// secret, but restricts the gap to the same physical line. The shared
+	// `detectors.PrefixRegex` allows `(?:.|[\n\r]){0,40}?`, which let the
+	// keyword and an unrelated token on a later line be matched together
+	// (e.g. a Dockerfile's `ARG GITLAB_ACCESS_TOKEN` on one line and
+	// `ARG MAVEN_SETTINGS_PROFILE` on the next produced a false positive on
+	// `MAVEN_SETTINGS_PROFILE`). Using `[^\n\r]{0,40}?` keeps the keyword and
+	// the candidate secret on the same line without weakening any real
+	// single-line match. See trufflesecurity/trufflehog#4756.
+	keyPat = regexp.MustCompile(`(?i:gitlab)[^\n\r]{0,40}?\b([a-zA-Z0-9][a-zA-Z0-9\-=_]{19,21})\b`)
 
 	BlockedUserMessage = "403 Forbidden - Your account has been blocked"
 )

--- a/pkg/detectors/gitlab/v1/gitlab_v1_test.go
+++ b/pkg/detectors/gitlab/v1/gitlab_v1_test.go
@@ -45,6 +45,17 @@ func TestGitLab_Pattern(t *testing.T) {
 			input: "GITLAB_TOKEN=ABc123456789dEFghIJK",
 			want:  []string{"ABc123456789dEFghIJKhttps://gitlab.com"},
 		},
+		{
+			name: "false positive - gitlab keyword and unrelated token on different lines (Dockerfile)",
+			// Regression test for #4756: a Dockerfile with `ARG GITLAB_ACCESS_TOKEN`
+			// on one line and `ARG MAVEN_SETTINGS_PROFILE=test` on the next line
+			// used to produce a false positive on `MAVEN_SETTINGS_PROFILE` because
+			// the shared PrefixRegex allowed the keyword-to-secret gap to span
+			// newlines. The candidate is 21 chars and passes the entropy gate, so
+			// without the same-line restriction this would incorrectly match.
+			input: "FROM scratch\nARG GITLAB_ACCESS_TOKEN_TYPE=Private-Token\nARG GITLAB_ACCESS_TOKEN\nARG MAVEN_SETTINGS_PROFILE=test_profile_value\n",
+			want:  []string{},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The GitLab v1 detector flagged a false positive on `MAVEN_SETTINGS_PROFILE` whenever a Dockerfile had a `GITLAB_ACCESS_TOKEN` `ARG` followed by an unrelated `ARG MAVEN_SETTINGS_PROFILE=...` line. Scans of such Dockerfiles (common in Java projects) produced findings on a value that is not a GitLab token at all.

Root cause: the detector built its pattern with the shared `detectors.PrefixRegex(["gitlab"])`, whose keyword-to-secret gap is `(?:.|[\n\r]){0,40}?`. That gap spans newlines, so the `gitlab` keyword on one line and a 20–22 character alnum/hyphen/equals/underscore candidate on a later line were matched together. `MAVEN_SETTINGS_PROFILE` is 21 characters and clears the 3.6 Shannon-entropy gate, so it was reported as a (unverified) GitLab token.

Fix: replace the shared prefix with an inline `(?i:gitlab)[^\n\r]{0,40}?` so the keyword and the captured candidate must sit on the same physical line. Single-line real matches such as `GITLAB_TOKEN=<secret>` are unchanged. The v2 and v3 GitLab detectors use the literal `glpat-` prefix and are not affected.

Added a regression test that reproduces the Dockerfile from the report: it fails on the old pattern (the candidate is matched across lines) and passes with the fix.

Fixes #4756

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow regex tightening for false-positive reduction; v2/v3 detectors unchanged and verification logic is untouched.
> 
> **Overview**
> **GitLab v1** token detection no longer ties a `gitlab` keyword on one line to a token-like string on a later line.
> 
> The detector replaces shared `PrefixRegex` (gap could cross newlines) with `(?i:gitlab)[^\n\r]{0,40}?` so keyword and candidate stay on the same physical line. That stops Dockerfile-style false positives (e.g. `GITLAB_ACCESS_TOKEN` `ARG` followed by `MAVEN_SETTINGS_PROFILE` on the next line). Single-line matches like `GITLAB_TOKEN=<secret>` are unchanged.
> 
> A regression test covers the multi-line Dockerfile case and expects zero findings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29f01c58bda8c13f27a797de04b41c44e191b325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->