### PR TITLE
fix(detectors/sonarcloud-v1): reject git commit/<sha> URL paths as false positives

### DIFF
--- a/pkg/detectors/sonarcloud/v1/sonarcloud.go
+++ b/pkg/detectors/sonarcloud/v1/sonarcloud.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	regexp "github.com/wasilibs/go-re2"
 
@@ -50,8 +51,25 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	dataStr := string(data)
 
 	uniqueTokenMatches := make(map[string]struct{})
-	for _, match := range keyPat.FindAllStringSubmatch(dataStr, -1) {
-		uniqueTokenMatches[match[1]] = struct{}{}
+	for _, match := range keyPat.FindAllStringSubmatchIndex(dataStr, -1) {
+		// match[0]:match[1] is the full match (including the optional
+		// non-"@" prefix byte captured by the leading non-capturing group),
+		// match[2]:match[3] is the 40-char token group.
+		fullStart, groupStart, groupEnd := match[0], match[2], match[3]
+
+		// Reject git commit URLs (e.g. github.com/.../commit/<sha>) and
+		// "commit/<sha>" paths anywhere in the document. These SHA-1 hashes
+		// are 40 lowercase hex chars and otherwise look exactly like a
+		// SonarCloud token. See issue #5000.
+		windowStart := fullStart
+		if windowStart < 0 {
+			windowStart = 0
+		}
+		if endsWithCommitPath(dataStr[windowStart:groupEnd]) {
+			continue
+		}
+
+		uniqueTokenMatches[dataStr[groupStart:groupEnd]] = struct{}{}
 	}
 
 	for match := range uniqueTokenMatches {
@@ -120,6 +138,24 @@ func (s Scanner) verifyMatch(ctx context.Context, client *http.Client, token str
 
 func (s Scanner) Type() detector_typepb.DetectorType {
 	return detector_typepb.DetectorType_SonarCloud
+}
+
+// endsWithCommitPath reports whether the end of s matches a git commit URL
+// path of the form "...commit/<sha>" (optionally URL-encoded with %2F). This
+// filters SHA-1 commit hashes reported as SonarCloud false positives; see
+// issue #5000.
+func endsWithCommitPath(s string) bool {
+	idx := strings.LastIndex(strings.ToLower(s), "commit/")
+	if idx < 0 {
+		return false
+	}
+	tail := s[idx+len("commit/"):]
+	if strings.HasSuffix(tail, "/") {
+		return false
+	}
+	// The remainder must be exactly the 40-char hash that the caller passed in
+	// (s already ends at the end of the matched token).
+	return len(tail) == 40
 }
 
 func (s Scanner) Description() string {

--- a/pkg/detectors/sonarcloud/v1/sonarcloud.go
+++ b/pkg/detectors/sonarcloud/v1/sonarcloud.go
@@ -145,7 +145,7 @@ func (s Scanner) Type() detector_typepb.DetectorType {
 // filters SHA-1 commit hashes reported as SonarCloud false positives; see
 // issue #5000.
 func endsWithCommitPath(s string) bool {
-	idx := strings.LastIndex(strings.ToLower(s), "commit/")
+	idx := lastIndexFoldASCII(s, "commit/")
 	if idx < 0 {
 		return false
 	}
@@ -156,6 +156,24 @@ func endsWithCommitPath(s string) bool {
 	// The remainder must be exactly the 40-char hash that the caller passed in
 	// (s already ends at the end of the matched token).
 	return len(tail) == 40
+}
+
+// lastIndexFoldASCII returns the start index of the last case-insensitive
+// occurrence of needle (which must be ASCII) in s, or -1. It scans s directly
+// instead of lowercasing the whole haystack, so the returned offset is always
+// a valid byte offset into the original s even when strings.ToLower would
+// change the byte length of non-ASCII characters in s.
+func lastIndexFoldASCII(s, needle string) int {
+	if needle == "" {
+		return len(s)
+	}
+	n := len(needle)
+	for i := len(s) - n; i >= 0; i-- {
+		if strings.EqualFold(s[i:i+n], needle) {
+			return i
+		}
+	}
+	return -1
 }
 
 func (s Scanner) Description() string {

--- a/pkg/detectors/sonarcloud/v1/sonarcloud_test.go
+++ b/pkg/detectors/sonarcloud/v1/sonarcloud_test.go
@@ -50,6 +50,22 @@ func TestSonarCloud_Pattern(t *testing.T) {
 			input: fmt.Sprintf("%s token = '@%s'", keyword, validPattern),
 			want:  []string{},
 		},
+		{
+			// Regression test for issue #5000: dependabot PR bodies contain
+			// "github.com/<org>/<repo>/commit/<40-char-sha>" URLs whose SHA-1
+			// hashes otherwise look exactly like a SonarCloud token and are
+			// preceded by the "sonar" keyword within the prefix window.
+			name:  "github commit sha is not a sonar token",
+			input: fmt.Sprintf("Updates sonarsource/sonarqube-scan-action. See https://github.com/SonarSource/sonarqube-scan-action/commit/56568530eddcb15ab65e7880af318fba5b859e2e for details."),
+			want:  []string{},
+		},
+		{
+			// Same family of FP: a bare "commit/<sha>" path with the keyword
+			// elsewhere in the window must also be rejected.
+			name:  "commit path without host is not a sonar token",
+			input: fmt.Sprintf("sonar scanner bumped, see commit/7006c4492b2e0ee0f816d36501671557c97f5995 in the upstream repo"),
+			want:  []string{},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/detectors/sonarcloud/v1/sonarcloud_test.go
+++ b/pkg/detectors/sonarcloud/v1/sonarcloud_test.go
@@ -56,14 +56,14 @@ func TestSonarCloud_Pattern(t *testing.T) {
 			// hashes otherwise look exactly like a SonarCloud token and are
 			// preceded by the "sonar" keyword within the prefix window.
 			name:  "github commit sha is not a sonar token",
-			input: fmt.Sprintf("Updates sonarsource/sonarqube-scan-action. See https://github.com/SonarSource/sonarqube-scan-action/commit/56568530eddcb15ab65e7880af318fba5b859e2e for details."),
+			input: "Updates sonarsource/sonarqube-scan-action. See https://github.com/SonarSource/sonarqube-scan-action/commit/56568530eddcb15ab65e7880af318fba5b859e2e for details.",
 			want:  []string{},
 		},
 		{
 			// Same family of FP: a bare "commit/<sha>" path with the keyword
 			// elsewhere in the window must also be rejected.
 			name:  "commit path without host is not a sonar token",
-			input: fmt.Sprintf("sonar scanner bumped, see commit/7006c4492b2e0ee0f816d36501671557c97f5995 in the upstream repo"),
+			input: "sonar scanner bumped, see commit/7006c4492b2e0ee0f816d36501671557c97f5995 in the upstream repo",
 			want:  []string{},
 		},
 	}


### PR DESCRIPTION
The SonarCloud v1 detector regex matches any 40-char lowercase hex string preceded by the "sonar" keyword within the prefix window. That window also catches SHA-1 commit hashes embedded in GitHub commit URLs (github.com/<org>/<repo>/commit/<sha>), which appear verbatim in dependabot PR bodies that bump sonarsource/sonarqube-scan-action and similar actions. These hashes get reported as unverified SonarCloud tokens (issue #5000).

This change filters out matches whose captured token is the trailing segment of a "commit/<sha>" path before adding them to the result set. The check is case-insensitive and accepts both full URLs and bare paths so it covers all the locations a commit hash can appear next to the sonar keyword.

I added two regression tests to TestSonarCloud_Pattern: one mirroring the exact dependabot PR body from the issue (full github.com commit URL), and one covering a bare commit/<sha> path with the keyword nearby. Both reproduce the false positive on main and pass with this fix. The existing positive and negative cases still pass.

Fixes #5000.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped post-regex filter in one detector with regression tests; low risk of missing real tokens unless they appear exactly as a commit URL hash segment.
> 
> **Overview**
> Reduces SonarCloud v1 false positives where **40-character SHA-1 commit hashes** in `commit/<sha>` paths (including full GitHub commit URLs) were reported as tokens when **"sonar"** appeared nearby—common in Dependabot PR bodies (#5000).
> 
> **`FromData`** now uses **`FindAllStringSubmatchIndex`** and, before accepting a match, skips candidates whose span ends as the hash in a case-insensitive **`commit/`** path via **`endsWithCommitPath`** and **`lastIndexFoldASCII`**. Verification behavior is unchanged.
> 
> **`TestSonarCloud_Pattern`** adds regression cases for a full `github.com/.../commit/<sha>` URL and a bare `commit/<sha>` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2f6b6a8e8c059cdae8f086761821fabc575d7bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->