### PR TITLE
fix(detectors/metabase): reject URL slug false positives

### DIFF
--- a/pkg/detectors/metabase/metabase.go
+++ b/pkg/detectors/metabase/metabase.go
@@ -23,8 +23,12 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	client = detectors.DetectorHttpClientWithLocalAddresses
 
-	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"metabase"}) + `\b([a-zA-Z0-9-]{36})\b`)
+	// Metabase session tokens are 36-character alphanumeric strings (mixed
+	// case + digits) that do not contain hyphens. Including hyphens in the
+	// character class caused false positives on URL slugs such as
+	// "-journal-deduplication-id-to-voucher", which happen to be 36 chars and
+	// appear near the "metabase" keyword and a URL. See issue #4633.
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"metabase"}) + `\b([a-zA-Z0-9]{36})\b`)
 
 	baseURL = regexp.MustCompile(detectors.PrefixRegex([]string{"metabase"}) + `\b(https?:\/\/[-a-zA-Z0-9@:%._\+~#=]{7,256})\b`)
 )

--- a/pkg/detectors/metabase/metabase_test.go
+++ b/pkg/detectors/metabase/metabase_test.go
@@ -12,8 +12,12 @@ import (
 )
 
 var (
-	validKeyPattern       = "Y49ftoUer6aYZOzdkRzlENnW8PHnD9zf9dP9"
-	invalidKeyPattern     = "=49ftoUer6aYZOzdkRzlENnW8PHnD9zf9dP9"
+	validKeyPattern   = "Y49ftoUer6aYZOzdkRzlENnW8PHnD9zf9dP9"
+	invalidKeyPattern = "=49ftoUer6aYZOzdkRzlENnW8PHnD9zf9dP9"
+	// slugFP is a 36-char URL slug (lowercase words separated by hyphens) that
+	// was falsely reported as a Metabase session token because the old pattern
+	// allowed hyphens. See issue #4633.
+	slugFP                = "-journal-deduplication-id-to-voucher"
 	validBaseUrlPattern   = "https://tiwRdoa.metabase.com"
 	invalidBaseUrlPattern = "https://tiwRdo^.metabase.com"
 	keyword               = "metabase"
@@ -40,6 +44,11 @@ func TestMetabase_Pattern(t *testing.T) {
 		{
 			name:  "invalid pattern",
 			input: fmt.Sprintf("%s key = '%s' url = '%s'", keyword, invalidKeyPattern, invalidBaseUrlPattern),
+			want:  []string{},
+		},
+		{
+			name:  "false positive - URL slug with hyphens is not a session token",
+			input: fmt.Sprintf("metabase query - https://metabase.example.com/question/12345%s?partition_key=202501", slugFP),
 			want:  []string{},
 		},
 	}


### PR DESCRIPTION
The Metabase session token detector matched any 36-character alphanumeric string including hyphens. Real Metabase session tokens are 36-character alphanumeric strings without hyphens, so allowing hyphens caused false positives on URL slugs such as '-journal-deduplication-id-to-voucher' that happen to be 36 chars and appear near the metabase keyword and a URL.

This removes the hyphen from the key pattern character class so only hyphen-free 36-char alphanumeric candidates match, which aligns with the real token format. The valid-key test fixture (Y49ftoUer6aYZOzdkRzlENnW8PHnD9zf9dP9) already uses this format, so existing tests still pass. I also added a regression test using the exact slug reported in the issue.

Fixes #4633

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized detector regex change that reduces false positives; verification behavior is unchanged.
> 
> **Overview**
> Tightens the Metabase session-token regex so candidates must be **36 alphanumeric characters with no hyphens**, matching real tokens and stopping matches on hyphenated URL slugs near `metabase` and URLs (issue #4633).
> 
> Adds a regression test for the reported slug `-journal-deduplication-id-to-voucher` and documents the pattern change in `metabase.go`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 498bd9d9cc3370b3c4050fa6865cd9f34d82b916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->