### PR TITLE
fix(detectors/gitlab-v1): detect prefixless dotted PATs from older self-hosted GitLab

### DIFF
--- a/pkg/detectors/gitlab/v1/gitlab.go
+++ b/pkg/detectors/gitlab/v1/gitlab.go
@@ -34,7 +34,13 @@ func (Scanner) CloudEndpoint() string { return "https://gitlab.com" }
 
 var (
 	defaultClient = common.SaneHttpClient()
-	keyPat        = regexp.MustCompile(detectors.PrefixRegex([]string{"gitlab"}) + `\b([a-zA-Z0-9][a-zA-Z0-9\-=_]{19,21})\b`)
+	// keyPat matches the legacy unprefixed 20-22 char PATs.
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"gitlab"}) + `\b([a-zA-Z0-9][a-zA-Z0-9\-=_]{19,21})\b`)
+	// dottedKeyPat matches the newer dotted PAT format emitted by some
+	// self-hosted GitLab instances that adopted the dotted token structure
+	// before adding the `glpat-` prefix (see issue #4880). The body/suffix
+	// shape mirrors the prefixed v3 pattern; only the prefix is absent here.
+	dottedKeyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"gitlab"}) + `\b([a-zA-Z0-9][a-zA-Z0-9\-=_]{26,299}\.[0-9a-z]{2}\.[a-z0-9]{9})\b`)
 
 	BlockedUserMessage = "403 Forbidden - Your account has been blocked"
 )
@@ -65,50 +71,62 @@ func (s Scanner) Description() string {
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
 	dataStr := string(data)
 
-	matches := keyPat.FindAllStringSubmatch(dataStr, -1)
-	for _, match := range matches {
-		resMatch := strings.TrimSpace(match[1])
+	// Track matches already emitted so the legacy and dotted patterns can't
+	// double-report the same secret (the dotted body can also contain a
+	// 20-22 char prefix substring).
+	seen := make(map[string]struct{})
 
-		// ignore v2 detectors which have a prefix of `glpat-`
-		if strings.Contains(match[0], "glpat-") {
-			continue
-		}
+	for _, pat := range []*regexp.Regexp{keyPat, dottedKeyPat} {
+		matches := pat.FindAllStringSubmatch(dataStr, -1)
+		for _, match := range matches {
+			resMatch := strings.TrimSpace(match[1])
 
-		// to avoid false positives
-		if detectors.StringShannonEntropy(resMatch) < 3.6 {
-			continue
-		}
-
-		for _, endpoint := range s.Endpoints() {
-			s1 := detectors.Result{
-				DetectorType: detector_typepb.DetectorType_Gitlab,
-				Raw:          []byte(resMatch),
-				RawV2:        []byte(resMatch + endpoint),
-				ExtraData: map[string]string{
-					"rotation_guide": "https://howtorotate.com/docs/tutorials/gitlab/",
-					"version":        fmt.Sprintf("%d", s.Version()),
-				},
-				SecretParts: map[string]string{
-					"key":  resMatch,
-					"host": endpoint,
-				},
+			// ignore v2/v3 detectors which have a prefix of `glpat-`
+			if strings.Contains(match[0], "glpat-") {
+				continue
 			}
 
-			if verify {
-				isVerified, extraData, verificationErr := VerifyGitlab(ctx, s.getClient(), endpoint, resMatch)
-				s1.Verified = isVerified
-				maps.Copy(s1.ExtraData, extraData)
+			// to avoid false positives
+			if detectors.StringShannonEntropy(resMatch) < 3.6 {
+				continue
+			}
 
-				s1.SetVerificationError(verificationErr)
+			if _, ok := seen[resMatch]; ok {
+				continue
+			}
+			seen[resMatch] = struct{}{}
 
-				// for verified keys break out of the endpoint loop to continue to next secret
-				if s1.Verified {
-					results = append(results, s1)
-					break
+			for _, endpoint := range s.Endpoints() {
+				s1 := detectors.Result{
+					DetectorType: detector_typepb.DetectorType_Gitlab,
+					Raw:          []byte(resMatch),
+					RawV2:        []byte(resMatch + endpoint),
+					ExtraData: map[string]string{
+						"rotation_guide": "https://howtorotate.com/docs/tutorials/gitlab/",
+						"version":        fmt.Sprintf("%d", s.Version()),
+					},
+					SecretParts: map[string]string{
+						"key":  resMatch,
+						"host": endpoint,
+					},
 				}
-			}
 
-			results = append(results, s1)
+				if verify {
+					isVerified, extraData, verificationErr := VerifyGitlab(ctx, s.getClient(), endpoint, resMatch)
+					s1.Verified = isVerified
+					maps.Copy(s1.ExtraData, extraData)
+
+					s1.SetVerificationError(verificationErr)
+
+					// for verified keys break out of the endpoint loop to continue to next secret
+					if s1.Verified {
+						results = append(results, s1)
+						break
+					}
+				}
+
+				results = append(results, s1)
+			}
 		}
 	}
 

--- a/pkg/detectors/gitlab/v1/gitlab_v1_test.go
+++ b/pkg/detectors/gitlab/v1/gitlab_v1_test.go
@@ -45,6 +45,11 @@ func TestGitLab_Pattern(t *testing.T) {
 			input: "GITLAB_TOKEN=ABc123456789dEFghIJK",
 			want:  []string{"ABc123456789dEFghIJKhttps://gitlab.com"},
 		},
+		{
+			name:  "prefixless dotted PAT from older self-hosted GitLab (issue #4880)",
+			input: `gitlab_token ="ThisIsNotAValidTokenAtAllNoWayXx.01.a1b2c3d4e"`,
+			want:  []string{"ThisIsNotAValidTokenAtAllNoWayXx.01.a1b2c3d4ehttps://gitlab.com"},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
GitLab instances that adopted the dotted token format (e.g. XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.XX.XXXXXXXXX) before adding the `glpat-` prefix are currently invisible to all three GitLab detectors: v1 only matches 20-22 char bodies (too short), and v2/v3 both require the `glpat-` prefix. Personal access tokens from these self-hosted instances are silently missed (closes #4880).

I added a second regex (`dottedKeyPat`) to the v1 detector whose body/suffix shape mirrors the prefixed v3 pattern, without requiring the prefix. The v1 detector already handles unprefixed tokens and uses `gitlab` as its keyword, so the dotted format is picked up in the same `gitlab_token` / `GITLAB_TOKEN` contexts as the legacy 20-22 char PATs. The existing `glpat-` skip, Shannon-entropy threshold, and verification path all apply unchanged. A `seen`-set deduplicates between the legacy and dotted patterns so a single secret is never reported twice.

Verified with `go test ./pkg/detectors/gitlab/...` (v1/v2/v3 all pass) and added a test case using the exact reproduction string from the issue. `gofmt` and `go vet` are clean.

Drafted with assistance from an AI agent (Hermes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to GitLab v1 detection regex and dedup logic; existing entropy, prefix skip, and verification behavior are preserved.
> 
> **Overview**
> Extends the **GitLab v1** secret scanner so it can find **prefixless dotted personal access tokens** from older self-hosted instances (issue #4880), which v2/v3 miss because they require `glpat-`.
> 
> A new **`dottedKeyPat`** regex matches the dotted body/suffix shape (same idea as v3, without the prefix) alongside the existing legacy 20–22 character pattern. **`FromData`** now runs both patterns in one loop; **`glpat-`** matches are still skipped, Shannon entropy and verification are unchanged, and a **`seen`** map prevents duplicate findings when the dotted token overlaps the legacy substring match.
> 
> Adds a pattern test using the issue reproduction string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fa6b47066892e3c71697b58ce2bb09804fcbfdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->