### PR TITLE
fix(detectors/gitlab-v1): reject UUID-shaped candidates to stop webhook UUID false positives

### DIFF
--- a/pkg/detectors/gitlab/v1/gitlab.go
+++ b/pkg/detectors/gitlab/v1/gitlab.go
@@ -35,6 +35,11 @@ func (Scanner) CloudEndpoint() string { return "https://gitlab.com" }
 var (
 	defaultClient = common.SaneHttpClient()
 	keyPat        = regexp.MustCompile(detectors.PrefixRegex([]string{"gitlab"}) + `\b([a-zA-Z0-9][a-zA-Z0-9\-=_]{19,21})\b`)
+	// uuidPat matches a full UUID (8-4-4-4-12 hex) or the trailing tail of one
+	// (the 4-4-4-12 / 4-4-12 / 4-12 segments that a 20-22 char capture window can
+	// slice out of "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"). GitLab webhook event
+	// IDs are sent in headers like x-gitlab-event-uuid and are not API tokens.
+	uuidPat = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}|[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4,12}|[0-9a-fA-F]{4}-[0-9a-fA-F]{8,12}`)
 
 	BlockedUserMessage = "403 Forbidden - Your account has been blocked"
 )
@@ -76,6 +81,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 		// to avoid false positives
 		if detectors.StringShannonEntropy(resMatch) < 3.6 {
+			continue
+		}
+
+		// reject UUID-shaped candidates (e.g. GitLab webhook x-gitlab-event-uuid
+		// values) and full UUIDs whose 20-22 char tail slides into the capture
+		// window. Real v1 tokens are opaque alnum strings, never UUID fragments.
+		if uuidPat.MatchString(resMatch) {
 			continue
 		}
 

--- a/pkg/detectors/gitlab/v1/gitlab_v1_test.go
+++ b/pkg/detectors/gitlab/v1/gitlab_v1_test.go
@@ -45,6 +45,21 @@ func TestGitLab_Pattern(t *testing.T) {
 			input: "GITLAB_TOKEN=ABc123456789dEFghIJK",
 			want:  []string{"ABc123456789dEFghIJKhttps://gitlab.com"},
 		},
+		{
+			name: "webhook event UUID is not flagged (x-gitlab-event-uuid)",
+			input: `{
+  "x-gitlab-event": "Push Hook",
+  "x-gitlab-event-uuid": "c3e2f2b7-a945-4c58-924b-38d8186e200a",
+  "body": "gitlab payload"
+}`,
+			want: nil,
+		},
+		{
+			name: "hyphenated hex string near gitlab keyword is not flagged",
+			// 23-char candidate "a1b2-c3d4-e5f6a7b8c9d0" is a UUID fragment, not a token.
+			input: `{"gitlab": "a1b2-c3d4-e5f6a7b8c9d0"}`,
+			want:  nil,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The GitLab v1 detector was flagging any 20-22 character alphanumeric string (with hyphens/underscores/equals) that appeared near the keyword "gitlab". GitLab webhook event UUIDs sent in the x-gitlab-event-uuid header follow the standard 8-4-4-4-12 hex shape, and any 20-22 char slice of one (e.g. "a1b2-c3d4-e5f6a7b8c9d0" from the report, or "4c58-924b-38d8186e200a" from a real webhook UUID) cleared both the length and the 3.6 Shannon-entropy gate, producing unverified false-positive findings.

This adds a uuidPat that matches full UUIDs and their 4-4-4-12 / 4-4-12 / 4-12 tails, and skips any candidate that matches it. Real v1 tokens are opaque alphanumeric strings (occasionally containing a single underscore or hyphen) and never match this shape, so detection of genuine tokens is unchanged. The capture regex, entropy threshold, and verification logic are all untouched.

Added two regression tests: one for the x-gitlab-event-uuid header case from a real webhook payload, and one for the minimal JSON repro from the issue. Both fail on the old code and pass with the fix. go test ./pkg/detectors/gitlab/v1/ passes (4 subtests).

Fixes #4493

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow false-positive filter in secret detection only; genuine v1 token matching is intended to be unchanged.
> 
> **Overview**
> Fixes false positives where the GitLab **v1** detector treated 20–22 character strings near the `gitlab` keyword as tokens—including slices of webhook **`x-gitlab-event-uuid`** values that already passed length and Shannon entropy checks.
> 
> Adds **`uuidPat`** and skips any candidate that looks like a full UUID or a typical tail fragment (4-4-4-12 / 4-4-12 / 4-12 hex segments). Capture regex, entropy threshold, and verification are unchanged.
> 
> Regression tests cover a real webhook JSON payload and a hyphenated UUID fragment in minimal JSON; both should produce no findings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7af88485952c6ab09a49d1cfc75e767dbe1ce6f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->