### PR TITLE
Propagate job attempts through source progress

### DIFF
--- a/pkg/sources/job_attempt.go
+++ b/pkg/sources/job_attempt.go
@@ -1,0 +1,16 @@
+package sources
+
+import "github.com/trufflesecurity/trufflehog/v3/pkg/context"
+
+type jobAttemptIDContextKey struct{}
+
+// ContextWithJobAttemptID associates a caller-defined attempt with source
+// progress created by a SourceManager. Zero means unspecified.
+func ContextWithJobAttemptID(ctx context.Context, attemptID JobAttemptID) context.Context {
+	return context.WithValue(ctx, jobAttemptIDContextKey{}, attemptID)
+}
+
+func jobAttemptIDFromContext(ctx context.Context) JobAttemptID {
+	attemptID, _ := ctx.Value(jobAttemptIDContextKey{}).(JobAttemptID)
+	return attemptID
+}

--- a/pkg/sources/job_progress.go
+++ b/pkg/sources/job_progress.go
@@ -43,10 +43,11 @@ type JobProgressHook interface {
 // If the job supports it, the reference can also be used to cancel running via
 // CancelRun.
 type JobProgressRef struct {
-	JobID       JobID    `json:"job_id"`
-	SourceID    SourceID `json:"source_id"`
-	SourceName  string   `json:"source_name"`
-	jobProgress *JobProgress
+	JobID        JobID        `json:"job_id"`
+	SourceID     SourceID     `json:"source_id"`
+	SourceName   string       `json:"source_name"`
+	JobAttemptID JobAttemptID `json:"job_attempt_id,omitempty"`
+	jobProgress  *JobProgress
 }
 
 // Snapshot returns a snapshot of the job's current metrics.
@@ -108,6 +109,8 @@ type JobProgress struct {
 	JobID      JobID
 	SourceID   SourceID
 	SourceName string
+	// Caller-defined identity for a specific attempt of this job.
+	jobAttemptID JobAttemptID
 	// Tracks whether the job is finished or not.
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -156,6 +159,10 @@ func WithHooks(hooks ...JobProgressHook) func(*JobProgress) {
 // WithCancel allows cancelling the job by the JobProgressRef.
 func WithCancel(cancel context.CancelCauseFunc) func(*JobProgress) {
 	return func(jp *JobProgress) { jp.jobCancel = cancel }
+}
+
+func withJobAttemptID(attemptID JobAttemptID) func(*JobProgress) {
+	return func(jp *JobProgress) { jp.jobAttemptID = attemptID }
 }
 
 // NewJobProgress creates a new job report for the given source and job ID.
@@ -300,10 +307,11 @@ func (jp *JobProgress) ReportError(err error) {
 // Ref provides a read-only reference to the JobProgress.
 func (jp *JobProgress) Ref() JobProgressRef {
 	return JobProgressRef{
-		SourceID:    jp.SourceID,
-		JobID:       jp.JobID,
-		SourceName:  jp.SourceName,
-		jobProgress: jp,
+		SourceID:     jp.SourceID,
+		JobID:        jp.JobID,
+		SourceName:   jp.SourceName,
+		JobAttemptID: jp.jobAttemptID,
+		jobProgress:  jp,
 	}
 }
 

--- a/pkg/sources/job_progress_hook.go
+++ b/pkg/sources/job_progress_hook.go
@@ -67,7 +67,7 @@ func (u *UnitHook) id(ref JobProgressRef, unit SourceUnit) string {
 		id, kind := unit.SourceUnitID()
 		unitID = fmt.Sprintf("%s:%s", kind, id)
 	}
-	return fmt.Sprintf("%d/%d/%s", ref.SourceID, ref.JobID, unitID)
+	return fmt.Sprintf("%d/%d/%d/%s", ref.SourceID, ref.JobID, ref.JobAttemptID, unitID)
 }
 
 func (u *UnitHook) ejectFinishedMetrics(metrics UnitMetrics) {

--- a/pkg/sources/job_progress_hook.go
+++ b/pkg/sources/job_progress_hook.go
@@ -67,7 +67,7 @@ func (u *UnitHook) id(ref JobProgressRef, unit SourceUnit) string {
 		id, kind := unit.SourceUnitID()
 		unitID = fmt.Sprintf("%s:%s", kind, id)
 	}
-	return fmt.Sprintf("%d/%d/%d/%s", ref.SourceID, ref.JobID, ref.JobAttemptID, unitID)
+	return fmt.Sprintf("%d/%d/%s/%d", ref.SourceID, ref.JobID, unitID, ref.JobAttemptID)
 }
 
 func (u *UnitHook) ejectFinishedMetrics(metrics UnitMetrics) {

--- a/pkg/sources/job_progress_test.go
+++ b/pkg/sources/job_progress_test.go
@@ -42,7 +42,8 @@ func TestJobProgressRef(t *testing.T) {
 	assert.Equal(t, JobID(123), ref.JobID)
 	assert.Equal(t, SourceID(456), ref.SourceID)
 	assert.Equal(t, JobAttemptID(7), ref.JobAttemptID)
-	assert.Contains(t, map[JobProgressRef]bool{ref: true}, ref)
+	// This map literal is a compile-time assertion that JobProgressRef remains comparable.
+	_ = map[JobProgressRef]struct{}{ref: {}}
 
 	// Test Done() blocks until Finish() is called.
 	select {

--- a/pkg/sources/job_progress_test.go
+++ b/pkg/sources/job_progress_test.go
@@ -1,6 +1,7 @@
 package sources
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -36,10 +37,12 @@ func TestJobProgressFatalErrors(t *testing.T) {
 }
 
 func TestJobProgressRef(t *testing.T) {
-	jp := NewJobProgress(123, 456, "source name")
+	jp := NewJobProgress(123, 456, "source name", withJobAttemptID(7))
 	ref := jp.Ref()
 	assert.Equal(t, JobID(123), ref.JobID)
 	assert.Equal(t, SourceID(456), ref.SourceID)
+	assert.Equal(t, JobAttemptID(7), ref.JobAttemptID)
+	assert.Contains(t, map[JobProgressRef]bool{ref: true}, ref)
 
 	// Test Done() blocks until Finish() is called.
 	select {
@@ -54,6 +57,16 @@ func TestJobProgressRef(t *testing.T) {
 	default:
 		assert.FailNow(t, "job should be finished")
 	}
+}
+
+func TestJobProgressRefAttemptJSON(t *testing.T) {
+	legacy, err := json.Marshal(NewJobProgress(123, 456, "source name").Ref())
+	assert.NoError(t, err)
+	assert.NotContains(t, string(legacy), "job_attempt_id")
+
+	attempt, err := json.Marshal(NewJobProgress(123, 456, "source name", withJobAttemptID(7)).Ref())
+	assert.NoError(t, err)
+	assert.Contains(t, string(attempt), `"job_attempt_id":7`)
 }
 
 func TestJobProgressHook(t *testing.T) {

--- a/pkg/sources/source_manager.go
+++ b/pkg/sources/source_manager.go
@@ -128,12 +128,14 @@ func (s *SourceManager) GetIDs(ctx context.Context, sourceName string, kind sour
 // JobProgressRef as it becomes available.
 func (s *SourceManager) EnumerateAndScan(ctx context.Context, sourceName string, source Source, targets ...ChunkingTarget) (JobProgressRef, error) {
 	sourceID, jobID := source.SourceID(), source.JobID()
+	jobAttemptID := jobAttemptIDFromContext(ctx)
 	// Do preflight checks before waiting on the pool.
 	if err := s.preflightChecks(ctx); err != nil {
 		return JobProgressRef{
-			SourceName: sourceName,
-			SourceID:   sourceID,
-			JobID:      jobID,
+			SourceName:   sourceName,
+			SourceID:     sourceID,
+			JobID:        jobID,
+			JobAttemptID: jobAttemptID,
 		}, err
 	}
 	// Create a JobProgress object for tracking progress.
@@ -142,7 +144,7 @@ func (s *SourceManager) EnumerateAndScan(ctx context.Context, sourceName string,
 		sem = s.prioritySem
 	}
 	ctx, cancel := context.WithCancelCause(ctx)
-	progress := NewJobProgress(jobID, sourceID, sourceName, WithHooks(s.hooks...), WithCancel(cancel))
+	progress := NewJobProgress(jobID, sourceID, sourceName, WithHooks(s.hooks...), WithCancel(cancel), withJobAttemptID(jobAttemptID))
 	if err := sem.Acquire(ctx, 1); err != nil {
 		// Context cancelled.
 		progress.ReportError(Fatal{err})
@@ -177,18 +179,20 @@ func (s *SourceManager) EnumerateAndScan(ctx context.Context, sourceName string,
 
 func (s *SourceManager) Enumerate(ctx context.Context, sourceName string, source Source, reporter UnitReporter) (JobProgressRef, error) {
 	sourceID, jobID := source.SourceID(), source.JobID()
+	jobAttemptID := jobAttemptIDFromContext(ctx)
 	// Do preflight checks before waiting on the pool.
 	if err := s.preflightChecks(ctx); err != nil {
 		return JobProgressRef{
-			SourceName: sourceName,
-			SourceID:   sourceID,
-			JobID:      jobID,
+			SourceName:   sourceName,
+			SourceID:     sourceID,
+			JobID:        jobID,
+			JobAttemptID: jobAttemptID,
 		}, err
 	}
 
 	// Create a JobProgress object for tracking progress.
 	ctx, cancel := context.WithCancelCause(ctx)
-	progress := NewJobProgress(jobID, sourceID, sourceName, WithHooks(s.hooks...), WithCancel(cancel))
+	progress := NewJobProgress(jobID, sourceID, sourceName, WithHooks(s.hooks...), WithCancel(cancel), withJobAttemptID(jobAttemptID))
 
 	// Wrap the passed in reporter so we update the progress information.
 	reporter = baseUnitReporter{
@@ -222,17 +226,19 @@ func (s *SourceManager) Enumerate(ctx context.Context, sourceName string, source
 // accessible via the JobProgressRef as it becomes available.
 func (s *SourceManager) Scan(ctx context.Context, sourceName string, source Source, unit SourceUnit) (JobProgressRef, error) {
 	sourceID, jobID := source.SourceID(), source.JobID()
+	jobAttemptID := jobAttemptIDFromContext(ctx)
 	// Do preflight checks before waiting on the pool.
 	if err := s.preflightChecks(ctx); err != nil {
 		return JobProgressRef{
-			SourceName: sourceName,
-			SourceID:   sourceID,
-			JobID:      jobID,
+			SourceName:   sourceName,
+			SourceID:     sourceID,
+			JobID:        jobID,
+			JobAttemptID: jobAttemptID,
 		}, err
 	}
 	// Create a JobProgress object for tracking progress.
 	ctx, cancel := context.WithCancelCause(ctx)
-	progress := NewJobProgress(jobID, sourceID, sourceName, WithHooks(s.hooks...), WithCancel(cancel))
+	progress := NewJobProgress(jobID, sourceID, sourceName, WithHooks(s.hooks...), WithCancel(cancel), withJobAttemptID(jobAttemptID))
 	if err := s.sem.Acquire(ctx, 1); err != nil {
 		// Context cancelled.
 		progress.ReportError(Fatal{err})

--- a/pkg/sources/source_manager_test.go
+++ b/pkg/sources/source_manager_test.go
@@ -109,6 +109,17 @@ func tryRead(ch <-chan *Chunk) (*Chunk, error) {
 	}
 }
 
+func readUnitMetrics(t *testing.T, ch <-chan UnitMetrics) UnitMetrics {
+	t.Helper()
+	select {
+	case metrics := <-ch:
+		return metrics
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for unit metrics")
+		return UnitMetrics{}
+	}
+}
+
 func TestSourceManagerRun(t *testing.T) {
 	mgr := NewManager(WithBufferedOutput(8))
 	source, err := buildDummy(&counterChunker{count: 1})
@@ -223,6 +234,67 @@ func TestSourceManagerScan(t *testing.T) {
 		// The Chunks channel should be empty now.
 		_, err = tryRead(mgr.Chunks())
 		assert.Error(t, err)
+	}
+}
+
+func TestSourceManagerJobAttemptID(t *testing.T) {
+	const attemptID JobAttemptID = 7
+
+	tests := map[string]func(*SourceManager, context.Context, Source) (JobProgressRef, error){
+		"enumerate and scan": func(mgr *SourceManager, ctx context.Context, source Source) (JobProgressRef, error) {
+			return mgr.EnumerateAndScan(ctx, "dummy", source)
+		},
+		"enumerate": func(mgr *SourceManager, ctx context.Context, source Source) (JobProgressRef, error) {
+			return mgr.Enumerate(ctx, "dummy", source, nil)
+		},
+		"scan": func(mgr *SourceManager, ctx context.Context, source Source) (JobProgressRef, error) {
+			return mgr.Scan(ctx, "dummy", source, countChunk(1))
+		},
+	}
+
+	for name, start := range tests {
+		t.Run(name, func(t *testing.T) {
+			mgr := NewManager(WithBufferedOutput(8), WithSourceUnits())
+			source, err := buildDummy(&counterChunker{count: 1})
+			assert.NoError(t, err)
+			ctx := ContextWithJobAttemptID(context.Background(), attemptID)
+
+			ref, err := start(mgr, ctx, source)
+			assert.NoError(t, err)
+			assert.Equal(t, attemptID, ref.JobAttemptID)
+			<-ref.Done()
+		})
+	}
+}
+
+func TestSourceManagerPreflightPreservesJobAttemptID(t *testing.T) {
+	const attemptID JobAttemptID = 7
+
+	tests := map[string]func(*SourceManager, context.Context, Source) (JobProgressRef, error){
+		"enumerate and scan": func(mgr *SourceManager, ctx context.Context, source Source) (JobProgressRef, error) {
+			return mgr.EnumerateAndScan(ctx, "dummy", source)
+		},
+		"enumerate": func(mgr *SourceManager, ctx context.Context, source Source) (JobProgressRef, error) {
+			return mgr.Enumerate(ctx, "dummy", source, nil)
+		},
+		"scan": func(mgr *SourceManager, ctx context.Context, source Source) (JobProgressRef, error) {
+			return mgr.Scan(ctx, "dummy", source, countChunk(1))
+		},
+	}
+
+	for name, start := range tests {
+		t.Run(name, func(t *testing.T) {
+			mgr := NewManager()
+			source, err := buildDummy(&counterChunker{count: 1})
+			assert.NoError(t, err)
+			ctx, cancel := context.WithCancel(context.Background())
+			ctx = ContextWithJobAttemptID(ctx, attemptID)
+			cancel()
+
+			ref, err := start(mgr, ctx, source)
+			assert.Error(t, err)
+			assert.Equal(t, attemptID, ref.JobAttemptID)
+		})
 	}
 }
 
@@ -510,4 +582,46 @@ func TestSourceManagerUnitHookNoUnits(t *testing.T) {
 	assert.NotZero(t, m.EndTime)
 	assert.NotZero(t, m.ElapsedTime())
 	assert.Equal(t, 0, len(m.Errors))
+}
+
+func TestUnitHookSeparatesJobAttempts(t *testing.T) {
+	hook, ch := NewUnitHook(context.TODO())
+	unit := CommonSourceUnit{ID: "same unit"}
+	ref1 := JobProgressRef{JobID: 123, SourceID: 456, JobAttemptID: 1}
+	ref2 := JobProgressRef{JobID: 123, SourceID: 456, JobAttemptID: 2}
+	start := time.Now()
+
+	hook.StartUnitChunking(ref1, unit, start)
+	hook.StartUnitChunking(ref2, unit, start)
+	hook.ReportChunk(ref1, unit, &Chunk{Data: []byte("one")})
+	hook.ReportChunk(ref2, unit, &Chunk{Data: []byte("second")})
+	hook.EndUnitChunking(ref1, unit, start.Add(time.Second))
+	hook.EndUnitChunking(ref2, unit, start.Add(2*time.Second))
+
+	first, second := readUnitMetrics(t, ch), readUnitMetrics(t, ch)
+	assert.Equal(t, JobAttemptID(1), first.Parent.JobAttemptID)
+	assert.Equal(t, uint64(3), first.TotalBytes)
+	assert.Equal(t, JobAttemptID(2), second.Parent.JobAttemptID)
+	assert.Equal(t, uint64(6), second.TotalBytes)
+}
+
+func TestUnitHookSeparatesJobAttemptsWithoutUnits(t *testing.T) {
+	hook, ch := NewUnitHook(context.TODO())
+	ref1 := JobProgressRef{JobID: 123, SourceID: 456, JobAttemptID: 1}
+	ref2 := JobProgressRef{JobID: 123, SourceID: 456, JobAttemptID: 2}
+
+	hook.ReportChunk(ref1, nil, &Chunk{Data: []byte("one")})
+	hook.ReportChunk(ref2, nil, &Chunk{Data: []byte("second")})
+	hook.Finish(ref1)
+	inProgress := hook.InProgressSnapshot()
+	if assert.Len(t, inProgress, 1) {
+		assert.Equal(t, JobAttemptID(2), inProgress[0].Parent.JobAttemptID)
+	}
+	hook.Finish(ref2)
+
+	first, second := readUnitMetrics(t, ch), readUnitMetrics(t, ch)
+	assert.Equal(t, JobAttemptID(1), first.Parent.JobAttemptID)
+	assert.Equal(t, uint64(3), first.TotalBytes)
+	assert.Equal(t, JobAttemptID(2), second.Parent.JobAttemptID)
+	assert.Equal(t, uint64(6), second.TotalBytes)
 }

--- a/pkg/sources/sources.go
+++ b/pkg/sources/sources.go
@@ -17,6 +17,8 @@ import (
 type (
 	SourceID int64
 	JobID    int64
+	// JobAttemptID identifies a caller-defined attempt of a job.
+	JobAttemptID int64
 )
 
 // Chunk contains data to be decoded and scanned along with context on where it came from.


### PR DESCRIPTION
### Description:

Overlapping runs of the same source job can currently share UnitHook correlation state because progress is identified only by source, job, and unit. One attempt can overwrite or finish another attempt's in-flight metrics when those identifiers are reused.

This adds an optional, caller-defined `JobAttemptID` to source progress. Callers attach it through `ContextWithJobAttemptID`, and every SourceManager entry point preserves it on the returned `JobProgressRef`, including preflight errors. UnitHook includes the attempt in its internal correlation key for both unit and non-unit sources, so distinct attempts remain independent.

The zero value remains unspecified and is omitted from JSON, preserving behavior for existing callers. `JobProgressRef` also remains comparable. This draft makes the smallest OSS-facing contract concrete for maintainer feedback before downstream adoption.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional API in `pkg/sources` with no auth or data-path changes; behavior unchanged when attempt ID is not set.
> 
> **Overview**
> Adds an optional, caller-defined **`JobAttemptID`** so concurrent retries or overlapping runs of the same source/job no longer collide in **`UnitHook`** metrics (previously keyed only by source, job, and unit).
> 
> Callers set the attempt via **`ContextWithJobAttemptID`**; **`SourceManager`** entry points (`EnumerateAndScan`, `Enumerate`, `Scan`) read it from context, attach it to **`JobProgress`**, and expose it on **`JobProgressRef`** (including on preflight failures). **`UnitHook`** includes the attempt in its internal correlation key for unit and non-unit paths.
> 
> **`job_attempt_id`** is omitted from JSON when zero; **`JobProgressRef`** stays comparable. Tests cover propagation, preflight, JSON, and attempt-separated hook metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd7fbed1f8ec62babcd04ad3bcb6a698dc99692e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->