### PR TITLE
Make engine health metrics granular on chunk and result

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -869,12 +869,13 @@ func (e *Engine) scannerWorker(ctx context.Context) {
 		chunk.OriginalData = chunk.Data
 		decoded := iterativeDecode(chunk, e.decoders, e.maxDecodeDepth)
 
+		anyMatched := false
 		for _, d := range decoded {
 			matchingDetectors := e.AhoCorasickCore.FindDetectorMatches(d.Data)
 			if len(matchingDetectors) == 0 {
-				chunksDropped.WithLabelValues("scanner", "no_matching_detectors", sourceTypeStr).Inc()
 				continue
 			}
+			anyMatched = true
 			if len(matchingDetectors) > 1 && !e.verificationOverlap {
 				wgVerificationOverlap.Add(1)
 				e.verificationOverlapChunksChan <- verificationOverlapChunk{
@@ -896,6 +897,9 @@ func (e *Engine) scannerWorker(ctx context.Context) {
 					wgDoneFn: wgDetect.Done,
 				}
 			}
+		}
+		if !anyMatched {
+			chunksDropped.WithLabelValues("scanner", "no_matching_detectors", sourceTypeStr).Inc()
 		}
 
 		dataSize := float64(len(chunk.Data))
@@ -1012,6 +1016,7 @@ func (e *Engine) verificationOverlapWorker(ctx context.Context) {
 	for chunk := range e.verificationOverlapChunksChan {
 		sourceTypeStr := chunk.chunk.SourceType.String()
 		chunksEnteredStage.WithLabelValues("verification_overlap", sourceTypeStr).Inc()
+		hadDetectorError := false
 		for _, detector := range chunk.detectors {
 			isFalsePositive := detectors.GetFalsePositiveCheck(detector.Detector)
 			detectorNameStr := detector.Key.Type().String()
@@ -1027,7 +1032,7 @@ func (e *Engine) verificationOverlapWorker(ctx context.Context) {
 						err, "error finding results in chunk during verification overlap",
 						"detector", detectorNameStr,
 					)
-					chunksDropped.WithLabelValues("verification_overlap", "detector_error", sourceTypeStr).Inc()
+					hadDetectorError = true
 				}
 
 				if len(results) == 0 {
@@ -1109,6 +1114,10 @@ func (e *Engine) verificationOverlapWorker(ctx context.Context) {
 			delete(detectorKeysWithResults, k)
 		}
 
+		if hadDetectorError {
+			chunksDropped.WithLabelValues("verification_overlap", "detector_error", sourceTypeStr).Inc()
+		}
+
 		chunk.verificationOverlapWgDoneFn()
 	}
 
@@ -1146,6 +1155,7 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 	isFalsePositive := detectors.GetFalsePositiveCheck(data.detector.Detector)
 
 	var matchCount int
+	hadDetectorError := false
 	// To reduce the overhead of regex calls in the detector,
 	// we limit the amount of data passed to each detector.
 	// The matches field of the DetectorMatch struct contains the
@@ -1170,7 +1180,7 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 		cancel()
 		if err != nil {
 			ctx.Logger().Error(err, "error finding results in chunk")
-			chunksDropped.WithLabelValues("detect", "detector_error", sourceTypeStr).Inc()
+			hadDetectorError = true
 			continue
 		}
 
@@ -1219,6 +1229,10 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 	}
 
 	matchesPerChunk.Observe(float64(matchCount))
+
+	if hadDetectorError {
+		chunksDropped.WithLabelValues("detect", "detector_error", sourceTypeStr).Inc()
+	}
 
 	ctx.Logger().V(5).Info("Finished detecting chunk")
 

--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -119,7 +119,7 @@ var (
 		Namespace: common.MetricsNamespace,
 		Subsystem: common.MetricsSubsystem,
 		Name:      "chunks_dropped_total",
-		Help:      "Total number of chunks dropped by pipeline stage and reason.",
+		Help:      "Total number of chunks (or per-detector work items) dropped by pipeline stage and reason. Counted at the same granularity as chunks_entered_stage_total for the same stage.",
 	},
 		[]string{"stage", "reason", "source_type"},
 	)


### PR DESCRIPTION


<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Some metrics were emitting multiple times per chunk or result, so this adds logic to track it on a per chunk and result basis. This will help us describe the percentage of items getting filtered out in each stage.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metrics-only changes; scanning, detection, and verification behavior are unchanged.
> 
> **Overview**
> Aligns **`chunks_dropped_total`** with **`chunks_entered_stage_total`** so drop reasons are counted **once per work item** at each stage, instead of firing multiple times inside loops.
> 
> At the **scanner**, **`no_matching_detectors`** is emitted only when **no** decoded variant gets any Aho–Corasick detector match (not once per empty decoded slice). In **verification overlap** and **detect**, **`detector_error`** is recorded at most **once per chunk** when any match/`FromData` call fails, rather than on every failing iteration.
> 
> The **`chunks_dropped_total`** metric help text now states it uses the same granularity as **`chunks_entered_stage_total`** for the same stage, so drop ratios per stage are meaningful.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6927e58423da5c6e8009c00f88879047e6ac7421. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->