### PR TITLE
[chore] Change job_id in metric to source_type

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1183,7 +1183,7 @@ func (e *Engine) detectChunk(ctx context.Context, data detectableChunk) {
 
 		detectorExecutionCount.WithLabelValues(
 			detectorNameStr,
-			strconv.Itoa(int(data.chunk.JobID)),
+			sourceTypeStr,
 			data.chunk.SourceName,
 		).Inc()
 		detectorExecutionDuration.WithLabelValues(

--- a/pkg/engine/metrics.go
+++ b/pkg/engine/metrics.go
@@ -16,7 +16,7 @@ var (
 			Name:      "detector_execution_count",
 			Help:      "Total number of times a detector has been executed.",
 		},
-		[]string{"detector_name", "job_id", "source_name"},
+		[]string{"detector_name", "source_type", "source_name"},
 	)
 
 	// Note this is the time taken to call FromData on each detector, not necessarily the time taken


### PR DESCRIPTION

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
job_id has high cardinality, exploding the metrics we collect. source_type better aligns with our other metrics (along with source_name).

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only label change; dashboards or alerts keyed on `job_id` for this metric need updating, but scan behavior is unchanged.
> 
> **Overview**
> Replaces the **`job_id`** label on **`detector_execution_count`** with **`source_type`**, keeping **`detector_name`** and **`source_name`**.
> 
> In **`detectChunk`**, the counter now increments with `sourceTypeStr` (from `chunk.SourceType`) instead of stringifying **`JobID`**, so detector runs are grouped by source kind rather than per job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a64ac25ec1db86070870f3469fa8434985c1b85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->