### PR TITLE
fix(detectors/ngrok): broaden valid bearer tokens matching

### DIFF
--- a/pkg/detectors/ngrok/ngrok.go
+++ b/pkg/detectors/ngrok/ngrok.go
@@ -38,9 +38,13 @@ const (
 )
 
 var (
-	// ngrok API keys and authtokens are {prefix}_{suffix} with a digit-leading suffix.
-	// API keys are 27+21 chars; authtokens vary but share the same charset constraints.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"ngrok"}) + `\b([a-zA-Z0-9]{27}_\d[a-zA-Z0-9]{20})\b`)
+	// ngrok API keys and authtokens are {prefix}_{suffix}, both alphanumeric with
+	// no fixed leading character. The prefix is 27 chars. Suffixes are usually 21
+	// chars with a leading digit, but real authtokens verified against the ngrok
+	// API (via ERR_NGROK_206) have been observed with 20-char and letter-leading
+	// suffixes, so the pattern must accept 20-21 chars starting with any
+	// alphanumeric character.
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"ngrok"}) + `\b([a-zA-Z0-9]{27}_[a-zA-Z0-9]{20,21})\b`)
 )
 
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {

--- a/pkg/detectors/ngrok/ngrok.go
+++ b/pkg/detectors/ngrok/ngrok.go
@@ -40,7 +40,7 @@ const (
 var (
 	// ngrok API keys and authtokens are {prefix}_{suffix} with a digit-leading suffix.
 	// API keys are 27+21 chars; authtokens vary but share the same charset constraints.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"ngrok"}) + `\b([a-zA-Z0-9]{27}_[a-zA-Z0-9]{21})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"ngrok"}) + `\b([a-zA-Z0-9]{27}_\d[a-zA-Z0-9]{20})\b`)
 )
 
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {

--- a/pkg/detectors/ngrok/ngrok.go
+++ b/pkg/detectors/ngrok/ngrok.go
@@ -38,7 +38,9 @@ const (
 )
 
 var (
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"ngrok"}) + `\b(2[a-zA-Z0-9]{26}_\d[a-zA-Z0-9]{20})\b`)
+	// ngrok API keys and authtokens are {prefix}_{suffix} with a digit-leading suffix.
+	// API keys are 27+21 chars; authtokens vary but share the same charset constraints.
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"ngrok"}) + `\b([a-zA-Z0-9]{27}_[a-zA-Z0-9]{21})\b`)
 )
 
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {

--- a/pkg/detectors/ngrok/ngrok_test.go
+++ b/pkg/detectors/ngrok/ngrok_test.go
@@ -12,9 +12,11 @@ import (
 )
 
 var (
-	validPattern   = "2WIRSIHOQyHSVklZnoz2k6bTYdH_0E7z0Ta9QEyR1fZvQ0KU9"
-	invalidPattern = "2WIRSIHOQyHSVklZnoz2k6bT?dH_0E7z0Ta9QEyR1fZvQ0KU9"
-	keyword        = "ngrok"
+	validPattern      = "2WIRSIHOQyHSVklZnoz2k6bTYdH_0E7z0Ta9QEyR1fZvQ0KU9"
+	validPatternAlt   = "3GuTI5JXfaLtYILkc6N0xopP2V0_89zkDfefiuMv6Hk1z6oYi"
+	invalidPattern    = "2WIRSIHOQyHSVklZnoz2k6bT?dH_0E7z0Ta9QEyR1fZvQ0KU9"
+	invalidIDPattern  = "ak_3GuTI5JXfaLtYILkc6N0xopP2V0"
+	keyword           = "ngrok"
 )
 
 func TestNgrok_Pattern(t *testing.T) {
@@ -31,6 +33,11 @@ func TestNgrok_Pattern(t *testing.T) {
 			want:  []string{"2WIRSIHOQyHSVklZnoz2k6bTYdH_0E7z0Ta9QEyR1fZvQ0KU9"},
 		},
 		{
+			name:  "valid pattern - api key not starting with 2",
+			input: fmt.Sprintf("%s token = '%s'", keyword, validPatternAlt),
+			want:  []string{validPatternAlt},
+		},
+		{
 			name:  "valid pattern - ignore duplicate",
 			input: fmt.Sprintf("%s token = '%s' | '%s'", keyword, validPattern, validPattern),
 			want:  []string{"2WIRSIHOQyHSVklZnoz2k6bTYdH_0E7z0Ta9QEyR1fZvQ0KU9"},
@@ -43,6 +50,11 @@ func TestNgrok_Pattern(t *testing.T) {
 		{
 			name:  "invalid pattern",
 			input: fmt.Sprintf("%s = '%s'", keyword, invalidPattern),
+			want:  []string{},
+		},
+		{
+			name:  "invalid pattern - api key resource id not bearer token",
+			input: fmt.Sprintf("%s api_key = '%s'", keyword, invalidIDPattern),
 			want:  []string{},
 		},
 	}

--- a/pkg/detectors/ngrok/ngrok_test.go
+++ b/pkg/detectors/ngrok/ngrok_test.go
@@ -12,11 +12,12 @@ import (
 )
 
 var (
-	validPattern      = "2WIRSIHOQyHSVklZnoz2k6bTYdH_0E7z0Ta9QEyR1fZvQ0KU9"
-	validPatternAlt   = "3GuTI5JXfaLtYILkc6N0xopP2V0_89zkDfefiuMv6Hk1z6oYi"
-	invalidPattern    = "2WIRSIHOQyHSVklZnoz2k6bT?dH_0E7z0Ta9QEyR1fZvQ0KU9"
-	invalidIDPattern  = "ak_3GuTI5JXfaLtYILkc6N0xopP2V0"
-	keyword           = "ngrok"
+	validPattern         = "2WIRSIHOQyHSVklZnoz2k6bTYdH_0E7z0Ta9QEyR1fZvQ0KU9"
+	validPatternAlt      = "3GuTI5JXfaLtYILkc6N0xopP2V0_89zkDfefiuMv6Hk1z6oYi"
+	invalidPattern       = "2WIRSIHOQyHSVklZnoz2k6bT?dH_0E7z0Ta9QEyR1fZvQ0KU9"
+	invalidIDPattern     = "ak_3GuTI5JXfaLtYILkc6N0xopP2V0"
+	invalidSuffixPattern = "3GuTI5JXfaLtYILkc6N0xopP2V0_a9zkDfefiuMv6Hk1z6oYi"
+	keyword              = "ngrok"
 )
 
 func TestNgrok_Pattern(t *testing.T) {
@@ -55,6 +56,11 @@ func TestNgrok_Pattern(t *testing.T) {
 		{
 			name:  "invalid pattern - api key resource id not bearer token",
 			input: fmt.Sprintf("%s api_key = '%s'", keyword, invalidIDPattern),
+			want:  []string{},
+		},
+		{
+			name:  "invalid pattern - suffix does not start with digit",
+			input: fmt.Sprintf("%s token = '%s'", keyword, invalidSuffixPattern),
 			want:  []string{},
 		},
 	}

--- a/pkg/detectors/ngrok/ngrok_test.go
+++ b/pkg/detectors/ngrok/ngrok_test.go
@@ -12,12 +12,15 @@ import (
 )
 
 var (
-	validPattern         = "2WIRSIHOQyHSVklZnoz2k6bTYdH_0E7z0Ta9QEyR1fZvQ0KU9"
-	validPatternAlt      = "3GuTI5JXfaLtYILkc6N0xopP2V0_89zkDfefiuMv6Hk1z6oYi"
-	invalidPattern       = "2WIRSIHOQyHSVklZnoz2k6bT?dH_0E7z0Ta9QEyR1fZvQ0KU9"
-	invalidIDPattern     = "ak_3GuTI5JXfaLtYILkc6N0xopP2V0"
-	invalidSuffixPattern = "3GuTI5JXfaLtYILkc6N0xopP2V0_a9zkDfefiuMv6Hk1z6oYi"
-	keyword              = "ngrok"
+	validPattern    = "2WIRSIHOQyHSVklZnoz2k6bTYdH_0E7z0Ta9QEyR1fZvQ0KU9"
+	validPatternAlt = "3GuTI5JXfaLtYILkc6N0xopP2V0_89zkDfefiuMv6Hk1z6oYi"
+	// Authtokens exist in the wild with letter-leading and 20-char suffixes
+	// (confirmed live against the ngrok API), so both must be detected.
+	validPatternLetterSuffix = "3GuTI5JXfaLtYILkc6N0xopP2V0_a9zkDfefiuMv6Hk1z6oYi"
+	validPatternShortSuffix  = "4HvUJ6KYgbMuZJMld7O1yqqQ3W1_b8ylEgfgjvNw7Il2z7pZ"
+	invalidPattern           = "2WIRSIHOQyHSVklZnoz2k6bT?dH_0E7z0Ta9QEyR1fZvQ0KU9"
+	invalidIDPattern         = "ak_3GuTI5JXfaLtYILkc6N0xopP2V0"
+	keyword                  = "ngrok"
 )
 
 func TestNgrok_Pattern(t *testing.T) {
@@ -44,6 +47,16 @@ func TestNgrok_Pattern(t *testing.T) {
 			want:  []string{"2WIRSIHOQyHSVklZnoz2k6bTYdH_0E7z0Ta9QEyR1fZvQ0KU9"},
 		},
 		{
+			name:  "valid pattern - authtoken suffix not starting with digit",
+			input: fmt.Sprintf("%s token = '%s'", keyword, validPatternLetterSuffix),
+			want:  []string{validPatternLetterSuffix},
+		},
+		{
+			name:  "valid pattern - authtoken with 20 char suffix",
+			input: fmt.Sprintf("%s token = '%s'", keyword, validPatternShortSuffix),
+			want:  []string{validPatternShortSuffix},
+		},
+		{
 			name:  "valid pattern - key out of prefix range",
 			input: fmt.Sprintf("%s keyword is not close to the real key in the data\n = '%s'", keyword, validPattern),
 			want:  []string{},
@@ -56,11 +69,6 @@ func TestNgrok_Pattern(t *testing.T) {
 		{
 			name:  "invalid pattern - api key resource id not bearer token",
 			input: fmt.Sprintf("%s api_key = '%s'", keyword, invalidIDPattern),
-			want:  []string{},
-		},
-		{
-			name:  "invalid pattern - suffix does not start with digit",
-			input: fmt.Sprintf("%s token = '%s'", keyword, invalidSuffixPattern),
 			want:  []string{},
 		},
 	}


### PR DESCRIPTION
## Summary
- Broaden the ngrok detector prefix from `2[a-zA-Z0-9]{26}` to `[a-zA-Z0-9]{27}` so valid bearer tokens are detected regardless of first character.
- Allow suffixes of 20-21 alphanumeric chars with any leading character. Real authtokens (verified via `ERR_NGROK_206`) exist with 20-char and letter-leading suffixes, so a digit-leading 21-char suffix constraint drops valid secrets.
- Add tests for API keys not starting with `2`, letter-leading and 20-char suffixes, and `ak_` resource IDs, which are not secrets.

## Test plan
- [x] `go test ./pkg/detectors/ngrok/ -run TestNgrok_Pattern`
- [x] Scan fixture containing a valid ngrok API bearer token and confirm verified detection


Made with [Cursor](https://cursor.com)