### PR TITLE
fix(detectors/harness): allow underscore in PAT account segment

### DIFF
--- a/pkg/detectors/harness/harness.go
+++ b/pkg/detectors/harness/harness.go
@@ -32,7 +32,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	defaultClient = common.SaneHttpClient()
 
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"harness"}) + `\b(pat\.[A-Za-z0-9]{22}\.[0-9a-f]{24}\.[A-Za-z0-9]{20})\b`)
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"harness"}) + `\b(pat\.[A-Za-z0-9_]{22}\.[0-9a-f]{24}\.[A-Za-z0-9]{20})\b`)
 )
 
 func (s Scanner) getClient() *http.Client {

--- a/pkg/detectors/harness/harness_test.go
+++ b/pkg/detectors/harness/harness_test.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	validKey               = "pat.4oXWHvYFRNOGLVpFTZGGTA.68077fc826afe36865614d58.2fFEmr57WO3zPmev3jze"
+	validKeyWithUnderscore = "pat.YDfcEm2LT_OUZrFZv1WVlg.6a4f91eb79dfb04b036caf48.FrDL8MGzpMygCMzZv1Kq"
 	validKeyWithoutKeyword = `API Key Token: pat.4oXWHvYFRNOGLVpFTZGGTA.68077fc826afe36865614d58.2fFEmr57WO3zPmev3jze
 	url |https://api.harness.io/`
 	invalidKey = "pat.4oXWHvYFRNOGLVpFTZGGTA.6807c5bed9599c324f6368ce.usCT2fzvADwSoXzXc"
@@ -30,6 +31,11 @@ func TestHarness_Pattern(t *testing.T) {
 			name:  "valid pattern",
 			input: fmt.Sprintf("%s token = '%s'", keyword, validKey),
 			want:  []string{validKey},
+		},
+		{
+			name:  "valid pattern with underscore in account segment",
+			input: fmt.Sprintf("%s = '%s'", keyword, validKeyWithUnderscore),
+			want:  []string{validKeyWithUnderscore},
 		},
 		{
 			name:  "valid pattern - no keyword",


### PR DESCRIPTION
## Summary
- Allow `_` in the 22-character account segment of Harness `pat.*` API keys so tokens like `pat.YDfcEm2LT_OUZrFZv1WVlg...` are detected during scans.
- Add a unit test covering underscore-bearing PATs.

## Test plan
- [x] `go test ./pkg/detectors/harness/ -run TestHarness_Pattern -v`
- [ ] CI


Made with [Cursor](https://cursor.com)