### PR TITLE
fix(detectors/sonarcloud-v1): reject commit SHAs in URL/action paths (dependabot FP)

### DIFF
--- a/pkg/detectors/sonarcloud/v1/sonarcloud.go
+++ b/pkg/detectors/sonarcloud/v1/sonarcloud.go
@@ -28,7 +28,10 @@ var (
 	defaultClient = common.SaneHttpClient()
 
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"sonar"}) + `(?:^|[^@])\b([0-9a-z]{40})\b`)
+	// The lookbehind rejects tokens preceded by '@' (action refs like org/repo@<sha>),
+	// '/' or '\' (URL or filesystem path segments, e.g. github.com/.../commit/<sha>),
+	// which are the most common source of 40-char SHA false positives.
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"sonar"}) + `(?:^|[^@/\\])\b([0-9a-z]{40})\b`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/sonarcloud/v1/sonarcloud_test.go
+++ b/pkg/detectors/sonarcloud/v1/sonarcloud_test.go
@@ -50,6 +50,22 @@ func TestSonarCloud_Pattern(t *testing.T) {
 			input: fmt.Sprintf("%s token = '@%s'", keyword, validPattern),
 			want:  []string{},
 		},
+		{
+			// Git commit SHAs in dependabot PR bodies (e.g. sonarqube-scan-action
+			// bump notes) sit on a "/commit/<sha>" URL path and share the 40-char
+			// lowercase hex shape, producing false positives. A real token is never
+			// preceded by a path separator.
+			name: "commit SHA in sonarqube action bump body is ignored",
+			input: "sonarsource/sonarqube-scan-action/commit/" +
+				"56568530eddcb15ab65e7880af318fba5b859e2e",
+			want: []string{},
+		},
+		{
+			name: "commit SHA on https URL path near sonar keyword is ignored",
+			input: "https://github.com/SonarSource/sonarqube-scan-action/commit/" +
+				"e050aa9e699112ca0664dd2a5c694ddab05dc555",
+			want: []string{},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Dependabot PRs that bump sonarsource/sonarqube-scan-action produce a flurry of unverified SonarCloud findings (#5000). The bump body carries several github.com/SonarSource/sonarqube-scan-action/commit/<sha> links plus @<sha> action refs, and the 40-char lowercase SHA is indistinguishable from a v1 token by shape alone.

The lookbehind on the v1 pattern already rejected tokens directly preceded by '@'. This extends it to also reject '/' and '\' so SHAs sitting on a URL/filesystem path segment (by far the most common shape here) no longer match. Real tokens are preceded by assignment operators, quotes, or whitespace, never a path separator.

Added two table cases reproducing the dependabot body (both a /commit/ path and a full https URL) that previously matched and now return nothing, alongside the existing positive cases to confirm legitimate detection is unaffected. go vet and go build clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped regex tightening in one detector with added tests; may miss a hypothetical token placed directly after a path separator, which is not a realistic secret format.
> 
> **Overview**
> Tightens the SonarCloud v1 token regex so **40-character lowercase hex strings on URL or filesystem paths** (e.g. `.../commit/<sha>` in Dependabot bump text) are no longer treated as secrets, while still allowing tokens after quotes, whitespace, and assignment-style context.
> 
> The lookbehind that already blocked `@` (action refs) now also blocks **`/` and `\`**, since real tokens are not immediately preceded by path separators. **Two pattern tests** lock in the Dependabot-style `/commit/` and full `https://github.com/.../commit/` cases as non-matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f09e8c4519785d8bd0bf6576035d990520e7428a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->