### PR TITLE
fix(analyzers/groq): surface free and paid plan resources

### DIFF
--- a/pkg/analyzer/analyzers/groq/groq.go
+++ b/pkg/analyzer/analyzers/groq/groq.go
@@ -19,7 +19,7 @@ type Analyzer struct {
 	Cfg *config.Config
 }
 
-// SecretInfo hold the information about the groq key
+// SecretInfo holds information gathered about a Groq API key.
 type SecretInfo struct {
 	Valid         bool
 	Reference     string
@@ -28,7 +28,7 @@ type SecretInfo struct {
 	Misc          map[string]string
 }
 
-// GroqResource is a single groq resource which can be accessed with groq api key
+// GroqResource is a single resource accessible with a Groq API key.
 type GroqResource struct {
 	ID         string
 	Name       string
@@ -37,17 +37,17 @@ type GroqResource struct {
 	Metadata   map[string]string
 }
 
-// appendGroqResource append the single groq resource to secretinfo groqresources list
+// appendGroqResource appends a resource onto the secret info list.
 func (s *SecretInfo) appendGroqResource(resource GroqResource) {
 	s.GroqResources = append(s.GroqResources, resource)
 }
 
-// updateMetadata safely update the metadata of the groq resource
-func (g GroqResource) updateMetadata(key, value string) {
+// updateMetadata sets a metadata key on the resource. Pointer receiver so
+// writes persist when callers mutate before appending.
+func (g *GroqResource) updateMetadata(key, value string) {
 	if g.Metadata == nil {
 		g.Metadata = map[string]string{}
 	}
-
 	g.Metadata[key] = value
 }
 
@@ -74,7 +74,6 @@ func (a Analyzer) Analyze(_ context.Context, credInfo map[string]string) (*analy
 func AnalyzeAndPrintPermissions(cfg *config.Config, key string) {
 	info, err := AnalyzePermissions(cfg, key)
 	if err != nil {
-		// just print the error in cli and continue as a partial success
 		color.Red("[x] Invalid Groq API key\n")
 		color.Red("[x] Error : %s", err.Error())
 		return
@@ -96,15 +95,18 @@ func AnalyzeAndPrintPermissions(cfg *config.Config, key string) {
 }
 
 func AnalyzePermissions(cfg *config.Config, apiKey string) (*SecretInfo, error) {
-	// create a HTTP client
 	client := analyzers.NewAnalyzeClient(cfg)
+	secretInfo := &SecretInfo{Valid: true}
 
-	var secretInfo = &SecretInfo{Valid: true}
-
+	// Models are on every plan and guarantee analyze bindings. Batches and files
+	// are paid Developer-tier APIs; when available we surface those resources too,
+	// and when the plan denies them we skip without failing the analysis.
+	if err := captureModels(client, apiKey, secretInfo); err != nil {
+		return nil, err
+	}
 	if err := captureBatches(client, apiKey, secretInfo); err != nil {
 		return nil, err
 	}
-
 	if err := captureFiles(client, apiKey, secretInfo); err != nil {
 		return nil, err
 	}
@@ -112,19 +114,22 @@ func AnalyzePermissions(cfg *config.Config, apiKey string) (*SecretInfo, error) 
 	return secretInfo, nil
 }
 
-// secretInfoToAnalyzerResult translate secret info to Analyzer Result
+// secretInfoToAnalyzerResult translates secret info into Analyzer Result bindings.
+// Permissions in the UI come from these bindings; an empty list looks like "no
+// permissions" even when the CLI printed Full Access.
 func secretInfoToAnalyzerResult(info *SecretInfo) *analyzers.AnalyzerResult {
 	if info == nil {
 		return nil
 	}
 
+	fullAccess := analyzers.Permission{Value: PermissionStrings[FullAccess]}
 	result := analyzers.AnalyzerResult{
 		AnalyzerType: analyzers.AnalyzerTypeGroq,
 		Metadata:     map[string]any{"Valid_Key": info.Valid},
-		Bindings:     make([]analyzers.Binding, len(info.GroqResources)),
+		// Cap only — length 0 so append does not leave zero-value placeholders.
+		Bindings: make([]analyzers.Binding, 0, len(info.GroqResources)),
 	}
 
-	// extract information to create bindings and append to result bindings
 	for _, groqResource := range info.GroqResources {
 		binding := analyzers.Binding{
 			Resource: analyzers.Resource{
@@ -133,15 +138,11 @@ func secretInfoToAnalyzerResult(info *SecretInfo) *analyzers.AnalyzerResult {
 				Type:               groqResource.Type,
 				Metadata:           map[string]any{},
 			},
-			Permission: analyzers.Permission{
-				Value: groqResource.Permission,
-			},
+			Permission: fullAccess,
 		}
-
 		for key, value := range groqResource.Metadata {
 			binding.Resource.Metadata[key] = value
 		}
-
 		result.Bindings = append(result.Bindings, binding)
 	}
 

--- a/pkg/analyzer/analyzers/groq/groq_test.go
+++ b/pkg/analyzer/analyzers/groq/groq_test.go
@@ -1,7 +1,6 @@
 package groq
 
 import (
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -25,13 +24,11 @@ func TestAnalyzer_Analyze(t *testing.T) {
 	tests := []struct {
 		name    string
 		apiKey  string
-		want    string
 		wantErr bool
 	}{
 		{
-			name:    "valid dockerhub credentials",
+			name:    "valid groq credentials",
 			apiKey:  apiKey,
-			want:    `{"AnalyzerType":2,"Bindings":[],"UnboundedResources":null,"Metadata":{"Valid_Key":true}}`,
 			wantErr: false,
 		},
 	}
@@ -45,7 +42,6 @@ func TestAnalyzer_Analyze(t *testing.T) {
 				return
 			}
 
-			// marshal the actual result to JSON
 			gotJSON, err := json.Marshal(got)
 			if err != nil {
 				t.Fatalf("could not marshal got to JSON: %s", err)
@@ -53,19 +49,22 @@ func TestAnalyzer_Analyze(t *testing.T) {
 
 			fmt.Println(string(gotJSON))
 
-			// compare the JSON strings
-			if string(gotJSON) != string(tt.want) {
-				// pretty-print both JSON strings for easier comparison
-				var gotIndented, wantIndented []byte
-				gotIndented, err = json.MarshalIndent(got, "", " ")
-				if err != nil {
-					t.Fatalf("could not marshal got to indented JSON: %s", err)
+			if got == nil {
+				t.Fatal("Analyzer.Analyze() returned nil result")
+			}
+
+			if got.Metadata["Valid_Key"] != true {
+				t.Fatalf("expected Valid_Key metadata to be true, got %#v", got.Metadata["Valid_Key"])
+			}
+
+			if len(got.Bindings) == 0 {
+				t.Fatal("expected at least one model binding for a valid Groq API key")
+			}
+
+			for _, binding := range got.Bindings {
+				if binding.Permission.Value != PermissionStrings[FullAccess] {
+					t.Fatalf("expected full_access permission, got %q", binding.Permission.Value)
 				}
-				wantIndented, err = json.MarshalIndent(tt.want, "", " ")
-				if err != nil {
-					t.Fatalf("could not marshal want to indented JSON: %s", err)
-				}
-				t.Errorf("Analyzer.Analyze() = %s, want %s", gotIndented, wantIndented)
 			}
 		})
 	}

--- a/pkg/analyzer/analyzers/groq/requests.go
+++ b/pkg/analyzer/analyzers/groq/requests.go
@@ -8,12 +8,16 @@ import (
 	"time"
 )
 
-var (
+const (
+	modelsURL  = "https://api.groq.com/openai/v1/models"
+	batchesURL = "https://api.groq.com/openai/v1/batches"
+	filesURL   = "https://api.groq.com/openai/v1/files"
+
 	permissionErr       = "permissions_error"
 	notAvailableForPlan = "not_available_for_plan"
 )
 
-// errorResponse is the response from groq APIs in case of any error
+// errorResponse is the body Groq returns when a call is denied.
 type errorResponse struct {
 	Error struct {
 		Message string `json:"message"`
@@ -22,12 +26,25 @@ type errorResponse struct {
 	} `json:"error"`
 }
 
-// listBatchesResponse is the response of /v1/batches API
+// listModelsResponse is the response of GET /openai/v1/models.
+type listModelsResponse struct {
+	Data []model `json:"data"`
+}
+
+// model is a single entry from the models list (free and paid plans).
+type model struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	OwnedBy string `json:"owned_by"`
+	Created int64  `json:"created"`
+}
+
+// listBatchesResponse is the response of GET /openai/v1/batches (paid Developer tier).
 type listBatchesResponse struct {
 	Data []batch `json:"data"`
 }
 
-// batch represent a single batch inside batches list
+// batch is a single batch job.
 type batch struct {
 	ID          string `json:"id"`
 	Object      string `json:"object"`
@@ -37,12 +54,12 @@ type batch struct {
 	ExpiresAt   int64  `json:"expires_at"`
 }
 
-// listBatchesResponse is the response of /v1/files API
+// listFilesResponse is the response of GET /openai/v1/files (paid Developer tier).
 type listFilesResponse struct {
 	Data []file `json:"data"`
 }
 
-// file represents a single file object inside files list
+// file is a single uploaded file object.
 type file struct {
 	ID        string `json:"id"`
 	Object    string `json:"object"`
@@ -51,24 +68,17 @@ type file struct {
 	Purpose   string `json:"purpose"`
 }
 
-func isPermissionError(err errorResponse) bool {
-	// has permissions error or not available for the plan subscribed
-	if err.Error.Type == permissionErr && err.Error.Code == notAvailableForPlan {
-		return true
-	}
-
-	return false
+func isPlanRestricted(err errorResponse) bool {
+	return err.Error.Type == permissionErr && err.Error.Code == notAvailableForPlan
 }
 
-// makeGroqRequest send the API request to passed url with passed key as API Key and return response body and status code
+// makeGroqRequest sends an authenticated GET and returns body and status code.
 func makeGroqRequest(client *http.Client, url, key string) ([]byte, int, error) {
-	// create request
 	req, err := http.NewRequest(http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	// add required keys in the header
 	req.Header.Set("Authorization", "Bearer "+key)
 	req.Header.Set("Content-Type", "application/json")
 
@@ -90,9 +100,50 @@ func makeGroqRequest(client *http.Client, url, key string) ([]byte, int, error) 
 	return responseBodyByte, resp.StatusCode, nil
 }
 
+// captureModels lists models via the free-tier endpoint used for detector verification.
+// docs: https://console.groq.com/docs/api-reference#models-list
+//
+// Every valid key can list models, so this is what guarantees analyze bindings
+// even when batches/files are plan-restricted or empty.
+func captureModels(client *http.Client, key string, secretInfo *SecretInfo) error {
+	response, statusCode, err := makeGroqRequest(client, modelsURL, key)
+	if err != nil {
+		return err
+	}
+
+	switch statusCode {
+	case http.StatusOK:
+		var models listModelsResponse
+		if err := json.Unmarshal(response, &models); err != nil {
+			return err
+		}
+
+		for _, m := range models.Data {
+			resource := &GroqResource{
+				ID:         m.ID,
+				Name:       m.ID,
+				Type:       m.Object,
+				Permission: PermissionStrings[FullAccess],
+			}
+			resource.updateMetadata("owned by", m.OwnedBy)
+			resource.updateMetadata("created at", time.Unix(m.Created, 0).UTC().Format("2006-01-02 15:04:05 UTC"))
+			secretInfo.appendGroqResource(*resource)
+		}
+		return nil
+	case http.StatusUnauthorized:
+		secretInfo.Valid = false
+		return fmt.Errorf("invalid Groq API key")
+	default:
+		return fmt.Errorf("unexpected status code: %d", statusCode)
+	}
+}
+
+// captureBatches lists batch jobs when the account plan includes Batch API.
 // docs: https://console.groq.com/docs/api-reference#batches-list
+//
+// Free-tier keys get not_available_for_plan; treat that as empty, not invalid.
 func captureBatches(client *http.Client, key string, secretInfo *SecretInfo) error {
-	response, statusCode, err := makeGroqRequest(client, "https://api.groq.com/openai/v1/batches", key)
+	response, statusCode, err := makeGroqRequest(client, batchesURL, key)
 	if err != nil {
 		return err
 	}
@@ -100,48 +151,44 @@ func captureBatches(client *http.Client, key string, secretInfo *SecretInfo) err
 	switch statusCode {
 	case http.StatusOK:
 		var batches listBatchesResponse
-
 		if err := json.Unmarshal(response, &batches); err != nil {
 			return err
 		}
 
-		for _, batch := range batches.Data {
-			resource := GroqResource{
-				ID:         batch.ID,
-				Name:       batch.ID, // no specific name for batch
-				Type:       batch.Object,
+		for _, b := range batches.Data {
+			resource := &GroqResource{
+				ID:         b.ID,
+				Name:       b.ID,
+				Type:       b.Object,
 				Permission: PermissionStrings[FullAccess],
 			}
-
-			resource.updateMetadata("status", batch.Status)
-			resource.updateMetadata("endpoint", batch.Endpoint)
-			resource.updateMetadata("input file id", batch.InputFileID)
-			resource.updateMetadata("expires at", time.Unix(batch.ExpiresAt, 0).UTC().Format("2006-01-02 15:04:05 UTC"))
-
-			secretInfo.appendGroqResource(resource)
+			resource.updateMetadata("status", b.Status)
+			resource.updateMetadata("endpoint", b.Endpoint)
+			resource.updateMetadata("input file id", b.InputFileID)
+			resource.updateMetadata("expires at", time.Unix(b.ExpiresAt, 0).UTC().Format("2006-01-02 15:04:05 UTC"))
+			secretInfo.appendGroqResource(*resource)
 		}
-
 		return nil
 	case http.StatusForbidden:
 		var errResp errorResponse
-
 		if err := json.Unmarshal(response, &errResp); err != nil {
 			return err
 		}
-
-		if isPermissionError(errResp) {
+		if isPlanRestricted(errResp) {
 			return nil
 		}
-
 		return fmt.Errorf("unexpected error: %s", errResp.Error.Message)
 	default:
 		return fmt.Errorf("unexpected status code: %d", statusCode)
 	}
 }
 
+// captureFiles lists uploaded files when the account plan includes Files API.
 // docs: https://console.groq.com/docs/api-reference#files-list
+//
+// Free-tier keys get not_available_for_plan; treat that as empty, not invalid.
 func captureFiles(client *http.Client, key string, secretInfo *SecretInfo) error {
-	response, statusCode, err := makeGroqRequest(client, "https://api.groq.com/openai/v1/files", key)
+	response, statusCode, err := makeGroqRequest(client, filesURL, key)
 	if err != nil {
 		return err
 	}
@@ -149,37 +196,30 @@ func captureFiles(client *http.Client, key string, secretInfo *SecretInfo) error
 	switch statusCode {
 	case http.StatusOK:
 		var files listFilesResponse
-
 		if err := json.Unmarshal(response, &files); err != nil {
 			return err
 		}
 
-		for _, file := range files.Data {
-			resource := GroqResource{
-				ID:         file.ID,
-				Name:       file.Filename,
-				Type:       file.Object,
+		for _, f := range files.Data {
+			resource := &GroqResource{
+				ID:         f.ID,
+				Name:       f.Filename,
+				Type:       f.Object,
 				Permission: PermissionStrings[FullAccess],
 			}
-
-			resource.updateMetadata("purpose", file.Purpose)
-			resource.updateMetadata("created at", time.Unix(file.CreatedAt, 0).UTC().Format("2006-01-02 15:04:05 UTC"))
-
-			secretInfo.appendGroqResource(resource)
+			resource.updateMetadata("purpose", f.Purpose)
+			resource.updateMetadata("created at", time.Unix(f.CreatedAt, 0).UTC().Format("2006-01-02 15:04:05 UTC"))
+			secretInfo.appendGroqResource(*resource)
 		}
-
 		return nil
 	case http.StatusForbidden:
 		var errResp errorResponse
-
 		if err := json.Unmarshal(response, &errResp); err != nil {
 			return err
 		}
-
-		if isPermissionError(errResp) {
+		if isPlanRestricted(errResp) {
 			return nil
 		}
-
 		return fmt.Errorf("unexpected error: %s", errResp.Error.Message)
 	default:
 		return fmt.Errorf("unexpected status code: %d", statusCode)


### PR DESCRIPTION
## Summary
- Surface whatever the Groq key can access: models on every plan, plus batches and files on paid Developer plans.
- Free keys no longer look like they have zero permissions; paid keys still pick up batch/file resources when available.
- Fix metadata and binding construction so analyze results are populated correctly.

## Test plan
- [ ] Free-tier key: `go run . analyze groq` shows model resources with `full_access`
- [ ] Paid Developer key with batches/files: same command also shows those resources with `full_access`
- [ ] `go build ./pkg/analyzer/analyzers/groq/`
- [ ] `go test ./pkg/analyzer/analyzers/groq/ -count=1` (needs GCP test secrets)