### PR TITLE
fix(detectors/gitlab-v1): reject hyphenated UUIDs to stop webhook false positives

### DIFF
--- a/pkg/detectors/gitlab/v1/gitlab.go
+++ b/pkg/detectors/gitlab/v1/gitlab.go
@@ -34,7 +34,7 @@ func (Scanner) CloudEndpoint() string { return "https://gitlab.com" }
 
 var (
 	defaultClient = common.SaneHttpClient()
-	keyPat        = regexp.MustCompile(detectors.PrefixRegex([]string{"gitlab"}) + `\b([a-zA-Z0-9][a-zA-Z0-9\-=_]{19,21})\b`)
+	keyPat        = regexp.MustCompile(detectors.PrefixRegex([]string{"gitlab"}) + `\b([a-zA-Z0-9][a-zA-Z0-9=_]{19,21})\b`)
 
 	BlockedUserMessage = "403 Forbidden - Your account has been blocked"
 )

--- a/pkg/detectors/gitlab/v1/gitlab_v1_test.go
+++ b/pkg/detectors/gitlab/v1/gitlab_v1_test.go
@@ -45,6 +45,21 @@ func TestGitLab_Pattern(t *testing.T) {
 			input: "GITLAB_TOKEN=ABc123456789dEFghIJK",
 			want:  []string{"ABc123456789dEFghIJKhttps://gitlab.com"},
 		},
+		{
+			name: "uuid webhook header is not detected",
+			input: `{
+  "x-gitlab-event": "Push Hook",
+  "x-gitlab-event-uuid": "c3e2f2b7-a945-4c58-924b-38d8186e200a"
+}`,
+			want: []string{},
+		},
+		{
+			name: "hyphenated identifier near gitlab keyword is not detected",
+			input: `{
+  "gitlab": "a1b2-c3d4-e5f6a7b8c9d0"
+}`,
+			want: []string{},
+		},
 	}
 
 	for _, test := range tests {
@@ -62,11 +77,17 @@ func TestGitLab_Pattern(t *testing.T) {
 			}
 
 			if len(results) != len(test.want) {
-				if len(results) == 0 {
+				if len(test.want) == 0 {
+					t.Errorf("expected no results, received %d", len(results))
+				} else if len(results) == 0 {
 					t.Errorf("did not receive result")
 				} else {
 					t.Errorf("expected %d results, only received %d", len(test.want), len(results))
 				}
+				return
+			}
+
+			if len(test.want) == 0 {
 				return
 			}
 


### PR DESCRIPTION
The GitLab v1 detector catches prefixless PATs from older self-hosted instances — 20-22 character alphanumeric strings. The regex character class included hyphens, which real tokens never contain, so it was matching UUIDs from webhook headers like `x-gitlab-event-uuid` and any hyphenated identifier near the keyword "gitlab". This is a significant source of false positives that has prompted users to disable the GitLab check entirely (see #4493).

Removing the hyphen from the character class eliminates UUID-shaped matches while preserving detection of legitimate tokens, which use only `[a-zA-Z0-9=_]`. Added two test cases: a full webhook header UUID and the minimal repro from the issue, both now correctly produce zero results. The existing valid-token tests still pass unchanged.

Closes #4493

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrower matching on a single detector regex with added regression tests; legitimate v1 tokens were already limited to alphanumeric, `=`, and `_`.
> 
> **Overview**
> Tightens the GitLab **v1** token regex by dropping **`-`** from the allowed character class so 20–22 character matches must use only `[a-zA-Z0-9=_]`. That stops UUID-shaped strings (e.g. `x-gitlab-event-uuid` webhook headers and hyphenated values near a `gitlab` keyword) from being reported as legacy prefixless PATs.
> 
> Adds pattern tests that expect **no** findings for those cases and updates the test harness so **zero** expected results fail clearly when the detector still fires.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fe977c3bfafd81060ffb31e49244a8171c30dd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->