### PR TITLE
fix: stop treating HubSpot WAF 403 block pages as verified tokens

### DIFF
--- a/pkg/detectors/hubspot_apikey/v2/apikey.go
+++ b/pkg/detectors/hubspot_apikey/v2/apikey.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	regexp "github.com/wasilibs/go-re2"
 
@@ -91,8 +92,18 @@ func verifyToken(ctx context.Context, client *http.Client, token string) (bool, 
 	case http.StatusUnauthorized:
 		return false, nil
 	case http.StatusForbidden:
-		// The token is valid but lacks permission for the endpoint.
-		return true, nil
+		// HubSpot returns 403 for two distinct cases:
+		// 1. A valid token lacking permission for the endpoint (JSON error).
+		// 2. A WAF block page (HTML), which can happen for any token, valid or not.
+		// Only treat the JSON case as a verified token.
+		bodyBytes, err := io.ReadAll(res.Body)
+		if err != nil {
+			return false, err
+		}
+		if strings.Contains(string(bodyBytes), "correlationId") {
+			return true, nil
+		}
+		return false, nil
 	default:
 		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
 	}

--- a/pkg/detectors/hubspot_apikey/v2/apikey_test.go
+++ b/pkg/detectors/hubspot_apikey/v2/apikey_test.go
@@ -2,6 +2,9 @@ package v2
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -9,6 +12,67 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 )
+
+// stubTransport returns a canned response without touching the network.
+type stubTransport struct {
+	statusCode int
+	body       string
+}
+
+func (t *stubTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: t.statusCode,
+		Body:       io.NopCloser(strings.NewReader(t.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func TestVerifyToken(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		want       bool
+	}{
+		{
+			name:       "ok",
+			statusCode: http.StatusOK,
+			body:       `{"status":"ok"}`,
+			want:       true,
+		},
+		{
+			name:       "unauthorized",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"status":"error","message":"Authentication credentials not found."}`,
+			want:       false,
+		},
+		{
+			name:       "forbidden api json error means valid token",
+			statusCode: http.StatusForbidden,
+			body:       `{"status":"error","message":"The token is valid but lacks permission.","correlationId":"abc123"}`,
+			want:       true,
+		},
+		{
+			name:       "forbidden waf block page is not verified",
+			statusCode: http.StatusForbidden,
+			body:       "<html><body>You have been blocked.</body></html>",
+			want:       false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &http.Client{Transport: &stubTransport{statusCode: test.statusCode, body: test.body}}
+			got, err := verifyToken(context.Background(), client, "pat-na1-deadbeef-0000-1111-2222-333344445555")
+			if err != nil {
+				t.Fatalf("verifyToken() error = %v", err)
+			}
+			if got != test.want {
+				t.Errorf("verifyToken() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
 
 func TestHubspotV2_Pattern(t *testing.T) {
 	d := Scanner{}


### PR DESCRIPTION
## Summary

The v2 HubSpot API key detector reports any 403 response as a verified token. HubSpot's WAF returns 403 with an HTML block page for requests it decides to block, and that can happen for bogus tokens too. So random `pat-na1-*` strings end up reported as verified secrets.

## Changes

- `pkg/detectors/hubspot_apikey/v2/apikey.go`: in `verifyToken`, a 403 is only treated as verified when the response is a HubSpot API JSON error (contains `correlationId`). HTML block pages now return unverified.
- `pkg/detectors/hubspot_apikey/v2/apikey_test.go`: added `TestVerifyToken` covering 200, 401, API JSON 403, and WAF HTML 403 cases.

## Test plan

- `go test ./pkg/detectors/hubspot_apikey/...` passes.
- `go vet ./pkg/detectors/hubspot_apikey/...` and `go build ./...` pass.
- Live check: a bogus `pat-na1-` token gets a 401 `INVALID_AUTHENTICATION` from the API and is reported unverified, same as before.

## Notes

The v1 detector uses a different endpoint (`contacts/v1/lists?hapikey=`) which already returns 401 for invalid keys, so it needed no change.

Fixes #5164

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to HubSpot v2 verification logic and tests; reduces false positives without changing auth or data paths.
> 
> **Overview**
> Fixes false positives where the v2 HubSpot API key detector marked any **403** as a verified token. HubSpot’s WAF can return **403** with an HTML block page for invalid or blocked requests, not only when a real token lacks permission.
> 
> **`verifyToken`** now reads the **403** body and only counts the token as verified when the response looks like HubSpot API JSON (presence of **`correlationId`**). WAF HTML pages are treated as **unverified**.
> 
> Adds **`TestVerifyToken`** with a stub HTTP transport for **200**, **401**, permission-denied JSON **403**, and WAF HTML **403**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1dca7083b3b8995154b283057698faa70eba8a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->