### PR TITLE
[SCAN-1018] Treat SlackWebhook invalid_token (HTTP 400) as determinate not-live

### DIFF
--- a/pkg/detectors/slackwebhook/slackwebhook.go
+++ b/pkg/detectors/slackwebhook/slackwebhook.go
@@ -88,6 +88,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 						s1.Verified = true
 					case res.StatusCode == http.StatusBadRequest && bytes.Equal(bodyBytes, []byte("invalid_payload")):
 						s1.Verified = true
+					case res.StatusCode == http.StatusBadRequest && bytes.Contains(bodyBytes, []byte("invalid_token")):
+						// When a webhook is revoked or the workspace/channel is gone: determinate verified=false (SCAN-1018)
 					case res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusForbidden:
 						// Not a real webhook or the owning app's OAuth token has been revoked or the app has been deleted
 						// You might want to handle this case or log it.

--- a/pkg/detectors/slackwebhook/slackwebhook.go
+++ b/pkg/detectors/slackwebhook/slackwebhook.go
@@ -89,7 +89,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					case res.StatusCode == http.StatusBadRequest && bytes.Equal(bodyBytes, []byte("invalid_payload")):
 						s1.Verified = true
 					case res.StatusCode == http.StatusBadRequest && bytes.Contains(bodyBytes, []byte("invalid_token")):
-						// When a webhook is revoked or the workspace/channel is gone: determinate verified=false (SCAN-1018)
+						// Slack may return the bare error code or embed it in a longer body. Contains (not Equal,
+						// unlike invalid_payload above) matches both. Revoked webhook / gone workspace or channel
+						// is determinate verified=false.
 					case res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusForbidden:
 						// Not a real webhook or the owning app's OAuth token has been revoked or the app has been deleted
 						// You might want to handle this case or log it.

--- a/pkg/detectors/slackwebhook/slackwebhook.go
+++ b/pkg/detectors/slackwebhook/slackwebhook.go
@@ -89,9 +89,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 					case res.StatusCode == http.StatusBadRequest && bytes.Equal(bodyBytes, []byte("invalid_payload")):
 						s1.Verified = true
 					case res.StatusCode == http.StatusBadRequest && bytes.Contains(bodyBytes, []byte("invalid_token")):
-						// Slack may return the bare error code or embed it in a longer body. Contains (not Equal,
-						// unlike invalid_payload above) matches both. Revoked webhook / gone workspace or channel
-						// is determinate verified=false.
+						// Slack may return the bare error code or embed it in a longer body, hence Contains not Equal.
+						// Revoked webhook / gone workspace or channel is determinate verified=false.
 					case res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusForbidden:
 						// Not a real webhook or the owning app's OAuth token has been revoked or the app has been deleted
 						// You might want to handle this case or log it.

--- a/pkg/detectors/slackwebhook/slackwebhook_test.go
+++ b/pkg/detectors/slackwebhook/slackwebhook_test.go
@@ -2,10 +2,12 @@ package slackwebhook
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 )
@@ -74,6 +76,64 @@ func TestSlackWebHook_Pattern(t *testing.T) {
 
 			if diff := cmp.Diff(expected, actual); diff != "" {
 				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}
+
+func TestSlackWebhook_InvalidTokenVerification(t *testing.T) {
+	tests := []struct {
+		name                string
+		statusCode          int
+		body                string
+		wantVerified        bool
+		wantVerificationErr bool
+	}{
+		{
+			name:                "invalid_token is determinate not-live",
+			statusCode:          http.StatusBadRequest,
+			body:                "invalid_token",
+			wantVerified:        false,
+			wantVerificationErr: false,
+		},
+		{
+			name:                "invalid_token substring is determinate not-live",
+			statusCode:          http.StatusBadRequest,
+			body:                "error: invalid_token for webhook",
+			wantVerified:        false,
+			wantVerificationErr: false,
+		},
+		{
+			name:                "unexpected 400 remains indeterminate",
+			statusCode:          http.StatusBadRequest,
+			body:                "something_else",
+			wantVerified:        false,
+			wantVerificationErr: true,
+		},
+		{
+			name:                "invalid_payload is verified",
+			statusCode:          http.StatusBadRequest,
+			body:                "invalid_payload",
+			wantVerified:        true,
+			wantVerificationErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := Scanner{client: common.ConstantResponseHttpClient(tt.statusCode, tt.body)}
+			got, err := s.FromData(context.Background(), true, []byte(validPattern))
+			if err != nil {
+				t.Fatalf("FromData error: %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(got))
+			}
+			if got[0].Verified != tt.wantVerified {
+				t.Errorf("Verified = %v, want %v", got[0].Verified, tt.wantVerified)
+			}
+			if (got[0].VerificationError() != nil) != tt.wantVerificationErr {
+				t.Errorf("VerificationError = %v, wantVerificationErr %v", got[0].VerificationError(), tt.wantVerificationErr)
 			}
 		})
 	}


### PR DESCRIPTION
### Description:
Slack returns HTTP 400 with body containing `invalid_token` when a webhook is revoked or its workspace/channel is gone. That was classified as indeterminate (`SetVerificationError`), so secrets stayed verified and retried forever.

Treat `invalid_token` like 404/403: leave `Verified=false` with no verification error (determinate not-live). Adds unit coverage for `invalid_token` vs other 400 bodies.

### Checklist:
* [x] Tests passing (`make test-community`)? — `go test ./pkg/detectors/slackwebhook/ -count=1`
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to Slack webhook verification classification only; reduces false-positive retry loops with no auth or data-path impact.
> 
> **Overview**
> Slack webhook verification now treats **HTTP 400** responses whose body contains **`invalid_token`** as a **determinate not-live** outcome (`Verified=false`, no verification error), matching **404/403** behavior instead of falling through to an indeterminate `SetVerificationError` that caused endless retries.
> 
> Matching uses **`bytes.Contains`** so both bare `invalid_token` and longer error bodies are recognized. **`invalid_payload`** on 400 remains **verified=true**.
> 
> Adds **`TestSlackWebhook_InvalidTokenVerification`** with a mocked HTTP client covering `invalid_token`, substring bodies, other 400 bodies (still indeterminate), and `invalid_payload`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cc0e95fa969501733e5faeda5b1b40defee2b37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->