### PR TITLE
make cwd-changing normalization tests non-parallel to fix flaky clone failures

### DIFF
--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -1286,19 +1286,14 @@ func TestNormalizeFileURI(t *testing.T) {
 	}
 }
 
+// Relative file URIs resolve against the process working directory, so this
+// test has to chdir and cannot run in parallel: every other test in this
+// package shells out to git, and a git subprocess that inherits a working
+// directory this test later removes fails with "Unable to read current
+// working directory".
 func TestPrepareRepoWithNormalization(t *testing.T) {
 	repoPath := setupTestRepo(t, "test-repo")
 	addTestFileAndCommit(t, repoPath, "test.txt", "test content")
-
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get current directory: %v", err)
-	}
-	defer func() {
-		if err := os.Chdir(originalDir); err != nil {
-			t.Fatalf("failed to restore original directory: %v", err)
-		}
-	}()
 
 	// Test absolute paths first (without changing directory)
 	absoluteTests := []struct {
@@ -1338,10 +1333,8 @@ func TestPrepareRepoWithNormalization(t *testing.T) {
 		})
 	}
 
-	// Now change to temp directory for relative path tests
-	if err := os.Chdir(repoPath); err != nil {
-		t.Fatalf("failed to change to temp directory: %v", err)
-	}
+	// Now change to temp directory for relative path tests.
+	t.Chdir(repoPath)
 
 	relativeTests := []struct {
 		name             string
@@ -1382,8 +1375,6 @@ func TestPrepareRepoWithNormalization(t *testing.T) {
 }
 
 func TestPrepareRepoWithNormalizationBare(t *testing.T) {
-	t.Parallel()
-
 	workingRepoPath := setupTestRepo(t, "working-repo-original")
 	addTestFileAndCommit(t, workingRepoPath, "test.txt", "test content")
 
@@ -1395,16 +1386,6 @@ func TestPrepareRepoWithNormalizationBare(t *testing.T) {
 	assert.NoError(t, err, "Bare repository should have refs directory")
 	_, err = os.Stat(filepath.Join(bareRepoPath, "HEAD"))
 	assert.NoError(t, err, "Bare repository should have HEAD file")
-
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get current directory: %v", err)
-	}
-	defer func() {
-		if err := os.Chdir(originalDir); err != nil {
-			t.Fatalf("failed to restore original directory: %v", err)
-		}
-	}()
 
 	// Test absolute paths first (without changing directory)
 	absoluteTests := []struct {
@@ -1456,11 +1437,7 @@ func TestPrepareRepoWithNormalizationBare(t *testing.T) {
 		})
 	}
 
-	// Now change to temp directory for relative path tests
-	if err := os.Chdir(tempDir); err != nil {
-		t.Fatalf("failed to change to temp directory: %v", err)
-	}
-
+	t.Chdir(tempDir)
 	relativeTests := []struct {
 		name             string
 		uri              string

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -1286,16 +1286,11 @@ func TestNormalizeFileURI(t *testing.T) {
 	}
 }
 
-// Relative file URIs resolve against the process working directory, so this
-// test has to chdir and cannot run in parallel: every other test in this
-// package shells out to git, and a git subprocess that inherits a working
-// directory this test later removes fails with "Unable to read current
-// working directory".
 func TestPrepareRepoWithNormalization(t *testing.T) {
 	repoPath := setupTestRepo(t, "test-repo")
+	t.Chdir(repoPath)
 	addTestFileAndCommit(t, repoPath, "test.txt", "test content")
 
-	// Test absolute paths first (without changing directory)
 	absoluteTests := []struct {
 		name             string
 		uri              string
@@ -1332,9 +1327,6 @@ func TestPrepareRepoWithNormalization(t *testing.T) {
 			}
 		})
 	}
-
-	// Now change to temp directory for relative path tests.
-	t.Chdir(repoPath)
 
 	relativeTests := []struct {
 		name             string
@@ -1375,10 +1367,12 @@ func TestPrepareRepoWithNormalization(t *testing.T) {
 }
 
 func TestPrepareRepoWithNormalizationBare(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+
 	workingRepoPath := setupTestRepo(t, "working-repo-original")
 	addTestFileAndCommit(t, workingRepoPath, "test.txt", "test content")
 
-	tempDir := t.TempDir()
 	bareRepoPath := filepath.Join(tempDir, "bare-repo")
 	assert.NoError(t, exec.Command("git", "clone", workingRepoPath, bareRepoPath, "--bare").Run())
 
@@ -1387,7 +1381,6 @@ func TestPrepareRepoWithNormalizationBare(t *testing.T) {
 	_, err = os.Stat(filepath.Join(bareRepoPath, "HEAD"))
 	assert.NoError(t, err, "Bare repository should have HEAD file")
 
-	// Test absolute paths first (without changing directory)
 	absoluteTests := []struct {
 		name             string
 		uri              string
@@ -1437,7 +1430,6 @@ func TestPrepareRepoWithNormalizationBare(t *testing.T) {
 		})
 	}
 
-	t.Chdir(tempDir)
 	relativeTests := []struct {
 		name             string
 		uri              string


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
stop TestPrepareRepoWithNormalizationBare from running in parallel, to fix test that was failing PRs.
```
OSS prs are failing the test pull-request test on this error:
failed to clone file Git repo (file:///tmp/TestGitConfigSanitization508720935/001/test-repo): could not clone repo: file:///tmp/TestGitConfigSanitization508720935/001/test-repo, error executing git clone: exit status 128, fatal: Unable to read current working directory: No such file or directory
``` 

The test chdir'd into its own t.TempDir while parallel, so concurrently
forked `git clone` subprocesses inherited a working directory that was
deleted on cleanup, failing with "Unable to read current working
directory". Switched both normalization tests to t.Chdir so the
directory is restored before cleanup removes it.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to working-directory handling; no production git source behavior is modified.
> 
> **Overview**
> Fixes CI flakes where parallel git normalization tests changed the process working directory into a `t.TempDir()` that could be removed before child `git clone` processes finished, causing **"Unable to read current working directory"**.
> 
> **`TestPrepareRepoWithNormalization`** and **`TestPrepareRepoWithNormalizationBare`** now use **`t.Chdir`** instead of manual `os.Chdir` plus defer restore, so the test harness restores cwd before temp cleanup. **`TestPrepareRepoWithNormalizationBare`** no longer calls **`t.Parallel()`**, and its setup is reordered so the test chdirs into its temp directory before running bare-repo clone scenarios (including relative `file://` URIs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51364b74acf972503c39bccf57b7cb13dccb66d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->