### PR TITLE
Anthropic detector: surface API error detail on non-2xx verification

### DIFF
--- a/pkg/detectors/anthropic/anthropic.go
+++ b/pkg/detectors/anthropic/anthropic.go
@@ -83,15 +83,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	return results, nil
 }
 
-/*
-verifyAnthropicKey verify the anthropic key passed against the endpoint
-
-Endpoints:
-
-  - For api keys: https://docs.anthropic.com/en/api/models-list
-
-  - For admin keys:  https://docs.anthropic.com/en/api/admin-api/apikeys/list-api-keys
-*/
+// verifyAnthropicKey verifies key against endpoint (models-list for API keys,
+// admin api_keys-list for admin keys).
 func verifyAnthropicKey(ctx context.Context, client *http.Client, endpoint, key string) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)
 	if err != nil {
@@ -120,19 +113,14 @@ func verifyAnthropicKey(ctx context.Context, client *http.Client, endpoint, key 
 		return false, nil
 
 	default:
-		// Everything else is indeterminate. In particular a 400 is always
-		// invalid_request_error: the API returns it for a missing or malformed
-		// anthropic-version header or a bad query parameter, and never for the state of
-		// the key itself (every bad-key case above returns 401). A 400 therefore means
-		// the request was altered in transit rather than that the key is dead, so it
-		// must not be treated as determinate not-live. Include the API's own error
-		// type and message so the cause is diagnosable from the log alone.
+		// A 400 is invalid_request_error, never a bad-key signal (that's always 401),
+		// so it must stay indeterminate rather than count as not-live.
 		return false, apiError(res)
 	}
 }
 
-// anthropicErrorResponse is the error envelope the Anthropic API returns on a non-2xx
-// response. See https://platform.claude.com/docs/en/api/errors.
+// anthropicErrorResponse is the Anthropic API's error envelope for non-2xx responses.
+// See https://platform.claude.com/docs/en/api/errors.
 type anthropicErrorResponse struct {
 	Error struct {
 		Type    string `json:"type"`
@@ -140,13 +128,9 @@ type anthropicErrorResponse struct {
 	} `json:"error"`
 }
 
-// maxErrorBodySize bounds how much of an error response is read before giving up on
-// extracting a description from it.
-const maxErrorBodySize = 4 << 10
+const maxErrorBodySize = 4 << 10 // cap how much of the error body we bother parsing
 
-// apiError describes an unexpected response, enriching it with the API's own error type
-// and message when the body carries them. The message describes the request, not the
-// credential, so it is safe to attach to the verification error.
+// apiError enriches an unexpected status with the API's own error type/message when present.
 func apiError(res *http.Response) error {
 	body, err := io.ReadAll(io.LimitReader(res.Body, maxErrorBodySize))
 	if err != nil {

--- a/pkg/detectors/anthropic/anthropic.go
+++ b/pkg/detectors/anthropic/anthropic.go
@@ -83,8 +83,15 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	return results, nil
 }
 
-// verifyAnthropicKey verifies key against endpoint (models-list for API keys,
-// admin api_keys-list for admin keys).
+/*
+verifyAnthropicKey verify the anthropic key passed against the endpoint
+
+Endpoints:
+
+  - For api keys: https://docs.anthropic.com/en/api/models-list
+
+  - For admin keys:  https://docs.anthropic.com/en/api/admin-api/apikeys/list-api-keys
+*/
 func verifyAnthropicKey(ctx context.Context, client *http.Client, endpoint, key string) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)
 	if err != nil {

--- a/pkg/detectors/anthropic/anthropic.go
+++ b/pkg/detectors/anthropic/anthropic.go
@@ -95,7 +95,7 @@ Endpoints:
 func verifyAnthropicKey(ctx context.Context, client *http.Client, endpoint, key string) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, http.NoBody)
 	if err != nil {
-		return false, nil
+		return false, err
 	}
 
 	req.Header.Set("x-api-key", key)

--- a/pkg/detectors/anthropic/anthropic.go
+++ b/pkg/detectors/anthropic/anthropic.go
@@ -2,8 +2,9 @@ package anthropic
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -59,22 +60,21 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				client = defaultClient
 			}
 
-			isAdminKey := isAdminKey(keyMatch)
-			var isVerified bool
-			var err error
+			var (
+				isVerified      bool
+				verificationErr error
+			)
 
-			if isAdminKey {
-				isVerified, err = verifyAnthropicKey(ctx, client, adminKeyEndpoint, keyMatch)
+			if isAdminKey(keyMatch) {
 				s1.ExtraData["Type"] = "Admin Key"
-			} else if !isAdminKey {
-				isVerified, err = verifyAnthropicKey(ctx, client, apiKeyEndpoint, keyMatch)
-				s1.ExtraData["Type"] = "API Key"
+				isVerified, verificationErr = verifyAnthropicKey(ctx, client, adminKeyEndpoint, keyMatch)
 			} else {
-				return nil, errors.New("unknown key type detected for anthropic")
+				s1.ExtraData["Type"] = "API Key"
+				isVerified, verificationErr = verifyAnthropicKey(ctx, client, apiKeyEndpoint, keyMatch)
 			}
 
 			s1.Verified = isVerified
-			s1.SetVerificationError(err, keyMatch)
+			s1.SetVerificationError(verificationErr, keyMatch)
 		}
 
 		results = append(results, s1)
@@ -106,7 +106,10 @@ func verifyAnthropicKey(ctx context.Context, client *http.Client, endpoint, key 
 	if err != nil {
 		return false, err
 	}
-	defer func() { _ = res.Body.Close() }()
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
 
 	switch res.StatusCode {
 	case http.StatusOK:
@@ -117,8 +120,46 @@ func verifyAnthropicKey(ctx context.Context, client *http.Client, endpoint, key 
 		return false, nil
 
 	default:
-		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+		// Everything else is indeterminate. In particular a 400 is always
+		// invalid_request_error: the API returns it for a missing or malformed
+		// anthropic-version header or a bad query parameter, and never for the state of
+		// the key itself (every bad-key case above returns 401). A 400 therefore means
+		// the request was altered in transit rather than that the key is dead, so it
+		// must not be treated as determinate not-live. Include the API's own error
+		// type and message so the cause is diagnosable from the log alone.
+		return false, apiError(res)
 	}
+}
+
+// anthropicErrorResponse is the error envelope the Anthropic API returns on a non-2xx
+// response. See https://platform.claude.com/docs/en/api/errors.
+type anthropicErrorResponse struct {
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// maxErrorBodySize bounds how much of an error response is read before giving up on
+// extracting a description from it.
+const maxErrorBodySize = 4 << 10
+
+// apiError describes an unexpected response, enriching it with the API's own error type
+// and message when the body carries them. The message describes the request, not the
+// credential, so it is safe to attach to the verification error.
+func apiError(res *http.Response) error {
+	body, err := io.ReadAll(io.LimitReader(res.Body, maxErrorBodySize))
+	if err != nil {
+		return fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
+
+	var apiErr anthropicErrorResponse
+	if err := json.Unmarshal(body, &apiErr); err != nil || apiErr.Error.Type == "" {
+		return fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
+
+	return fmt.Errorf("unexpected HTTP response status %d (%s: %s)",
+		res.StatusCode, apiErr.Error.Type, apiErr.Error.Message)
 }
 
 func (s Scanner) Type() detector_typepb.DetectorType {

--- a/pkg/detectors/anthropic/anthropic_test.go
+++ b/pkg/detectors/anthropic/anthropic_test.go
@@ -2,14 +2,100 @@ package anthropic
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 )
+
+func TestAnthropic_VerifyMatch(t *testing.T) {
+	const key = "sk-ant-api03-Dtjm9IZ_rYhS_ihHLZmPXhjJ6PN8UPp7vNO7qO3735RRDpf8xbWGinsch0McONXznUm-4KWoA7WU2otvvwHBR5QRjiLakAA"
+
+	tests := []struct {
+		name         string
+		statusCode   int
+		body         string
+		wantVerified bool
+		wantErr      bool
+		// wantErrContains, when set, must appear in the verification error. It pins that
+		// the API's own explanation survives into the error rather than being discarded.
+		wantErrContains string
+	}{
+		{
+			name:         "200 is verified",
+			statusCode:   http.StatusOK,
+			body:         `{"data":[]}`,
+			wantVerified: true,
+		},
+		{
+			name:       "401 is determinate not-live",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"type":"error","error":{"type":"authentication_error","message":"API key is invalid."}}`,
+		},
+		{
+			name:       "404 is determinate not-live",
+			statusCode: http.StatusNotFound,
+			body:       `{"type":"error","error":{"type":"not_found_error","message":"Not found"}}`,
+		},
+		{
+			// 400 is invalid_request_error: the API returns it for a malformed request,
+			// never for the state of the key (bad keys return 401). It must stay
+			// indeterminate, otherwise a request mangled in transit silently marks a live
+			// key as not-verified.
+			name:            "400 stays indeterminate and keeps the API message",
+			statusCode:      http.StatusBadRequest,
+			body:            `{"type":"error","error":{"type":"invalid_request_error","message":"anthropic-version: header is required"}}`,
+			wantErr:         true,
+			wantErrContains: "anthropic-version: header is required",
+		},
+		{
+			name:            "429 stays indeterminate",
+			statusCode:      http.StatusTooManyRequests,
+			body:            `{"type":"error","error":{"type":"rate_limit_error","message":"Number of requests has exceeded your rate limit"}}`,
+			wantErr:         true,
+			wantErrContains: "rate_limit_error",
+		},
+		{
+			name:       "500 stays indeterminate",
+			statusCode: http.StatusInternalServerError,
+			body:       `{"type":"error","error":{"type":"api_error","message":"Internal server error"}}`,
+			wantErr:    true,
+		},
+		{
+			// A gateway that returns a non-JSON body must still degrade to a plain
+			// status-code error rather than panicking or losing the error entirely.
+			name:            "unparseable body still yields an error",
+			statusCode:      http.StatusBadRequest,
+			body:            `<html>502 Bad Gateway</html>`,
+			wantErr:         true,
+			wantErrContains: "unexpected HTTP response status 400",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := common.ConstantResponseHttpClient(test.statusCode, test.body)
+
+			verified, err := verifyAnthropicKey(context.Background(), client, apiKeyEndpoint, key)
+
+			if test.wantErr {
+				require.Error(t, err)
+				if test.wantErrContains != "" {
+					assert.Contains(t, err.Error(), test.wantErrContains)
+				}
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, test.wantVerified, verified)
+		})
+	}
+}
 
 func TestAnthropic_Pattern(t *testing.T) {
 	d := Scanner{}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The Anthropic detector treated any non-200/401/404 response as a plain "unexpected HTTP response status" error. A 400 from the API is `invalid_request_error` and never a bad-key signal (bad keys return 401), so it must stay indeterminate rather than being read as not-live, but the error gave no way to tell why a request was rejected.

This enriches that error with the API's own `error.type`/`error.message` when the body carries them, so a 400 (or any other unexpected status) is diagnosable from the log alone. Also drains the response body before closing it, drops a dead branch in the key-type dispatch, and adds test coverage for the verification status codes (200/401/404/400/429/500) plus a malformed-body fallback.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Anthropic detector verification and logging; behavior for 401/404 unchanged, with added tests for edge statuses.
> 
> **Overview**
> Improves **Anthropic API key verification** when the HTTP response is not 200, 401, or 404. Those unexpected statuses still leave the key **unverified** (not treated as definitively dead), but verification errors now include Anthropic’s **`error.type` and `error.message`** when the response body is valid JSON.
> 
> Also **propagates errors** from building the outbound request (instead of dropping them), **drains the response body** before close, and **simplifies** admin vs API key dispatch by removing an unreachable branch.
> 
> Adds **`TestAnthropic_VerifyMatch`** covering 200/401/404/400/429/500 and non-JSON error bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 447b1ea80be02ade2cd271f82a4763e4d749ab87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->