### PR TITLE
fix(github): fallback resource Name to avoid empty-string proto validation failure

### DIFF
--- a/pkg/analyzer/analyzers/github/github.go
+++ b/pkg/analyzer/analyzers/github/github.go
@@ -120,8 +120,17 @@ func secretInfoToRepoBindings(info *common.SecretInfo) []analyzers.Binding {
 		if owner := repo.GetOwner(); owner != nil {
 			parent = userToResource(owner)
 		}
+		// repo.GetName() could theoretically be empty for a deleted/ghost repo
+		// object; fall back to FullName so Name is never empty.
+		name := repo.GetName()
+		if name == "" {
+			name = repo.GetFullName()
+		}
+		if name == "" {
+			continue
+		}
 		resource := analyzers.Resource{
-			Name:               repo.GetName(),
+			Name:               name,
 			FullyQualifiedName: fmt.Sprintf("github.com/%s", repo.GetFullName()),
 			Type:               "repository",
 			Parent:             parent,
@@ -140,8 +149,14 @@ func secretInfoToGistBindings(info *common.SecretInfo) []analyzers.Binding {
 		if gist.GetOwner() == nil {
 			continue
 		}
+		// Gist descriptions are optional; fall back to the gist ID so Name is
+		// never empty (proto validation requires len >= 1).
+		name := gist.GetDescription()
+		if name == "" {
+			name = gist.GetID()
+		}
 		resource := analyzers.Resource{
-			Name:               gist.GetDescription(),
+			Name:               name,
 			FullyQualifiedName: fmt.Sprintf("gist.github.com/%s/%s", gist.GetOwner().GetLogin(), gist.GetID()),
 			Type:               "gist",
 			Parent:             userToResource(gist.GetOwner()),

--- a/pkg/analyzer/analyzers/github/github_test.go
+++ b/pkg/analyzer/analyzers/github/github_test.go
@@ -20,7 +20,9 @@ func makeOwner(login, userType string) *gh.User {
 }
 
 // TestSecretInfoToGistBindings exercises nil-field edge cases that caused a
-// production panic (nil Description and nil Owner from the GitHub API).
+// production panic (nil Description and nil Owner from the GitHub API), and
+// the empty-description proto-validation failure (CSM-1554) where Name must
+// be non-empty.
 func TestSecretInfoToGistBindings(t *testing.T) {
 	owner := makeOwner("truffle-sandbox", "User")
 	scope := []analyzers.Permission{{Value: "gist"}}
@@ -33,13 +35,22 @@ func TestSecretInfoToGistBindings(t *testing.T) {
 		wantNames []string // parallel to wantFQNs; checked unconditionally (including empty string)
 	}{
 		{
-			name: "nil description produces empty name, gist is still included",
+			name: "nil description falls back to gist ID as name",
 			gists: []*gh.Gist{
 				{ID: strPtr("abc123"), Description: nil, Owner: owner},
 			},
 			wantLen:   1,
 			wantFQNs:  []string{"gist.github.com/truffle-sandbox/abc123"},
-			wantNames: []string{""},
+			wantNames: []string{"abc123"},
+		},
+		{
+			name: "empty description falls back to gist ID as name",
+			gists: []*gh.Gist{
+				{ID: strPtr("abc123"), Description: strPtr(""), Owner: owner},
+			},
+			wantLen:   1,
+			wantFQNs:  []string{"gist.github.com/truffle-sandbox/abc123"},
+			wantNames: []string{"abc123"},
 		},
 		{
 			name: "nil owner: gist is skipped entirely",
@@ -107,7 +118,8 @@ func TestSecretInfoToRepoBindings(t *testing.T) {
 		repos         []*gh.Repository
 		wantLen       int
 		wantFQNs      []string
-		wantParentNil []bool // parallel to wantFQNs
+		wantNames     []string // parallel to wantFQNs; nil slice skips the check
+		wantParentNil []bool   // parallel to wantFQNs
 	}{
 		{
 			name: "valid repo produces binding with populated parent",
@@ -116,7 +128,25 @@ func TestSecretInfoToRepoBindings(t *testing.T) {
 			},
 			wantLen:       1,
 			wantFQNs:      []string{"github.com/truffle-sandbox/my-repo"},
+			wantNames:     []string{"my-repo"},
 			wantParentNil: []bool{false},
+		},
+		{
+			name: "empty repo name falls back to full name (CSM-1554: Name must be non-empty)",
+			repos: []*gh.Repository{
+				{Name: strPtr(""), FullName: strPtr("truffle-sandbox/ghost-repo"), Owner: owner},
+			},
+			wantLen:       1,
+			wantFQNs:      []string{"github.com/truffle-sandbox/ghost-repo"},
+			wantNames:     []string{"truffle-sandbox/ghost-repo"},
+			wantParentNil: []bool{false},
+		},
+		{
+			name: "both name and full name empty: repo is skipped",
+			repos: []*gh.Repository{
+				{Name: strPtr(""), FullName: strPtr(""), Owner: owner},
+			},
+			wantLen: 0,
 		},
 		{
 			name: "nil owner: repo is still included with nil parent",
@@ -167,6 +197,14 @@ func TestSecretInfoToRepoBindings(t *testing.T) {
 				gotNil := got[i].Resource.Parent == nil
 				if gotNil != wantNil {
 					t.Errorf("binding[%d].Parent nil = %v, want %v", i, gotNil, wantNil)
+				}
+			}
+			for i, name := range tt.wantNames {
+				if i >= len(got) {
+					break
+				}
+				if got[i].Resource.Name != name {
+					t.Errorf("binding[%d].Name = %q, want %q", i, got[i].Resource.Name, name)
 				}
 			}
 		})


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Gist descriptions are optional; empty description produced empty Resource.Name, failing CreateAnalysisResultsRequest validation and dropping the whole payload. Fall back to gist ID / repo FullName.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized edge-case handling in GitHub analyzer binding construction with matching unit tests; no auth or API behavior changes.
> 
> **Overview**
> Fixes **CSM-1554**, where GitHub analyzer bindings could emit an empty `Resource.Name` and fail `CreateAnalysisResultsRequest` validation (dropping the whole analysis payload).
> 
> **Gist bindings** now use the gist ID when the description is missing or empty, instead of leaving `Name` blank.
> 
> **Repository bindings** use `FullName` when `Name` is empty; repos with both empty are skipped so no invalid resource is emitted.
> 
> Unit tests were updated to expect these fallbacks and to assert `Resource.Name` on repo bindings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eedf8d6282100b961385a87ff350199fa3cda280. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->