### PR TITLE
giturl: don't append a line anchor to issue and pull request links

### DIFF
--- a/pkg/giturl/giturl.go
+++ b/pkg/giturl/giturl.go
@@ -214,6 +214,12 @@ func GenerateLink(repo, commit, file string, line int64) string {
 var (
 	linePattern        = regexp.MustCompile(`L\d+`)
 	bbCloudLinePattern = regexp.MustCompile(`lines-\d+(:\d+)?`)
+
+	// issueOrPullRequestPath matches the path of an issue or pull request page,
+	// e.g. /owner/repo/issues/123 or /owner/repo/pull/123. Paths continuing past the
+	// number, such as a pull request's "Files changed" view, are deliberately not
+	// matched: those do address lines.
+	issueOrPullRequestPath = regexp.MustCompile(`^/[^/]+/[^/]+/(?:issues|pull)/\d+$`)
 )
 
 // UpdateLinkLineNumber updates the line number in a repository link.
@@ -230,6 +236,13 @@ func UpdateLinkLineNumber(ctx context.Context, link string, newLine int64) strin
 
 	if newLine <= 0 {
 		// Don't change the link if the line number is 0.
+		return link
+	}
+
+	if issueOrPullRequestPath.MatchString(parsedURL.Path) {
+		// Issue and pull request pages have no line anchors. The fragment there already
+		// addresses the issue itself or one of its comments (#issue-N, #issuecomment-N),
+		// and appending L<number> to it yields an anchor the page does not have.
 		return link
 	}
 

--- a/pkg/giturl/giturl_test.go
+++ b/pkg/giturl/giturl_test.go
@@ -297,6 +297,30 @@ func TestUpdateLinkLineNumber(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			name: "Leave a github issue link untouched",
+			args: args{
+				link:    "https://github.com/trufflesecurity/trufflehog/issues/1913#issue-1950209402",
+				newLine: int64(5),
+			},
+			want: "https://github.com/trufflesecurity/trufflehog/issues/1913#issue-1950209402",
+		},
+		{
+			name: "Leave a github pull request comment link untouched",
+			args: args{
+				link:    "https://github.com/trufflesecurity/trufflehog/pull/1914#issuecomment-1801234567",
+				newLine: int64(5),
+			},
+			want: "https://github.com/trufflesecurity/trufflehog/pull/1914#issuecomment-1801234567",
+		},
+		{
+			name: "Still add a line to a file inside a repository named issues",
+			args: args{
+				link:    "https://github.com/org/issues/blob/047b4a2ba42fc5b6c0bd535c5307434a666db5ec/main.go",
+				newLine: int64(7),
+			},
+			want: "https://github.com/org/issues/blob/047b4a2ba42fc5b6c0bd535c5307434a666db5ec/main.go#L7",
+		},
+		{
 			name: "Update Bitbucket Cloud link with line",
 			args: args{
 				link:    "https://bitbucket.org/org/repo/src/xyz123/main.go",


### PR DESCRIPTION
Fixes #1913.

`UpdateLinkLineNumber` appends `L<n>` to the fragment of every link it does not recognise as Bitbucket or Azure. For a file that is correct, but issue and pull request links already carry a fragment addressing the issue or one of its comments, and those pages have no line anchors:

```
    https://github.com/trufflesecurity/trufflehog/issues/1913#issue-1950209402
 -> https://github.com/trufflesecurity/trufflehog/issues/1913#issue-1950209402L5
```

Such links are now returned unchanged.

The path pattern requires the number to end the path, so a pull request's "Files changed" view is still given a line, and a file inside a repository that happens to be named `issues` is unaffected — there is a test for the latter, and it passes both before and after.

Verified before and after: `pkg/giturl` goes from 2 failures to green. `pkg/engine` has one failure, `TestGitEngineWithMirrorAndBareClones`, which is present on a clean tree as well and is unchanged by this.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to link post-processing with explicit tests; no auth, data, or security impact.
> 
> **Overview**
> **`UpdateLinkLineNumber` no longer corrupts GitHub issue and pull request URLs** by appending `L<n>` to fragments that already target an issue or comment (`#issue-…`, `#issuecomment-…`).
> 
> A new path regex (`issueOrPullRequestPath`) detects `/owner/repo/issues/<id>` and `/owner/repo/pull/<id>` when the path ends at the number, so those links are returned unchanged. Deeper paths (e.g. PR “Files changed”) and normal blob links—including repos named `issues`—still get line updates.
> 
> Tests cover issue links, PR comment links, and the `issues` repo name edge case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d161acd2ae66eba1e991fd4766e0df7e592d58ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->