### PR TITLE
fix twilio detectortype bug

### DIFF
--- a/pkg/detectors/twilioapikey/twilioapikey.go
+++ b/pkg/detectors/twilioapikey/twilioapikey.go
@@ -67,7 +67,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	for apiKey := range uniqueAPIKeys {
 		for secret := range uniqueSecrets {
 			s1 := detectors.Result{
-				DetectorType: detector_typepb.DetectorType_Twilio,
+				DetectorType: detector_typepb.DetectorType_TwilioApiKey,
 				Raw:          []byte(apiKey),
 				RawV2:        []byte(apiKey + secret),
 				Redacted:     secret[:5] + "...",


### PR DESCRIPTION
### Description:
The `TwilioApiKey` detector was incorrectly referencing `DetectorType: ... Twilio`.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field metadata fix in one detector with no change to matching or verification logic.
> 
> **Overview**
> Fixes a labeling bug in the **Twilio API key** scanner: findings from `FromData` now set `DetectorType` to `DetectorType_TwilioApiKey` instead of `DetectorType_Twilio`.
> 
> That matches `Scanner.Type()` and verification/dedup paths that already use the API-key detector enum, so reported secrets are classified as Twilio API keys rather than the separate Twilio detector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2f2e7ceed64df8bf59e4e32e895719fef9d89c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->