### PR TITLE
Do not verify Lob keys on forbidden responses

### DIFF
--- a/pkg/detectors/lob/lob.go
+++ b/pkg/detectors/lob/lob.go
@@ -86,11 +86,10 @@ func (s Scanner) verify(ctx context.Context, key string) (bool, error) {
 	}
 	defer func() { _ = res.Body.Close() }()
 	switch res.StatusCode {
-	case http.StatusForbidden, http.StatusUnprocessableEntity:
-		// 403 indicates key is active but no billing method on file
+	case http.StatusUnprocessableEntity:
 		// 422 indicates key is active but request body is invalid
 		return true, nil
-	case http.StatusUnauthorized:
+	case http.StatusForbidden, http.StatusUnauthorized:
 		return false, nil
 	default:
 		return false, fmt.Errorf("unexpected status code: %d", res.StatusCode)

--- a/pkg/detectors/lob/lob_test.go
+++ b/pkg/detectors/lob/lob_test.go
@@ -3,6 +3,7 @@ package lob
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -16,6 +17,12 @@ var (
 	validPatternTest = "test_0979969b3f6cc23ed67e9b650bfaf64f710"
 	invalidPattern   = "live_0979969b3f6cc23ed67e9b650bfaf64f71"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func TestLob_Pattern(t *testing.T) {
 	d := Scanner{}
@@ -85,6 +92,69 @@ func TestLob_Pattern(t *testing.T) {
 
 			if diff := cmp.Diff(expected, actual); diff != "" {
 				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}
+
+func TestLob_VerifyStatusCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		want       bool
+	}{
+		{
+			name:       "forbidden is unverified",
+			statusCode: http.StatusForbidden,
+			want:       false,
+		},
+		{
+			name:       "unauthorized is unverified",
+			statusCode: http.StatusUnauthorized,
+			want:       false,
+		},
+		{
+			name:       "unprocessable entity is verified",
+			statusCode: http.StatusUnprocessableEntity,
+			want:       true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			scanner := Scanner{
+				client: &http.Client{
+					Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+						if req.Method != http.MethodPost {
+							t.Errorf("method = %q, want %q", req.Method, http.MethodPost)
+						}
+						if req.URL.String() != "https://api.lob.com/v1/us_verifications" {
+							t.Errorf("url = %q, want https://api.lob.com/v1/us_verifications", req.URL.String())
+						}
+						username, password, ok := req.BasicAuth()
+						if !ok {
+							t.Fatal("expected basic auth")
+						}
+						if username != validPattern {
+							t.Errorf("username = %q, want %q", username, validPattern)
+						}
+						if password != "" {
+							t.Errorf("password = %q, want empty", password)
+						}
+						return &http.Response{
+							StatusCode: test.statusCode,
+							Body:       http.NoBody,
+						}, nil
+					}),
+				},
+			}
+
+			got, err := scanner.verify(context.Background(), validPattern)
+			if err != nil {
+				t.Fatalf("verify returned error: %v", err)
+			}
+			if got != test.want {
+				t.Errorf("verify = %t, want %t", got, test.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Treat Lob 403 Forbidden verification responses as unverified instead of verified
- Keep 422 Unprocessable Entity as the positive verification signal
- Add status-code coverage for Lob verification responses

## Tests
- go test ./pkg/detectors/lob