### PR TITLE
fix(detectors/sqlserver): skip format-string placeholder passwords

### DIFF
--- a/pkg/detectors/sqlserver/placeholder_test.go
+++ b/pkg/detectors/sqlserver/placeholder_test.go
@@ -1,0 +1,47 @@
+package sqlserver
+
+import (
+	"context"
+	"testing"
+)
+
+func TestSqlServer_FromData_SkipsPlaceholderPasswords(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantCount int
+	}{
+		{
+			name:      "dotnet string.Format template",
+			input:     `Server={0};Database={3};User Id={1};Password={2};`,
+			wantCount: 0,
+		},
+		{
+			name:      "named placeholder tokens",
+			input:     `Server={ServerName};Database={DbName};User Id={UserId};Password={Password};`,
+			wantCount: 0,
+		},
+		{
+			name:      "real credential is still reported",
+			input:     `Server=db.internal.example.com;Database=payroll;User Id=sa;Password=P@ssw0rd!;`,
+			wantCount: 1,
+		},
+		{
+			name:      "password containing braces is still reported",
+			input:     `Server=db.internal.example.com;Database=payroll;User Id=sa;Password=a{0}b;`,
+			wantCount: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := Scanner{}.FromData(context.Background(), false, []byte(test.input))
+			if err != nil {
+				t.Fatalf("FromData() returned error: %v", err)
+			}
+			if len(got) != test.wantCount {
+				t.Errorf("got %d results, want %d", len(got), test.wantCount)
+			}
+		})
+	}
+}

--- a/pkg/detectors/sqlserver/sqlserver.go
+++ b/pkg/detectors/sqlserver/sqlserver.go
@@ -54,6 +54,11 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	// SQLServer connection string is a semicolon delimited set of case-insensitive parameters which may go in any order.
 	pattern = regexp.MustCompile("(?:\n|`|'|\"| )?((?:[A-Za-z0-9_ ]+=[^;$'`\"$]+;?){3,})(?:'|`|\"|\r\n|\n)?")
+
+	// A password that is exactly one brace-delimited token is a templating
+	// placeholder rather than a credential. Covers .NET string.Format positional
+	// arguments ({0}, {1}, ...) and named tokens such as {Password}.
+	placeholderPattern = regexp.MustCompile(`^\{[^{}]*\}$`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -75,6 +80,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if paramsUnsafe.Password == "" {
+			continue
+		}
+
+		if placeholderPattern.MatchString(paramsUnsafe.Password) {
 			continue
 		}
 


### PR DESCRIPTION
### Description:

Fixes #3681.

A .NET connection-string template matches the sqlserver detector pattern, and `msdsn.Parse` parses it happily, so `Password` comes back as the literal placeholder token. The only content filter in `FromData` was the empty-password check, which a token like `{2}` passes. Every `string.Format` connection-string template in a scanned repository is therefore reported as a SQL Server secret.

```
Server={0};Database={3};User Id={1};Password={2};   ->  Raw = "{2}"
Server={ServerName};...;Password={Password};        ->  Raw = "{Password}"
```

This skips a password that is exactly one brace-delimited token. A password that merely contains braces, such as `Password=a{0}b;`, is still reported, and there is a test pinning that so the guard cannot quietly widen.

One note for anyone reproducing the original issue. #3681 reports the symptom as `invalid URL escape "%7B"`, and you will not see that string today. Since #4174 added a TCP pre-dial ahead of `sql.Open`, the braced host fails name resolution first and the verification error is now `lookup {0}: no such host`. The escape error is still reachable in the driver leg if you hand the generated DSN straight to `sql.Open` plus `PingContext`. Either way the false positive is the part worth fixing, and it is unchanged since the detector was added.

Also worth knowing: `%7B` is only rejected by `net/url` when it lands in the host component. A placeholder confined to the password, user or database re-parses fine.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

Verified fail-before and pass-after on the new test. With the guard removed both placeholder cases return 1 result instead of 0; with it in place the package suite is green and `go vet` is clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow false-positive filter in the sqlserver detector with targeted tests; no auth or verification logic changes beyond skipping templated passwords.
> 
> **Overview**
> Stops the SQL Server detector from treating **.NET connection-string templates** as real secrets when the parsed `Password` is a single brace-wrapped token (e.g. `{2}`, `{Password}`).
> 
> `FromData` now skips matches where the password matches `^\{[^{}]*\}$`, while **real passwords** and values that only **contain** braces (e.g. `a{0}b`) are still reported.
> 
> Adds `placeholder_test.go` with table-driven cases for templates, named placeholders, a live-looking connection string, and a braced-but-not-placeholder password.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11dc73440527357899743438edd0f96ee10353ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->