### PR TITLE
docs: mention MegaLinter in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,12 @@ security-secrets:
 
 In the example pipeline above, we're scanning for live secrets in all repository directories and files. This job runs only when the pipeline source is a merge request event, meaning it's triggered when a new merge request is created.
 
+## MegaLinter
+
+TruffleHog is natively embedded within [MegaLinter](https://megalinter.io), an open-source linters aggregator for CI, so you can run it together with other code quality and security tools in a single job.
+
+See the [TruffleHog page in MegaLinter documentation](https://megalinter.io/latest/descriptors/repository_trufflehog/) for more information.
+
 ## Pre-commit Hook
 
 TruffleHog can be used in a pre-commit hook to prevent credentials from leaking before they ever leave your computer.


### PR DESCRIPTION
### Description:

Hi! I maintain [MegaLinter](https://megalinter.io), an open-source linters aggregator for CI that ships TruffleHog as one of its built-in security scanners. This PR just adds a short note about it in the README, next to the other CI integrations (GitHub Action, GitLab CI), so TruffleHog users know they can also get it through MegaLinter: https://megalinter.io/latest/descriptors/repository_trufflehog/

Happy to tweak wording or placement if you'd prefer it elsewhere.

### Checklist:
* [x] Tests passing (`make test-community`)? — docs-only change
* [x] Lint passing (`make lint`)? — docs-only change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no runtime or security impact.
> 
> **Overview**
> Adds a **MegaLinter** subsection to the README’s CI integrations area (after GitLab CI, before Pre-commit Hook).
> 
> It notes that TruffleHog ships inside [MegaLinter](https://megalinter.io) so teams can run it alongside other linters in one CI job, and links to MegaLinter’s [TruffleHog descriptor docs](https://megalinter.io/latest/descriptors/repository_trufflehog/).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ea09519b5b4428db91fb618174bd3e9cf7a42b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->