### PR TITLE
docs: add generic config-secret custom detector example

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,6 +798,8 @@ Custom Detectors support a few different filtering mechanisms: entropy, regex ta
 and excluded word lists checked against the secret (captured group if present, entire match if capture group is not present). Note that if
 your custom detector has multiple `regex` set (in this example `hogID`, and `hogToken`), then the filters get applied to each regex. [Here](examples/generic_with_filters.yml) is an example of a custom detector using these filters.
 
+The `verify` section is optional — if you omit it, matches are still reported as unverified, no webhook required. This makes Custom Detectors useful for flagging generic hardcoded secrets (e.g. `*.password=`, `*.secret=`) in config files like `.properties`, `.env`, or `.yaml` that TruffleHog's built-in, verified detectors won't otherwise catch. [Here](examples/generic_config_secrets.yml) is an example tuned for that use case.
+
 **NB:** This feature is alpha and subject to change.
 
 ### Regex Detector Example

--- a/examples/generic_config_secrets.yml
+++ b/examples/generic_config_secrets.yml
@@ -1,0 +1,44 @@
+detectors:
+- name: generic-config-secret
+  keywords:
+  - secret
+  - password
+  - passwd
+  - pwd
+  - apikey
+  - api_key
+  - api-key
+  - token
+  - credential
+  - cred
+  - auth
+  regex:
+    secret: |-
+      (?i)[\w.-]{0,50}?(?:secret|passw(?:or)?d|pwd|api[_-]?key|token|credentials?|creds?|auth)[\w.-]{0,20}\s*[=:]\s*["'`]?([^\s"'`,;]{6,150})["'`]?\s*(?:$|[\r\n#;])
+  entropy: 2.5
+  exclude_regexes_match:
+  - '(?i)\$\{[^}]*\}'
+  - '(?i)\{\{[^}]*\}\}'
+  - '(?i)%[A-Z_]+%'
+  - '(?i)\$[A-Z_][A-Z0-9_]*'
+  - '(?i)(?:env|process\.env|os\.environ|getenv|System\.getenv)\b'
+  - '(?i)(?:vault|kms|secretsmanager|parameterstore)://'
+  exclude_words:
+  - "changeme"
+  - "change_me"
+  - "change-me"
+  - "changethis"
+  - "xxxxxx"
+  - "example"
+  - "placeholder"
+  - "dummy"
+  - "redacted"
+  - "your_api_key"
+  - "your-api-key"
+  - "yourapikey"
+  - "insert_secret_here"
+  - "todo"
+  - "fixme"
+  - "null"
+  - "none"
+  - "false"

--- a/examples/generic_config_secrets.yml
+++ b/examples/generic_config_secrets.yml
@@ -16,13 +16,16 @@ detectors:
     secret: |-
       (?i)[\w.-]{0,50}?(?:secret|passw(?:or)?d|pwd|api[_-]?key|token|credentials?|creds?|auth)[\w.-]{0,20}\s*[=:]\s*["'`]?([^\s"'`,;]{6,150})["'`]?\s*(?:$|[\r\n#;])
   entropy: 2.5
-  exclude_regexes_match:
-  - '(?i)\$\{[^}]*\}'
-  - '(?i)\{\{[^}]*\}\}'
-  - '(?i)%[A-Z_]+%'
-  - '(?i)\$[A-Z_][A-Z0-9_]*'
-  - '(?i)(?:env|process\.env|os\.environ|getenv|System\.getenv)\b'
-  - '(?i)(?:vault|kms|secretsmanager|parameterstore)://'
+  # Applied to the captured value only (not the key), so a key path like
+  # `env.password` or `app.env.secret` doesn't cause a real hardcoded
+  # secret to be excluded just because "env" appears in the key.
+  exclude_regexes_capture:
+  - '(?i)^\$\{[^}]*\}$'
+  - '(?i)^\{\{[^}]*\}\}$'
+  - '(?i)^%[A-Z_]+%$'
+  - '(?i)^\$[A-Z_][A-Z0-9_]*$'
+  - '(?i)^(?:process\.env\.|os\.environ|getenv\(|System\.getenv\()'
+  - '(?i)^(?:vault|kms|secretsmanager|parameterstore)://'
   exclude_words:
   - "changeme"
   - "change_me"

--- a/pkg/custom_detectors/CUSTOM_DETECTORS.md
+++ b/pkg/custom_detectors/CUSTOM_DETECTORS.md
@@ -41,6 +41,8 @@ This guide will walk you through setting up a custom detector in TruffleHog to i
 
      When only one of the two fields is configured, non-matching responses are treated as the opposite state (e.g., if only `successRanges` is set, any response that doesn't match is treated as rotated; if only `rotatedRanges` is set, any non-matching response is treated as live). When both fields are configured and the response matches neither, the result is treated as unknown/inconclusive.
 
+     Since `verify` is optional, Custom Detectors can also be used without a webhook to flag generic hardcoded secrets (e.g. `*.password=`, `*.secret=`) in config files such as `.properties`, `.env`, or `.yaml`. [Here](/examples/generic_config_secrets.yml) is an example config tuned for that use case.
+
    Here's an example with configurable verification ranges:
 
    ```yaml


### PR DESCRIPTION
## Summary

- Custom Detectors already support omitting the `verify` webhook block — matches are then simply reported as unverified. This makes them usable for flagging generic hardcoded secrets (e.g. `*.password=`, `*.secret=`) in config files like `.properties`, `.env`, or `.yaml`, which TruffleHog's built-in, verified detectors intentionally don't cover.
- Adds `examples/generic_config_secrets.yml`, tuned for that use case: looser matching than `examples/generic_with_filters.yml` (which requires the match to contain both a digit and a special character), with an entropy filter and exclude rules for common placeholders (`changeme`, `${VAR}`, `{{ .template }}`, env-var references, etc.) to keep false positives down.
- Links to the new example from `README.md` and `pkg/custom_detectors/CUSTOM_DETECTORS.md`, right next to the existing docs explaining that `verify` is optional.

Addresses #4957, where a user reported that a default `trufflehog git ... --fail` scan doesn't flag hardcoded secrets in a `.properties` file. That's expected (no built-in detector targets arbitrary config keys), but the ask can already be met with Custom Detectors — this PR just makes that path discoverable with a ready-to-use example.

## Test plan

- [x] Built from source and reproduced the issue: default scan of a `.properties` file containing `knox.auth.client.secret=...`, `jwt.secretkey=...`, `test.auth.password=...` reports 0 findings.
- [x] Same file scanned with `--config=examples/generic_config_secrets.yml` reports all 3 as unverified findings.
- [x] Verified the exclude rules correctly skip common false-positive patterns in the same file: `${DB_PASSWORD}`, `changeme`, `{{ .Values.token }}`, and a plain `true` value.
- [x] Docs-only change elsewhere; no code paths modified.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and example YAML only; no runtime or detector code changes.
> 
> **Overview**
> Documents that Custom Detectectors work **without** a `verify` webhook (findings stay unverified) and adds a ready-to-use example for catching hardcoded secrets in config files (`.properties`, `.env`, `.yaml`) that built-in verified detectors miss.
> 
> **`examples/generic_config_secrets.yml`** defines `generic-config-secret`: keyword-triggered regex for `key=value` / `key: value` patterns, entropy `2.5`, and capture-level excludes for placeholders (`changeme`, `${VAR}`, `{{ templates }}`, env refs, vault URLs, etc.)—looser than `generic_with_filters.yml`, which enforces digit/special-char validations and no `verify` block.
> 
> **README** and **`pkg/custom_detectors/CUSTOM_DETECTORS.md`** now call out the optional-`verify` workflow and link to the new example beside the existing filter docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75c4ad6489f12eda0355010928664873befab3b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->