### PR TITLE
fix(blogger): anchor regex to AIzaSy prefix to eliminate false positives

### DIFF
--- a/pkg/detectors/blogger/blogger.go
+++ b/pkg/detectors/blogger/blogger.go
@@ -22,8 +22,10 @@ var _ detectors.Detector = (*Scanner)(nil)
 var (
 	client = common.SaneHttpClient()
 
-	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
-	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"blogger"}) + `\b([0-9A-Za-z-]{39})\b`)
+	// Google API keys always start with "AIzaSy" (6-char prefix + 33 remaining = 39 total).
+	// The prefix regex retains "blogger" proximity to distinguish from other Google API-backed things.
+	// No trailing \b because keys can end with '-', which is not a word character.
+	keyPat = regexp.MustCompile(detectors.PrefixRegex([]string{"blogger"}) + `\b(AIzaSy[0-9A-Za-z_-]{33})`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/blogger/blogger_test.go
+++ b/pkg/detectors/blogger/blogger_test.go
@@ -25,6 +25,53 @@ func TestBlogger_Pattern(t *testing.T) {
 			input: `
 				func main() {
 					// Create a new request with the secret as a header
+					req, err := http.NewRequest("GET", "https://api.example.com/v1/blogger/blogs?key=AIzaSyDaGmWKa4JsXZ-HjGw7ISLn_3namBGewQe", http.NoBody)
+					if err != nil {
+						fmt.Println("Error creating request:", err)
+						return
+					}
+
+					// Perform the request
+					client := &http.Client{}
+					resp, _ := client.Do(req)
+					defer func() { _ = resp.Body.Close() }()
+
+					// Check response status
+					if resp.StatusCode == http.StatusOK {
+						fmt.Println("Request successful!")
+					} else {
+						fmt.Println("Request failed with status:", resp.Status)
+					}
+				}
+				`,
+			want: []string{"AIzaSyDaGmWKa4JsXZ-HjGw7ISLn_3namBGewQe"},
+		},
+		{
+			name: "valid pattern - xml",
+			input: `
+				<com.cloudbees.plugins.credentials.impl.StringCredentialsImpl>
+					<scope>GLOBAL</scope>
+					<id>{blogger}</id>
+					<secret>{blogger AIzaSyCjkL9m2nOp4qRsTuVwXyZ0a1B2c3D4e5F}</secret>
+					<description>configuration for production</description>
+					<creationDate>2023-05-18T14:32:10Z</creationDate>
+					<owner>jenkins-admin</owner>
+				</com.cloudbees.plugins.credentials.impl.StringCredentialsImpl>
+			`,
+			want: []string{"AIzaSyCjkL9m2nOp4qRsTuVwXyZ0a1B2c3D4e5F"},
+		},
+		{
+			name: "false positive - java class name (CSM-2238)",
+			input: `
+				EJBLogger.logfinderReturnedMultipleValuesLoggable("@finderMethodName");
+			`,
+			want: nil,
+		},
+		{
+			name: "invalid pattern - wrong prefix",
+			input: `
+				func main() {
+					// Create a new request with the secret as a header
 					req, err := http.NewRequest("GET", "https://api.example.com/v1/blogger/blogs?key=fnWLw7pz1tc6uCzq6qocQZIxRF6SqUaOOkLqePY", http.NoBody)
 					if err != nil {
 						fmt.Println("Error creating request:", err)
@@ -44,43 +91,16 @@ func TestBlogger_Pattern(t *testing.T) {
 					}
 				}
 				`,
-			want: []string{"fnWLw7pz1tc6uCzq6qocQZIxRF6SqUaOOkLqePY"},
+			want: nil,
 		},
 		{
-			name: "valid pattern - xml",
-			input: `
-				<com.cloudbees.plugins.credentials.impl.StringCredentialsImpl>
-  					<scope>GLOBAL</scope>
-  					<id>{blogger}</id>
-  					<secret>{blogger AQAAABAAA mtkwpygpNROxOgLZCnEvl7gNme1IuFiQm9oxPzJ}</secret>
-  					<description>configuration for production</description>
-					<creationDate>2023-05-18T14:32:10Z</creationDate>
-  					<owner>jenkins-admin</owner>
-				</com.cloudbees.plugins.credentials.impl.StringCredentialsImpl>
-			`,
-			want: []string{"mtkwpygpNROxOgLZCnEvl7gNme1IuFiQm9oxPzJ"},
-		},
-		{
-			name: "invalid pattern",
+			name: "invalid pattern - special characters",
 			input: `
 				func main() {
-					// Create a new request with the secret as a header
-					req, err := http.NewRequest("GET", "https://api.example.com/v1/blogger/blogs?key=fnWL(w7pz1t)6uCz-q6qocQZIxRF6S/UqePY", http.NoBody)
+					req, err := http.NewRequest("GET", "https://api.example.com/v1/blogger/blogs?key=AIzaSy(w7pz1t)6uCz-q6qocQZIxRF6S/UqePY", http.NoBody)
 					if err != nil {
 						fmt.Println("Error creating request:", err)
 						return
-					}
-
-					// Perform the request
-					client := &http.Client{}
-					resp, _ := client.Do(req)
-					defer func() { _ = resp.Body.Close() }()
-
-					// Check response status
-					if resp.StatusCode == http.StatusOK {
-						fmt.Println("Request successful!")
-					} else {
-						fmt.Println("Request failed with status:", resp.Status)
 					}
 				}
 				`,


### PR DESCRIPTION
### Description:
Fix false positive in the Blogger detector triggered by Java class names (e.g. `EJBLogger.logfinderReturnedMultipleValuesLoggable`). The regex `[0-9A-Za-z-]{39}` matches any 39-character alphanumeric string within 40 characters of "blogger" (case-insensitive). This false positive above just so happened to be exactly 39 characters between word boundaries, so it was detected.

All Google API keys start with `AIzaSy`, the fix anchors the capture group to that prefix and also adds `_` to the character class since Google keys can contain underscores.

A note on the Corpora "regression" - the test files were adjusted to start looking for the right key prefixes, so while they were technically removed, this is expected I believe, since the corpus of public code hopefully does not contain any exposed Blogger API keys.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e385039ffc4d243bbead75908ac203832af25fba. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->