### PR TITLE
fix(huggingface): move unscoped fine-grained models to UnboundedResources

### DIFF
--- a/pkg/analyzer/analyzers/huggingface/huggingface.go
+++ b/pkg/analyzer/analyzers/huggingface/huggingface.go
@@ -91,9 +91,9 @@ func bakeUnfineGrainedBindings(allModels []Model, tokenJSON HFTokenJSON) []analy
 	return bindings
 }
 
-// finegrained scopes are grouped by org, user or model.
-func bakefineGrainedBindings(allModels []Model, tokenJSON HFTokenJSON) []analyzers.Binding {
-	// this section will extract the relevant permissions for each entity and store them in a map
+// bakefineGrainedBindings resolves each model's permission from the token's
+// fine-grained scopes (grouped by org, user, or model).
+func bakefineGrainedBindings(allModels []Model, tokenJSON HFTokenJSON) ([]analyzers.Binding, []analyzers.Resource) {
 	var nameToPermissions = make(map[string]analyzers.Permission)
 	for _, permission := range tokenJSON.Auth.AccessToken.FineGrained.Scoped {
 		privs := analyzers.Permission{
@@ -115,10 +115,9 @@ func bakefineGrainedBindings(allModels []Model, tokenJSON HFTokenJSON) []analyze
 		}
 	}
 
-	bindings := make([]analyzers.Binding, len(allModels))
-	for idx, model := range allModels {
-
-		// Add Read Privs to All Models
+	var bindings []analyzers.Binding
+	var unbounded []analyzers.Resource
+	for _, model := range allModels {
 		modelResource := analyzers.Resource{
 			Name:               model.Name,
 			FullyQualifiedName: "huggingface.com/model/" + model.ID,
@@ -129,22 +128,27 @@ func bakefineGrainedBindings(allModels []Model, tokenJSON HFTokenJSON) []analyze
 		}
 
 		var perm analyzers.Permission
-		// get username/orgname for each model and apply those permissions
 		modelUsername := strings.Split(model.Name, "/")[0]
 		if permissions, ok := nameToPermissions[modelUsername]; ok {
 			perm = permissions
 		}
-		// override model permissions with repo-specific permissions
 		if permissions, ok := nameToPermissions[model.Name]; ok {
 			perm = permissions
 		}
 
-		bindings[idx] = analyzers.Binding{
+		// Models without an explicit fine-grained scope are visible to the
+		// token but have no bound permission; they belong in UnboundedResources.
+		if perm.Value == "" {
+			unbounded = append(unbounded, modelResource)
+			continue
+		}
+
+		bindings = append(bindings, analyzers.Binding{
 			Resource:   modelResource,
 			Permission: perm,
-		}
+		})
 	}
-	return bindings
+	return bindings, unbounded
 }
 
 func bakeOrganizationBindings(tokenJSON HFTokenJSON) []analyzers.Binding {
@@ -259,7 +263,9 @@ func secretInfoToAnalyzerResult(info *SecretInfo) *analyzers.AnalyzerResult {
 	result.Bindings = make([]analyzers.Binding, 0)
 
 	if info.Token.Auth.AccessToken.Type == FINEGRAINED {
-		result.Bindings = append(result.Bindings, bakefineGrainedBindings(info.Models, info.Token)...)
+		fgBindings, fgUnbounded := bakefineGrainedBindings(info.Models, info.Token)
+		result.Bindings = append(result.Bindings, fgBindings...)
+		result.UnboundedResources = append(result.UnboundedResources, fgUnbounded...)
 		result.Bindings = append(result.Bindings, bakeOrganizationBindings(info.Token)...)
 		result.Bindings = append(result.Bindings, bakeUserBindings(info.Token)...)
 	} else {

--- a/pkg/analyzer/analyzers/huggingface/huggingface_test.go
+++ b/pkg/analyzer/analyzers/huggingface/huggingface_test.go
@@ -118,3 +118,132 @@ func TestAnalyzer_Analyze(t *testing.T) {
 		})
 	}
 }
+
+// Test_secretInfoToAnalyzerResult_FineGrainedUnboundedResources verifies that
+// models outside the token's fine-grained permission scopes land in
+// UnboundedResources rather than producing bindings with empty Permission.Value.
+func Test_secretInfoToAnalyzerResult_FineGrainedUnboundedResources(t *testing.T) {
+	info := &SecretInfo{
+		Token: HFTokenJSON{
+			Username: "testuser",
+			Name:     "Test User",
+			Auth: struct {
+				AccessToken struct {
+					Name        string `json:"displayName"`
+					Type        string `json:"role"`
+					CreatedAt   string `json:"createdAt"`
+					FineGrained struct {
+						Global []string `json:"global"`
+						Scoped []struct {
+							Entity struct {
+								Type string `json:"type"`
+								Name string `json:"name"`
+								ID   string `json:"_id"`
+							} `json:"entity"`
+							Permissions []string `json:"permissions"`
+						} `json:"scoped"`
+					} `json:"fineGrained"`
+				}
+			}{
+				AccessToken: struct {
+					Name        string `json:"displayName"`
+					Type        string `json:"role"`
+					CreatedAt   string `json:"createdAt"`
+					FineGrained struct {
+						Global []string `json:"global"`
+						Scoped []struct {
+							Entity struct {
+								Type string `json:"type"`
+								Name string `json:"name"`
+								ID   string `json:"_id"`
+							} `json:"entity"`
+							Permissions []string `json:"permissions"`
+						} `json:"scoped"`
+					} `json:"fineGrained"`
+				}{
+					Name: "test-token",
+					Type: FINEGRAINED,
+					FineGrained: struct {
+						Global []string `json:"global"`
+						Scoped []struct {
+							Entity struct {
+								Type string `json:"type"`
+								Name string `json:"name"`
+								ID   string `json:"_id"`
+							} `json:"entity"`
+							Permissions []string `json:"permissions"`
+						} `json:"scoped"`
+					}{
+						Scoped: []struct {
+							Entity struct {
+								Type string `json:"type"`
+								Name string `json:"name"`
+								ID   string `json:"_id"`
+							} `json:"entity"`
+							Permissions []string `json:"permissions"`
+						}{
+							{
+								Entity: struct {
+									Type string `json:"type"`
+									Name string `json:"name"`
+									ID   string `json:"_id"`
+								}{Type: "user", Name: "testuser"},
+								Permissions: []string{"repo.content.read"},
+							},
+						},
+					},
+				},
+			},
+		},
+		Models: []Model{
+			{Name: "testuser/scoped-model", ID: "abc123", Private: true},
+			{Name: "other-org/unscoped-model", ID: "def456", Private: false},
+			{Name: "another-org/also-unscoped", ID: "ghi789", Private: false},
+		},
+	}
+
+	result := secretInfoToAnalyzerResult(info)
+
+	// The scoped model should appear as a binding with a non-empty permission.
+	if len(result.Bindings) == 0 {
+		t.Fatal("expected at least one binding for the scoped model")
+	}
+	foundScoped := false
+	for _, b := range result.Bindings {
+		if b.Resource.Name == "testuser/scoped-model" {
+			foundScoped = true
+			if b.Permission.Value == "" {
+				t.Error("scoped model binding has empty Permission.Value")
+			}
+		}
+		if b.Permission.Value == "" {
+			t.Errorf("binding for %q has empty Permission.Value (would fail proto validation)", b.Resource.Name)
+		}
+	}
+	if !foundScoped {
+		t.Error("expected testuser/scoped-model in Bindings")
+	}
+
+	// Unscoped models should appear in UnboundedResources, not Bindings.
+	unscopedNames := map[string]bool{
+		"other-org/unscoped-model":  false,
+		"another-org/also-unscoped": false,
+	}
+	for _, r := range result.UnboundedResources {
+		if _, want := unscopedNames[r.Name]; want {
+			unscopedNames[r.Name] = true
+		}
+	}
+	for name, found := range unscopedNames {
+		if !found {
+			t.Errorf("expected %q in UnboundedResources, but it was missing", name)
+		}
+	}
+
+	// Verify unscoped models are NOT in Bindings.
+	for _, b := range result.Bindings {
+		if _, isUnscoped := unscopedNames[b.Resource.Name]; isUnscoped {
+			t.Errorf("unscoped model %q should not appear in Bindings", b.Resource.Name)
+		}
+	}
+}


### PR DESCRIPTION
### Description:

The HuggingFace analyzer produces bindings with empty `Permission.Value` for fine-grained tokens when a model's owner isn't in the token's scoped permissions. This causes `CreateAnalysisResults` to reject the request because the proto validation requires `Permission.Name` to be at least 1 rune.

The root cause is that `bakefineGrainedBindings()` creates a `Binding` for every model returned by the `/api/models` API, but the HuggingFace API returns all visible models (including public ones) regardless of the token's fine-grained scope. Models outside the scope end up with a zero-value `Permission{}`.

The fix splits models into two groups: those that resolve a non-empty permission become `Binding` entries, and those without a matching scope go into`UnboundedResources`.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized HuggingFace analyzer output shaping with a focused regression test; no auth or shared infrastructure changes.
> 
> **Overview**
> Fixes **fine-grained HuggingFace** analysis so models that are visible via the API but **not covered by the token’s scoped permissions** no longer produce `Binding` entries with empty `Permission.Value` (which broke downstream **proto validation** on `CreateAnalysisResults`).
> 
> `bakefineGrainedBindings` now returns both bindings and extra resources: models that resolve a non-empty permission stay in **Bindings**; everything else is appended to **`UnboundedResources`** from `secretInfoToAnalyzerResult`. A unit test locks in scoped vs unscoped model placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63c3f3af5cb58114c3700d0274a83bb99703ef87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->