### PR TITLE
feat(detectors): enforce endpoint order, support multi-cloud endpoints, fix stop-on-verify bugs

### DIFF
--- a/pkg/detectors/artifactory/artifactory.go
+++ b/pkg/detectors/artifactory/artifactory.go
@@ -37,7 +37,7 @@ var (
 	errNoHost = errors.New("no such host")
 )
 
-func (Scanner) CloudEndpoint() string { return "" }
+func (Scanner) CloudEndpoints() []string { return nil }
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
@@ -69,7 +69,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	// add found + configured endpoints to the list
-	for _, endpoint := range s.Endpoints(foundUrls...) {
+	for _, endpoint := range s.Endpoints(foundUrls) {
 		// if any configured endpoint has `https://` remove it because we append that during verification
 		endpoint = strings.TrimPrefix(endpoint, "https://")
 		uniqueUrls[endpoint] = struct{}{}

--- a/pkg/detectors/artifactory/artifactory_test.go
+++ b/pkg/detectors/artifactory/artifactory_test.go
@@ -150,10 +150,10 @@ func TestArtifactory_Pattern(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// this detector uses endpoint customizer interface so we need to enable them based on test case
 			d.UseFoundEndpoints(test.useFoundEndpoint)
-			d.UseCloudEndpoint(test.useCloudEndpoint)
+			d.UseCloudEndpoints(test.useCloudEndpoint)
 			// if the test case provides cloud endpoint, then use it
 			if test.useCloudEndpoint && test.cloudEndpoint != "" {
-				d.SetCloudEndpoint(test.cloudEndpoint)
+				d.SetCloudEndpoints(test.cloudEndpoint)
 			}
 
 			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
@@ -199,7 +199,7 @@ func TestArtifactory_Endpoint_Contains_CustomEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error in setting configured endpoint")
 	}
-	configuredEndpoints := s.Endpoints()
+	configuredEndpoints := s.Endpoints(nil)
 	if len(configuredEndpoints) == 0 {
 		t.Fatal("No Confiured endpoint found")
 	}

--- a/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken.go
+++ b/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken.go
@@ -37,7 +37,7 @@ var (
 	errNoHost    = errors.New("no such host")
 )
 
-func (Scanner) CloudEndpoint() string { return "" }
+func (Scanner) CloudEndpoints() []string { return nil }
 
 // Keywords are used for efficiently pre-filtering chunks.
 func (s Scanner) Keywords() []string {
@@ -68,7 +68,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	// Add found + configured endpoints to the list
-	for _, endpoint := range s.Endpoints(foundUrls...) {
+	for _, endpoint := range s.Endpoints(foundUrls) {
 		// If any configured endpoint has `https://` remove it because we append that during verification
 		endpoint = strings.TrimPrefix(endpoint, "https://")
 		uniqueUrls[endpoint] = struct{}{}

--- a/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken_test.go
+++ b/pkg/detectors/artifactoryreferencetoken/artifactoryreferencetoken_test.go
@@ -162,9 +162,9 @@ func TestArtifactoryReferenceToken_Pattern(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// Configure endpoint customizer based on test case
 			d.UseFoundEndpoints(test.useFoundEndpoint)
-			d.UseCloudEndpoint(test.useCloudEndpoint)
+			d.UseCloudEndpoints(test.useCloudEndpoint)
 			if test.useCloudEndpoint && test.cloudEndpoint != "" {
-				d.SetCloudEndpoint(test.cloudEndpoint)
+				d.SetCloudEndpoints(test.cloudEndpoint)
 			}
 
 			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
@@ -213,7 +213,7 @@ func TestArtifactoryreferencetoken_Endpoint_Contains_CustomEndpoint(t *testing.T
 	if err != nil {
 		t.Fatal("Error in setting configured endpoint")
 	}
-	configuredEndpoints := s.Endpoints()
+	configuredEndpoints := s.Endpoints(nil)
 	if len(configuredEndpoints) == 0 {
 		t.Fatal("No Confiured endpoint found")
 	}

--- a/pkg/detectors/atlassiandatacenter/bitbucketdatacenter/bitbucketdatacenter_test.go
+++ b/pkg/detectors/atlassiandatacenter/bitbucketdatacenter/bitbucketdatacenter_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestBitbucketDataCenter_Pattern(t *testing.T) {
 	d := Scanner{}
-	d.UseCloudEndpoint(true)
+	d.UseCloudEndpoints(true)
 	d.UseFoundEndpoints(true)
 
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})

--- a/pkg/detectors/atlassiandatacenter/common.go
+++ b/pkg/detectors/atlassiandatacenter/common.go
@@ -41,7 +41,7 @@ func GetURLPat(prefixes []string) *regexp.Regexp {
 // FindEndpoints extracts all URLs matching urlPat from data, passes them through
 // the resolve function (typically s.Endpoints), deduplicates the results, and
 // returns them as a slice with trailing slashes stripped.
-func FindEndpoints(data string, urlPat *regexp.Regexp, resolve func(...string) []string) []string {
+func FindEndpoints(data string, urlPat *regexp.Regexp, resolve func([]string, ...string) []string) []string {
 	seen := make(map[string]struct{})
 	for _, m := range urlPat.FindAllStringSubmatch(data, -1) {
 		seen[m[1]] = struct{}{}
@@ -53,7 +53,7 @@ func FindEndpoints(data string, urlPat *regexp.Regexp, resolve func(...string) [
 	}
 
 	resolved := make(map[string]struct{})
-	for _, u := range resolve(raw...) {
+	for _, u := range resolve(raw) {
 		resolved[strings.TrimRight(u, "/")] = struct{}{}
 	}
 

--- a/pkg/detectors/atlassiandatacenter/common_test.go
+++ b/pkg/detectors/atlassiandatacenter/common_test.go
@@ -122,12 +122,12 @@ func TestFindEndpoints(t *testing.T) {
 	urlPat := GetURLPat([]string{"jira", "atlassian"})
 
 	// identity resolver: returns exactly what it receives (simulates UseFoundEndpoints only)
-	identity := func(urls ...string) []string { return urls }
+	identity := func(urls []string, _ ...string) []string { return urls }
 
 	tests := []struct {
 		name    string
 		data    string
-		resolve func(...string) []string
+		resolve func([]string, ...string) []string
 		want    []string
 	}{
 		{
@@ -169,7 +169,7 @@ func TestFindEndpoints(t *testing.T) {
 		{
 			name: "resolve can inject configured endpoints not in data",
 			data: "no urls here but jira keyword present",
-			resolve: func(urls ...string) []string {
+			resolve: func(urls []string, _ ...string) []string {
 				return append(urls, "https://configured.jira.com")
 			},
 			want: []string{"https://configured.jira.com"},
@@ -177,7 +177,7 @@ func TestFindEndpoints(t *testing.T) {
 		{
 			name: "resolve can filter out URLs",
 			data: "jira url: https://jira.corp.com",
-			resolve: func(urls ...string) []string {
+			resolve: func(urls []string, _ ...string) []string {
 				return []string{} // simulate UseFoundEndpoints(false) with no configured endpoint
 			},
 			want: []string{},

--- a/pkg/detectors/atlassiandatacenter/confluencedatacenter/confluencedatacenter.go
+++ b/pkg/detectors/atlassiandatacenter/confluencedatacenter/confluencedatacenter.go
@@ -24,7 +24,7 @@ var (
 	_ detectors.EndpointCustomizer = (*Scanner)(nil)
 )
 
-func (Scanner) CloudEndpoint() string { return "" }
+func (Scanner) CloudEndpoints() []string { return nil }
 
 var (
 	defaultClient = detectors.DetectorHttpClientWithLocalAddresses

--- a/pkg/detectors/datadogapikey/datadogapikey.go
+++ b/pkg/detectors/datadogapikey/datadogapikey.go
@@ -24,7 +24,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 var _ detectors.EndpointCustomizer = (*Scanner)(nil)
 var _ detectors.CloudProvider = (*Scanner)(nil)
 
-func (Scanner) CloudEndpoint() string { return "https://api.datadoghq.com" }
+func (Scanner) CloudEndpoints() []string { return []string{"https://api.datadoghq.com"} }
 
 var (
 	client = common.SaneHttpClient()
@@ -70,8 +70,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		}
 
 		if verify {
-			for _, baseURL := range s.Endpoints(endpoints...) {
-				client := s.getClient()
+			client := s.getClient()
+			for _, baseURL := range s.Endpoints(endpoints) {
 				isVerified, verificationErr := verifyMatch(ctx, client, resApiMatch, baseURL)
 				if isVerified {
 					s1.Verified = isVerified

--- a/pkg/detectors/datadogapikey/datadogapikey_integration_test.go
+++ b/pkg/detectors/datadogapikey/datadogapikey_integration_test.go
@@ -96,8 +96,8 @@ func TestDataDogApiKey_FromChunk(t *testing.T) {
 			s := Scanner{}
 
 			// use default cloud endpoint
-			s.UseCloudEndpoint(true)
-			s.SetCloudEndpoint(s.CloudEndpoint())
+			s.UseCloudEndpoints(true)
+			s.SetCloudEndpoints(s.CloudEndpoints()...)
 			s.UseFoundEndpoints(true)
 
 			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)

--- a/pkg/detectors/datadogtoken/datadogtoken.go
+++ b/pkg/detectors/datadogtoken/datadogtoken.go
@@ -26,7 +26,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 var _ detectors.EndpointCustomizer = (*Scanner)(nil)
 var _ detectors.CloudProvider = (*Scanner)(nil)
 
-func (Scanner) CloudEndpoint() string { return "https://api.datadoghq.com" }
+func (Scanner) CloudEndpoints() []string { return []string{"https://api.datadoghq.com"} }
 
 var (
 	defaultClient = common.SaneHttpClient()
@@ -141,7 +141,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				for _, baseURL := range s.Endpoints(endpoints...) {
+				for _, baseURL := range s.Endpoints(endpoints) {
 					res, isVerified, verificationErr := verifyMatch(ctx, client, resApiMatch, resAppMatch, baseURL)
 					s1.Verified = isVerified
 					s1.SetVerificationError(verificationErr, resApiMatch, resAppMatch)

--- a/pkg/detectors/datadogtoken/datadogtoken_integration_test.go
+++ b/pkg/detectors/datadogtoken/datadogtoken_integration_test.go
@@ -106,8 +106,8 @@ func TestDatadogToken_FromChunk(t *testing.T) {
 			s := Scanner{}
 
 			// use default cloud endpoint
-			s.UseCloudEndpoint(true)
-			s.SetCloudEndpoint(s.CloudEndpoint())
+			s.UseCloudEndpoints(true)
+			s.SetCloudEndpoints(s.CloudEndpoints()...)
 			s.UseFoundEndpoints(true)
 
 			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
@@ -157,8 +157,8 @@ func TestDatadogToken_FromChunk_Unverified(t *testing.T) {
 	))
 
 	s := Scanner{}
-	s.UseCloudEndpoint(true)
-	s.SetCloudEndpoint(s.CloudEndpoint())
+	s.UseCloudEndpoints(true)
+	s.SetCloudEndpoints(s.CloudEndpoints()...)
 	s.UseFoundEndpoints(true)
 
 	results, err := s.FromData(ctx, true, data)

--- a/pkg/detectors/detectors.go
+++ b/pkg/detectors/detectors.go
@@ -87,13 +87,13 @@ type MultiPartCredentialProvider interface {
 // support verifying against user-supplied endpoints.
 type EndpointCustomizer interface {
 	SetConfiguredEndpoints(...string) error
-	SetCloudEndpoint(string)
-	UseCloudEndpoint(bool)
+	SetCloudEndpoints(...string)
+	UseCloudEndpoints(bool)
 	UseFoundEndpoints(bool)
 }
 
 type CloudProvider interface {
-	CloudEndpoint() string
+	CloudEndpoints() []string
 }
 
 type Result struct {

--- a/pkg/detectors/endpoint_customizer.go
+++ b/pkg/detectors/endpoint_customizer.go
@@ -2,18 +2,22 @@ package detectors
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 )
 
 // EndpointSetter implements a sensible default for the SetEndpoints function
 // of the EndpointCustomizer interface. A detector can embed this struct to
-// gain the functionality.
+// gain the functionality. See Endpoints for the order sources are tried in.
 type EndpointSetter struct {
 	configuredEndpoints []string
-	cloudEndpoint       string
-	useCloudEndpoint    bool
-	useFoundEndpoints   bool
+
+	cloudEndpoints   []string
+	useCloudEndpoints bool
+
+	useFoundEndpoints bool
 }
 
 func (e *EndpointSetter) SetConfiguredEndpoints(userConfiguredEndpoints ...string) error {
@@ -28,25 +32,105 @@ func (e *EndpointSetter) SetConfiguredEndpoints(userConfiguredEndpoints ...strin
 	return nil
 }
 
-func (e *EndpointSetter) SetCloudEndpoint(url string) {
-	e.cloudEndpoint = url
+// SetCloudEndpoints sets the provider's default (non-user-configured)
+// endpoints. Most providers have one; some (gov-cloud, regional deployments)
+// have several, all tried in the given order.
+func (e *EndpointSetter) SetCloudEndpoints(cloudEndpoints ...string) {
+	deduped := make([]string, 0, len(cloudEndpoints))
+	for _, endpoint := range cloudEndpoints {
+		if endpoint == "" {
+			continue
+		}
+		common.AddStringSliceItem(endpoint, &deduped)
+	}
+	e.cloudEndpoints = deduped
 }
 
-func (e *EndpointSetter) UseCloudEndpoint(enabled bool) {
-	e.useCloudEndpoint = enabled
+func (e *EndpointSetter) UseCloudEndpoints(enabled bool) {
+	e.useCloudEndpoints = enabled
 }
 
 func (e *EndpointSetter) UseFoundEndpoints(enabled bool) {
 	e.useFoundEndpoints = enabled
 }
 
-func (e *EndpointSetter) Endpoints(foundEndpoints ...string) []string {
-	endpoints := e.configuredEndpoints
-	if e.useCloudEndpoint && e.cloudEndpoint != "" {
-		endpoints = append(endpoints, e.cloudEndpoint)
+// Endpoints returns the endpoints to try, in order: configured, then cloud,
+// then found. Found endpoints are last and never precede the others, because
+// they come from attacker-controlled scanned content, not operator intent.
+//
+// allowedFoundSuffixes is optional and applies only to foundEndpoints: when
+// given, a found endpoint is only included if its host ends in one of these
+// suffixes (e.g. ".jira.com"), guarding against a scanned chunk steering
+// verification at an arbitrary host (SSRF). Configured and cloud endpoints
+// are never filtered - they're operator/developer trusted, not scanned text.
+func (e *EndpointSetter) Endpoints(foundEndpoints []string, allowedFoundSuffixes ...string) []string {
+	endpoints := make([]string, 0, len(e.configuredEndpoints)+len(e.cloudEndpoints)+len(foundEndpoints))
+	seen := make(map[string]struct{}, cap(endpoints))
+	add := func(endpoint string) {
+		if _, ok := seen[endpoint]; ok {
+			return
+		}
+		seen[endpoint] = struct{}{}
+		endpoints = append(endpoints, endpoint)
 	}
+
+	// Deduped across all three sources, not just within each: the same host
+	// can legitimately show up as both configured and found (or cloud and
+	// found), and callers counting distinct endpoints (e.g. to decide whether
+	// a match is confident) need one entry per host, not one per source.
+	for _, endpoint := range e.configuredEndpoints {
+		add(endpoint)
+	}
+
+	if e.useCloudEndpoints {
+		for _, endpoint := range e.cloudEndpoints {
+			add(endpoint)
+		}
+	}
+
 	if e.useFoundEndpoints {
-		endpoints = append(endpoints, foundEndpoints...)
+		for _, found := range foundEndpoints {
+			if foundEndpointAllowed(found, allowedFoundSuffixes) {
+				add(found)
+			}
+		}
 	}
+
 	return endpoints
+}
+
+func foundEndpointAllowed(rawURL string, allowedSuffixes []string) bool {
+	if len(allowedSuffixes) == 0 {
+		return true
+	}
+	host := hostOf(rawURL)
+	if host == "" {
+		return false
+	}
+	for _, suffix := range allowedSuffixes {
+		if strings.HasSuffix(host, strings.ToLower(suffix)) {
+			return true
+		}
+	}
+	return false
+}
+
+// hostOf extracts the lowercased hostname (no port) from rawURL. rawURL may
+// or may not include a scheme - detectors' found-endpoint regexes vary
+// (some match full URLs, some match bare hostnames) - so a bare hostname is
+// reparsed with a scheme to get url.Parse to populate Host at all. Never
+// falls back to matching against the raw string: an unparseable or
+// ambiguous value must not slip past the suffix check.
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	if u.Host == "" {
+		u, err = url.Parse("https://" + rawURL)
+		if err != nil {
+			return ""
+		}
+	}
+	return strings.ToLower(u.Hostname())
 }

--- a/pkg/detectors/endpoint_customizer_test.go
+++ b/pkg/detectors/endpoint_customizer_test.go
@@ -15,7 +15,7 @@ func TestEmbeddedEndpointSetter(t *testing.T) {
 		s.useFoundEndpoints = true
 
 		// "baz" is passed to Endpoints, should appear in the result
-		assert.Equal(t, []string{"baz"}, s.Endpoints("baz"))
+		assert.Equal(t, []string{"baz"}, s.Endpoints([]string{"baz"}))
 	})
 
 	t.Run("setting configured endpoints", func(t *testing.T) {
@@ -29,32 +29,123 @@ func TestEmbeddedEndpointSetter(t *testing.T) {
 	// "foo" and "bar" are added as configured endpoint
 
 	t.Run("useFoundEndpoints adds new endpoints", func(t *testing.T) {
-		// "baz" is added because useFoundEndpoints is true
-		assert.Equal(t, []string{"foo", "bar", "baz"}, s.Endpoints("baz"))
+		// "baz" is added because useFoundEndpoints is true, and after configured endpoints
+		assert.Equal(t, []string{"foo", "bar", "baz"}, s.Endpoints([]string{"baz"}))
 	})
 
-	t.Run("useCloudEndpoint is true", func(t *testing.T) {
-		s.useCloudEndpoint = true
-		s.cloudEndpoint = "test"
+	t.Run("useCloudEndpoints is true", func(t *testing.T) {
+		s.useCloudEndpoints = true
+		s.cloudEndpoints = []string{"test"}
 
-		// "test" is added because useCloudEndpoint is true and cloudEndpoint is set
-		assert.Equal(t, []string{"foo", "bar", "test"}, s.Endpoints())
+		// "test" is added because useCloudEndpoints is true and cloudEndpoints is set,
+		// and appears before found endpoints
+		assert.Equal(t, []string{"foo", "bar", "test"}, s.Endpoints(nil))
+	})
+
+	t.Run("multiple cloud endpoints are all added, in order, before found endpoints", func(t *testing.T) {
+		s.cloudEndpoints = []string{"cloud1", "cloud2"}
+
+		assert.Equal(t, []string{"foo", "bar", "cloud1", "cloud2", "baz"}, s.Endpoints([]string{"baz"}))
 	})
 
 	t.Run("disable both foundEndpoints and cloudEndpoint", func(t *testing.T) {
-		// now disable both useFoundEndpoints and useCloudEndpoint
+		// now disable both useFoundEndpoints and useCloudEndpoints
 		s.useFoundEndpoints = false
-		s.useCloudEndpoint = false
+		s.useCloudEndpoints = false
 
 		// "test" won't be added
-		assert.Equal(t, []string{"foo", "bar"}, s.Endpoints("test"))
+		assert.Equal(t, []string{"foo", "bar"}, s.Endpoints([]string{"test"}))
 	})
 
-	t.Run("cloudEndpoint not added when useCloudEndpoint is false", func(t *testing.T) {
-		s.cloudEndpoint = "new"
+	t.Run("cloudEndpoints not added when useCloudEndpoints is false", func(t *testing.T) {
+		s.cloudEndpoints = []string{"new"}
 
-		// "new" is not added because useCloudEndpoint is false
-		assert.Equal(t, []string{"foo", "bar"}, s.Endpoints())
+		// "new" is not added because useCloudEndpoints is false
+		assert.Equal(t, []string{"foo", "bar"}, s.Endpoints(nil))
 	})
+}
 
+func TestEndpointSetterOrder(t *testing.T) {
+	var e EndpointSetter
+	assert.NoError(t, e.SetConfiguredEndpoints("configured"))
+	e.SetCloudEndpoints("cloud1", "cloud2")
+	e.UseCloudEndpoints(true)
+	e.UseFoundEndpoints(true)
+
+	// Configured, then cloud (in the order given), then found - always, regardless
+	// of call order above, since found endpoints come from scanned content and
+	// must never be tried ahead of operator-controlled sources.
+	assert.Equal(t, []string{"configured", "cloud1", "cloud2", "found"}, e.Endpoints([]string{"found"}))
+}
+
+func TestEndpointSetterFoundEndpointSuffixFilter(t *testing.T) {
+	var e EndpointSetter
+	e.UseFoundEndpoints(true)
+
+	// allowedFoundSuffixes is passed at the call site, per call - no stored state.
+	got := e.Endpoints(
+		[]string{"https://myteam.jira.com", "https://evil.com", "https://evil.com/.jira.com", "notreal.jira.com.evil.com"},
+		".jira.com",
+	)
+	assert.Equal(t, []string{"https://myteam.jira.com"}, got)
+}
+
+func TestEndpointSetterFoundEndpointSuffixFilterPortStripped(t *testing.T) {
+	var e EndpointSetter
+	e.UseFoundEndpoints(true)
+
+	// Port must not defeat the suffix match.
+	got := e.Endpoints([]string{"https://myteam.jira.com:8443/path"}, ".jira.com")
+	assert.Equal(t, []string{"https://myteam.jira.com:8443/path"}, got)
+}
+
+func TestEndpointSetterFoundEndpointSuffixFilterSchemeless(t *testing.T) {
+	var e EndpointSetter
+	e.UseFoundEndpoints(true)
+
+	got := e.Endpoints(
+		[]string{
+			"myteam.jira.com",           // bare host, no scheme - allowed
+			"evil.com/.jira.com",        // no scheme; url.Parse gives empty Host - must not fall back to raw-string match
+			"notreal.jira.com.evil.com", // host really is evil.com, not jira.com
+		},
+		".jira.com",
+	)
+	assert.Equal(t, []string{"myteam.jira.com"}, got)
+}
+
+func TestEndpointSetterFoundEndpointSuffixFilterUnset(t *testing.T) {
+	var e EndpointSetter
+	e.UseFoundEndpoints(true)
+
+	// No suffixes passed: nothing is filtered.
+	got := e.Endpoints([]string{"https://anything.example.com"})
+	assert.Equal(t, []string{"https://anything.example.com"}, got)
+}
+
+func TestEndpointSetterCloudEndpointsDeduped(t *testing.T) {
+	var e EndpointSetter
+	e.SetCloudEndpoints("https://a.com", "https://a.com", "", "https://b.com")
+	e.UseCloudEndpoints(true)
+
+	assert.Equal(t, []string{"https://a.com", "https://b.com"}, e.Endpoints(nil))
+}
+
+func TestEndpointSetterDedupesAcrossSources(t *testing.T) {
+	var e EndpointSetter
+	assert.NoError(t, e.SetConfiguredEndpoints("shared.example.com", "configured-only.example.com"))
+	e.SetCloudEndpoints("shared.example.com", "cloud-only.example.com")
+	e.UseCloudEndpoints(true)
+	e.UseFoundEndpoints(true)
+
+	// "shared.example.com" appears as both configured and found, and also as
+	// cloud - must appear exactly once in the result, at its highest-priority
+	// position (configured), not once per source.
+	got := e.Endpoints([]string{"shared.example.com", "found-only.example.com"})
+	assert.Equal(t, []string{
+		"shared.example.com",
+		"configured-only.example.com",
+		"cloud-only.example.com",
+		"found-only.example.com",
+	}, got)
 }

--- a/pkg/detectors/github/v1/github_old.go
+++ b/pkg/detectors/github/v1/github_old.go
@@ -23,7 +23,7 @@ var _ detectors.EndpointCustomizer = (*Scanner)(nil)
 var _ detectors.CloudProvider = (*Scanner)(nil)
 
 func (Scanner) Version() int          { return 1 }
-func (Scanner) CloudEndpoint() string { return "https://api.github.com" }
+func (Scanner) CloudEndpoints() []string { return []string{"https://api.github.com"} }
 
 var (
 	// Oauth token
@@ -151,7 +151,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 func (s Scanner) VerifyGithub(ctx context.Context, client *http.Client, token string) (bool, *UserRes, *HeaderInfo, error) {
 	// https://developer.github.com/v3/users/#get-the-authenticated-user
 	var requestErr error
-	for _, url := range s.Endpoints() {
+	for _, url := range s.Endpoints(nil) {
 		requestErr = nil
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/user", url), nil)

--- a/pkg/detectors/github/v2/github.go
+++ b/pkg/detectors/github/v2/github.go
@@ -26,7 +26,7 @@ var _ detectors.CloudProvider = (*Scanner)(nil)
 func (s Scanner) Version() int {
 	return 2
 }
-func (Scanner) CloudEndpoint() string { return "https://api.github.com" }
+func (Scanner) CloudEndpoints() []string { return []string{"https://api.github.com"} }
 
 var (
 	// Oauth token

--- a/pkg/detectors/github/v2/github_integration_test.go
+++ b/pkg/detectors/github/v2/github_integration_test.go
@@ -212,8 +212,8 @@ func TestGitHub_FromChunk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Scanner{}
-			s.UseCloudEndpoint(true)
-			s.SetCloudEndpoint(s.CloudEndpoint())
+			s.UseCloudEndpoints(true)
+			s.SetCloudEndpoints(s.CloudEndpoints()...)
 			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GitHub.FromData() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/detectors/gitlab/v1/gitlab.go
+++ b/pkg/detectors/gitlab/v1/gitlab.go
@@ -30,7 +30,7 @@ var (
 )
 
 func (Scanner) Version() int          { return 1 }
-func (Scanner) CloudEndpoint() string { return "https://gitlab.com" }
+func (Scanner) CloudEndpoints() []string { return []string{"https://gitlab.com"} }
 
 var (
 	defaultClient = common.SaneHttpClient()
@@ -79,7 +79,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			continue
 		}
 
-		for _, endpoint := range s.Endpoints() {
+		for _, endpoint := range s.Endpoints(nil) {
 			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_Gitlab,
 				Raw:          []byte(resMatch),

--- a/pkg/detectors/gitlab/v1/gitlab_integration_test.go
+++ b/pkg/detectors/gitlab/v1/gitlab_integration_test.go
@@ -175,8 +175,8 @@ func TestGitlab_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.s.SetCloudEndpoint("https://gitlab.com")
-			tt.s.UseCloudEndpoint(true)
+			tt.s.SetCloudEndpoints("https://gitlab.com")
+			tt.s.UseCloudEndpoints(true)
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gitlab.FromData() error = %v, wantErr %v", err, tt.wantErr)
@@ -367,8 +367,8 @@ func TestGitlab_FromChunk_WithV3Secrets(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.s.SetCloudEndpoint("https://gitlab.com")
-			tt.s.UseCloudEndpoint(true)
+			tt.s.SetCloudEndpoints("https://gitlab.com")
+			tt.s.UseCloudEndpoints(true)
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gitlab.FromData() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/detectors/gitlab/v1/gitlab_v1_test.go
+++ b/pkg/detectors/gitlab/v1/gitlab_v1_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestGitLab_Pattern(t *testing.T) {
 	d := Scanner{}
-	d.SetCloudEndpoint("https://gitlab.com")
-	d.UseCloudEndpoint(true)
+	d.SetCloudEndpoints("https://gitlab.com")
+	d.UseCloudEndpoints(true)
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 
 	tests := []struct {

--- a/pkg/detectors/gitlab/v2/gitlab_integration_test.go
+++ b/pkg/detectors/gitlab/v2/gitlab_integration_test.go
@@ -87,8 +87,8 @@ func TestGitlabV2_FromChunk_WithV1Secrets(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.s.SetCloudEndpoint("https://gitlab.com")
-			tt.s.UseCloudEndpoint(true)
+			tt.s.SetCloudEndpoints("https://gitlab.com")
+			tt.s.UseCloudEndpoints(true)
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gitlab.FromData() error = %v, wantErr %v", err, tt.wantErr)
@@ -181,8 +181,8 @@ func TestGitlabV2_FromChunk_WithV3Secrets(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.s.SetCloudEndpoint("https://gitlab.com")
-			tt.s.UseCloudEndpoint(true)
+			tt.s.SetCloudEndpoints("https://gitlab.com")
+			tt.s.UseCloudEndpoints(true)
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gitlab.FromData() error = %v, wantErr %v", err, tt.wantErr)
@@ -360,8 +360,8 @@ func TestGitlabV2_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.s.UseCloudEndpoint(true)
-			tt.s.SetCloudEndpoint(tt.s.CloudEndpoint())
+			tt.s.UseCloudEndpoints(true)
+			tt.s.SetCloudEndpoints(tt.s.CloudEndpoints()...)
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gitlab.FromData() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/detectors/gitlab/v2/gitlab_v2.go
+++ b/pkg/detectors/gitlab/v2/gitlab_v2.go
@@ -26,7 +26,7 @@ var _ detectors.EndpointCustomizer = (*Scanner)(nil)
 var _ detectors.Versioner = (*Scanner)(nil)
 
 func (Scanner) Version() int          { return 2 }
-func (Scanner) CloudEndpoint() string { return "https://gitlab.com" }
+func (Scanner) CloudEndpoints() []string { return []string{"https://gitlab.com"} }
 
 var (
 	defaultClient = common.SaneHttpClient()
@@ -61,7 +61,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	for _, match := range matches {
 		resMatch := strings.TrimSpace(match[1])
 
-		for _, endpoint := range s.Endpoints() {
+		for _, endpoint := range s.Endpoints(nil) {
 			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_Gitlab,
 				Raw:          []byte(resMatch),

--- a/pkg/detectors/gitlab/v2/gitlab_v2_test.go
+++ b/pkg/detectors/gitlab/v2/gitlab_v2_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestGitLab_Pattern(t *testing.T) {
 	d := Scanner{}
-	d.SetCloudEndpoint("https://gitlab.com")
-	d.UseCloudEndpoint(true)
+	d.SetCloudEndpoints("https://gitlab.com")
+	d.UseCloudEndpoints(true)
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 
 	tests := []struct {

--- a/pkg/detectors/gitlab/v3/gitlab_v3.go
+++ b/pkg/detectors/gitlab/v3/gitlab_v3.go
@@ -26,7 +26,7 @@ var _ detectors.EndpointCustomizer = (*Scanner)(nil)
 var _ detectors.Versioner = (*Scanner)(nil)
 
 func (Scanner) Version() int          { return 3 }
-func (Scanner) CloudEndpoint() string { return "https://gitlab.com" }
+func (Scanner) CloudEndpoints() []string { return []string{"https://gitlab.com"} }
 
 var (
 	defaultClient = common.SaneHttpClient()
@@ -62,7 +62,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	for _, match := range matches {
 		resMatch := strings.TrimSpace(match[1])
 
-		for _, endpoint := range s.Endpoints() {
+		for _, endpoint := range s.Endpoints(nil) {
 			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_Gitlab,
 				Raw:          []byte(resMatch),

--- a/pkg/detectors/gitlab/v3/gitlab_v3_integration_test.go
+++ b/pkg/detectors/gitlab/v3/gitlab_v3_integration_test.go
@@ -156,8 +156,8 @@ func TestGitlabV3_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.s.UseCloudEndpoint(true)
-			tt.s.SetCloudEndpoint(tt.s.CloudEndpoint())
+			tt.s.UseCloudEndpoints(true)
+			tt.s.SetCloudEndpoints(tt.s.CloudEndpoints()...)
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gitlab.FromData() error = %v, wantErr %v", err, tt.wantErr)
@@ -266,8 +266,8 @@ func TestGitlabV3_FromChunk_WithV1Secrets(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.s.SetCloudEndpoint("https://gitlab.com")
-			tt.s.UseCloudEndpoint(true)
+			tt.s.SetCloudEndpoints("https://gitlab.com")
+			tt.s.UseCloudEndpoints(true)
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Gitlab.FromData() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/detectors/gitlab/v3/gitlab_v3_test.go
+++ b/pkg/detectors/gitlab/v3/gitlab_v3_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestGitLab_Pattern(t *testing.T) {
 	d := Scanner{}
-	d.SetCloudEndpoint("https://gitlab.com")
-	d.UseCloudEndpoint(true)
+	d.SetCloudEndpoints("https://gitlab.com")
+	d.UseCloudEndpoints(true)
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 
 	tests := []struct {

--- a/pkg/detectors/gitlaboauth2/gitlaboauth2.go
+++ b/pkg/detectors/gitlaboauth2/gitlaboauth2.go
@@ -21,7 +21,7 @@ type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
 }
 
-func (Scanner) CloudEndpoint() string { return "https://gitlab.com" }
+func (Scanner) CloudEndpoints() []string { return []string{"https://gitlab.com"} }
 
 var (
 	// Ensure the Scanner satisfies the interfaces at compile time.
@@ -64,7 +64,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	for clientId := range uniqueIdMatches {
 	secretLoop:
 		for clientSecret := range uniqueSecretMatches {
-			for _, endpoint := range s.Endpoints() {
+			for _, endpoint := range s.Endpoints(nil) {
 				s1 := detectors.Result{
 					DetectorType: s.Type(),
 					Raw:          []byte(clientSecret),

--- a/pkg/detectors/gitlaboauth2/gitlaboauth2_integration_test.go
+++ b/pkg/detectors/gitlaboauth2/gitlaboauth2_integration_test.go
@@ -142,8 +142,8 @@ func TestGitlabOauth_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.s.SetCloudEndpoint(tt.s.CloudEndpoint())
-			tt.s.UseCloudEndpoint(true)
+			tt.s.SetCloudEndpoints(tt.s.CloudEndpoints()...)
+			tt.s.UseCloudEndpoints(true)
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GitlabOauth.FromData() error = %v, wantErr %v", err, tt.wantErr)
@@ -169,8 +169,8 @@ func TestGitlabOauth_FromChunk(t *testing.T) {
 func BenchmarkFromData(benchmark *testing.B) {
 	ctx := context.Background()
 	s := Scanner{}
-	s.SetCloudEndpoint(s.CloudEndpoint())
-	s.UseCloudEndpoint(true)
+	s.SetCloudEndpoints(s.CloudEndpoints()...)
+	s.UseCloudEndpoints(true)
 	for name, data := range detectors.MustGetBenchmarkData() {
 		benchmark.Run(name, func(b *testing.B) {
 			b.ResetTimer()

--- a/pkg/detectors/gitlaboauth2/gitlaboauth2_test.go
+++ b/pkg/detectors/gitlaboauth2/gitlaboauth2_test.go
@@ -13,8 +13,8 @@ import (
 
 func TestGitlabOauth_Pattern(t *testing.T) {
 	d := Scanner{}
-	d.SetCloudEndpoint("https://gitlab.com")
-	d.UseCloudEndpoint(true)
+	d.SetCloudEndpoints("https://gitlab.com")
+	d.UseCloudEndpoints(true)
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {
 		name  string

--- a/pkg/detectors/hashicorpvault/hashicorpvaultbatchtoken/hashicorpvaultbatchtoken.go
+++ b/pkg/detectors/hashicorpvault/hashicorpvaultbatchtoken/hashicorpvaultbatchtoken.go
@@ -37,7 +37,7 @@ func (s Scanner) Keywords() []string {
 	return []string{"hvb."}
 }
 
-func (Scanner) CloudEndpoint() string { return "" }
+func (Scanner) CloudEndpoints() []string { return nil }
 
 func (s Scanner) Description() string {
 	return "This detector detects and verifies HashiCorp Vault batch tokens"
@@ -74,7 +74,7 @@ func (s Scanner) FromData(
 		endpoints = append(endpoints, endpoint)
 	}
 
-	for _, endpoint := range s.Endpoints(endpoints...) {
+	for _, endpoint := range s.Endpoints(endpoints) {
 		for token := range uniqueTokens {
 			result := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_HashiCorpVaultBatchToken,

--- a/pkg/detectors/hashicorpvault/hashicorpvaultbatchtoken/hashicorpvaultbatchtoken_integration_test.go
+++ b/pkg/detectors/hashicorpvault/hashicorpvaultbatchtoken/hashicorpvaultbatchtoken_integration_test.go
@@ -79,7 +79,7 @@ func TestBatchToken_FromData(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			scanner := Scanner{}
 			scanner.UseFoundEndpoints(true)
-			scanner.UseCloudEndpoint(true)
+			scanner.UseCloudEndpoints(true)
 
 			results, err := scanner.FromData(ctx, tt.verify, []byte(tt.input))
 			require.NoError(t, err)

--- a/pkg/detectors/hashicorpvault/hashicorpvaulttoken/hashicorpvaulttoken.go
+++ b/pkg/detectors/hashicorpvault/hashicorpvaulttoken/hashicorpvaulttoken.go
@@ -40,7 +40,7 @@ func (s Scanner) Keywords() []string {
 	return []string{"hvs.", "vault"}
 }
 
-func (Scanner) CloudEndpoint() string { return "" }
+func (Scanner) CloudEndpoints() []string { return nil }
 
 func (s Scanner) Description() string {
 	return "HashiCorp Vault is a secrets management service. Vault tokens (periodic, service, and admin) can be used to access and manage stored secrets and resources."
@@ -77,7 +77,7 @@ func (s Scanner) FromData(
 	}
 
 	for token := range uniqueTokens {
-		for _, endpoint := range s.Endpoints(endpoints...) {
+		for _, endpoint := range s.Endpoints(endpoints) {
 			result := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_HashiCorpVaultToken,
 				Raw:          []byte(token),

--- a/pkg/detectors/hashicorpvault/hashicorpvaulttoken/hashicorpvaulttoken_integration_test.go
+++ b/pkg/detectors/hashicorpvault/hashicorpvaulttoken/hashicorpvaulttoken_integration_test.go
@@ -86,7 +86,7 @@ func TestVaultToken_FromData_Integration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			scanner := Scanner{}
 			scanner.UseFoundEndpoints(true)
-			scanner.UseCloudEndpoint(true)
+			scanner.UseCloudEndpoints(true)
 			results, err := scanner.FromData(ctx, tt.verify, []byte(tt.input))
 			require.NoError(t, err)
 

--- a/pkg/detectors/hashicorpvaultauth/hashicorpvaultauth.go
+++ b/pkg/detectors/hashicorpvaultauth/hashicorpvaultauth.go
@@ -74,7 +74,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	var uniqueUrls = make(map[string]struct{})
-	for _, endpoint := range s.Endpoints(endpoints...) {
+	for _, endpoint := range s.Endpoints(endpoints) {
 		uniqueUrls[endpoint] = struct{}{}
 	}
 	// create combination results that can be verified

--- a/pkg/detectors/hashicorpvaultauth/hashicorpvaultauth_integration_test.go
+++ b/pkg/detectors/hashicorpvaultauth/hashicorpvaultauth_integration_test.go
@@ -142,7 +142,7 @@ func TestHashiCorpVaultAuth_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.s.UseCloudEndpoint(true)
+			tt.s.UseCloudEndpoints(true)
 			tt.s.UseFoundEndpoints(true)
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
@@ -177,7 +177,7 @@ func TestHashiCorpVaultAuth_WithCustomEndpoint(t *testing.T) {
 	secretId := testSecrets.MustGetField("HASHICORPVAULTAUTH_SECRET_ID")
 	vaultUrl := testSecrets.MustGetField("HASHICORPVAULTAUTH_URL")
 	s := Scanner{}
-	s.UseCloudEndpoint(true)
+	s.UseCloudEndpoints(true)
 	s.UseFoundEndpoints(true)
 	s.SetConfiguredEndpoints(vaultUrl)
 	data := fmt.Appendf(nil, "hashicorp config:\nrole_id: %s\nsecret_id: %s", roleId, secretId)

--- a/pkg/detectors/hashicorpvaultauth/hashicorpvaultauth_test.go
+++ b/pkg/detectors/hashicorpvaultauth/hashicorpvaultauth_test.go
@@ -126,7 +126,7 @@ func TestHashiCorpVaultAppRoleAuth_Pattern(t *testing.T) {
 				t.Errorf("keywords '%v' not matched by: %s", d.Keywords(), test.input)
 				return
 			}
-			d.UseCloudEndpoint(true)
+			d.UseCloudEndpoints(true)
 			d.UseFoundEndpoints(true)
 			results, err := d.FromData(context.Background(), false, []byte(test.input))
 			if err != nil {

--- a/pkg/detectors/jiratoken/v1/jiratoken.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken.go
@@ -40,7 +40,7 @@ func (Scanner) Version() int { return 1 }
 // The graphql API answers on this host as long as the credentials are valid.
 const CloudHost = "api.atlassian.com"
 
-func (Scanner) CloudEndpoint() string { return "https://" + CloudHost }
+func (Scanner) CloudEndpoints() []string { return []string{"https://" + CloudHost} }
 
 var (
 	defaultClient = detectors.DetectorHttpClientWithLocalAddresses
@@ -168,7 +168,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	}
 
 	found := FoundHosts(uniqueDomains)
-	hosts := VerificationHosts(s.Endpoints(found...), found)
+	hosts := VerificationHosts(s.Endpoints(found), found)
 
 	for email := range uniqueEmails {
 		for token := range uniqueTokens {

--- a/pkg/detectors/jiratoken/v1/jiratoken_integration_test.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken_integration_test.go
@@ -141,8 +141,8 @@ func TestJiraToken_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.s.SetCloudEndpoint(tt.s.CloudEndpoint())
-			tt.s.UseCloudEndpoint(true)
+			tt.s.SetCloudEndpoints(tt.s.CloudEndpoints()...)
+			tt.s.UseCloudEndpoints(true)
 			tt.s.UseFoundEndpoints(true)
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
@@ -168,8 +168,8 @@ func TestJiraToken_FromChunk(t *testing.T) {
 func BenchmarkFromData(benchmark *testing.B) {
 	ctx := context.Background()
 	s := Scanner{}
-	s.SetCloudEndpoint(s.CloudEndpoint())
-	s.UseCloudEndpoint(true)
+	s.SetCloudEndpoints(s.CloudEndpoints()...)
+	s.UseCloudEndpoints(true)
 	s.UseFoundEndpoints(true)
 	for name, data := range detectors.MustGetBenchmarkData() {
 		benchmark.Run(name, func(b *testing.B) {

--- a/pkg/detectors/jiratoken/v1/jiratoken_test.go
+++ b/pkg/detectors/jiratoken/v1/jiratoken_test.go
@@ -26,8 +26,8 @@ var (
 
 func TestJiraToken_Pattern(t *testing.T) {
 	d := Scanner{}
-	d.SetCloudEndpoint(d.CloudEndpoint())
-	d.UseCloudEndpoint(true)
+	d.SetCloudEndpoints(d.CloudEndpoints()...)
+	d.UseCloudEndpoints(true)
 	d.UseFoundEndpoints(true)
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/jiratoken/v2/jiratoken_v2.go
+++ b/pkg/detectors/jiratoken/v2/jiratoken_v2.go
@@ -28,7 +28,7 @@ var _ detectors.CloudProvider = (*Scanner)(nil)
 
 func (Scanner) Version() int { return 2 }
 
-func (Scanner) CloudEndpoint() string { return "https://" + v1.CloudHost }
+func (Scanner) CloudEndpoints() []string { return []string{"https://" + v1.CloudHost} }
 
 var (
 	defaultClient = detectors.DetectorHttpClientWithLocalAddresses
@@ -73,7 +73,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	// domainPat here is not even keyword-gated, so it captures every domain in the chunk.
 	found := v1.FoundHosts(uniqueDomains)
-	hosts := v1.VerificationHosts(s.Endpoints(found...), found)
+	hosts := v1.VerificationHosts(s.Endpoints(found), found)
 
 	for email := range uniqueEmails {
 		for token := range uniqueTokens {

--- a/pkg/detectors/jiratoken/v2/jiratoken_v2_integration_test.go
+++ b/pkg/detectors/jiratoken/v2/jiratoken_v2_integration_test.go
@@ -141,8 +141,8 @@ func TestJiraToken_FromChunk(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.s.SetCloudEndpoint(tt.s.CloudEndpoint())
-			tt.s.UseCloudEndpoint(true)
+			tt.s.SetCloudEndpoints(tt.s.CloudEndpoints()...)
+			tt.s.UseCloudEndpoints(true)
 			tt.s.UseFoundEndpoints(true)
 			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
@@ -168,8 +168,8 @@ func TestJiraToken_FromChunk(t *testing.T) {
 func BenchmarkFromData(benchmark *testing.B) {
 	ctx := context.Background()
 	s := Scanner{}
-	s.SetCloudEndpoint(s.CloudEndpoint())
-	s.UseCloudEndpoint(true)
+	s.SetCloudEndpoints(s.CloudEndpoints()...)
+	s.UseCloudEndpoints(true)
 	s.UseFoundEndpoints(true)
 	for name, data := range detectors.MustGetBenchmarkData() {
 		benchmark.Run(name, func(b *testing.B) {

--- a/pkg/detectors/jiratoken/v2/jiratoken_v2_test.go
+++ b/pkg/detectors/jiratoken/v2/jiratoken_v2_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestJiraToken_Pattern(t *testing.T) {
 	d := Scanner{}
-	d.SetCloudEndpoint(d.CloudEndpoint())
-	d.UseCloudEndpoint(true)
+	d.SetCloudEndpoints(d.CloudEndpoints()...)
+	d.UseCloudEndpoints(true)
 	d.UseFoundEndpoints(true)
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {

--- a/pkg/detectors/newrelicbrowserkey/newrelicbrowserkey.go
+++ b/pkg/detectors/newrelicbrowserkey/newrelicbrowserkey.go
@@ -18,15 +18,40 @@ import (
 
 type Scanner struct {
 	client *http.Client
+	detectors.EndpointSetter
 }
 
 // Ensure the Scanner satisfies the interfaces at compile time.
-var _ detectors.Detector = (*Scanner)(nil)
+var (
+	_ detectors.Detector           = (*Scanner)(nil)
+	_ detectors.EndpointCustomizer = (*Scanner)(nil)
+	_ detectors.CloudProvider      = (*Scanner)(nil)
+)
 
 var (
 	defaultClient = common.SaneHttpClient()
 	keyPat        = regexp.MustCompile(`\b(NRBR-[0-9a-f]{19})\b`)
 )
+
+const (
+	usEndpoint = "https://bam.nr-data.net/1/"
+	euEndpoint = "https://bam.eu01.nr-data.net/1/"
+)
+
+func (Scanner) CloudEndpoints() []string { return []string{usEndpoint, euEndpoint} }
+
+// regionForEndpoint labels the well-known US/EU cloud endpoints. A
+// user-configured or found endpoint has no known region, so it's left blank.
+func regionForEndpoint(endpoint string) string {
+	switch endpoint {
+	case usEndpoint:
+		return "us"
+	case euEndpoint:
+		return "eu"
+	default:
+		return ""
+	}
+}
 
 func (s Scanner) getClient() *http.Client {
 	if s.client != nil {
@@ -84,26 +109,27 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 // A 400 Bad Request response indicates that the key is valid but the request is malformed (because we are not sending the expected payload)
 // A 403 Forbidden response indicates that the key is invalid or revoked
 func (s Scanner) verify(ctx context.Context, key string) (bool, map[string]string, error) {
-	regionUrls := map[string]string{
-		"us": "https://bam.nr-data.net/1/",
-		"eu": "https://bam.eu01.nr-data.net/1/",
-	}
-	errs := make([]error, 0, len(regionUrls))
-	for region, regionUrl := range regionUrls {
-		verified, err := s.verifyRegion(ctx, key, regionUrl)
+	endpoints := s.Endpoints(nil)
+	errs := make([]error, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		verified, err := s.verifyEndpoint(ctx, key, endpoint)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("error verifying region %s: %w", region, err))
+			errs = append(errs, fmt.Errorf("error verifying endpoint %s: %w", endpoint, err))
 			continue
 		}
 		if verified {
-			return true, map[string]string{"region": region}, nil
+			extraData := map[string]string{}
+			if region := regionForEndpoint(endpoint); region != "" {
+				extraData["region"] = region
+			}
+			return true, extraData, nil
 		}
 	}
 	return false, nil, errors.Join(errs...)
 }
 
-func (s Scanner) verifyRegion(ctx context.Context, key string, regionUrl string) (bool, error) {
-	fullUrl, err := url.JoinPath(regionUrl, key)
+func (s Scanner) verifyEndpoint(ctx context.Context, key string, endpoint string) (bool, error) {
+	fullUrl, err := url.JoinPath(endpoint, key)
 	if err != nil {
 		return false, fmt.Errorf("error constructing URL: %w", err)
 	}

--- a/pkg/detectors/newrelicbrowserkey/newrelicbrowserkey_integration_test.go
+++ b/pkg/detectors/newrelicbrowserkey/newrelicbrowserkey_integration_test.go
@@ -112,6 +112,8 @@ func TestNewRelicBrowserKey_FromChunk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Scanner{}
+			s.SetCloudEndpoints(s.CloudEndpoints()...)
+			s.UseCloudEndpoints(true)
 			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewRelicBrowserKey.FromData() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/detectors/newrelicinsightsinsertkey/newrelicinsightsinsertkey.go
+++ b/pkg/detectors/newrelicinsightsinsertkey/newrelicinsightsinsertkey.go
@@ -17,15 +17,40 @@ import (
 
 type Scanner struct {
 	client *http.Client
+	detectors.EndpointSetter
 }
 
 // Ensure the Scanner satisfies the interfaces at compile time.
-var _ detectors.Detector = (*Scanner)(nil)
+var (
+	_ detectors.Detector           = (*Scanner)(nil)
+	_ detectors.EndpointCustomizer = (*Scanner)(nil)
+	_ detectors.CloudProvider      = (*Scanner)(nil)
+)
 
 var (
 	defaultClient = common.SaneHttpClient()
 	keyPat        = regexp.MustCompile(`\b(NRII-[a-zA-Z0-9-_]{25})`)
 )
+
+const (
+	usEndpoint = "https://insights-collector.newrelic.com/v1/accounts/`nowaythiscanexist/events"
+	euEndpoint = "https://insights-collector.eu01.nr-data.net/v1/accounts/`nowaythiscanexist/events"
+)
+
+func (Scanner) CloudEndpoints() []string { return []string{usEndpoint, euEndpoint} }
+
+// regionForEndpoint labels the well-known US/EU cloud endpoints. A
+// user-configured or found endpoint has no known region, so it's left blank.
+func regionForEndpoint(endpoint string) string {
+	switch endpoint {
+	case usEndpoint:
+		return "us"
+	case euEndpoint:
+		return "eu"
+	default:
+		return ""
+	}
+}
 
 func (s Scanner) getClient() *http.Client {
 	if s.client != nil {
@@ -80,27 +105,28 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 // Even though the response is 200, no data is actually published to New Relic since the request body is empty.
 // https://docs.newrelic.com/docs/data-apis/ingest-apis/event-api/introduction-event-api/
 func (s Scanner) verify(ctx context.Context, key string) (bool, map[string]string, error) {
-	regionUrls := map[string]string{
-		"us": "https://insights-collector.newrelic.com/v1/accounts/`nowaythiscanexist/events",
-		"eu": "https://insights-collector.eu01.nr-data.net/v1/accounts/`nowaythiscanexist/events",
-	}
-	errs := make([]error, 0, len(regionUrls))
-	for region, regionUrl := range regionUrls {
-		verified, err := s.verifyRegion(ctx, key, regionUrl)
+	endpoints := s.Endpoints(nil)
+	errs := make([]error, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		verified, err := s.verifyEndpoint(ctx, key, endpoint)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("error verifying region %s: %w", region, err))
+			errs = append(errs, fmt.Errorf("error verifying endpoint %s: %w", endpoint, err))
 			continue
 		}
 		if verified {
-			return true, map[string]string{"region": region}, nil
+			extraData := map[string]string{}
+			if region := regionForEndpoint(endpoint); region != "" {
+				extraData["region"] = region
+			}
+			return true, extraData, nil
 		}
 	}
 	return false, nil, errors.Join(errs...)
 }
 
-func (s Scanner) verifyRegion(ctx context.Context, key, regionUrl string) (bool, error) {
+func (s Scanner) verifyEndpoint(ctx context.Context, key, endpoint string) (bool, error) {
 	req, err := http.NewRequestWithContext(
-		ctx, http.MethodPost, regionUrl, http.NoBody)
+		ctx, http.MethodPost, endpoint, http.NoBody)
 	if err != nil {
 		return false, fmt.Errorf("error constructing request: %w", err)
 	}

--- a/pkg/detectors/newrelicinsightsinsertkey/newrelicinsightsinsertkey_integration_test.go
+++ b/pkg/detectors/newrelicinsightsinsertkey/newrelicinsightsinsertkey_integration_test.go
@@ -109,6 +109,8 @@ func TestNewRelicInsightsInsertKey_FromChunk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Scanner{}
+			s.SetCloudEndpoints(s.CloudEndpoints()...)
+			s.UseCloudEndpoints(true)
 			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewRelicInsightsInsertKey.FromData() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/detectors/newrelicinsightsquerykey/newrelicinsightsquerykey.go
+++ b/pkg/detectors/newrelicinsightsquerykey/newrelicinsightsquerykey.go
@@ -17,18 +17,45 @@ import (
 
 type Scanner struct {
 	detectors.DefaultMultiPartCredentialProvider
+	detectors.EndpointSetter
 
 	client *http.Client
 }
 
 // Ensure the Scanner satisfies the interfaces at compile time.
-var _ detectors.Detector = (*Scanner)(nil)
+var (
+	_ detectors.Detector           = (*Scanner)(nil)
+	_ detectors.EndpointCustomizer = (*Scanner)(nil)
+	_ detectors.CloudProvider      = (*Scanner)(nil)
+)
 
 var (
 	defaultClient = common.SaneHttpClient()
 	keyPat        = regexp.MustCompile(`\b(NRIQ-[a-zA-Z0-9-_]{25})`)
 	accountIDPat  = regexp.MustCompile(detectors.PrefixRegex([]string{"relic", "account", "id"}) + `\b(\d{4,10})\b`)
 )
+
+// Cloud endpoints here are hosts, not full URLs - the account ID (discovered
+// per match, not fixed) is appended to build the actual request URL.
+const (
+	usHost = "https://insights-api.newrelic.com"
+	euHost = "https://insights-api.eu.newrelic.com"
+)
+
+func (Scanner) CloudEndpoints() []string { return []string{usHost, euHost} }
+
+// regionForHost labels the well-known US/EU cloud hosts. A user-configured
+// or found host has no known region, so it's left blank.
+func regionForHost(host string) string {
+	switch host {
+	case usHost:
+		return "us"
+	case euHost:
+		return "eu"
+	default:
+		return ""
+	}
+}
 
 func (s Scanner) getClient() *http.Client {
 	if s.client != nil {
@@ -79,8 +106,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				isVerified, extraData, verificationErr := s.verify(ctx, keyResMatch, accountIDResMatch)
 				s1.Verified = isVerified
 				s1.ExtraData = extraData
-				if extraData != nil {
-					s1.SecretParts["region"] = extraData["region"]
+				if region, ok := extraData["region"]; ok {
+					s1.SecretParts["region"] = region
 				}
 				s1.SetVerificationError(verificationErr)
 			}
@@ -97,27 +124,29 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 // It checks both the US and EU endpoints before returning an error.
 // Account ID is required to verify as the API endpoint is account-specific.
 func (s Scanner) verify(ctx context.Context, key string, accountID string) (bool, map[string]string, error) {
-	regionUrls := map[string]string{
-		"us": fmt.Sprintf("https://insights-api.newrelic.com/v1/accounts/%s/query?nrql=SELECT%%201", accountID),
-		"eu": fmt.Sprintf("https://insights-api.eu.newrelic.com/v1/accounts/%s/query?nrql=SELECT%%201", accountID),
-	}
-	errs := make([]error, 0, len(regionUrls))
-	for region, regionUrl := range regionUrls {
-		verified, err := s.verifyRegion(ctx, key, regionUrl)
+	hosts := s.Endpoints(nil)
+	errs := make([]error, 0, len(hosts))
+	for _, host := range hosts {
+		endpoint := fmt.Sprintf("%s/v1/accounts/%s/query?nrql=SELECT%%201", host, accountID)
+		verified, err := s.verifyEndpoint(ctx, key, endpoint)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("error verifying region %s: %w", region, err))
+			errs = append(errs, fmt.Errorf("error verifying host %s: %w", host, err))
 			continue
 		}
 		if verified {
-			return true, map[string]string{"region": region}, nil
+			extraData := map[string]string{}
+			if region := regionForHost(host); region != "" {
+				extraData["region"] = region
+			}
+			return true, extraData, nil
 		}
 	}
 	return false, nil, errors.Join(errs...)
 }
 
-func (s Scanner) verifyRegion(ctx context.Context, key, regionUrl string) (bool, error) {
+func (s Scanner) verifyEndpoint(ctx context.Context, key, endpoint string) (bool, error) {
 	req, err := http.NewRequestWithContext(
-		ctx, http.MethodGet, regionUrl, http.NoBody)
+		ctx, http.MethodGet, endpoint, http.NoBody)
 	if err != nil {
 		return false, fmt.Errorf("error constructing request: %w", err)
 	}

--- a/pkg/detectors/newrelicinsightsquerykey/newrelicinsightsquerykey_integration_test.go
+++ b/pkg/detectors/newrelicinsightsquerykey/newrelicinsightsquerykey_integration_test.go
@@ -125,6 +125,8 @@ func TestNewRelicInsightsQueryKey_FromChunk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Scanner{}
+			s.SetCloudEndpoints(s.CloudEndpoints()...)
+			s.UseCloudEndpoints(true)
 			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewRelicInsightsQueryKey.FromData() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/detectors/newrelicuserkey/newrelicuserkey.go
+++ b/pkg/detectors/newrelicuserkey/newrelicuserkey.go
@@ -18,15 +18,40 @@ import (
 
 type Scanner struct {
 	client *http.Client
+	detectors.EndpointSetter
 }
 
 // Ensure the Scanner satisfies the interfaces at compile time.
-var _ detectors.Detector = (*Scanner)(nil)
+var (
+	_ detectors.Detector           = (*Scanner)(nil)
+	_ detectors.EndpointCustomizer = (*Scanner)(nil)
+	_ detectors.CloudProvider      = (*Scanner)(nil)
+)
 
 var (
 	defaultClient = common.SaneHttpClient()
 	keyPat        = regexp.MustCompile(`\b(NRAK-[A-Z0-9]{27})\b`)
 )
+
+const (
+	usEndpoint = "https://api.newrelic.com/graphql"
+	euEndpoint = "https://api.eu.newrelic.com/graphql"
+)
+
+func (Scanner) CloudEndpoints() []string { return []string{usEndpoint, euEndpoint} }
+
+// regionForEndpoint labels the well-known US/EU cloud endpoints. A
+// user-configured or found endpoint has no known region, so it's left blank.
+func regionForEndpoint(endpoint string) string {
+	switch endpoint {
+	case usEndpoint:
+		return "us"
+	case euEndpoint:
+		return "eu"
+	default:
+		return ""
+	}
+}
 
 func (s Scanner) getClient() *http.Client {
 	if s.client != nil {
@@ -67,8 +92,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			isVerified, extraData, verificationErr := s.verify(ctx, resMatch)
 			s1.Verified = isVerified
 			s1.ExtraData = extraData
-			if extraData != nil {
-				s1.SecretParts["region"] = extraData["region"]
+			if region, ok := extraData["region"]; ok {
+				s1.SecretParts["region"] = region
 			}
 			s1.SetVerificationError(verificationErr)
 		}
@@ -92,16 +117,12 @@ type graphqlResponse struct {
 // Invalid key will return in 401 Unauthorized, and a key with incorrect region will return a 403 Forbidden.
 // https://docs.newrelic.com/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/
 func (s Scanner) verify(ctx context.Context, key string) (bool, map[string]string, error) {
-	regionUrls := map[string]string{
-		"us": "https://api.newrelic.com/graphql",
-		"eu": "https://api.eu.newrelic.com/graphql",
-	}
-
-	errs := make([]error, 0, len(regionUrls))
-	for region, regionUrl := range regionUrls {
-		verified, extraData, err := s.verifyRegion(ctx, key, region, regionUrl)
+	endpoints := s.Endpoints(nil)
+	errs := make([]error, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		verified, extraData, err := s.verifyEndpoint(ctx, key, endpoint)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("error verifying region %s: %w", region, err))
+			errs = append(errs, fmt.Errorf("error verifying endpoint %s: %w", endpoint, err))
 			continue
 		}
 		if verified {
@@ -111,10 +132,10 @@ func (s Scanner) verify(ctx context.Context, key string) (bool, map[string]strin
 	return false, nil, errors.Join(errs...)
 }
 
-func (s Scanner) verifyRegion(ctx context.Context, key, region, regionUrl string) (bool, map[string]string, error) {
+func (s Scanner) verifyEndpoint(ctx context.Context, key, endpoint string) (bool, map[string]string, error) {
 	body := `{"query": "{ requestContext { userId } }"}`
 	req, err := http.NewRequestWithContext(
-		ctx, http.MethodPost, regionUrl, strings.NewReader(body))
+		ctx, http.MethodPost, endpoint, strings.NewReader(body))
 	if err != nil {
 		return false, nil, fmt.Errorf("error constructing request: %w", err)
 	}
@@ -135,13 +156,17 @@ func (s Scanner) verifyRegion(ctx context.Context, key, region, regionUrl string
 	case http.StatusOK:
 		var resp graphqlResponse
 		if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
-			return false, nil, fmt.Errorf("error decoding response for region %s: %w", region, err)
+			return false, nil, fmt.Errorf("error decoding response for endpoint %s: %w", endpoint, err)
 		}
-		return true, map[string]string{"region": region, "user_id": resp.Data.RequestContext.UserID}, nil
+		extraData := map[string]string{"user_id": resp.Data.RequestContext.UserID}
+		if region := regionForEndpoint(endpoint); region != "" {
+			extraData["region"] = region
+		}
+		return true, extraData, nil
 	case http.StatusUnauthorized, http.StatusForbidden:
-		// 401 means the key is invalid, 403 means the region is incorrect
+		// 401 means the key is invalid, 403 means the endpoint/region is incorrect
 		return false, nil, nil
 	default:
-		return false, nil, fmt.Errorf("unexpected status code for region %s: %d", region, res.StatusCode)
+		return false, nil, fmt.Errorf("unexpected status code for endpoint %s: %d", endpoint, res.StatusCode)
 	}
 }

--- a/pkg/detectors/newrelicuserkey/newrelicuserkey_integration_test.go
+++ b/pkg/detectors/newrelicuserkey/newrelicuserkey_integration_test.go
@@ -122,6 +122,8 @@ func TestNewRelicUserKey_FromChunk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Scanner{}
+			s.SetCloudEndpoints(s.CloudEndpoints()...)
+			s.UseCloudEndpoints(true)
 			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewRelicUserKey.FromData() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/detectors/sumologickey/sumologickey.go
+++ b/pkg/detectors/sumologickey/sumologickey.go
@@ -44,8 +44,11 @@ func (s Scanner) Keywords() []string {
 	return []string{"sumo", "accessId", "accessKey"}
 }
 
-// Default US API endpoint.
-func (Scanner) CloudEndpoint() string { return "api.sumologic.com" }
+// defaultCloudEndpoint is the US API endpoint, used when no region-specific
+// endpoint is found in the scanned content.
+const defaultCloudEndpoint = "api.sumologic.com"
+
+func (Scanner) CloudEndpoints() []string { return []string{defaultCloudEndpoint} }
 
 // FromData will find and optionally verify SumoLogicKey secrets in a given set of bytes.
 func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
@@ -59,13 +62,19 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	for _, match := range keyPat.FindAllStringSubmatch(dataStr, -1) {
 		keyMatches[match[1]] = struct{}{}
 	}
-	endpointMatches := make(map[string]struct{})
+
+	uniqueFoundEndpoints := make(map[string]struct{})
 	for _, match := range urlPat.FindAllStringSubmatch(dataStr, -1) {
-		endpointMatches[match[0]] = struct{}{}
+		uniqueFoundEndpoints[match[0]] = struct{}{}
 	}
-	if len(endpointMatches) == 0 {
-		endpointMatches[s.CloudEndpoint()] = struct{}{}
+	foundEndpoints := make([]string, 0, len(uniqueFoundEndpoints))
+	for e := range uniqueFoundEndpoints {
+		foundEndpoints = append(foundEndpoints, e)
 	}
+
+	// Honors configured/cloud/found endpoint toggles and --verifier-endpoint,
+	// same as every other EndpointCustomizer detector.
+	endpoints := s.Endpoints(foundEndpoints)
 
 	for accessKey := range keyMatches {
 		var (
@@ -77,7 +86,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		for id := range idMatches {
 			accessId = id
 
-			for e := range endpointMatches {
+			for _, e := range endpoints {
 				apiEndpoint = e
 
 				if verify {
@@ -99,10 +108,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			if len(idMatches) != 1 {
 				accessId = ""
 			}
-			if len(endpointMatches) != 1 || apiEndpoint == s.CloudEndpoint() {
-				apiEndpoint = ""
-			}
-			r = createResult(accessId, accessKey, apiEndpoint, false, nil)
+			r = createResult(accessId, accessKey, confidentEndpoint(endpoints), false, nil)
 		}
 		results = append(results, *r)
 	}
@@ -110,8 +116,33 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	return results, nil
 }
 
+// confidentEndpoint returns the single endpoint tried that isn't the
+// synthetic default cloud fallback, or "" if there's zero or more than one.
+// Endpoints() unions the cloud default with any found/configured endpoint,
+// so its length alone can't signal confidence - a lone found regional host
+// (e.g. "api.us2.sumologic.com") plus the always-present cloud default would
+// otherwise look like two candidates instead of one confident match.
+func confidentEndpoint(endpoints []string) string {
+	var confident string
+	count := 0
+	for _, e := range endpoints {
+		if e != defaultCloudEndpoint {
+			count++
+			confident = e
+		}
+	}
+	if count != 1 {
+		return ""
+	}
+	return confident
+}
+
 func verifyMatch(ctx context.Context, client *http.Client, endpoint string, id string, key string) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s/api/v1/users", endpoint), nil)
+	// endpoint may be a bare host (cloud/found, e.g. "api.sumologic.com") or a
+	// full URL (configured via --verifier-endpoint, e.g. "https://host.com") -
+	// normalize to a bare host so it isn't double-prefixed below.
+	host := strings.TrimSuffix(strings.TrimPrefix(strings.TrimPrefix(endpoint, "https://"), "http://"), "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("https://%s/api/v1/users", host), nil)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/detectors/sumologickey/sumologickey_integration_test.go
+++ b/pkg/detectors/sumologickey/sumologickey_integration_test.go
@@ -86,6 +86,9 @@ func TestSumoLogicKey_FromChunk(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := Scanner{}
+			s.SetCloudEndpoints(s.CloudEndpoints()...)
+			s.UseCloudEndpoints(true)
+			s.UseFoundEndpoints(true)
 			got, err := s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("SumoLogicKey.FromData() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/detectors/sumologickey/sumologickey_test.go
+++ b/pkg/detectors/sumologickey/sumologickey_test.go
@@ -2,16 +2,25 @@ package sumologickey
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
 func TestSumoLogicKey_Pattern(t *testing.T) {
 	d := Scanner{}
+	d.UseFoundEndpoints(true)
 	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
 	tests := []struct {
 		name  string
@@ -91,4 +100,94 @@ sumoKey2 = 'Khk3i2ugMxMgkb8bIA2auj4I8juZ3HiimDNssjzYdGqfizPZcxHK21a0LckgRSCL'`,
 			}
 		})
 	}
+}
+
+// TestSumoLogicKey_Pattern_CloudAndFoundEnabled mirrors production wiring
+// (defaults.go enables both cloud and found endpoints together). A single
+// found regional host must still be reported confidently even though
+// Endpoints() also includes the always-present cloud default alongside it.
+// TestVerifyMatch_NormalizesEndpointScheme guards against double-prefixing
+// endpoints that already carry a scheme. --verifier-endpoint values are
+// required to be full https:// URLs (repo-wide convention), while cloud and
+// found endpoints are bare hosts; verifyMatch must handle both without
+// producing "https://https://...".
+func TestVerifyMatch_NormalizesEndpointScheme(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		wantURL  string
+	}{
+		{"bare host (cloud/found)", "api.sumologic.com", "https://api.sumologic.com/api/v1/users"},
+		{"configured full URL", "https://custom.sumologic.example.com", "https://custom.sumologic.example.com/api/v1/users"},
+		{"configured URL with trailing slash", "https://custom.sumologic.example.com/", "https://custom.sumologic.example.com/api/v1/users"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedURL string
+			client := &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					capturedURL = req.URL.String()
+					return &http.Response{StatusCode: http.StatusUnauthorized, Body: io.NopCloser(strings.NewReader(""))}, nil
+				}),
+			}
+
+			_, err := verifyMatch(context.Background(), client, tt.endpoint, "id", "key")
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantURL, capturedURL)
+			assert.NotContains(t, capturedURL, "https://https://")
+		})
+	}
+}
+
+func TestSumoLogicKey_Pattern_CloudAndFoundEnabled(t *testing.T) {
+	d := Scanner{}
+	d.UseFoundEndpoints(true)
+	d.UseCloudEndpoints(true)
+	d.SetCloudEndpoints(d.CloudEndpoints()...)
+
+	input := `sumologic:
+  baseUrl: api.us2.sumologic.com
+  accessId: suDkVYKjXZAwsz
+  accessKey: Khk3i2ugMxMgkb8bIA2auj4I8juZ3HiimDNssjzYdGqfizPZcxHK70a0LckgRSCL
+  clusterName: Kubernetes_cluster-2024-10-25T21:34:23.096Z`
+
+	results, err := d.FromData(context.Background(), false, []byte(input))
+	if err != nil {
+		t.Fatalf("error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	want := `{"accessId":"suDkVYKjXZAwsz","accessKey":"Khk3i2ugMxMgkb8bIA2auj4I8juZ3HiimDNssjzYdGqfizPZcxHK70a0LckgRSCL","url":"api.us2.sumologic.com"}`
+	if got := string(results[0].RawV2); got != want {
+		t.Errorf("RawV2 = %q, want %q", got, want)
+	}
+}
+
+// TestSumoLogicKey_Pattern_ConfiguredMatchesFound covers the case where the
+// same host arrives via two sources: --verifier-endpoint (configured) and
+// text extraction (found). Endpoints() must dedupe these to one entry, or
+// confidentEndpoint sees two occurrences of the same host and wrongly treats
+// it as ambiguous, dropping the url from RawV2 even though there's exactly
+// one distinct region.
+func TestSumoLogicKey_Pattern_ConfiguredMatchesFound(t *testing.T) {
+	d := Scanner{}
+	assert.NoError(t, d.SetConfiguredEndpoints("api.us2.sumologic.com"))
+	d.UseFoundEndpoints(true)
+
+	input := `sumologic:
+  baseUrl: api.us2.sumologic.com
+  accessId: suDkVYKjXZAwsz
+  accessKey: Khk3i2ugMxMgkb8bIA2auj4I8juZ3HiimDNssjzYdGqfizPZcxHK70a0LckgRSCL`
+
+	results, err := d.FromData(context.Background(), false, []byte(input))
+	assert.NoError(t, err)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	want := `{"accessId":"suDkVYKjXZAwsz","accessKey":"Khk3i2ugMxMgkb8bIA2auj4I8juZ3HiimDNssjzYdGqfizPZcxHK70a0LckgRSCL","url":"api.us2.sumologic.com"}`
+	assert.Equal(t, want, string(results[0].RawV2))
 }

--- a/pkg/detectors/tableau/tableau.go
+++ b/pkg/detectors/tableau/tableau.go
@@ -27,7 +27,7 @@ type Scanner struct {
 var _ detectors.Detector = (*Scanner)(nil)
 var _ detectors.EndpointCustomizer = (*Scanner)(nil)
 
-func (Scanner) CloudEndpoint() string { return "" }
+func (Scanner) CloudEndpoints() []string { return nil }
 
 var (
 	defaultClient = common.SaneHttpClient()
@@ -74,7 +74,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	var uniqueEndpoints = make(map[string]struct{})
 
 	// Add endpoints to the list
-	for _, endpoint := range s.Endpoints(foundURLs...) {
+	for _, endpoint := range s.Endpoints(foundURLs) {
 		// Remove https:// prefix if present since we add it during verification
 		endpoint = strings.TrimPrefix(endpoint, "https://")
 		uniqueEndpoints[endpoint] = struct{}{}

--- a/pkg/detectors/user/user.go
+++ b/pkg/detectors/user/user.go
@@ -35,7 +35,7 @@ var (
 	errNoHost    = errors.New("no such host")
 )
 
-func (Scanner) CloudEndpoint() string { return "" }
+func (Scanner) CloudEndpoints() []string { return nil }
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
@@ -67,7 +67,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	// Merge found endpoints with any user-configured endpoints.
 	// Callers must call UseFoundEndpoints(true) to include endpoints extracted from data.
-	for _, endpoint := range s.Endpoints(foundURLs...) {
+	for _, endpoint := range s.Endpoints(foundURLs) {
 		endpoint = strings.TrimPrefix(endpoint, "https://")
 		uniqueURLs[endpoint] = struct{}{}
 	}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -1912,9 +1912,9 @@ func DefaultDetectors() []detectors.Detector {
 		}
 		// Default to always use the cloud endpoints (if available) and the found endpoints.
 		customizer.UseFoundEndpoints(true)
-		customizer.UseCloudEndpoint(true)
+		customizer.UseCloudEndpoints(true)
 		if cloudProvider, ok := d.(detectors.CloudProvider); ok {
-			customizer.SetCloudEndpoint(cloudProvider.CloudEndpoint())
+			customizer.SetCloudEndpoints(cloudProvider.CloudEndpoints()...)
 		}
 	}
 

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -311,7 +311,7 @@ func NewEngine(ctx context.Context, cfg *Config) (*Engine, error) {
 			}
 
 			if cfg.CustomVerifiersOnly && len(urls) > 0 {
-				customizer.UseCloudEndpoint(false)
+				customizer.UseCloudEndpoints(false)
 				customizer.UseFoundEndpoints(false)
 			}
 

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1483,9 +1483,11 @@ func TestEngineInitializesCloudProviderDetectors(t *testing.T) {
 	}
 
 	for _, det := range e.detectors {
-		if endpoints, ok := det.(interface{ Endpoints(...string) []string }); ok {
+		if endpoints, ok := det.(interface {
+			Endpoints([]string, ...string) []string
+		}); ok {
 			id := config.GetDetectorID(det)
-			if len(endpoints.Endpoints()) == 0 {
+			if len(endpoints.Endpoints(nil)) == 0 {
 				if _, ok := noCloudEndpointDetectors[det.Type()]; !ok {
 					t.Fatalf("detector %q Endpoints() is empty", id.String())
 				}


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Endpoints() now always tries configured, then cloud, then found endpoints in that fixed order, with an optional per-call suffix filter on found endpoints to guard against SSRF from scanned text. CloudProvider now returns []string, letting detectors declare multiple cloud endpoints; migrated 4 NewRelic detectors and sumologickey off ad-hoc endpoint logic onto this shared path, and fixed a latent bug where datadogapikey/datadogtoken could silently overwrite a verified result with a later failed endpoint check.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes verification target selection and ordering for many detectors, including SSRF-related filtering of scanned URLs; incorrect suffix or ordering could mis-verify secrets or skip valid hosts.
> 
> **Overview**
> Refactors detector endpoint handling so verification always tries **configured → cloud → found** endpoints, with deduplication across sources and found URLs only accepted when they pass an optional per-call host suffix filter (SSRF mitigation).
> 
> **`CloudProvider` / `EndpointCustomizer`** now expose plural APIs (`CloudEndpoints()`, `SetCloudEndpoints`, `UseCloudEndpoints`) and `Endpoints(found []string, allowedSuffixes ...)` instead of variadic found URLs and a single cloud URL. **`EndpointSetter`** implements the new ordering, multi-cloud lists, and suffix checks via `hostOf`.
> 
> Call sites across Artifactory, GitHub/GitLab, Datadog, Jira, Vault, Tableau, Atlassian DC helpers, engine defaults, and custom-verifier wiring are updated to the new signatures.
> 
> **Behavior fixes:** Datadog API key/token verification stops after the first successful endpoint so a later failure cannot overwrite a verified result. **Sumo Logic** routes hosts through `Endpoints()` and adds `confidentEndpoint` plus scheme normalization for `--verifier-endpoint` URLs. **Four New Relic detectors** adopt `EndpointSetter` with US/EU cloud endpoints instead of hard-coded regional loops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23ce397016099327a4702929b34345aabc03671e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->