### PR TITLE
fix(action): warn when an unhandled event falls back to a full-history scan

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -93,6 +93,14 @@ runs:
           elif [ "${{ github.event_name }}" == "pull_request" ]; then
             BASE=${{github.event.pull_request.base.sha}}
             HEAD=${{github.event.pull_request.head.sha}}
+          else
+            # Unhandled event type (release, merge_group, pull_request_target, ...).
+            # BASE and HEAD stay empty, so the scan below covers the full history of
+            # every fetched ref rather than a diff. That may be what you want, but it
+            # should not be silent: say so, and name the event that caused it.
+            BASE=""
+            HEAD=""
+            echo "::warning::TruffleHog has no diff range for event '${{ github.event_name }}', so it is scanning the full history of all fetched refs. Set the 'base' and 'head' inputs explicitly to scan a specific range. Please see documentation (https://github.com/trufflesecurity/trufflehog#octocat-trufflehog-github-action)."
           fi
         fi
         ##########################################

--- a/action.yml
+++ b/action.yml
@@ -104,6 +104,19 @@ runs:
           fi
         fi
         ##########################################
+        ## Log the resolved scan scope          ##
+        ##########################################
+        if [ -n "$BASE" ] && [ -n "$HEAD" ]; then
+          SCOPE="diff"
+        elif [ -n "$HEAD" ]; then
+          SCOPE="full history of branch '$HEAD'"
+        elif [ -n "$BASE" ]; then
+          SCOPE="every commit after '$BASE'"
+        else
+          SCOPE="full history of all fetched refs"
+        fi
+        echo "TruffleHog scan scope: ${SCOPE} [event='${{ github.event_name }}', since-commit='${BASE}', branch='${HEAD}']"
+        ##########################################
         ##          Run TruffleHog              ##
         ##########################################
         docker run --rm -v .:/tmp -w /tmp \


### PR DESCRIPTION
### Description:

Fixes #5190.

The event-dispatch ladder in `action.yml` has branches for `push`, `workflow_dispatch`/`schedule` and `pull_request`. Any other `github.event_name` falls out of the ladder with `BASE` and `HEAD` still unset, so the scan runs with empty `--since-commit` and `--branch`:

```bash
elif [ "${{ github.event_name }}" == "pull_request" ]; then
  BASE=${{github.event.pull_request.base.sha}}
  HEAD=${{github.event.pull_request.head.sha}}
fi                       # <- no else
...
--since-commit ${BASE:-''} --branch ${HEAD:-''}
```

Combined with the `fetch-depth: 0` checkout the README recommends, that silently turns an expected diff scan into a full-history scan across every fetched ref, with nothing in the log to indicate the scope changed. As the issue notes, `release` is one case; `merge_group`, `pull_request_target`, `create` and `workflow_run` behave the same way.

Worth contrasting with the guard immediately above, which handles the opposite failure explicitly — when `BASE == HEAD` it prints `::error::` and exits, because scanning *nothing* is worth shouting about. Scanning *everything*, unasked, was silent.

This adds the missing `else`. It sets `BASE`/`HEAD` explicitly so the fallback reads as intentional rather than incidental, and emits a `::warning::` naming the event that caused it and pointing at the `base`/`head` inputs.

**Deliberately a warning, not an error.** Erroring out would break any workflow currently relying on the fallback, and "scan everything" is sometimes the right outcome for these events — it just should not be invisible. The scan still runs; only the log gains a line.

### Verification

The change is confined to `action.yml`; no Go code is touched.

I modelled the dispatch ladder in a shell harness and ran every event type against the current and patched logic:

| Event | Before | After |
|---|---|---|
| `push` | `since-commit=<before-sha> branch=<after-sha>` | identical |
| `workflow_dispatch` | `since-commit=<> branch=<>` | identical |
| `schedule` | `since-commit=<> branch=<>` | identical |
| `pull_request` | `since-commit=<base-sha> branch=<head-sha>` | identical |
| `release` | `since-commit=<> branch=<>`, no warning | same scan, **warning emitted** |
| `merge_group` | as above | **warning emitted** |
| `pull_request_target` | as above | **warning emitted** |
| `create` | as above | **warning emitted** |
| `workflow_run` | as above | **warning emitted** |
| `issue_comment` | as above | **warning emitted** |

All four handled events are byte-identical, so there is no regression; every unhandled event now warns.

Also confirmed `action.yml` still parses as YAML, and the extracted `run:` body passes `bash -n`.

### Checklist:
* [ ] Tests passing (`make test-community`)? — not run: this change touches no Go code, only `action.yml`. Happy to run it if you would like the confirmation anyway.
* [ ] Lint passing (`make lint`)? — same; `golangci-lint` does not cover this file.
* [x] Man page — not affected; no CLI flags or subcommands added, removed or renamed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Composite action shell-only change; handled events are unchanged and unhandled events still scan but are now visible in logs.
> 
> **Overview**
> **Unhandled GitHub events** (`release`, `merge_group`, `pull_request_target`, etc.) no longer fall through the `action.yml` dispatch ladder with empty `BASE`/`HEAD` and no signal. An explicit `else` keeps the same full-history scan behavior but emits a **`::warning::`** naming the event and pointing users at the `base`/`head` inputs.
> 
> **Every run** now logs a one-line **scan scope** summary (diff vs full branch vs full fetched refs) with event name and resolved `since-commit` / `branch` values before TruffleHog starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d315c36ee67b134c200b7f06f5d8c72c8d5020f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->