### PR TITLE
fix(git): do not force TrustLocalGitConfig on repos go-git cannot open

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/log"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/output"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/sources"
+	gitSource "github.com/trufflesecurity/trufflehog/v3/pkg/sources/git"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/tui"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/updater"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/verificationcache"
@@ -880,8 +881,12 @@ func runSingleScan(ctx context.Context, cmd string, cfg engine.Config) (metrics,
 		if isPreCommitHook() {
 			ctx.Logger().Info("Running as a pre-commit hook, overriding default flags for hook context")
 
-			// Override git configuration for pre-commit hook context
-			gitCfg.TrustLocalGitConfig = true
+			// Override git configuration for pre-commit hook context.
+			// Probe whether go-git can open the repo directly; if not (e.g. the repo
+			// uses extensions.worktreeConfig or extensions.reftable), fall back to
+			// a clone which strips unsupported extensions.
+			// See: https://github.com/trufflesecurity/trufflehog/issues/5181
+			gitCfg.TrustLocalGitConfig = gitSource.CanTrustLocalGitConfig(*gitScanURI)
 			gitCfg.BaseRef = "HEAD" // Only scan staged changes
 
 			// Override result filters for pre-commit hook context

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -410,6 +410,22 @@ func RepoFromPath(path string) (*git.Repository, error) {
 	return git.PlainOpenWithOptions(path, options)
 }
 
+// CanTrustLocalGitConfig probes whether go-git can open the repo at uriString
+// directly. Returns true only for file:// URIs that go-git can open without
+// error; false for remote URIs, missing repos, or unsupported formats (e.g.
+// extensions.worktreeConfig, extensions.reftable). When false, PrepareRepo
+// falls back to a clone which strips unsupported extensions.
+func CanTrustLocalGitConfig(uriString string) bool {
+	uri, err := GitURLParse(uriString)
+	if err != nil || uri.Scheme != "file" {
+		return false
+	}
+	// Build the path exactly as PrepareRepo does for the trusted branch, so the
+	// probe opens the same path the scan will.
+	_, err = RepoFromPath(fmt.Sprintf("%s%s", uri.Host, uri.Path))
+	return err == nil
+}
+
 func CleanOnError(err *error, path string) {
 	if *err != nil {
 		_ = os.RemoveAll(path)

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -884,6 +884,38 @@ func TestChunkUnit(t *testing.T) {
 	assert.Equal(t, 0, len(reporter.ChunkErrs))
 }
 
+func TestCanTrustLocalGitConfig(t *testing.T) {
+	normalRepo := setupTestRepo(t, "normal")
+	worktreeConfigRepo := setupTestRepo(t, "worktree-config")
+	for _, args := range [][]string{
+		{"-C", worktreeConfigRepo, "config", "core.repositoryformatversion", "1"},
+		{"-C", worktreeConfigRepo, "config", "extensions.worktreeConfig", "true"},
+	} {
+		if output, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, output)
+		}
+	}
+
+	tests := []struct {
+		name string
+		uri  string
+		want bool
+	}{
+		{name: "worktree config repo", uri: "file://" + worktreeConfigRepo, want: false},
+		{name: "normal repo", uri: "file://" + normalRepo, want: true},
+		{name: "non-existent path", uri: "file://" + filepath.Join(t.TempDir(), "missing"), want: false},
+		{name: "remote URI", uri: "https://github.com/trufflesecurity/trufflehog.git", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CanTrustLocalGitConfig(tt.uri); got != tt.want {
+				t.Fatalf("CanTrustLocalGitConfig(%q) = %v, want %v", tt.uri, got, tt.want)
+			}
+		})
+	}
+}
+
 func setupTestRepo(t *testing.T, repoName string) string {
 	tempDir := t.TempDir()
 	repoPath := filepath.Join(tempDir, repoName)


### PR DESCRIPTION
### Description:

Fixes #5181.

Pre-commit hook mode unconditionally set `TrustLocalGitConfig = true` (`main.go`). That selects the local-open shortcut in `PrepareRepo`, which hands the repository path straight to go-git. go-git refuses repositories declaring extensions it does not implement, so scanning a repo with `extensions.worktreeConfig` set fails with:

```
error chunking dir: core.repositoryformatversion does not support extension: worktreeconfig
```

and reports zero chunks scanned. The non-trusted path clones first, which strips unsupported extensions, so the same repository scans correctly outside pre-commit mode.

**The documented workaround does not work either.** The override also overwrote an explicitly supplied `--no-trust-local-git-config`, so in pre-commit mode users had no way out. Scenario 4 below shows this, and shows it fixed.

### Approach

Rather than pattern-matching on extension names, probe with the same call the scan will make: if go-git can open the repository, keep the shortcut; otherwise leave `TrustLocalGitConfig` alone and let `PrepareRepo` clone.

That needs no list of extension names to maintain (`worktreeConfig`, `reftable`, `objectFormat`, …), and it starts trusting repositories automatically if go-git gains support for them later.

`CanTrustLocalGitConfig` builds its path with `fmt.Sprintf("%s%s", uri.Host, uri.Path)` — deliberately identical to `PrepareRepo`'s trusted branch — so the probe opens exactly the path the scan will. For `file://` URIs `prepareRepoSinceCommit` delegates to `PrepareRepo`, so that is the only path construction that matters here.

### Failing case / reproduction

```bash
mkdir /tmp/r-wt && cd /tmp/r-wt && git init -q .
echo placeholder > secret.txt && git add . && git commit -qm init
git config core.repositoryformatversion 1
git config extensions.worktreeConfig true
printf 'AKIAIOSFODNN7EXAMPLE\n' >> secret.txt && git add secret.txt

TRUFFLEHOG_PRE_COMMIT=1 trufflehog git file:///tmp/r-wt
```

Built `main` and this branch from source and ran four scenarios against each binary:

| Scenario | Before | After |
|---|---|---|
| 1. pre-commit + `worktreeConfig` repo (the bug) | `error: does not support extension`, 0 chunks | `"chunks": 1` |
| 2. pre-commit + normal repo (regression guard) | `"chunks": 1` | `"chunks": 1` — unchanged |
| 3. normal mode + `worktreeConfig` repo | `"chunks": 3` | `"chunks": 3` — unchanged |
| 4. pre-commit + explicit `--no-trust-local-git-config` | `error: does not support extension`, 0 chunks | `"chunks": 1` |

The scanned repository's `extensions.worktreeConfig=true` is preserved throughout; the fix never mutates the target repo.

### Tests

`TestCanTrustLocalGitConfig` covers a `worktreeConfig` repo, a normal repo, a non-existent path, and a remote URI. Verified the test actually catches the bug by stubbing the function to `return true` — the three false-expecting cases then fail.

Note: `TestSource_Scan` and `TestSource_Chunks_Edge_Cases` fail in this package both with and without this change; they require GCP Secret Manager credentials (`could not find default credentials`), so they are environmental rather than related to this PR.

### Checklist:
* [x] Tests passing — `go test ./pkg/sources/git/ -run TestCanTrustLocalGitConfig` passes; `go build ./...` and `go vet . ./pkg/sources/git/` clean. Full `make test-community` not run locally (see the credentials note above).
* [ ] Lint passing (`make lint`) — not run locally; no `golangci-lint` in the environment. Happy to address anything CI flags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted change to pre-commit git path selection with a probe matching existing open logic; normal and non-hook scans are unchanged.
> 
> **Overview**
> Pre-commit hook mode no longer **always** sets `TrustLocalGitConfig` to true. It now calls **`CanTrustLocalGitConfig`** on the scan URI so local-open is only used when go-git can actually open the repo at the same path `PrepareRepo` would use.
> 
> That fixes scans failing with zero chunks on repos using unsupported format extensions (e.g. **`extensions.worktreeConfig`**) while keeping the fast local path for normal `file://` repos. When the probe fails, **`TrustLocalGitConfig` stays false** and the existing clone path strips unsupported extensions—so explicit **`--no-trust-local-git-config`** is respected again in hook mode.
> 
> Adds **`TestCanTrustLocalGitConfig`** for worktree-config, normal, missing, and remote URIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9da2537b8a414ab127c9ba89b770baf964f126f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->