### PR TITLE
Update base image to golang:1.25-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:bullseye as builder
+FROM --platform=${BUILDPLATFORM} golang:1.25-bookworm AS builder
 
 WORKDIR /build
 COPY . . 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Explain the purpose of the PR.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Dockerfile base-image bump with no application code changes; main risk is build/toolchain compatibility in CI and release images.
> 
> **Overview**
> Updates the multi-stage **Dockerfile** builder stage from `golang:bullseye` to **`golang:1.25-bookworm`**, pinning Go **1.25** on Debian Bookworm instead of an unversioned Bullseye tag.
> 
> Also normalizes the stage alias to `AS builder`. The Alpine runtime image and build steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2613bdb682a3b46178a2a84b4601dbdb5aec9868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->