### PR TITLE
preallocate bindings capacity in dockerhub and groq, with unit tests

### DIFF
--- a/pkg/analyzer/analyzers/dockerhub/dockerhub.go
+++ b/pkg/analyzer/analyzers/dockerhub/dockerhub.go
@@ -133,7 +133,7 @@ func secretInfoToAnalyzerResult(info *SecretInfo) *analyzers.AnalyzerResult {
 	result := analyzers.AnalyzerResult{
 		AnalyzerType: analyzers.AnalyzerTypeDockerHub,
 		Metadata:     map[string]any{"Valid_Key": info.Valid},
-		Bindings:     make([]analyzers.Binding, len(info.Repositories)),
+		Bindings:     make([]analyzers.Binding, 0, len(info.Repositories)),
 	}
 
 	// extract information to create bindings and append to result bindings

--- a/pkg/analyzer/analyzers/dockerhub/dockerhub_test.go
+++ b/pkg/analyzer/analyzers/dockerhub/dockerhub_test.go
@@ -15,6 +15,90 @@ import (
 //go:embed result_output.json
 var expectedOutput []byte
 
+func repo(name string) Repository {
+	return Repository{
+		ID:        "user123/repo/image/" + name,
+		Name:      name,
+		Type:      "image",
+		IsPrivate: true,
+		StarCount: 1,
+		PullCount: 2,
+	}
+}
+
+func TestSecretInfoToAnalyzerResult(t *testing.T) {
+	tests := []struct {
+		name      string
+		repos     []Repository
+		wantLen   int
+		wantNames []string
+	}{
+		{
+			name:      "one repository produces exactly one binding",
+			repos:     []Repository{repo("repo1")},
+			wantLen:   1,
+			wantNames: []string{"repo1"},
+		},
+		{
+			name:      "three repositories produce exactly three bindings, not six",
+			repos:     []Repository{repo("repo1"), repo("repo2"), repo("repo3")},
+			wantLen:   3,
+			wantNames: []string{"repo1", "repo2", "repo3"},
+		},
+		{
+			name:    "no repositories: no bindings",
+			repos:   nil,
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := &SecretInfo{
+				Valid:        true,
+				User:         User{ID: "uuid-123", Username: "user123", Email: "user123@example.com"},
+				Permissions:  []string{"repo:admin"},
+				Repositories: tt.repos,
+			}
+
+			result := secretInfoToAnalyzerResult(info)
+			if result == nil {
+				t.Fatal("secretInfoToAnalyzerResult() returned nil")
+			}
+
+			if len(result.Bindings) != tt.wantLen {
+				t.Errorf("got %d bindings, want %d", len(result.Bindings), tt.wantLen)
+			}
+
+			// Mirrors the four proto min_len constraints so this test fails for
+			// the same reason the enterprise API does.
+			for i, binding := range result.Bindings {
+				if binding.Resource.Name == "" {
+					t.Errorf("binding[%d].Resource.Name is empty", i)
+				}
+				if binding.Resource.Type == "" {
+					t.Errorf("binding[%d].Resource.Type is empty", i)
+				}
+				if binding.Resource.FullyQualifiedName == "" {
+					t.Errorf("binding[%d].Resource.FullyQualifiedName is empty", i)
+				}
+				if binding.Permission.Value == "" {
+					t.Errorf("binding[%d].Permission.Value is empty", i)
+				}
+			}
+
+			for i, name := range tt.wantNames {
+				if i >= len(result.Bindings) {
+					break
+				}
+				if result.Bindings[i].Resource.Name != name {
+					t.Errorf("binding[%d].Resource.Name = %q, want %q", i, result.Bindings[i].Resource.Name, name)
+				}
+			}
+		})
+	}
+}
+
 func TestAnalyzer_Analyze(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()

--- a/pkg/analyzer/analyzers/groq/groq.go
+++ b/pkg/analyzer/analyzers/groq/groq.go
@@ -121,7 +121,7 @@ func secretInfoToAnalyzerResult(info *SecretInfo) *analyzers.AnalyzerResult {
 	result := analyzers.AnalyzerResult{
 		AnalyzerType: analyzers.AnalyzerTypeGroq,
 		Metadata:     map[string]any{"Valid_Key": info.Valid},
-		Bindings:     make([]analyzers.Binding, len(info.GroqResources)),
+		Bindings:     make([]analyzers.Binding, 0, len(info.GroqResources)),
 	}
 
 	// extract information to create bindings and append to result bindings

--- a/pkg/analyzer/analyzers/groq/groq_test.go
+++ b/pkg/analyzer/analyzers/groq/groq_test.go
@@ -27,7 +27,8 @@ func TestSecretInfoToAnalyzerResult(t *testing.T) {
 		name      string
 		resources []GroqResource
 		wantLen   int
-		wantNames []string 
+		wantNames []string
+	}{
 		{
 			name:      "one resource produces exactly one binding",
 			resources: []GroqResource{resource("batch_123", "batch_123", "batch")},

--- a/pkg/analyzer/analyzers/groq/groq_test.go
+++ b/pkg/analyzer/analyzers/groq/groq_test.go
@@ -12,6 +12,90 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 )
 
+func resource(id, name, resourceType string) GroqResource {
+	return GroqResource{
+		ID:         id,
+		Name:       name,
+		Type:       resourceType,
+		Permission: PermissionStrings[FullAccess],
+		Metadata:   map[string]string{"status": "completed"},
+	}
+}
+
+func TestSecretInfoToAnalyzerResult(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources []GroqResource
+		wantLen   int
+		wantNames []string 
+		{
+			name:      "one resource produces exactly one binding",
+			resources: []GroqResource{resource("batch_123", "batch_123", "batch")},
+			wantLen:   1,
+			wantNames: []string{"batch_123"},
+		},
+		{
+			name: "three resources produce exactly three bindings, not six",
+			resources: []GroqResource{
+				resource("batch_123", "batch_123", "batch"),
+				resource("file_456", "training.jsonl", "file"),
+				resource("file_789", "eval.jsonl", "file"),
+			},
+			wantLen:   3,
+			wantNames: []string{"batch_123", "training.jsonl", "eval.jsonl"},
+		},
+		{
+			name:      "no resources: no bindings",
+			resources: nil,
+			wantLen:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info := &SecretInfo{
+				Valid:         true,
+				GroqResources: tt.resources,
+			}
+
+			result := secretInfoToAnalyzerResult(info)
+			if result == nil {
+				t.Fatal("secretInfoToAnalyzerResult() returned nil")
+			}
+
+			if len(result.Bindings) != tt.wantLen {
+				t.Errorf("got %d bindings, want %d", len(result.Bindings), tt.wantLen)
+			}
+
+			// Mirrors the four proto min_len constraints so this test fails for
+			// the same reason the enterprise API does.
+			for i, binding := range result.Bindings {
+				if binding.Resource.Name == "" {
+					t.Errorf("binding[%d].Resource.Name is empty", i)
+				}
+				if binding.Resource.Type == "" {
+					t.Errorf("binding[%d].Resource.Type is empty", i)
+				}
+				if binding.Resource.FullyQualifiedName == "" {
+					t.Errorf("binding[%d].Resource.FullyQualifiedName is empty", i)
+				}
+				if binding.Permission.Value == "" {
+					t.Errorf("binding[%d].Permission.Value is empty", i)
+				}
+			}
+
+			for i, name := range tt.wantNames {
+				if i >= len(result.Bindings) {
+					break
+				}
+				if result.Bindings[i].Resource.Name != name {
+					t.Errorf("binding[%d].Resource.Name = %q, want %q", i, result.Bindings[i].Resource.Name, name)
+				}
+			}
+		})
+	}
+}
+
 func TestAnalyzer_Analyze(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
 	defer cancel()


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:

Problem: secretInfoToAnalyzerResult in the DockerHub and Groq analyzers allocated the bindings slice with a length instead of a capacity (make([]analyzers.Binding, len(...))) and then appended to it. That produced 2N bindings, where the first N were entirely zero-valued. Since the enterprise API enforces min_len = 1 on Resource.Name, Resource.ResourceType, Resource.FullyQualifiedResourceName, and Permission.Name, those empty bindings failed validation, and because protoc-gen-validate rejects the whole request, the valid bindings and the Valid_Key metadata were discarded too. Any DockerHub credential that could see at least one repository hit this, surfacing as "error saving analysis result" with InvalidArgument on bindings 0..N-1.

Fix: Changed both allocations to make([]analyzers.Binding, 0, len(...)), leaving the append loops as they were. Added a table-driven unit test on secretInfoToAnalyzerResult in each package that asserts the binding count isn't doubled, that no binding violates the four proto constraints, and that bindings come out in input order. Used https://github.com/trufflesecurity/trufflehog/pull/4746 as a reference, as it was the same issue.
### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets analyzer output consumed by the enterprise API; the fix is narrow and covered by new unit tests, but incorrect bindings previously broke saving analysis for affected credentials.
> 
> **Overview**
> **DockerHub and Groq** `secretInfoToAnalyzerResult` no longer emits **2N bindings** (N empty + N real) when building analyzer results from repositories/resources.
> 
> Both packages now use `make([]analyzers.Binding, 0, len(...))` instead of `make(..., len(...))` before the existing **append** loops. The old pattern left zero-valued bindings at the front, which failed enterprise API **min_len** validation on name/type/FQN/permission and could reject the whole analysis payload.
> 
> Table-driven **`TestSecretInfoToAnalyzerResult`** tests were added in each package to assert correct binding counts (including the “three resources → three bindings, not six” case), non-empty proto-required fields, and input order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e332836a1d08841ad5f7c7dd438b8a220647fc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->