### PR TITLE
Refine SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ Truffle Security treats blind SSRF (the ability to induce outbound requests with
 - Internal Exploitation: Using a blind request to trigger secondary vulnerabilities (e.g. RCE) on restricted internal services configured for defense-in-depth.
 
 **Hardening (No CVE):** We generally will not issue a CVE for:
-- Reflected Payloads: Inducing a request to an attacker-controlled URL that was already present in the scanned source code (i.e., the attacker receiving their own data back).
+- Reflected Payloads: Inducing a request to an attacker-controlled URL by inserting a URL into the scan input (i.e., the attacker receiving data back that they already had access to).
 - Basic Outbound Control: Demonstrating control over the request URL, Path, or Body, without demonstrating a path to credential leakage or internal system exploitation.
 - Service Probing: Simple open/closed port verification or basic interaction with internal services (e.g., triggering a GET request to a local web server) without a demonstrated compromise of data or system integrity.
 - Secondary Vulnerability Dependencies: Where the impact relies entirely on the pre-existing lack of authentication, misconfiguration, or known vulnerabilities of a third-party internal service.


### PR DESCRIPTION
This PR refines the existing SECURITY.md policy to clarify how reports will be handled for issues that involve attackers getting back their own data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only policy wording with no runtime or security behavior changes.
> 
> **Overview**
> Updates the **Hardening (No CVE)** definition of **Reflected Payloads** so it matches how reports are triaged when attackers get their own data back.
> 
> The bullet now describes inducing a request by **inserting a URL into scan input**, with the clarification that the attacker is only receiving data they **already had access to**—replacing the narrower wording about URLs **already present in scanned source code**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a90fad9f0fcb1777f233a488f337fe68b73d52c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->