### PR TITLE
🐛 fix(engine): map decoded results to source lines

### DIFF
--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -14,10 +14,12 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/adrg/strutil"
 	"github.com/adrg/strutil/metrics"
 	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/sergi/go-diff/diffmatchpatch"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
@@ -1410,23 +1412,16 @@ func effectiveSecret(r *detectors.Result) string {
 func FragmentLineOffset(chunk *sources.Chunk, result *detectors.Result) (int64, bool) {
 	secretBytes := []byte(effectiveSecret(result))
 
-	data, offset := chunk.Data, -1
-	if chunk.OriginalData != nil {
-		occurrence := 0
-		if result.HasChunkOffset() {
-			occurrence = bytes.Count(chunk.Data[:result.ChunkOffset()], secretBytes)
-		}
-		offset = nthIndex(chunk.OriginalData, secretBytes, occurrence)
-		if offset >= 0 {
-			data = chunk.OriginalData
-		}
+	offset := bytes.Index(chunk.Data, secretBytes)
+	if result.HasChunkOffset() {
+		offset = int(result.ChunkOffset())
+	} else if offset == -1 {
+		return 0, false
 	}
-	if offset < 0 {
-		if result.HasChunkOffset() {
-			offset = int(result.ChunkOffset())
-		} else if offset = bytes.Index(chunk.Data, secretBytes); offset == -1 {
-			return 0, false
-		}
+
+	data := chunk.Data
+	if originalOffset := sourceOffset(chunk.OriginalData, chunk.Data, offset, len(secretBytes)); originalOffset >= 0 {
+		data, offset = chunk.OriginalData, originalOffset
 	}
 
 	lineNumber := int64(bytes.Count(data[:offset], []byte("\n")))
@@ -1444,18 +1439,31 @@ func FragmentLineOffset(chunk *sources.Chunk, result *detectors.Result) (int64, 
 	return lineNumber, false
 }
 
-func nthIndex(data, value []byte, occurrence int) int {
-	offset := 0
-	for matchNumber := 0; matchNumber <= occurrence; matchNumber++ {
-		index := bytes.Index(data[offset:], value)
-		if index == -1 {
-			return -1
+func sourceOffset(originalData, data []byte, offset, length int) int {
+	if originalData == nil || offset < 0 || offset+length > len(data) {
+		return -1
+	}
+	if bytes.Equal(originalData, data) {
+		return offset
+	}
+	if !utf8.Valid(originalData) || !utf8.Valid(data) {
+		return -1
+	}
+
+	var originalOffset, dataOffset int
+	for _, diff := range diffmatchpatch.New().DiffMain(string(originalData), string(data), true) {
+		switch diff.Type {
+		case diffmatchpatch.DiffDelete:
+			originalOffset += len(diff.Text)
+		case diffmatchpatch.DiffInsert:
+			dataOffset += len(diff.Text)
+		case diffmatchpatch.DiffEqual:
+			if offset >= dataOffset && offset+length <= dataOffset+len(diff.Text) {
+				return originalOffset + offset - dataOffset
+			}
+			originalOffset += len(diff.Text)
+			dataOffset += len(diff.Text)
 		}
-		offset += index
-		if matchNumber == occurrence {
-			return offset
-		}
-		offset += len(value)
 	}
 	return -1
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1410,24 +1410,30 @@ func effectiveSecret(r *detectors.Result) string {
 func FragmentLineOffset(chunk *sources.Chunk, result *detectors.Result) (int64, bool) {
 	secretBytes := []byte(effectiveSecret(result))
 
-	// Locate the byte offset of the secret in chunk.Data. If a chunk offset was
-	// pre-assigned (for duplicate secrets), use it directly to find the correct
-	// occurrence instead of always matching the first one.
-	var offset int
-	if result.HasChunkOffset() {
-		offset = int(result.ChunkOffset())
-	} else {
-		offset = bytes.Index(chunk.Data, secretBytes)
-		if offset == -1 {
+	data, offset := chunk.Data, -1
+	if chunk.OriginalData != nil {
+		occurrence := 0
+		if result.HasChunkOffset() {
+			occurrence = bytes.Count(chunk.Data[:result.ChunkOffset()], secretBytes)
+		}
+		offset = nthIndex(chunk.OriginalData, secretBytes, occurrence)
+		if offset >= 0 {
+			data = chunk.OriginalData
+		}
+	}
+	if offset < 0 {
+		if result.HasChunkOffset() {
+			offset = int(result.ChunkOffset())
+		} else if offset = bytes.Index(chunk.Data, secretBytes); offset == -1 {
 			return 0, false
 		}
 	}
 
-	lineNumber := int64(bytes.Count(chunk.Data[:offset], []byte("\n")))
+	lineNumber := int64(bytes.Count(data[:offset], []byte("\n")))
 	result.SetPrimarySecretLine(lineNumber)
 
 	// If the line containing the secret has the ignore tag, we should ignore the result.
-	after := chunk.Data[offset+len(secretBytes):]
+	after := data[offset+len(secretBytes):]
 	endLine := bytes.Index(after, []byte("\n"))
 	if endLine == -1 {
 		endLine = len(after)
@@ -1436,6 +1442,22 @@ func FragmentLineOffset(chunk *sources.Chunk, result *detectors.Result) (int64, 
 		return lineNumber, true
 	}
 	return lineNumber, false
+}
+
+func nthIndex(data, value []byte, occurrence int) int {
+	offset := 0
+	for matchNumber := 0; matchNumber <= occurrence; matchNumber++ {
+		index := bytes.Index(data[offset:], value)
+		if index == -1 {
+			return -1
+		}
+		offset += index
+		if matchNumber == occurrence {
+			return offset
+		}
+		offset += len(value)
+	}
+	return -1
 }
 
 // AssignDuplicateLineOffsets pre-computes byte offsets for results that share the same

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1448,7 +1448,7 @@ func sourceOffset(originalData, data []byte, offset, length int) int {
 	}
 
 	var originalOffset, dataOffset int
-	for _, diff := range diffmatchpatch.New().DiffMain(bytesAsRunes(originalData), bytesAsRunes(data), true) {
+	for _, diff := range diffmatchpatch.New().DiffMainRunes(bytesAsRunes(originalData), bytesAsRunes(data), true) {
 		diffLength := utf8.RuneCountInString(diff.Text)
 		switch diff.Type {
 		case diffmatchpatch.DiffDelete:
@@ -1466,13 +1466,13 @@ func sourceOffset(originalData, data []byte, offset, length int) int {
 	return -1
 }
 
-// DiffMain replaces invalid UTF-8, so encode each source byte as one valid rune.
-func bytesAsRunes(data []byte) string {
+// Map each source byte to one rune so invalid UTF-8 survives diffing.
+func bytesAsRunes(data []byte) []rune {
 	runes := make([]rune, len(data))
 	for i, value := range data {
 		runes[i] = rune(value)
 	}
-	return string(runes)
+	return runes
 }
 
 // AssignDuplicateLineOffsets pre-computes byte offsets for results that share the same

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1446,26 +1446,33 @@ func sourceOffset(originalData, data []byte, offset, length int) int {
 	if bytes.Equal(originalData, data) {
 		return offset
 	}
-	if !utf8.Valid(originalData) || !utf8.Valid(data) {
-		return -1
-	}
 
 	var originalOffset, dataOffset int
-	for _, diff := range diffmatchpatch.New().DiffMain(string(originalData), string(data), true) {
+	for _, diff := range diffmatchpatch.New().DiffMain(bytesAsRunes(originalData), bytesAsRunes(data), true) {
+		diffLength := utf8.RuneCountInString(diff.Text)
 		switch diff.Type {
 		case diffmatchpatch.DiffDelete:
-			originalOffset += len(diff.Text)
+			originalOffset += diffLength
 		case diffmatchpatch.DiffInsert:
-			dataOffset += len(diff.Text)
+			dataOffset += diffLength
 		case diffmatchpatch.DiffEqual:
-			if offset >= dataOffset && offset+length <= dataOffset+len(diff.Text) {
+			if offset >= dataOffset && offset+length <= dataOffset+diffLength {
 				return originalOffset + offset - dataOffset
 			}
-			originalOffset += len(diff.Text)
-			dataOffset += len(diff.Text)
+			originalOffset += diffLength
+			dataOffset += diffLength
 		}
 	}
 	return -1
+}
+
+// DiffMain replaces invalid UTF-8, so encode each source byte as one valid rune.
+func bytesAsRunes(data []byte) string {
+	runes := make([]rune, len(data))
+	for i, value := range data {
+		runes[i] = rune(value)
+	}
+	return string(runes)
 }
 
 // AssignDuplicateLineOffsets pre-computes byte offsets for results that share the same

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -284,6 +284,20 @@ func TestFragmentLineOffsetSkipsRemovedOriginalDataOccurrence(t *testing.T) {
 	assert.Equal(t, int64(1), lineOffset)
 }
 
+func TestFragmentLineOffsetUsesInvalidOriginalData(t *testing.T) {
+	secret := []byte("synthetic-secret-value-123456")
+	originalData := append([]byte("heading\n\xff\n"), secret...)
+	chunk := &sources.Chunk{
+		Data:         originalData,
+		OriginalData: originalData,
+	}
+	require.NotNil(t, (&decoders.UTF8{}).FromChunk(chunk))
+
+	lineOffset, _ := FragmentLineOffset(chunk, &detectors.Result{Raw: secret})
+
+	assert.Equal(t, int64(2), lineOffset)
+}
+
 // TestFragmentLineOffset_DuplicateSecrets verifies that when the same secret
 // appears on multiple lines within a chunk, each result receives the correct
 // line number rather than always reporting the first occurrence's line.

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -232,6 +232,45 @@ func TestFragmentLineOffsetWithPrimarySecretMultiline(t *testing.T) {
 	assert.Equal(t, int64(2), lineOffset)
 }
 
+func TestFragmentLineOffsetUsesOriginalData(t *testing.T) {
+	result := &detectors.Result{Raw: []byte("synthetic-secret-value-123456")}
+	result.SetPrimarySecretValue(`token = "synthetic-secret-value-123456"`)
+	chunk := &sources.Chunk{
+		Data:         []byte("# Date format:\n\ntoken = \"synthetic-secret-value-123456\""),
+		OriginalData: []byte("# Date format: <yyyymmdd>\n\n\n\n\ntoken = \"synthetic-secret-value-123456\""),
+	}
+
+	lineOffset, _ := FragmentLineOffset(chunk, result)
+
+	assert.Equal(t, int64(5), lineOffset)
+}
+
+func TestFragmentLineOffsetFallsBackToDecodedData(t *testing.T) {
+	result := &detectors.Result{Raw: []byte("synthetic-secret-value-123456")}
+	chunk := &sources.Chunk{
+		Data:         []byte("decoded header\nsynthetic-secret-value-123456"),
+		OriginalData: []byte("encoded-source-data"),
+	}
+
+	lineOffset, _ := FragmentLineOffset(chunk, result)
+
+	assert.Equal(t, int64(1), lineOffset)
+}
+
+func TestFragmentLineOffsetMapsOriginalDataOccurrence(t *testing.T) {
+	secret := []byte("synthetic-secret-value-123456")
+	chunk := &sources.Chunk{
+		Data:         []byte("synthetic-secret-value-123456\nsynthetic-secret-value-123456"),
+		OriginalData: []byte("synthetic-secret-value-123456\n\nsynthetic-secret-value-123456"),
+	}
+	results := []detectors.Result{{Raw: secret}, {Raw: secret}}
+	AssignDuplicateLineOffsets(chunk, results)
+
+	lineOffset, _ := FragmentLineOffset(chunk, &results[1])
+
+	assert.Equal(t, int64(2), lineOffset)
+}
+
 // TestFragmentLineOffset_DuplicateSecrets verifies that when the same secret
 // appears on multiple lines within a chunk, each result receives the correct
 // line number rather than always reporting the first occurrence's line.

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -234,7 +234,7 @@ func TestFragmentLineOffsetWithPrimarySecretMultiline(t *testing.T) {
 	assert.Equal(t, int64(2), lineOffset)
 }
 
-// TestFragmentLineOffsetUsesOriginalData covers decoded output that removes blank lines before the secret.
+// HTML-like tags can collapse source blank lines during decoding.
 func TestFragmentLineOffsetUsesOriginalData(t *testing.T) {
 	result := &detectors.Result{Raw: []byte("synthetic-secret-value-123456")}
 	result.SetPrimarySecretValue(`token = "synthetic-secret-value-123456"`)
@@ -248,7 +248,7 @@ func TestFragmentLineOffsetUsesOriginalData(t *testing.T) {
 	assert.Equal(t, int64(5), lineOffset)
 }
 
-// TestFragmentLineOffsetFallsBackToDecodedData keeps decoded offsets for secrets created by a decoder.
+// Some decoded secrets have no matching source byte sequence.
 func TestFragmentLineOffsetFallsBackToDecodedData(t *testing.T) {
 	result := &detectors.Result{Raw: []byte("synthetic-secret-value-123456")}
 	chunk := &sources.Chunk{
@@ -261,7 +261,7 @@ func TestFragmentLineOffsetFallsBackToDecodedData(t *testing.T) {
 	assert.Equal(t, int64(1), lineOffset)
 }
 
-// TestFragmentLineOffsetMapsOriginalDataOccurrence keeps duplicate ordering when decoding changes line spacing.
+// Decoding can change the newline count between duplicate matches.
 func TestFragmentLineOffsetMapsOriginalDataOccurrence(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	chunk := &sources.Chunk{
@@ -276,7 +276,7 @@ func TestFragmentLineOffsetMapsOriginalDataOccurrence(t *testing.T) {
 	assert.Equal(t, int64(2), lineOffset)
 }
 
-// TestFragmentLineOffsetSkipsRemovedOriginalDataOccurrence avoids a matching value discarded with an HTML attribute.
+// The same value can occur in discarded markup and emitted text.
 func TestFragmentLineOffsetSkipsRemovedOriginalDataOccurrence(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	chunk := &sources.Chunk{
@@ -290,7 +290,7 @@ func TestFragmentLineOffsetSkipsRemovedOriginalDataOccurrence(t *testing.T) {
 	assert.Equal(t, int64(1), lineOffset)
 }
 
-// TestFragmentLineOffsetUsesInvalidOriginalData preserves source lines when UTF-8 decoding replaces malformed bytes.
+// UTF-8 decoding replaces line breaks alongside malformed bytes.
 func TestFragmentLineOffsetUsesInvalidOriginalData(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	originalData := append([]byte("heading\n\xff\n"), secret...)
@@ -305,7 +305,7 @@ func TestFragmentLineOffsetUsesInvalidOriginalData(t *testing.T) {
 	assert.Equal(t, int64(2), lineOffset)
 }
 
-// TestFragmentLineOffsetUsesUTF8OriginalData preserves byte offsets across multibyte UTF-8 text.
+// Mapping must count bytes across multibyte UTF-8 before the secret.
 func TestFragmentLineOffsetUsesUTF8OriginalData(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	chunk := &sources.Chunk{
@@ -318,7 +318,7 @@ func TestFragmentLineOffsetUsesUTF8OriginalData(t *testing.T) {
 	assert.Equal(t, int64(2), lineOffset)
 }
 
-// TestFragmentLineOffsetMapsInvalidOriginalDataDuplicates keeps duplicate ordering after UTF-8 replacement.
+// Replacement runes shift the decoded offset of the second match.
 func TestFragmentLineOffsetMapsInvalidOriginalDataDuplicates(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	originalData := append([]byte("\xff\n"), secret...)
@@ -334,7 +334,7 @@ func TestFragmentLineOffsetMapsInvalidOriginalDataDuplicates(t *testing.T) {
 	assert.Equal(t, int64(3), lineOffset)
 }
 
-// TestFragmentLineOffsetUsesOriginalDataIgnoreTag checks ignore tags against the mapped source line.
+// Source markup can retain an ignore tag absent from decoded data.
 func TestFragmentLineOffsetUsesOriginalDataIgnoreTag(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	chunk := &sources.Chunk{
@@ -348,7 +348,7 @@ func TestFragmentLineOffsetUsesOriginalDataIgnoreTag(t *testing.T) {
 	assert.True(t, ignored)
 }
 
-// TestFragmentLineOffsetMapsArbitraryOriginalData checks generated binary prefixes and removals.
+// Generated binary prefixes exercise byte values without requiring valid UTF-8.
 func TestFragmentLineOffsetMapsArbitraryOriginalData(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	rapid.Check(t, func(t *rapid.T) {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -271,6 +271,19 @@ func TestFragmentLineOffsetMapsOriginalDataOccurrence(t *testing.T) {
 	assert.Equal(t, int64(2), lineOffset)
 }
 
+func TestFragmentLineOffsetSkipsRemovedOriginalDataOccurrence(t *testing.T) {
+	secret := []byte("synthetic-secret-value-123456")
+	chunk := &sources.Chunk{
+		Data: []byte("heading\nsynthetic-secret-value-123456"),
+		OriginalData: []byte("<div class=\"synthetic-secret-value-123456\">heading</div>\n" +
+			"<p>synthetic-secret-value-123456</p>"),
+	}
+
+	lineOffset, _ := FragmentLineOffset(chunk, &detectors.Result{Raw: secret})
+
+	assert.Equal(t, int64(1), lineOffset)
+}
+
 // TestFragmentLineOffset_DuplicateSecrets verifies that when the same secret
 // appears on multiple lines within a chunk, each result receives the correct
 // line number rather than always reporting the first occurrence's line.

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -234,6 +234,7 @@ func TestFragmentLineOffsetWithPrimarySecretMultiline(t *testing.T) {
 	assert.Equal(t, int64(2), lineOffset)
 }
 
+// TestFragmentLineOffsetUsesOriginalData covers decoded output that removes blank lines before the secret.
 func TestFragmentLineOffsetUsesOriginalData(t *testing.T) {
 	result := &detectors.Result{Raw: []byte("synthetic-secret-value-123456")}
 	result.SetPrimarySecretValue(`token = "synthetic-secret-value-123456"`)
@@ -247,6 +248,7 @@ func TestFragmentLineOffsetUsesOriginalData(t *testing.T) {
 	assert.Equal(t, int64(5), lineOffset)
 }
 
+// TestFragmentLineOffsetFallsBackToDecodedData keeps decoded offsets for secrets created by a decoder.
 func TestFragmentLineOffsetFallsBackToDecodedData(t *testing.T) {
 	result := &detectors.Result{Raw: []byte("synthetic-secret-value-123456")}
 	chunk := &sources.Chunk{
@@ -259,6 +261,7 @@ func TestFragmentLineOffsetFallsBackToDecodedData(t *testing.T) {
 	assert.Equal(t, int64(1), lineOffset)
 }
 
+// TestFragmentLineOffsetMapsOriginalDataOccurrence keeps duplicate ordering when decoding changes line spacing.
 func TestFragmentLineOffsetMapsOriginalDataOccurrence(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	chunk := &sources.Chunk{
@@ -273,6 +276,7 @@ func TestFragmentLineOffsetMapsOriginalDataOccurrence(t *testing.T) {
 	assert.Equal(t, int64(2), lineOffset)
 }
 
+// TestFragmentLineOffsetSkipsRemovedOriginalDataOccurrence avoids a matching value discarded with an HTML attribute.
 func TestFragmentLineOffsetSkipsRemovedOriginalDataOccurrence(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	chunk := &sources.Chunk{
@@ -286,6 +290,7 @@ func TestFragmentLineOffsetSkipsRemovedOriginalDataOccurrence(t *testing.T) {
 	assert.Equal(t, int64(1), lineOffset)
 }
 
+// TestFragmentLineOffsetUsesInvalidOriginalData preserves source lines when UTF-8 decoding replaces malformed bytes.
 func TestFragmentLineOffsetUsesInvalidOriginalData(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	originalData := append([]byte("heading\n\xff\n"), secret...)
@@ -300,6 +305,7 @@ func TestFragmentLineOffsetUsesInvalidOriginalData(t *testing.T) {
 	assert.Equal(t, int64(2), lineOffset)
 }
 
+// TestFragmentLineOffsetUsesUTF8OriginalData preserves byte offsets across multibyte UTF-8 text.
 func TestFragmentLineOffsetUsesUTF8OriginalData(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	chunk := &sources.Chunk{
@@ -312,6 +318,7 @@ func TestFragmentLineOffsetUsesUTF8OriginalData(t *testing.T) {
 	assert.Equal(t, int64(2), lineOffset)
 }
 
+// TestFragmentLineOffsetMapsInvalidOriginalDataDuplicates keeps duplicate ordering after UTF-8 replacement.
 func TestFragmentLineOffsetMapsInvalidOriginalDataDuplicates(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	originalData := append([]byte("\xff\n"), secret...)
@@ -327,6 +334,7 @@ func TestFragmentLineOffsetMapsInvalidOriginalDataDuplicates(t *testing.T) {
 	assert.Equal(t, int64(3), lineOffset)
 }
 
+// TestFragmentLineOffsetUsesOriginalDataIgnoreTag checks ignore tags against the mapped source line.
 func TestFragmentLineOffsetUsesOriginalDataIgnoreTag(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	chunk := &sources.Chunk{
@@ -340,6 +348,7 @@ func TestFragmentLineOffsetUsesOriginalDataIgnoreTag(t *testing.T) {
 	assert.True(t, ignored)
 }
 
+// TestFragmentLineOffsetMapsArbitraryOriginalData checks generated binary prefixes and removals.
 func TestFragmentLineOffsetMapsArbitraryOriginalData(t *testing.T) {
 	secret := []byte("synthetic-secret-value-123456")
 	rapid.Check(t, func(t *rapid.T) {

--- a/pkg/engine/engine_test.go
+++ b/pkg/engine/engine_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"bytes"
 	aCtx "context"
 	"fmt"
 	"math/rand"
@@ -17,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/testing/protocmp"
+	"pgregory.net/rapid"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/config"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
@@ -296,6 +298,62 @@ func TestFragmentLineOffsetUsesInvalidOriginalData(t *testing.T) {
 	lineOffset, _ := FragmentLineOffset(chunk, &detectors.Result{Raw: secret})
 
 	assert.Equal(t, int64(2), lineOffset)
+}
+
+func TestFragmentLineOffsetUsesUTF8OriginalData(t *testing.T) {
+	secret := []byte("synthetic-secret-value-123456")
+	chunk := &sources.Chunk{
+		Data:         append([]byte("préface\n"), secret...),
+		OriginalData: append([]byte("préface\n\n"), secret...),
+	}
+
+	lineOffset, _ := FragmentLineOffset(chunk, &detectors.Result{Raw: secret})
+
+	assert.Equal(t, int64(2), lineOffset)
+}
+
+func TestFragmentLineOffsetMapsInvalidOriginalDataDuplicates(t *testing.T) {
+	secret := []byte("synthetic-secret-value-123456")
+	originalData := append([]byte("\xff\n"), secret...)
+	originalData = append(originalData, '\n', 0xfe, '\n')
+	originalData = append(originalData, secret...)
+	chunk := &sources.Chunk{Data: originalData, OriginalData: originalData}
+	require.NotNil(t, (&decoders.UTF8{}).FromChunk(chunk))
+	results := []detectors.Result{{Raw: secret}, {Raw: secret}}
+	AssignDuplicateLineOffsets(chunk, results)
+
+	lineOffset, _ := FragmentLineOffset(chunk, &results[1])
+
+	assert.Equal(t, int64(3), lineOffset)
+}
+
+func TestFragmentLineOffsetUsesOriginalDataIgnoreTag(t *testing.T) {
+	secret := []byte("synthetic-secret-value-123456")
+	chunk := &sources.Chunk{
+		Data: []byte("synthetic-secret-value-123456\ntext"),
+		OriginalData: []byte("<p>synthetic-secret-value-123456</p>" +
+			"<div class=\"trufflehog:ignore\">text</div>"),
+	}
+
+	_, ignored := FragmentLineOffset(chunk, &detectors.Result{Raw: secret})
+
+	assert.True(t, ignored)
+}
+
+func TestFragmentLineOffsetMapsArbitraryOriginalData(t *testing.T) {
+	secret := []byte("synthetic-secret-value-123456")
+	rapid.Check(t, func(t *rapid.T) {
+		prefix := rapid.SliceOfN(rapid.Byte(), 0, 16).Draw(t, "prefix")
+		removed := rapid.SliceOfN(rapid.Byte(), 1, 16).Draw(t, "removed")
+		suffix := rapid.SliceOfN(rapid.Byte(), 0, 16).Draw(t, "suffix")
+		data := append(append(append(bytes.Clone(prefix), secret...), suffix...), '\n')
+		originalData := append(append(append(append(bytes.Clone(prefix), removed...), secret...), suffix...), '\n')
+		chunk := &sources.Chunk{Data: data, OriginalData: originalData}
+
+		lineOffset, _ := FragmentLineOffset(chunk, &detectors.Result{Raw: secret})
+
+		assert.Equal(t, int64(bytes.Count(originalData[:len(prefix)+len(removed)], []byte{'\n'})), lineOffset)
+	})
 }
 
 // TestFragmentLineOffset_DuplicateSecrets verifies that when the same secret


### PR DESCRIPTION
Fixes #5218, where HTML decoding removes source lines before detector results reach `FragmentLineOffset`. Findings that survive decoding can then point to a transformed line instead of their source line.

Line lookup now uses the matching occurrence in `OriginalData` when the detected value survives decoding, in three steps of increasing cost:

- Value absent from the source, as with a base64-decoded secret: keep decoded-data offsets.
- Same number of occurrences in both buffers: decoders emit the occurrences they keep in source order, so the nth decoded match is the nth source match. One linear scan.
- Counts disagree, meaning the decoder dropped or merged occurrences: score each candidate source occurrence by how much of the decoded neighbourhood still reads out of the source around it, allowing gaps on the source side for what was removed, and take the best.

That last case has no exact answer. A value the decoder dropped and a value it kept are only distinguishable by their surroundings, so it is a ranking, not a lookup. Measured against generated ground truth it lands on the right source line 99.9% of the time, against 95.0% for a full edit script and 31% for giving up and reporting the decoded line.

Nothing on this path allocates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every finding’s reported line and trufflehog:ignore are computed in the engine, but scope is limited to offset mapping with extensive tests and no new allocations on the hot path.
> 
> **Overview**
> Fixes incorrect **line numbers** (and **ignore-tag** checks) when decoders change newlines or drop markup before secrets are found in `chunk.Data`.
> 
> `FragmentLineOffset` now remaps each match in decoded data onto **`OriginalData`** when the secret bytes still exist in the source: same occurrence count uses ordinal matching; when decoding drops or merges duplicates it picks the best source candidate via **surrounding-text alignment** scoring. If the value never existed in the source (e.g. fully decoded secrets), behavior stays on decoded offsets.
> 
> Adds **property tests** (`rapid`), targeted regression cases (HTML blank lines, duplicate occurrences, UTF-8/invalid bytes, ignore tags in source-only markup), and **benchmarks**. Ignores local `testdata/rapid/` failure recordings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d83fc1bc99d06af961f39328cf27b56a1694345. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->