### PR TITLE
Raised MongoDB detector timeout value

### DIFF
--- a/pkg/detectors/mongodb/mongodb.go
+++ b/pkg/detectors/mongodb/mongodb.go
@@ -27,7 +27,7 @@ var _ detectors.Detector = (*Scanner)(nil)
 var _ detectors.CustomFalsePositiveChecker = (*Scanner)(nil)
 
 var (
-	defaultTimeout = 5 * time.Second
+	defaultTimeout = 10 * time.Second
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	connStrPat = regexp.MustCompile(`\b(mongodb(?:\+srv)?://(?P<username>\S{3,50}):(?P<password>\S{3,88})@(?P<host>[-.%\w]+(?::\d{1,5})?(?:,[-.%\w]+(?::\d{1,5})?)*)(?:/(?P<authdb>[\w-]+)?(?P<options>\?\w+=[\w@/.$-]+(?:&(?:amp;)?\w+=[\w@/.$-]+)*)?)?)(?:\b|$)`)
 	// TODO: Add support for sharded cluster, replica set and Atlas Deployment.


### PR DESCRIPTION
Doubled timeout, as MongoDB secrets are repeatedly hitting this and failing to verify

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
The mongoDB detector has a hardcoded timeout of 5 seconds, but secrets are failing to verify because of this. Raised timeout value to 10 seconds to help alleviate it.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single constant change for secret verification timing only; no auth or detection logic changes.
> 
> **Overview**
> Raises the MongoDB detector’s **`defaultTimeout`** from **5s to 10s** when the scanner does not set a custom `timeout` on `Scanner`.
> 
> That value drives the context and client timeouts used during **`verifyUri`** (connect + primary ping), so verification gets more time before failing on slow or distant MongoDB endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3b49ce4d0c0c4b5c21f2406e236d04795fde9f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->