### PR TITLE
detectors/github/v2: differentiate token type in ExtraData

### DIFF
--- a/pkg/detectors/github/v2/github.go
+++ b/pkg/detectors/github/v2/github.go
@@ -39,31 +39,31 @@ var (
 	// TODO: Oauth2 client_id and client_secret
 	// https://developer.github.com/v3/#oauth2-keysecret
 
-	// tokenTypesByPrefix maps each GitHub token prefix to a human-readable type
-	// and its distinct remediation path. Each prefix identifies a materially
-	// different credential (PAT, OAuth grant, or GitHub App token) that is
-	// revoked/rotated through a different GitHub settings page.
+	// tokenTypesByPrefix maps each GitHub token prefix to a human-readable type.
+	// Each prefix identifies a materially different credential (PAT, OAuth
+	// grant, or GitHub App token) that is revoked/rotated through a different
+	// GitHub settings page.
 	// https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
-	tokenTypesByPrefix = map[string]struct{ TokenType, Remediation string }{
-		"ghp_":        {"Personal Access Token (classic)", "Revoke at https://github.com/settings/tokens"},
-		"github_pat_": {"Personal Access Token (fine-grained)", "Revoke at https://github.com/settings/personal-access-tokens"},
-		"gho_":        {"OAuth Access Token", "Revoke at https://github.com/settings/applications (Authorized OAuth Apps)"},
-		"ghu_":        {"GitHub App User-to-Server Token", "Revoke at https://github.com/settings/apps/authorizations (Authorized GitHub Apps) or uninstall at https://github.com/settings/installations"},
-		"ghs_":        {"GitHub App Server-to-Server (installation) Token", "Uninstall the GitHub App at https://github.com/settings/installations"},
-		"ghr_":        {"GitHub App Refresh Token", "Uninstall the GitHub App at https://github.com/settings/installations"},
+	tokenTypesByPrefix = map[string]string{
+		"ghp_":        "Personal Access Token (classic)",
+		"github_pat_": "Personal Access Token (fine-grained)",
+		"gho_":        "OAuth Access Token",
+		"ghu_":        "GitHub App User-to-Server Token",
+		"ghs_":        "GitHub App Server-to-Server (installation) Token",
+		"ghr_":        "GitHub App Refresh Token",
 	}
 )
 
-// githubTokenType returns the human-readable token type and remediation path
-// for a matched token, keyed off its prefix. Falls back to a generic label if
-// no known prefix matches (should not happen given keyPat, but keeps this safe).
-func githubTokenType(token string) (tokenType, remediation string) {
-	for prefix, info := range tokenTypesByPrefix {
+// githubTokenType returns the human-readable token type for a matched token,
+// keyed off its prefix. Falls back to a generic label if no known prefix
+// matches (should not happen given keyPat, but keeps this safe).
+func githubTokenType(token string) string {
+	for prefix, tokenType := range tokenTypesByPrefix {
 		if strings.HasPrefix(token, prefix) {
-			return info.TokenType, info.Remediation
+			return tokenType
 		}
 	}
-	return "Unknown GitHub token", "https://github.com/settings/security"
+	return "Unknown GitHub token"
 }
 
 // Keywords are used for efficiently pre-filtering chunks.
@@ -82,7 +82,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		// First match is entire regex, second is the first group.
 
 		token := match[1]
-		tokenType, remediation := githubTokenType(token)
 
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Github,
@@ -90,8 +89,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			ExtraData: map[string]string{
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
 				"version":        fmt.Sprintf("%d", s.Version()),
-				"token_type":     tokenType,
-				"remediation":    remediation,
+				"token_type":     githubTokenType(token),
 			},
 			SecretParts: map[string]string{"key": token},
 		}

--- a/pkg/detectors/github/v2/github.go
+++ b/pkg/detectors/github/v2/github.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	regexp "github.com/wasilibs/go-re2"
 
@@ -37,7 +38,33 @@ var (
 
 	// TODO: Oauth2 client_id and client_secret
 	// https://developer.github.com/v3/#oauth2-keysecret
+
+	// tokenTypesByPrefix maps each GitHub token prefix to a human-readable type
+	// and its distinct remediation path. Each prefix identifies a materially
+	// different credential (PAT, OAuth grant, or GitHub App token) that is
+	// revoked/rotated through a different GitHub settings page.
+	// https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/
+	tokenTypesByPrefix = map[string]struct{ TokenType, Remediation string }{
+		"ghp_":        {"Personal Access Token (classic)", "Revoke at https://github.com/settings/tokens"},
+		"github_pat_": {"Personal Access Token (fine-grained)", "Revoke at https://github.com/settings/personal-access-tokens"},
+		"gho_":        {"OAuth Access Token", "Revoke at https://github.com/settings/applications (Authorized OAuth Apps)"},
+		"ghu_":        {"GitHub App User-to-Server Token", "Revoke at https://github.com/settings/apps/authorizations (Authorized GitHub Apps) or uninstall at https://github.com/settings/installations"},
+		"ghs_":        {"GitHub App Server-to-Server (installation) Token", "Uninstall the GitHub App at https://github.com/settings/installations"},
+		"ghr_":        {"GitHub App Refresh Token", "Uninstall the GitHub App at https://github.com/settings/installations"},
+	}
 )
+
+// githubTokenType returns the human-readable token type and remediation path
+// for a matched token, keyed off its prefix. Falls back to a generic label if
+// no known prefix matches (should not happen given keyPat, but keeps this safe).
+func githubTokenType(token string) (tokenType, remediation string) {
+	for prefix, info := range tokenTypesByPrefix {
+		if strings.HasPrefix(token, prefix) {
+			return info.TokenType, info.Remediation
+		}
+	}
+	return "Unknown GitHub token", "https://github.com/settings/security"
+}
 
 // Keywords are used for efficiently pre-filtering chunks.
 // Use identifiers in the secret preferably, or the provider name.
@@ -55,6 +82,7 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		// First match is entire regex, second is the first group.
 
 		token := match[1]
+		tokenType, remediation := githubTokenType(token)
 
 		s1 := detectors.Result{
 			DetectorType: detector_typepb.DetectorType_Github,
@@ -62,6 +90,8 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			ExtraData: map[string]string{
 				"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
 				"version":        fmt.Sprintf("%d", s.Version()),
+				"token_type":     tokenType,
+				"remediation":    remediation,
 			},
 			SecretParts: map[string]string{"key": token},
 		}

--- a/pkg/detectors/github/v2/github_integration_test.go
+++ b/pkg/detectors/github/v2/github_integration_test.go
@@ -62,9 +62,10 @@ func TestGitHub_FromChunk(t *testing.T) {
 						"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
 						"scopes":         "notifications",
 						// "site_admin":     "false", // not present in test verifiedGhp
-						"url":      "https://github.com/truffle-sandbox",
-						"username": "truffle-sandbox",
-						"version":  "2",
+						"token_type": "Personal Access Token (classic)",
+						"url":        "https://github.com/truffle-sandbox",
+						"username":   "truffle-sandbox",
+						"version":    "2",
 					},
 				},
 			},
@@ -84,6 +85,7 @@ func TestGitHub_FromChunk(t *testing.T) {
 					Verified:     false,
 					ExtraData: map[string]string{
 						"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
+						"token_type":     "Personal Access Token (classic)",
 						"version":        "2",
 					},
 				},
@@ -104,6 +106,7 @@ func TestGitHub_FromChunk(t *testing.T) {
 					Verified:     false,
 					ExtraData: map[string]string{
 						"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
+						"token_type":     "OAuth Access Token",
 						"version":        "2",
 					},
 				},
@@ -124,6 +127,7 @@ func TestGitHub_FromChunk(t *testing.T) {
 					Verified:     false,
 					ExtraData: map[string]string{
 						"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
+						"token_type":     "GitHub App User-to-Server Token",
 						"version":        "2",
 					},
 				},
@@ -144,6 +148,7 @@ func TestGitHub_FromChunk(t *testing.T) {
 					Verified:     false,
 					ExtraData: map[string]string{
 						"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
+						"token_type":     "GitHub App Server-to-Server (installation) Token",
 						"version":        "2",
 					},
 				},
@@ -164,6 +169,7 @@ func TestGitHub_FromChunk(t *testing.T) {
 					Verified:     false,
 					ExtraData: map[string]string{
 						"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
+						"token_type":     "GitHub App Refresh Token",
 						"version":        "2",
 					},
 				},
@@ -184,6 +190,7 @@ func TestGitHub_FromChunk(t *testing.T) {
 					Verified:     false,
 					ExtraData: map[string]string{
 						"rotation_guide": "https://howtorotate.com/docs/tutorials/github/",
+						"token_type":     "Personal Access Token (classic)",
 						"version":        "2",
 					},
 				},

--- a/pkg/detectors/github/v2/github_test.go
+++ b/pkg/detectors/github/v2/github_test.go
@@ -176,6 +176,38 @@ func TestGithubTokenType_MappingMatchesKeyPatExactly(t *testing.T) {
 	}
 }
 
+// TestTokenTypesByPrefix_RowsAreWellFormed checks each row in
+// tokenTypesByPrefix in isolation, independent of keyPat. The tests above
+// confirm the map's keys line up with keyPat; none of them would catch a
+// malformed row added alongside a correct key — e.g. a copy-pasted value
+// that leaves two different prefixes describing the same token type, or a
+// blank value that silently degrades a finding.
+func TestTokenTypesByPrefix_RowsAreWellFormed(t *testing.T) {
+	const unknown = "Unknown GitHub token"
+
+	seenValues := make(map[string]string, len(tokenTypesByPrefix)) // value -> first prefix that used it
+
+	for prefix, tokenType := range tokenTypesByPrefix {
+		if prefix == "" {
+			t.Error("tokenTypesByPrefix has an empty-string prefix key")
+		}
+		if !strings.HasSuffix(prefix, "_") {
+			t.Errorf("prefix %q does not end in \"_\"; githubTokenType matches by strings.HasPrefix, so a bare prefix can match unrelated tokens", prefix)
+		}
+		if strings.TrimSpace(tokenType) == "" {
+			t.Errorf("prefix %q maps to an empty or blank token type", prefix)
+		}
+		if tokenType == unknown {
+			t.Errorf("prefix %q maps to the reserved fallback value %q; a real row must not collide with it", prefix, unknown)
+		}
+		if other, dup := seenValues[tokenType]; dup {
+			t.Errorf("prefixes %q and %q both map to token type %q; each prefix must describe a distinct credential", prefix, other, tokenType)
+		} else {
+			seenValues[tokenType] = prefix
+		}
+	}
+}
+
 // TestGithubTokenType_EveryKeyPatPrefixResolves closes the loop end to end:
 // build a token for each prefix keyPat actually accepts, confirm keyPat
 // matches it, and confirm githubTokenType resolves it to something other than

--- a/pkg/detectors/github/v2/github_test.go
+++ b/pkg/detectors/github/v2/github_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -176,12 +177,40 @@ func TestGithubTokenType_MappingMatchesKeyPatExactly(t *testing.T) {
 	}
 }
 
+// assertNoBlankFields checks that v is not a blank string, or — if v is a
+// struct — that none of its exported fields are blank strings. It exists so
+// that if a row's value type grows a second field (tokenTypesByPrefix held a
+// {TokenType, Remediation} struct before remediation was removed, and could
+// again), row validation below catches an unset field automatically instead
+// of depending on someone remembering to add a field-specific check.
+func assertNoBlankFields(t *testing.T, label string, v reflect.Value) {
+	t.Helper()
+
+	switch v.Kind() {
+	case reflect.String:
+		if strings.TrimSpace(v.String()) == "" {
+			t.Errorf("%s: blank value", label)
+		}
+	case reflect.Struct:
+		vt := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			field := vt.Field(i)
+			if !field.IsExported() {
+				continue
+			}
+			assertNoBlankFields(t, label+"."+field.Name, v.Field(i))
+		}
+	default:
+		t.Fatalf("%s: assertNoBlankFields does not know how to validate kind %s; extend the helper for the new row type", label, v.Kind())
+	}
+}
+
 // TestTokenTypesByPrefix_RowsAreWellFormed checks each row in
 // tokenTypesByPrefix in isolation, independent of keyPat. The tests above
 // confirm the map's keys line up with keyPat; none of them would catch a
 // malformed row added alongside a correct key — e.g. a copy-pasted value
 // that leaves two different prefixes describing the same token type, or a
-// blank value that silently degrades a finding.
+// field left blank.
 func TestTokenTypesByPrefix_RowsAreWellFormed(t *testing.T) {
 	const unknown = "Unknown GitHub token"
 
@@ -194,9 +223,7 @@ func TestTokenTypesByPrefix_RowsAreWellFormed(t *testing.T) {
 		if !strings.HasSuffix(prefix, "_") {
 			t.Errorf("prefix %q does not end in \"_\"; githubTokenType matches by strings.HasPrefix, so a bare prefix can match unrelated tokens", prefix)
 		}
-		if strings.TrimSpace(tokenType) == "" {
-			t.Errorf("prefix %q maps to an empty or blank token type", prefix)
-		}
+		assertNoBlankFields(t, prefix, reflect.ValueOf(tokenType))
 		if tokenType == unknown {
 			t.Errorf("prefix %q maps to the reserved fallback value %q; a real row must not collide with it", prefix, unknown)
 		}

--- a/pkg/detectors/github/v2/github_test.go
+++ b/pkg/detectors/github/v2/github_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	regexp "github.com/wasilibs/go-re2"
+
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
@@ -113,20 +115,91 @@ func TestGithubTokenType(t *testing.T) {
 	}
 }
 
-// TestGithubTokenType_KeyPatPrefixesCovered guards against drift: every
-// prefix matched by keyPat must have an entry in tokenTypesByPrefix, so a new
-// token format added to the regex doesn't silently fall back to "Unknown
-// GitHub token".
-func TestGithubTokenType_KeyPatPrefixesCovered(t *testing.T) {
-	keyPatPrefixes := []string{"ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_"}
+// prefixAlternationPat pulls the prefix alternation out of keyPat's source,
+// e.g. `(?:ghp|gho|ghu|ghs|ghr|github_pat)_` -> `ghp|gho|ghu|ghs|ghr|github_pat`.
+var prefixAlternationPat = regexp.MustCompile(`\(\?:([a-zA-Z0-9_|]+)\)_`)
 
-	for _, prefix := range keyPatPrefixes {
-		if _, ok := tokenTypesByPrefix[prefix]; !ok {
-			t.Errorf("keyPat prefix %q has no entry in tokenTypesByPrefix", prefix)
+// keyPatPrefixes derives the token prefixes directly from keyPat's own source
+// rather than from a hand-maintained list. If the two disagree, the regex is
+// the authority — it is what actually decides whether a token is matched at
+// all.
+func keyPatPrefixes(t *testing.T) []string {
+	t.Helper()
+
+	m := prefixAlternationPat.FindStringSubmatch(keyPat.String())
+	if m == nil {
+		t.Fatalf("could not find a prefix alternation group in keyPat: %s\n"+
+			"keyPat's shape changed; update prefixAlternationPat to match, or this "+
+			"drift guard is silently testing nothing.", keyPat.String())
+	}
+
+	var prefixes []string
+	for _, alt := range strings.Split(m[1], "|") {
+		prefixes = append(prefixes, alt+"_")
+	}
+	return prefixes
+}
+
+// TestGithubTokenType_MappingMatchesKeyPatExactly is the drift guard: it
+// derives the prefix set from keyPat itself rather than a hand-maintained
+// list, so a seventh prefix added to keyPat and forgotten in the map cannot
+// slip past silently — the regex and the map cannot diverge without a
+// failure.
+//
+// This matters more than a normal mapping test: an unmapped prefix does not
+// crash, it silently reports "Unknown GitHub token", which puts a responder
+// back in the position this detector change exists to fix — holding a real
+// leaked credential with no idea how to revoke it.
+func TestGithubTokenType_MappingMatchesKeyPatExactly(t *testing.T) {
+	prefixes := keyPatPrefixes(t)
+
+	if len(prefixes) == 0 {
+		t.Fatal("derived zero prefixes from keyPat; the guard is not testing anything")
+	}
+
+	fromKeyPat := make(map[string]bool, len(prefixes))
+	for _, p := range prefixes {
+		fromKeyPat[p] = true
+		if _, ok := tokenTypesByPrefix[p]; !ok {
+			t.Errorf("keyPat matches prefix %q but tokenTypesByPrefix has no entry for it; "+
+				"a leaked token with this prefix would be reported as %q",
+				p, "Unknown GitHub token")
 		}
 	}
 
-	if len(tokenTypesByPrefix) != len(keyPatPrefixes) {
-		t.Errorf("tokenTypesByPrefix has %d entries, expected %d to match keyPat prefixes exactly", len(tokenTypesByPrefix), len(keyPatPrefixes))
+	// The reverse direction: a mapping entry for a prefix keyPat cannot match is
+	// dead weight, and usually means a prefix was renamed in one place only.
+	for p := range tokenTypesByPrefix {
+		if !fromKeyPat[p] {
+			t.Errorf("tokenTypesByPrefix has an entry for %q, but keyPat never matches that prefix", p)
+		}
+	}
+}
+
+// TestGithubTokenType_EveryKeyPatPrefixResolves closes the loop end to end:
+// build a token for each prefix keyPat actually accepts, confirm keyPat
+// matches it, and confirm githubTokenType resolves it to something other than
+// the unknown fallback. The two tests above check the data structures agree;
+// this one checks the behaviour they produce is correct for every real input.
+func TestGithubTokenType_EveryKeyPatPrefixResolves(t *testing.T) {
+	const unknown = "Unknown GitHub token"
+
+	for _, prefix := range keyPatPrefixes(t) {
+		t.Run(prefix, func(t *testing.T) {
+			token := prefix + strings.Repeat("a", 36)
+
+			if !keyPat.MatchString(token) {
+				t.Fatalf("keyPat does not match %q built from its own prefix alternation; "+
+					"the derived prefix is wrong or keyPat's body changed", token)
+			}
+
+			got := githubTokenType(token)
+			if got == unknown {
+				t.Errorf("githubTokenType(%q) = %q; every prefix keyPat matches must resolve to a real type", token, got)
+			}
+			if got == "" {
+				t.Errorf("githubTokenType(%q) returned an empty type", token)
+			}
+		})
 	}
 }

--- a/pkg/detectors/github/v2/github_test.go
+++ b/pkg/detectors/github/v2/github_test.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -84,5 +85,48 @@ func TestGithub_Pattern(t *testing.T) {
 				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
 			}
 		})
+	}
+}
+
+func TestGithubTokenType(t *testing.T) {
+	tests := []struct {
+		prefix string
+		token  string
+		want   string
+	}{
+		{"ghp_", "ghp_" + strings.Repeat("a", 36), "Personal Access Token (classic)"},
+		{"github_pat_", "github_pat_" + strings.Repeat("a", 36), "Personal Access Token (fine-grained)"},
+		{"gho_", "gho_" + strings.Repeat("a", 36), "OAuth Access Token"},
+		{"ghu_", "ghu_" + strings.Repeat("a", 36), "GitHub App User-to-Server Token"},
+		{"ghs_", "ghs_" + strings.Repeat("a", 36), "GitHub App Server-to-Server (installation) Token"},
+		{"ghr_", "ghr_" + strings.Repeat("a", 36), "GitHub App Refresh Token"},
+		{"unknown", "not_a_github_token", "Unknown GitHub token"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.prefix, func(t *testing.T) {
+			got := githubTokenType(test.token)
+			if got != test.want {
+				t.Errorf("githubTokenType(%q) = %q, want %q", test.token, got, test.want)
+			}
+		})
+	}
+}
+
+// TestGithubTokenType_KeyPatPrefixesCovered guards against drift: every
+// prefix matched by keyPat must have an entry in tokenTypesByPrefix, so a new
+// token format added to the regex doesn't silently fall back to "Unknown
+// GitHub token".
+func TestGithubTokenType_KeyPatPrefixesCovered(t *testing.T) {
+	keyPatPrefixes := []string{"ghp_", "gho_", "ghu_", "ghs_", "ghr_", "github_pat_"}
+
+	for _, prefix := range keyPatPrefixes {
+		if _, ok := tokenTypesByPrefix[prefix]; !ok {
+			t.Errorf("keyPat prefix %q has no entry in tokenTypesByPrefix", prefix)
+		}
+	}
+
+	if len(tokenTypesByPrefix) != len(keyPatPrefixes) {
+		t.Errorf("tokenTypesByPrefix has %d entries, expected %d to match keyPat prefixes exactly", len(tokenTypesByPrefix), len(keyPatPrefixes))
 	}
 }


### PR DESCRIPTION
## Problem
`keyPat` in `pkg/detectors/github/v2/github.go` matches all six GitHub token prefixes with one regex: `ghp_`/`github_pat_` (PATs), `gho_` (OAuth), `ghu_`/`ghs_`/`ghr_` (GitHub App tokens). Every match gets the same `DetectorType_Github` and the same hardcoded PAT description. The prefix is captured in `token := match[1]` but discarded before it reaches `Result`.

Nothing downstream can tell a leaked OAuth grant or GitHub App token from a leaked PAT. That matters: each token type revokes through a different GitHub settings page. A user following PAT-revocation steps on a `ghu_`/`ghs_` finding revokes nothing.

## Fix
Add `token_type` and `remediation` to `ExtraData`, keyed off the matched prefix. Follows the existing `ExtraData["token_type"]` convention (`launchdarkly`, `slack`, `larksuite`).

## Why this matters
Hit this at NVIDIA: three findings kept reopening across repeated full PAT revocations because the leaked credential was OAuth/GitHub-App, not a PAT, and the finding never said so. Cost incident-response time and triggered a false "revocation is broken" alarm before we traced it here.

## Testing
`go build`, `go vet`, `gofmt -l`, `TestGithub_Pattern` all pass. Additive `ExtraData` fields only; no detection/verification behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive ExtraData only; no change to matching, verification, or secret handling.
> 
> **Overview**
> GitHub v2 findings now include `ExtraData["token_type"]` derived from the matched prefix (`ghp_`, `github_pat_`, `gho_`, `ghu_`, `ghs_`, `ghr_`), so responders can tell a PAT from an OAuth grant or GitHub App token.
> 
> Detection and verification are unchanged. Tests cover each prefix, plus drift guards so `keyPat` and `tokenTypesByPrefix` cannot diverge without failing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4072f231ee06aa34258cf1ff0ab7ab0bf64a858c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->