### PR TITLE
fix(detectors): report Unsplash verifier errors

### DIFF
--- a/pkg/detectors/unsplash/unsplash.go
+++ b/pkg/detectors/unsplash/unsplash.go
@@ -2,6 +2,7 @@ package unsplash
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -53,10 +54,19 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			res, err := client.Do(req)
 			if err == nil {
 				defer func() { _ = res.Body.Close() }()
-				if res.StatusCode >= 200 && res.StatusCode < 300 {
+				switch {
+				case res.StatusCode >= 200 && res.StatusCode < 300:
 					s1.Verified = true
+				case res.StatusCode == http.StatusUnauthorized:
+					// Determinately not verified — invalid key, nothing else to do.
+				default:
+					err = fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+					s1.SetVerificationError(err, resMatch)
 				}
+			} else {
+				s1.SetVerificationError(err, resMatch)
 			}
+
 		}
 
 		results = append(results, s1)


### PR DESCRIPTION
Improves error handling in the Unsplash detector's verification logic, per #4051.

**Before:** any non-2xx response (including request errors) was silently
treated as "not verified," with no distinction between "confirmed invalid
key" and "something went wrong during verification."

**After:**
- 2xx → verified
- 401 → determinately not verified (invalid key), nothing further to do
- any other status or request error → SetVerificationError, so it surfaces
  instead of silently failing

**Tested against the real Unsplash API:**
- Valid key → `200 OK`
- Invalid key → `401 Unauthorized`

Mentioning #4051 (not closing) since it's an umbrella issue covering
multiple detectors.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow detector verification-error handling change with no auth, data, or scanning-path behavior beyond how Unsplash results report errors.
> 
> **Overview**
> Stops treating all Unsplash verification failures as unverified secrets. 2xx still marks the key verified; **401** stays determinately invalid; other HTTP statuses and request errors now call `SetVerificationError` so they surface instead of failing silently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6c152f06fb8eddf09b5e7ccc1daef0f52d49375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->