### PR TITLE
Fix PagerDuty detector: treat 403 and 402 as verified credentials

### DIFF
--- a/pkg/detectors/pagerdutyapikey/pagerdutyapikey.go
+++ b/pkg/detectors/pagerdutyapikey/pagerdutyapikey.go
@@ -86,8 +86,35 @@ func verifyPagerdutyapikey(ctx context.Context, client *http.Client, token strin
 	case http.StatusOK:
 		return true, nil
 	case http.StatusUnauthorized:
+		// Token is missing, malformed, or invalid.
+		// Note that revoked (disabled) keys are treated as invalid.
+		return false, nil
+	case http.StatusForbidden:
+		// PagerDuty returns 403 when the token authenticated successfully but
+		// lacks permission for the requested resource -- e.g. a user token for
+		// a restricted-role user, or a scoped OAuth token missing users.read.
+		// This confirms the credential is live.
+		return true, nil
+	case http.StatusTooManyRequests:
+		// Rate-limited. Can't determine validity; keep indeterminate for retry.
+		return false, fmt.Errorf("PagerDuty rate limit reached")
+	case http.StatusBadRequest:
+		// Malformed request parameters. Shouldn't happen for our simple GET.
+		// Not transient -- the same request will always produce the same result.
+		return false, nil
+	case http.StatusPaymentRequired:
+		// Account lacks the pricing-plan abilities for this endpoint. PagerDuty
+		// must have authenticated the token before checking plan features, so
+		// the credential is live.
+		return true, nil
+	case http.StatusNotFound:
+		// Resource not found. Unusual on the /users collection endpoint.
+		// Not transient -- retrying won't make the endpoint appear.
+		// Shouldn't happen in practice.
 		return false, nil
 	default:
+		// Unknown status codes (including 5xx server errors) are potentially
+		// transient, so return an error to keep the result indeterminate.
 		return false, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
 	}
 }

--- a/pkg/detectors/pagerdutyapikey/pagerdutyapikey_integration_test.go
+++ b/pkg/detectors/pagerdutyapikey/pagerdutyapikey_integration_test.go
@@ -73,8 +73,40 @@ func TestPagerDutyApiKey_FromChunk(t *testing.T) {
 			wantVerificationErr: true,
 		},
 		{
-			name: "found, verified but unexpected api surface",
+			name: "found, unverified due to not found (404)",
 			s:    Scanner{client: common.ConstantResponseHttpClient(404, "")},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a pagerdutyapikey secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_PagerDutyApiKey,
+					Verified:     false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "found, verified via 403 (valid key, insufficient permissions)",
+			s:    Scanner{client: common.ConstantResponseHttpClient(403, `{"error":{"message":"Access Denied","code":2010}}`)},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a pagerdutyapikey secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_PagerDutyApiKey,
+					Verified:     true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "found, indeterminate due to rate limiting (429)",
+			s:    Scanner{client: common.ConstantResponseHttpClient(429, "")},
 			args: args{
 				ctx:    context.Background(),
 				data:   []byte(fmt.Sprintf("You can find a pagerdutyapikey secret %s within", secret)),
@@ -88,6 +120,38 @@ func TestPagerDutyApiKey_FromChunk(t *testing.T) {
 			},
 			wantErr:             false,
 			wantVerificationErr: true,
+		},
+		{
+			name: "found, unverified due to bad request (400)",
+			s:    Scanner{client: common.ConstantResponseHttpClient(400, "")},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a pagerdutyapikey secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_PagerDutyApiKey,
+					Verified:     false,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "found, verified via 402 (valid key, account plan limitation)",
+			s:    Scanner{client: common.ConstantResponseHttpClient(402, "")},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a pagerdutyapikey secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_PagerDutyApiKey,
+					Verified:     true,
+				},
+			},
+			wantErr: false,
 		},
 		{
 			name: "found, unverified",


### PR DESCRIPTION
### Description:

The PagerDuty detector's `verifyPagerdutyapikey` function only handled HTTP 200 (verified) and 401 (invalid), sending all other status codes into a `default` branch that returned `false` with an error. This caused valid keys to be misclassified:

- **403 Forbidden**: PagerDuty's API spec is explicit that 403 means "your authentication is valid, but the authenticated user or token does not have permission to perform this action." This happens with user tokens for restricted-role users and scoped OAuth tokens missing `users.read`. The detector was treating these valid credentials as verification errors.

- **402 Payment Required**: Similarly, if PagerDuty checks account plan features, the token must have already authenticated. These were also incorrectly treated as errors.

**Changes:**

- Expanded the switch to explicitly handle every status code in PagerDuty's API contract, with each case documented:
  - 200: verified
  - 401: definitively invalid (includes disabled/revoked keys)
  - 403: verified (valid key, insufficient permissions)
  - 402: verified (valid key, account plan limitation)
  - 429: indeterminate error (transient rate limit, retry-worthy)
  - 400, 404: definitively unverified (permanent conditions, not retried)
  - 5xx/unknown: indeterminate error (transient, retry-worthy)

- Carefully distinguished transient vs permanent failures: only 429 and unknown/5xx codes return errors (keeping results indeterminate for retry). Permanent conditions like 400 and 404 return `false, nil` to avoid churning.

- Added integration tests for 403, 429, 400, and 402 using `ConstantResponseHttpClient`, matching the existing test pattern. Updated the pre-existing 404 test case.

- Live-tested against PagerDuty API with full-access, read-only, and bogus keys. Full-access and read-only correctly verified; bogus correctly rejected.

### Checklist:
- [x] Tests passing (`make test-community`)?
- [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?


Made with [Cursor](https://cursor.com)