### PR TITLE
ci: let Renovate bump the golangci-lint pin in scripts/lint.sh

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>trufflesecurity/.github:renovate-config#v1.0.4"]
+  "extends": ["github>trufflesecurity/.github:renovate-config#v1.0.4"],
+  "customManagers": [
+    {
+      "description": "scripts/lint.sh pins the same golangci-lint version as .github/workflows/lint.yml",
+      "customType": "regex",
+      "managerFilePatterns": ["scripts/lint.sh"],
+      "matchStrings": ["GOLANGCI_LINT_VERSION=\"(?<currentValue>v[^\"]+)\""],
+      "depNameTemplate": "golangci/golangci-lint",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Keep the workflow and script golangci-lint pins in one PR",
+      "matchDepNames": ["golangci/golangci-lint"],
+      "groupName": "golangci-lint"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

`scripts/lint.sh` and `.github/workflows/lint.yml` each pin a `golangci-lint` version, and each carries a comment saying the two must match. Nothing enforces that: Renovate's `github-actions` manager sees the workflow pin but no manager reads shell scripts, so every bump silently leaves `make lint` behind.

This has now happened twice. #5036 landed the workflow on `v2.12.2` while the script stayed on `v2.11.4`, and #5197 moved the workflow to `v2.13.1` with the script still on `v2.12.2`. Both needed a manual catch-up commit. The drift in #5197 was more than cosmetic, since go1.27 support only arrived in golangci-lint `v2.13.0` and that PR also moves CI to Go 1.27, so `make lint` on the old pin would fail outright for anyone on that toolchain.

- Adds a regex custom manager that extracts `GOLANGCI_LINT_VERSION` from `scripts/lint.sh` against the `github-releases` datasource.
- Groups both pins under a `golangci-lint` group so they move in a single PR rather than two that can land apart.

## Test plan

- [x] `npx --package renovate@44 renovate-config-validator` passes (44.x is the version currently running against this repo).
- [ ] Confirm the next Renovate run picks up `scripts/lint.sh` — the Dependency Dashboard should list `golangci/golangci-lint` with both files under one group.

Made with [Cursor](https://cursor.com)