### PR TITLE
ci: enforce that the two golangci-lint pins agree

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,10 @@ jobs:
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Check golangci-lint version pins
-        run: ./scripts/check_lint_pins.py
+        # Invoked through python3, matching how scripts/test/diff_corpora_results.py
+        # is run in detector-corpora-test.yml, so the job does not depend on the
+        # file's git mode bit surviving.
+        run: python3 scripts/check_lint_pins.py
   man-page-staleness:
     name: man-page-staleness
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,17 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
-          # NOTE: Version and args must match scripts/lint.sh
+          # NOTE: Version and args must match scripts/lint.sh. The version half is
+          # enforced by the lint-pin-consistency job below; the args half is not.
           version: v2.13.1
           args: --enable bodyclose,copyloopvar,misspell --timeout 10m
+  lint-pin-consistency:
+    name: lint-pin-consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - name: Check golangci-lint version pins
+        run: ./scripts/check_lint_pins.py
   man-page-staleness:
     name: man-page-staleness
     runs-on: ubuntu-latest

--- a/scripts/check_lint_pins.py
+++ b/scripts/check_lint_pins.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Verify the two golangci-lint version pins agree, and that Renovate can see both.
+
+golangci-lint is pinned twice: as the `version` input to golangci-lint-action in
+.github/workflows/lint.yml, and as GOLANGCI_LINT_VERSION in scripts/lint.sh. Both
+files carry a NOTE comment saying the two must match, but until this check existed
+nothing enforced it, and the pins drifted twice -- once leaving the workflow on
+v2.12.2 while the script stayed on v2.11.4, and again leaving the script on v2.12.2
+after the workflow moved to v2.13.1. The second drift was more than cosmetic: go1.27
+support arrived in golangci-lint v2.13.0, so `make lint` on the stale pin failed
+outright for anyone on that toolchain.
+
+Renovate's github-actions manager reads the workflow pin. Nothing built in reads a
+shell variable, so .github/renovate.json carries a regex custom manager for
+scripts/lint.sh. That closes the bumping gap but introduces a quieter one: a regex
+that stops matching *fails open*. Renovate reports no dependency rather than an
+error, so reshaping that assignment -- switching to single quotes, wrapping it in
+`readonly`, interpolating it -- would silently return us to bumping the workflow
+alone, with nothing to notice.
+
+This check therefore does two things:
+
+  1. Asserts the two pins are equal and concrete, which catches drift however it
+     arrives -- including a hand edit Renovate was never involved in.
+  2. Applies the regex configured in .github/renovate.json to scripts/lint.sh and
+     requires it to match, so the custom manager cannot quietly stop tracking the
+     file it exists to track.
+
+Exits non-zero with an explanation on the first problem found.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+import re
+import sys
+from pathlib import Path
+
+DEP_NAME = "golangci/golangci-lint"
+SCRIPT_PATH = "scripts/lint.sh"
+WORKFLOW_PATH = ".github/workflows/lint.yml"
+RENOVATE_PATH = ".github/renovate.json"
+
+# A pin must be a full major.minor.patch. Rejecting only "latest" is not enough:
+# a partial tag such as "v2" floats just as much while reading like a pin.
+SEMVER = re.compile(r"^v?\d+\.\d+\.\d+$")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def fail(message: str) -> None:
+    print(f"ERROR: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def read(relative_path: str) -> str:
+    path = REPO_ROOT / relative_path
+    if not path.is_file():
+        fail(f"{relative_path} not found.")
+    return path.read_text()
+
+
+def path_matches_pattern(path: str, pattern: str) -> bool:
+    """Apply one Renovate managerFilePatterns entry to a repository-relative path.
+
+    Renovate treats a pattern wrapped in slashes as a regex and anything else as a
+    glob, so both spellings are honored here rather than assuming the current one.
+    """
+    if len(pattern) > 1 and pattern.startswith("/") and pattern.endswith("/"):
+        try:
+            return re.search(pattern[1:-1], path) is not None
+        except re.error as error:
+            fail(
+                f"the '{DEP_NAME}' customManager in {RENOVATE_PATH} has a "
+                f"managerFilePatterns entry that is not a valid regex: {pattern} ({error})"
+            )
+    return fnmatch.fnmatch(path, pattern)
+
+
+def extract_sole_match(pattern: re.Pattern[str], text: str, description: str) -> re.Match[str]:
+    """Require exactly one match. A second means the pattern now covers something else."""
+    matches = list(pattern.finditer(text))
+    if len(matches) != 1:
+        fail(
+            f"expected exactly one {description}, found {len(matches)} — "
+            "make this check's pattern more specific, or remove the duplicate pin."
+        )
+    return matches[0]
+
+
+def load_custom_manager(renovate_config: dict) -> dict:
+    managers = [
+        manager
+        for manager in renovate_config.get("customManagers", [])
+        if manager.get("customType") == "regex"
+        and manager.get("depNameTemplate") == DEP_NAME
+    ]
+    if len(managers) != 1:
+        fail(
+            f"{RENOVATE_PATH} must define exactly one regex customManager with "
+            f"depNameTemplate '{DEP_NAME}', found {len(managers)}. That manager is what "
+            f"lets Renovate see the pin in {SCRIPT_PATH}; without it the bot bumps "
+            f"{WORKFLOW_PATH} alone and the two pins drift."
+        )
+    return managers[0]
+
+
+def script_pin_from_renovate_regex(manager: dict) -> str:
+    """Apply the manager's own regex to scripts/lint.sh and return what it captures."""
+    datasource = manager.get("datasourceTemplate", "")
+    if datasource != "github-releases":
+        fail(
+            f"the '{DEP_NAME}' customManager in {RENOVATE_PATH} must use the "
+            f"'github-releases' datasource, found '{datasource or '<unset>'}'. The workflow "
+            "pin resolves against GitHub release tags, so the script pin has to resolve the "
+            "same way or the two can be offered different versions."
+        )
+
+    file_patterns = manager.get("managerFilePatterns", [])
+    if not any(path_matches_pattern(SCRIPT_PATH, pattern) for pattern in file_patterns):
+        fail(
+            f"the '{DEP_NAME}' customManager in {RENOVATE_PATH} must target {SCRIPT_PATH} "
+            f"through managerFilePatterns. It currently targets: {file_patterns}."
+        )
+
+    match_strings = manager.get("matchStrings", [])
+    if len(match_strings) != 1:
+        fail(
+            f"the '{DEP_NAME}' customManager in {RENOVATE_PATH} must declare exactly one "
+            f"matchStrings entry, found {len(match_strings)}. This check applies that single "
+            "pattern to the script; with several it cannot tell which one is meant to match."
+        )
+    match_string = match_strings[0]
+
+    if "(?<currentValue>" not in match_string:
+        fail(
+            f"the '{DEP_NAME}' matchStrings pattern in {RENOVATE_PATH} must capture the "
+            "version in a named group '(?<currentValue>...)'. Renovate uses that group to "
+            f"decide which substring to rewrite. Pattern: {match_string}"
+        )
+
+    # Renovate matches with RE2, which accepts both (?<name>) and (?P<name>);
+    # Python's re accepts only the latter. Renaming the group is the whole
+    # translation -- it does not change what the pattern matches.
+    try:
+        compiled = re.compile(match_string.replace("(?<currentValue>", "(?P<currentValue>"))
+    except re.error as error:
+        fail(
+            f"the '{DEP_NAME}' matchStrings pattern in {RENOVATE_PATH} does not compile: "
+            f"{error}. Pattern: {match_string}"
+        )
+
+    script_text = read(SCRIPT_PATH)
+    matches = list(compiled.finditer(script_text))
+    if len(matches) != 1:
+        fail(
+            f"the '{DEP_NAME}' matchStrings pattern from {RENOVATE_PATH} matched "
+            f"{len(matches)} times in {SCRIPT_PATH}, expected exactly 1. Renovate reports no "
+            "dependency when its regex stops matching, so it would quietly resume bumping "
+            f"{WORKFLOW_PATH} alone. Re-sync the pattern with the GOLANGCI_LINT_VERSION "
+            f"assignment. Pattern: {match_string}"
+        )
+    return matches[0].group("currentValue")
+
+
+def require_group_rule(renovate_config: dict) -> None:
+    for rule in renovate_config.get("packageRules", []):
+        if DEP_NAME in rule.get("matchDepNames", []) and rule.get("groupName"):
+            return
+    fail(
+        f"{RENOVATE_PATH} must contain a packageRule matching depName '{DEP_NAME}' and "
+        "setting a groupName. The shared preset groups all github-actions updates into one "
+        "PR, so without this rule the workflow pin and the script pin land in separate PRs "
+        "and whichever merges first leaves the pins drifted."
+    )
+
+
+def main() -> None:
+    try:
+        renovate_config = json.loads(read(RENOVATE_PATH))
+    except json.JSONDecodeError as error:
+        fail(f"{RENOVATE_PATH} is not valid JSON: {error}")
+
+    manager = load_custom_manager(renovate_config)
+    script_version = script_pin_from_renovate_regex(manager)
+    require_group_rule(renovate_config)
+
+    # The workflow pin is read straight out of the YAML text rather than parsed,
+    # to keep this check dependency-free on a bare runner.
+    workflow_match = extract_sole_match(
+        re.compile(r"^[ \t]*version:[ \t]*(?P<version>\S+)", re.MULTILINE),
+        read(WORKFLOW_PATH),
+        f"golangci-lint 'version:' key in {WORKFLOW_PATH}",
+    )
+    workflow_version = workflow_match.group("version")
+
+    for label, path, version in (
+        ("workflow", WORKFLOW_PATH, workflow_version),
+        ("script", SCRIPT_PATH, script_version),
+    ):
+        if not SEMVER.match(version):
+            fail(
+                f"{path} must pin golangci-lint to a concrete vX.Y.Z release, found "
+                f"'{version}'. A floating value such as 'latest' or 'v2' lets the linter "
+                f"change under a branch that did not change ({label} pin)."
+            )
+
+    if workflow_version != script_version:
+        fail(
+            f"golangci-lint is pinned to '{workflow_version}' in {WORKFLOW_PATH} but "
+            f"'{script_version}' in {SCRIPT_PATH}. Bump both together, or local `make lint` "
+            "and the CI lint job will disagree about what counts as a finding. Renovate is "
+            "configured to move them in one PR; if only one moved, check the customManager "
+            f"in {RENOVATE_PATH}."
+        )
+
+    print(f"golangci-lint pins agree ({workflow_version}), and Renovate tracks both.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# NOTE: Version and args must match .github/workflows/lint.yml
+# NOTE: Version and args must match .github/workflows/lint.yml. The version half is
+# enforced by scripts/check_lint_pins.py in CI; the args half is not. Renovate bumps
+# this assignment via a custom manager, which matches it by regex — see
+# .github/renovate.json before reshaping the line.
 GOLANGCI_LINT_VERSION="v2.13.1"
 
 LINT_ARGS="--enable bodyclose,copyloopvar,misspell --timeout 10m"


### PR DESCRIPTION
> [!NOTE]
> **Authorship:** this pull request description, and the code changes it describes, were drafted by Cursor (an AI coding assistant) on behalf of @bryanbeverly, who reviewed them before opening the PR.

## What changed

Adds `scripts/check_lint_pins.py` and a `lint-pin-consistency` job in `.github/workflows/lint.yml` that runs it.

`golangci-lint` is pinned twice — as the `version` input to `golangci-lint-action` in `.github/workflows/lint.yml`, and as `GOLANGCI_LINT_VERSION` in `scripts/lint.sh`. Both files say the two must match. Nothing enforced it.

The check does two things:

1. **Asserts the pins are equal and concrete.** This catches drift however it arrives, including a hand edit Renovate was never involved in, and rejects floating values like `latest` or a bare `v2` that read like a pin but aren't.
2. **Applies the regex from `.github/renovate.json` to `scripts/lint.sh` and requires it to match.** It also checks the datasource, the target file, and the grouping rule.

## Why it changed

The pins have drifted twice: `v2.12.2` in the workflow against `v2.11.4` in the script, then `v2.13.1` against `v2.12.2`. The second was more than cosmetic — go1.27 support arrived in `golangci-lint` v2.13.0, so `make lint` on the stale pin failed outright for anyone on that toolchain.

`1bc0db6b5` fixed the *bumping* gap with a Renovate custom manager. This PR addresses the quieter gap that fix introduced: **a regex that stops matching fails open.** Renovate reports no dependency rather than an error, so reshaping that assignment — single quotes, a `readonly` wrapper, interpolation — would silently resume bumping the workflow alone, with nothing to notice. Since the custom manager is currently the *only* thing holding these two files together, that failure mode is the whole exposure rather than an inconvenience.

Worth noting where this came from: the sibling repo `slack-integration-service` has the same double-pin, and a guard comparing the two pins has been catching drift there since `dc636205`. Its Renovate PRs go red rather than quietly wrong. This ports that backstop here.

## Design notes

- **Standard library only, and no YAML parsing.** The workflow pin is read as text. PyYAML is not installed on a bare `ubuntu-latest` runner, and this check shouldn't need a dependency install step to run.
- **Python rather than a shell script**, because the job is JSON parsing plus a PCRE named-group regex. `scripts/test/diff_corpora_results.py` is the precedent for a Python helper invoked from CI.
- **One translation is applied to Renovate's regex before use:** `(?<currentValue>` becomes `(?P<currentValue>`. Renovate matches with RE2, which accepts both spellings; Python's `re` accepts only the latter. Renaming the group is the entire translation and does not change what the pattern matches.
- **`managerFilePatterns` is honored in both spellings** — a slash-wrapped regex or a glob — rather than assuming the form currently in the config.
- Both `NOTE` comments now name the enforcing check, and say plainly that the **version** half is enforced while the **args** half is not.

## Deliberately not in this PR

The `NOTE` comments claim "Version **and args** must match." Only the version is enforced here. `LINT_ARGS` (`--enable bodyclose,copyloopvar,misspell --timeout 10m`) is duplicated across the same two files with no bot in the loop and no check, so it can still drift silently. Worth a follow-up; it's a different kind of comparison and didn't belong in the same change.

## How it was validated

Nine cases, each confirmed to fail for the intended reason or pass when it should:

| Case | Expected |
|---|---|
| Workflow bumped, script left behind | fail |
| Script pin reshaped to single quotes | fail |
| Script pin wrapped in `readonly` (still tracked) | **pass** |
| `customManager` deleted | fail |
| Grouping `packageRule` deleted | fail |
| Manager retargeted at the wrong file | fail |
| Workflow pin floated to `latest` | fail |
| Regex-form `managerFilePatterns` | **pass** |
| Clean baseline | **pass** |

The single-quote case is the one that matters most: it's the fail-open scenario, and it's now caught.

`actionlint` is clean on the modified workflow.

Made with [Cursor](https://cursor.com)