### PR TITLE
fix(detectors/ldap): verify TLS certificates before transmitting credentials during verification

### DIFF
--- a/pkg/detectors/ldap/ldap.go
+++ b/pkg/detectors/ldap/ldap.go
@@ -129,8 +129,13 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 func isErrDeterminate(err error) bool {
 	var neterr *net.OpError
+	var certErr *tls.CertificateVerificationError
 
+	// A certificate verification failure means no authenticated channel could
+	// be established — the credential was never tested, so the result is
+	// indeterminate, not "invalid credential".
 	if errors.As(err, &neterr) ||
+		errors.As(err, &certErr) ||
 		errors.Is(err, context.DeadlineExceeded) ||
 		errors.Is(err, context.Canceled) {
 		return false
@@ -158,19 +163,21 @@ func verifyLDAP(ctx context.Context, username, password string, ldapURL *url.URL
 			return nil
 		}
 
-		// STARTTLS
-		err = l.StartTLS(&tls.Config{InsecureSkipVerify: true})
+		// STARTTLS. tls.Client performs no ServerName inference, so set it
+		// explicitly; certificate verification stays enabled — the bind below
+		// transmits the credential, so the peer must be authenticated first.
+		err = l.StartTLS(&tls.Config{ServerName: ldapURL.Hostname()})
 		if err != nil {
 			return err
 		}
 		// STARTTLS verify
 		return l.BindContext(ctx, username, password)
 	case "ldaps":
-		// TLS dial
+		// TLS dial. The default config verifies the certificate against the
+		// dialed host (tls.Dialer fills in ServerName).
 		l, err := ldap.DialURL(
 			uri,
 			ldap.DialWithContext(ctx),
-			ldap.DialWithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
 		)
 		if err != nil {
 			return err

--- a/pkg/detectors/ldap/ldap_tls_test.go
+++ b/pkg/detectors/ldap/ldap_tls_test.go
@@ -1,0 +1,105 @@
+package ldap
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// selfSignedServer starts a TLS listener whose certificate no client trusts,
+// and counts every post-handshake application byte it receives.
+func selfSignedServer(t *testing.T) (addr string, gotBytes *atomic.Int64, closeFn func()) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "127.0.0.1"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert := tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{cert}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gotBytes = &atomic.Int64{}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				buf := make([]byte, 4096)
+				for {
+					n, err := c.Read(buf)
+					gotBytes.Add(int64(n))
+					if err != nil {
+						return
+					}
+				}
+			}(conn)
+		}
+	}()
+
+	return ln.Addr().String(), gotBytes, func() { ln.Close() }
+}
+
+// A server presenting a certificate the client cannot verify must cause
+// verification to fail BEFORE any credential is transmitted, and the failure
+// must read as indeterminate rather than as an invalid credential.
+func TestVerifyLDAP_UntrustedCertificate(t *testing.T) {
+	addr, gotBytes, closeFn := selfSignedServer(t)
+	defer closeFn()
+
+	ldapURL, err := url.Parse("ldaps://" + addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	verifyErr := verifyLDAP(ctx, "cn=admin,dc=example,dc=org", "hunter2", ldapURL)
+	if verifyErr == nil {
+		t.Fatal("expected verification to fail against an untrusted certificate")
+	}
+
+	var certErr *tls.CertificateVerificationError
+	if !errors.As(verifyErr, &certErr) {
+		t.Fatalf("expected a certificate verification error, got: %v", verifyErr)
+	}
+
+	if isErrDeterminate(verifyErr) {
+		t.Errorf("certificate verification failure must be indeterminate, not an invalid-credential verdict: %v", verifyErr)
+	}
+
+	// The handshake was refused client-side, so the credential must never have
+	// reached the wire.
+	if n := gotBytes.Load(); n != 0 {
+		t.Errorf("server received %d application bytes; the bind must not be sent over an unverified channel", n)
+	}
+}


### PR DESCRIPTION
### Description

Both TLS paths in the LDAP detector's `verifyLDAP` disabled certificate verification and then **bound with the discovered credential**:

```go
err = l.StartTLS(&tls.Config{InsecureSkipVerify: true})
...
ldap.DialWithTLSConfig(&tls.Config{InsecureSkipVerify: true}),
```

Verification is the step that transmits the secret. Over an unauthenticated channel, a machine-in-the-middle can present any certificate and receive the username and password trufflehog is in the act of checking and can also answer the bind with success, minting `Verified: true` for a credential it just captured. Same defect family as #5188 only the flaw sits in the verification arm.

**The fix:**

- **ldaps** - drop the insecure config entirely. `tls.Dialer`'s default behaviour fills in `ServerName` from the dialed host and verifies the certificate against it.
- **STARTTLS** - `tls.Client` performs no `ServerName` inference, so pass `ServerName: ldapURL.Hostname()` explicitly, with verification enabled.
- **`isErrDeterminate`** - a `tls.CertificateVerificationError` now reads as *indeterminate*: no authenticated channel could be established, so the credential was never tested. Previously a cert failure would have been reported as a determinate "not verified".

**Behaviour change:** LDAP servers with self-signed or otherwise untrusted certificates will no longer produce `Verified: true`. Those results become indeterminate with a verification error attached. That's probably the most an automated tool can assert without an authenticated channel, as the previous `Verified: true` was obtained by trusting an unauthenticated peer.

The new regression test (`TestVerifyLDAP_UntrustedCertificate`) spins up a TLS listener with an untrusted certificate and asserts: verification fails, the failure is a certificate verification error, it is indeterminate, and **zero application bytes reach the server**, and the credential doesn't get transmitted.

### Checklist:
* [x] `go test ./pkg/detectors/ldap/` passes, including the new regression test
* [x] `go vet` clean
* [ ] Integration test (`detectors && integration` tags, OpenLDAP container) exercises the plain-`ldap://` path, which is unchanged; deferring to CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credential verification and TLS behavior for LDAP secrets; legitimate servers with non-standard certs may stop verifying until trust is configured, but the security fix is intentional.
> 
> **Overview**
> **Stops sending LDAP bind credentials until the TLS peer is authenticated**, closing a MITM path where `InsecureSkipVerify` could yield `Verified: true` after secrets were sent to an unverified server.
> 
> For **STARTTLS**, certificate verification is enabled and `ServerName` is set from the LDAP URL hostname (no automatic inference). For **ldaps**, the insecure dial TLS config is removed so the default client verifies the cert against the dialed host. **`isErrDeterminate`** now treats `tls.CertificateVerificationError` as indeterminate (credential not tested), not a definitive invalid-credential result.
> 
> **User-visible change:** LDAP endpoints with untrusted or self-signed certs no longer get a successful verification verdict; those runs surface an indeterminate verification error instead.
> 
> Adds **`TestVerifyLDAP_UntrustedCertificate`**, which asserts cert failure, indeterminate classification, and zero application bytes sent to an untrusted TLS listener.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27a57fca6568406e3929eefebc103d06fd87687a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->