### PR TITLE
ci: scope workflow permissions to least privilege

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -9,6 +9,8 @@ jobs:
     if: ${{ ! github.event.pull_request.head.repo.fork }}
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,15 @@ on:
     tags:
       - v*
 
-permissions:
-  contents: write
-  packages: write
-  id-token: write
-
 jobs:
   Release:
     runs-on: ubuntu-latest
+    # Scoped to the job that publishes: contents (release + assets),
+    # packages (GHCR), id-token (cosign keyless signing).
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
@@ -87,6 +88,9 @@ jobs:
   mark-latest:
     needs: Release
     runs-on: ubuntu-latest
+    # Only needs to edit the release to flag it latest.
+    permissions:
+      contents: write
     steps:
       - name: Mark release as latest
         run: gh release edit "$TAG" --latest

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -13,6 +13,8 @@ jobs:
   test:
     if: ${{ github.repository == 'trufflesecurity/trufflehog' && !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -3,6 +3,9 @@ name: Smoke
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

`zizmor` **excessive-permissions**: four workflows either ran with the default token scope (no `permissions:` block) or granted write scopes at the workflow level where only one job needs them.

- **smoke.yml** — add workflow-level `contents: read`; both jobs only read.
- **performance.yml**, **secrets.yml** — add job-level `contents: read`.
- **release.yml** — move `contents: write`, `packages: write`, `id-token: write` off the workflow and onto the `Release` job that actually publishes. The `mark-latest` job then gets only `contents: write` (for `gh release edit --latest`) instead of inheriting `packages`/`id-token` write it never uses.

### Result
- zizmor **excessive-permissions**: 8 → 0
- `actionlint`: clean

### Checklist
* [x] Workflows parse and pass `actionlint`
* [x] Release job retains every scope its steps use (GHCR push, keyless cosign signing, release upload)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission scoping; release publishing retains the same scopes on the job that needs them.
> 
> **Overview**
> Tightens GitHub Actions `GITHUB_TOKEN` scopes to address **zizmor excessive-permissions** findings across four workflows, without changing what each job actually does.
> 
> **Smoke** gets workflow-level `contents: read` for read-only PR checks. **Performance** and **secrets** dogfood jobs get job-level `contents: read` only. **Release** moves publishing scopes off the workflow: the main **Release** job keeps `contents: write`, `packages: write`, and `id-token: write` for GoReleaser/GHCR/cosign; **mark-latest** is limited to `contents: write` for `gh release edit --latest` instead of inheriting package and OIDC write it never uses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fb18b2d47d915a865d3b404e0468ad62fd9ad0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->