### PR TITLE
ci(release): build from a clean Go cache to prevent cache poisoning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,11 @@ jobs:
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.27"
+          # Do not restore a shared build/module cache into the job that
+          # produces the released binaries: a cache entry poisoned by any
+          # other workflow (keyed on the same go.sum) would flow into the
+          # published artifacts. Release builds from a clean cache.
+          cache: false
       - name: Cosign install
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
       - name: Install UPX


### PR DESCRIPTION
### Description

`zizmor` **cache-poisoning**: the `release.yml` `Release` job publishes binaries, Docker images and a Homebrew tap, but restored a shared Go build/module cache (`actions/setup-go` caches by default). A cache entry poisoned by any other workflow keyed on the same `go.sum` could then flow into the released artifacts. This sets `cache: false` on the release `setup-go` so releases build from a clean cache.

### Scope note (deliberately narrow)
zizmor also flags the `setup-go` steps in `lint.yml` and `test.yml` under this rule, because those workflows carry tag triggers. Neither publishes runtime artifacts, so their caching is left in place to keep CI fast. Happy to disable those too if you'd prefer the rule fully silenced — but that trades CI speed for no real artifact-integrity gain, so I've scoped this PR to the one workflow where the risk is concrete.

### Result
- `release.yml` cache-poisoning finding: resolved
- `actionlint`: clean

### Checklist
* [x] `release.yml` parses and passes `actionlint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to release job caching; slightly slower release builds but no application or runtime behavior changes.
> 
> **Overview**
> Hardens the **Release** workflow so published Go binaries are not built from a restored shared module/build cache.
> 
> The `Set up Go` step in `release.yml` now sets **`cache: false`**, with comments noting that `actions/setup-go`’s default cache (keyed on `go.sum`) could be poisoned by another workflow and then influence artifacts shipped via GoReleaser. Release jobs therefore compile from a clean cache; other workflows keep caching for CI speed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4653c49a997fbea99d65360c0165bf277fd13788. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->