### PR TITLE
ci(lint): pin the semgrep container image by digest

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
     name: semgrep
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: returntocorp/semgrep:1.99.0@sha256:ae27024c16f7848cdbfd49c24ed0b78b13f13b85fcd7b87c679aaa8b0c0dce98
     if: (github.actor != 'dependabot[bot]')
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6


### PR DESCRIPTION
### Description

`zizmor` **unpinned-images**: the `semgrep` job in `lint.yml` ran `container: returntocorp/semgrep` with no tag or digest, so each run pulled a mutable `:latest` — a non-reproducible lint environment that trusts whatever that tag points to at run time. This pins to `1.99.0` at its current digest, matching the SHA-pinning this repo already applies to every `uses:` action.

```
returntocorp/semgrep:1.99.0@sha256:ae27024c16f7848cdbfd49c24ed0b78b13f13b85fcd7b87c679aaa8b0c0dce98
```

(Digest resolved from Docker Hub for tag `1.99.0` on 2026-08-26.)

### Result
- `lint.yml` unpinned-images finding: 0
- `actionlint`: clean

### Checklist
* [x] `lint.yml` parses and passes `actionlint`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change; no application, auth, or runtime behavior is affected.
> 
> **Overview**
> The **semgrep** job in `.github/workflows/lint.yml` no longer uses the bare `returntocorp/semgrep` image (effectively mutable `:latest`). It now runs **`returntocorp/semgrep:1.99.0`** pinned with a **SHA256 digest**, so lint runs use a fixed Semgrep version and image content, aligned with how other workflow dependencies are SHA-pinned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 892f59495007c944c35c4e1aa02236e4b3eeb3da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->