### PR TITLE
[INT-933] De-base64 SourceUnit.UnitData in the GitHub Source

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -129,6 +130,12 @@ type unitEnvelope struct {
 func (u unitEnvelope) SourceUnitID() (string, sources.SourceUnitKind) { return u.ID, u.Kind }
 func (u unitEnvelope) Display() string                                { return u.Name }
 
+func decodeBase64(data []byte) ([]byte, error) {
+	out := make([]byte, base64.StdEncoding.DecodedLen(len(data)))
+	n, err := base64.StdEncoding.Decode(out, data)
+	return out[:n], err
+}
+
 func unmarshalSourceUnit[unitType sources.SourceUnit](data []byte) (unitType, error) {
 	u := new(unitType)
 
@@ -164,12 +171,20 @@ func (s *Source) UnmarshalSourceUnit(data []byte) (sources.SourceUnit, error) {
 		return env, nil
 	case "repo":
 		if len(env.UnitData) > 0 {
-			return unmarshalSourceUnit[RepoUnit](env.UnitData)
+			decodedData, err := decodeBase64(env.UnitData)
+			if err != nil {
+				return nil, fmt.Errorf("error decoding repo unit data: %w", err)
+			}
+			return unmarshalSourceUnit[RepoUnit](decodedData)
 		}
 		return RepoUnit{Name: env.Name, URL: env.ID}, nil
 	case "gist":
+		decodedData, err := decodeBase64(env.UnitData)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding gist unit data: %w", err)
+		}
 		if len(env.UnitData) > 0 {
-			return unmarshalSourceUnit[GistUnit](env.UnitData)
+			return unmarshalSourceUnit[GistUnit](decodedData)
 		}
 		return GistUnit{Name: env.Name, URL: env.ID}, nil
 	default:

--- a/pkg/sources/github/map_installations_test.go
+++ b/pkg/sources/github/map_installations_test.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
@@ -23,6 +24,9 @@ func newMarshalledRepoUnit(t *testing.T, su sources.SourceUnit) []byte {
 
 	unitData, err := json.Marshal(su)
 	require.NoError(t, err)
+
+	// [CG] This additional base64 encoding mimics the pipeline's behavior
+	unitData = []byte(base64.StdEncoding.EncodeToString(unitData))
 
 	out, err := json.Marshal(map[string]any{
 		"id":        id,


### PR DESCRIPTION
In the pipeline, we run SourceUnit.UnitData through another round of `json.Marshal`, which encodes it with base64 as it's bytes. This means that we have to de-base64 it when we pull it back out.