### PR TITLE
[chore] Correct NewWebhookCustomRegex doc comment

### DIFF
--- a/pkg/custom_detectors/custom_detectors.go
+++ b/pkg/custom_detectors/custom_detectors.go
@@ -37,9 +37,7 @@ var _ detectors.Detector = (*CustomRegexWebhook)(nil)
 var _ detectors.CustomFalsePositiveChecker = (*CustomRegexWebhook)(nil)
 var _ detectors.MaxSecretSizeProvider = (*CustomRegexWebhook)(nil)
 
-// NewWebhookCustomRegex initializes and validates a CustomRegexWebhook. An
-// unexported type is intentionally returned here to ensure the values have
-// been validated.
+// NewWebhookCustomRegex initializes and validates a CustomRegexWebhook.
 func NewWebhookCustomRegex(pb *custom_detectorspb.CustomRegex) (*CustomRegexWebhook, error) {
 	// TODO: Return all validation errors.
 	if err := ValidateKeywords(pb.Keywords); err != nil {


### PR DESCRIPTION

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
An unexported type is no longer returned from this function.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no effect on code paths or public contracts beyond corrected comments.
> 
> **Overview**
> Updates the godoc on **`NewWebhookCustomRegex`** so it no longer claims the function returns an unexported type for validation encapsulation.
> 
> The comment now only states that the constructor initializes and validates a **`CustomRegexWebhook`**, which matches the actual exported return type **`(*CustomRegexWebhook, error)`**. No runtime or API behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c9683c9bfeca69fb814327bd1afda6b4e2c1bfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->