### PR TITLE
Update link to Truffle Security documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ The regex detectors can be used with any subcommand, while the sources defined
 in configuration are only for the `multi-scan` subcommand.
 
 The configuration format for sources can be found on Truffle Security's
-[source configuration documentation page](https://docs.trufflesecurity.com/scan-data-for-secrets).
+[source configuration documentation page](https://trufflesecurity.com/docs/connect-sources).
 
 Example GitHub source configuration and [options reference](https://docs.trufflesecurity.com/github#Fvm1I):
 


### PR DESCRIPTION
Updates the stale documentation link.

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [ ] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only hyperlink change with no runtime or security impact.
> 
> **Overview**
> Updates the **Configuration** section link for multi-scan source configuration docs from the old `docs.trufflesecurity.com/scan-data-for-secrets` URL to **`https://trufflesecurity.com/docs/connect-sources`**, so readers land on the current connect-sources documentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 164aba144e29ff609020f19e5e05df8b3228f6f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->