### PR TITLE
Low-memory Git Scanning

### DIFF
--- a/main.go
+++ b/main.go
@@ -91,6 +91,7 @@ var (
 	forceSkipBinaries        = cli.Flag("force-skip-binaries", "Force skipping binaries.").Bool()
 	forceSkipArchives        = cli.Flag("force-skip-archives", "Force skipping archives.").Bool()
 	gitCloneTimeout          = cli.Flag("git-clone-timeout", "Maximum time to spend cloning a repository, as a duration.").Hidden().Duration()
+	gitLowMemoryScan         = cli.Flag("git-low-memory-scan", "Reduce memory use for git scanning.").Hidden().Bool()
 	skipAdditionalRefs       = cli.Flag("skip-additional-refs", "Skip additional references.").Bool()
 	userAgentSuffix          = cli.Flag("user-agent-suffix", "Suffix to add to User-Agent.").String()
 	dropUnverifiedJWTResults = cli.Flag("drop-unverified-jwt-results", "Drop unverified results without any verification errors from the JWT detector.").Bool()
@@ -516,6 +517,10 @@ func run(state overseer.State, logSync func() error) {
 
 	if gitCloneTimeout != nil {
 		feature.GitCloneTimeoutDuration.Store(int64(*gitCloneTimeout))
+	}
+
+	if *gitLowMemoryScan {
+		feature.UseGitLowMemoryScan.Store(true)
 	}
 
 	if *skipAdditionalRefs {

--- a/pkg/feature/feature.go
+++ b/pkg/feature/feature.go
@@ -13,6 +13,7 @@ var (
 	UserAgentSuffix                          AtomicString
 	UseSimplifiedGitlabEnumeration           atomic.Bool
 	UseGitMirror                             atomic.Bool
+	UseGitLowMemoryScan                      atomic.Bool
 	GitlabProjectsPerPage                    atomic.Int64
 	UseGithubGraphQLAPI                      atomic.Bool // use github graphql api to fetch issues, pr's and comments
 	HTMLDecoderEnabled                       atomic.Bool

--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -3,11 +3,13 @@ package gitparse
 import (
 	"bufio"
 	"bytes"
+	"cmp"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -233,8 +235,17 @@ func NewParser(options ...Option) *Parser {
 	return parser
 }
 
+type gitArgs struct {
+	env    []string
+	global []string
+	log    []string
+	show   []string
+	paths  []string
+}
+
 // RepoPath parses the output of the `git log` command for the `source` path.
-// The Diff chan will return diffs in the order they are parsed from the log.
+// The Diff chan will return diffs in the order they are parsed from the log,
+// though the diffs are generated using `git show` in groups.
 func (c *Parser) RepoPath(
 	ctx context.Context,
 	source string,
@@ -242,51 +253,151 @@ func (c *Parser) RepoPath(
 	abbreviatedLog bool,
 	excludedGlobs []string,
 	isBare bool,
-	additionalArgs ...string,
 ) (chan *Diff, error) {
-	args := []string{
-		"-C", source,
-		"log",
-		"--patch", // https://git-scm.com/docs/git-log#Documentation/git-log.txt---patch
-		"--full-history",
-		"--date=iso-strict",
-		"--pretty=fuller", // https://git-scm.com/docs/git-log#_pretty_formats
-		"--notes",         // https://git-scm.com/docs/git-log#Documentation/git-log.txt---notesltrefgt
-	}
-	if abbreviatedLog {
-		args = append(args, "--diff-filter=AM")
-	}
-	if head != "" {
-		args = append(args, head)
-	} else {
-		args = append(args, "--all")
-	}
-	args = append(args, additionalArgs...) // These need to come before --
-	for _, glob := range excludedGlobs {
-		args = append(args, "--", ".", ":(exclude)"+glob)
+	const abbrevCommit = 20
+	const showGroupSize = 75
+	// Windows has a command length limit of 32767, so at these values we
+	// should only be using a tiny part of of that for the commit list
+	// ((abbrevCommit + 1) * showGroupSize).  We don't target any platforms
+	// with shorter limits.
+
+	args := c.prepGitArgs(source, abbrevCommit, head, abbreviatedLog, excludedGlobs, isBare)
+
+	allCommits, err := c.gatherGitLog(ctx, args)
+	if err != nil {
+		return nil, err
 	}
 
-	cmd := exec.CommandContext(ctx, "git", args...)
-	absPath, err := filepath.Abs(source)
-	if err == nil {
-		if !isBare {
-			cmd.Env = append(cmd.Env, "GIT_DIR="+filepath.Join(absPath, ".git"))
-		} else {
-			cmd.Env = append(cmd.Env,
-				"GIT_DIR="+absPath,
+	// c.executeCommand returns a channel that is later closed by a
+	// different goroutine after the command finishes, but we're not
+	// running a single command anymore. we'll use a channel of channels to
+	// reduce back to one channel we return to our caller.  Unbuffered so
+	// we have at most one git show running and one git show draining.
+	groupchan := make(chan chan *Diff)
+	go func() {
+		defer common.RecoverWithExit(ctx)
+		defer close(groupchan)
+
+		for group := range slices.Chunk(allCommits, showGroupSize) {
+			if common.IsDone(ctx) {
+				return
+			}
+
+			showCmd := exec.CommandContext(ctx,
+				"git",
+				slices.Concat(args.global, []string{"show"}, args.show, group, args.paths)...,
 			)
-			// We need those variables to handle incoming commits
-			// while using trufflehog in pre-receive hooks
-			if dir := os.Getenv("GIT_OBJECT_DIRECTORY"); dir != "" {
-				cmd.Env = append(cmd.Env, "GIT_OBJECT_DIRECTORY="+dir)
+			showCmd.Env = args.env
+
+			diffGroup, err := c.executeCommand(ctx, showCmd, false)
+			if err != nil {
+				ctx.Logger().Error(err, "Error executing git show for commit group.")
+				return
 			}
-			if dir := os.Getenv("GIT_ALTERNATE_OBJECT_DIRECTORIES"); dir != "" {
-				cmd.Env = append(cmd.Env, "GIT_ALTERNATE_OBJECT_DIRECTORIES="+dir)
+			groupchan <- groupdiffs
+		}
+	}()
+
+	// and this is the single channel we're responsible for returning and
+	// closing.
+	diffChan := make(chan *Diff)
+	go func() {
+		defer common.RecoverWithExit(ctx)
+		defer close(diffChan)
+
+		for groupdiffs := range groupchan {
+			for diff := range groupdiffs {
+				err = common.CancellableWrite(ctx, diffChan, diff)
+				if err != nil {
+					return // context cancel
+				}
 			}
+		}
+	}()
+
+	return diffChan, nil
+}
+
+// Ask git for a list of all relevant commit hashes but only hashes.  Git takes
+// on the work of linearizing history for us, then we work through the commit
+// list.
+func (c *Parser) gatherGitLog(ctx context.Context, args gitArgs) ([]string, error) {
+	cmd := exec.CommandContext(ctx, "git", slices.Concat(args.global, []string{"log"}, args.log)...)
+	cmd.WaitDelay = c.waitDelay
+	cmd.Env = args.env
+
+	commitLog, err := cmd.Output()
+	if err != nil {
+		if e, ok := err.(*exec.ExitError); ok {
+			ctx.Logger().V(2).Info(string(e.Stderr))
+		}
+		return nil, fmt.Errorf("failed to execute git log: %w", err)
+	}
+	return strings.Split(string(commitLog), "\n"), nil
+}
+
+func (c *Parser) prepGitArgs(source string, head string, abbreviatedLog bool, excludedGlobs []string, isBare bool) gitArgs {
+	args := gitArgs{
+		global: []string{
+			"-C", source,
+		},
+		log: []string{
+			// https://git-scm.com/docs/git-log#Documentation/git-log.txt---full-history
+			"--full-history",
+			// https://git-scm.com/docs/git-log#_pretty_formats
+			"--pretty=format:%h",
+			// https://git-scm.com/docs/git-log#Documentation/git-log.txt---abbrevn
+			fmt.Sprintf("--abbrev=%d", abbrevCommit),
+		},
+		show: []string{
+			// https://git-scm.com/docs/git-show#Documentation/git-show.txt---patch
+			"--patch",
+			// https://git-scm.com/docs/git-log#Documentation/git-log.txt---dateformat
+			"--date=iso-strict",
+			// https://git-scm.com/docs/git-show#_pretty_formats
+			"--pretty=fuller",
+			// https://git-scm.com/docs/git-show#Documentation/git-show.txt---notesref
+			"--notes",
+		},
+		paths: []string{},
+	}
+
+	if abbreviatedLog {
+		// https://git-scm.com/docs/git-show#Documentation/git-show.txt---diff-filterACDMRTUXB
+		args.log = append(args.log, "--diff-filter=AM")
+		args.show = append(args.show, "--diff-filter=AM")
+	}
+
+	// Keep head or all last, before the --, not required but sensible
+	// https://git-scm.com/docs/git-log#Documentation/git-log.txt---all
+	args.log = append(args.log, cmp.Or(head, "--all"))
+
+	// And then potentially add -- to args here
+	if len(excludedGlobs) != 0 {
+		args.paths = []string{"--", "."}
+		for _, glob := range excludedGlobs {
+			// This is not directly doc'd but added in git 1.9.0 and found in pathspec.c
+			args.paths = append(args.paths, ":(exclude)"+glob)
 		}
 	}
 
-	return c.executeCommand(ctx, cmd, false, c.waitDelay)
+	absPath, err := filepath.Abs(source)
+	if err == nil {
+		if !isBare {
+			args.env = append(args.env, "GIT_DIR="+filepath.Join(absPath, ".git"))
+		} else {
+			args.env = append(args.env, "GIT_DIR="+absPath)
+			// We need those variables to handle incoming commits
+			// while using trufflehog in pre-receive hooks
+			if dir := os.Getenv("GIT_OBJECT_DIRECTORY"); dir != "" {
+				args.env = append(args.env, "GIT_OBJECT_DIRECTORY="+dir)
+			}
+			if dir := os.Getenv("GIT_ALTERNATE_OBJECT_DIRECTORIES"); dir != "" {
+				args.env = append(args.env, "GIT_ALTERNATE_OBJECT_DIRECTORIES="+dir)
+			}
+		}
+	}
+	return args
 }
 
 // Staged parses the output of the `git diff` command for the `source` path.
@@ -301,29 +412,29 @@ func (c *Parser) Staged(ctx context.Context, source string) (chan *Diff, error) 
 		cmd.Env = append(cmd.Env, "GIT_DIR="+filepath.Join(absPath, ".git"))
 	}
 
-	return c.executeCommand(ctx, cmd, true, c.waitDelay)
+	return c.executeCommand(ctx, cmd, true)
 }
 
 // executeCommand runs an exec.Cmd, reads stdout and stderr, and waits for the Cmd to complete.
 // waitDelay specifies how long to wait after context cancellation before forcefully killing the process.
-func (c *Parser) executeCommand(ctx context.Context, cmd *exec.Cmd, isStaged bool, waitDelay time.Duration) (chan *Diff, error) {
+func (c *Parser) executeCommand(ctx context.Context, cmd *exec.Cmd, isStaged bool) (chan *Diff, error) {
 	diffChan := make(chan *Diff, 64)
 
 	stdOut, err := cmd.StdoutPipe()
 	if err != nil {
-		return diffChan, err
+		return nil, err
 	}
 	stdErr, err := cmd.StderrPipe()
 	if err != nil {
-		return diffChan, err
+		return nil, err
 	}
 
 	// Set WaitDelay to allow the command additional time to exit after context cancellation
-	cmd.WaitDelay = waitDelay
+	cmd.WaitDelay = c.waitDelay
 
 	err = cmd.Start()
 	if err != nil {
-		return diffChan, err
+		return nil, err
 	}
 
 	go func() {
@@ -355,7 +466,7 @@ func (c *Parser) FromReader(ctx context.Context, stdOut io.Reader, diffChan chan
 
 		totalLogSize int
 	)
-	var latestState = Initial
+	latestState := Initial
 
 	diff := func(c *Commit, opts ...diffOption) *Diff {
 		opts = append(opts, withCustomContentWriter(bufferwriter.New()))

--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -263,7 +263,7 @@ func (c *Parser) RepoPath(
 
 	args := c.prepGitArgs(source, abbrevCommit, head, abbreviatedLog, excludedGlobs, isBare)
 
-	allCommits, err := c.gatherGitLog(ctx, args)
+	commitGroups, err := c.gatherGitLog(ctx, args, showGroupSize)
 	if err != nil {
 		return nil, err
 	}
@@ -273,12 +273,12 @@ func (c *Parser) RepoPath(
 	// running a single command anymore. we'll use a channel of channels to
 	// reduce back to one channel we return to our caller.  Unbuffered so
 	// we have at most one git show running and one git show draining.
-	groupchan := make(chan chan *Diff)
+	diffGroups := make(chan chan *Diff)
 	go func() {
 		defer common.RecoverWithExit(ctx)
-		defer close(groupchan)
+		defer close(diffGroups)
 
-		for group := range slices.Chunk(allCommits, showGroupSize) {
+		for group := range commitGroups {
 			if common.IsDone(ctx) {
 				return
 			}
@@ -294,7 +294,11 @@ func (c *Parser) RepoPath(
 				ctx.Logger().Error(err, "Error executing git show for commit group.")
 				return
 			}
-			groupchan <- groupdiffs
+			err = common.CancellableWrite(ctx, diffGroups, diffGroup)
+			if err != nil {
+				ctx.Logger().Error(err, "git show interation cancelled")
+				return
+			}
 		}
 	}()
 
@@ -305,7 +309,8 @@ func (c *Parser) RepoPath(
 		defer common.RecoverWithExit(ctx)
 		defer close(diffChan)
 
-		for groupdiffs := range groupchan {
+		var err error
+		for groupdiffs := range diffGroups {
 			for diff := range groupdiffs {
 				err = common.CancellableWrite(ctx, diffChan, diff)
 				if err != nil {
@@ -320,20 +325,63 @@ func (c *Parser) RepoPath(
 
 // Ask git for a list of all relevant commit hashes but only hashes.  Git takes
 // on the work of linearizing history for us, then we work through the commit
-// list.
-func (c *Parser) gatherGitLog(ctx context.Context, args gitArgs) ([]string, error) {
+// list.  Returns a channel of groups of commit IDs, so scanning can start asap
+// even if git log is taking a bit for large repos.
+func (c *Parser) gatherGitLog(ctx context.Context, args gitArgs, showGroupSize int) (chan []string, error) {
 	cmd := exec.CommandContext(ctx, "git", slices.Concat(args.global, []string{"log"}, args.log)...)
 	cmd.WaitDelay = c.waitDelay
 	cmd.Env = args.env
 
-	commitLog, err := cmd.Output()
+	stdOut, err := cmd.StdoutPipe()
 	if err != nil {
-		if e, ok := err.(*exec.ExitError); ok {
-			ctx.Logger().V(2).Info(string(e.Stderr))
-		}
+		return nil, err
+	}
+
+	err = cmd.Start()
+	if err != nil {
 		return nil, fmt.Errorf("failed to execute git log: %w", err)
 	}
-	return strings.Split(string(commitLog), "\n"), nil
+
+	commitGroups := make(chan []string)
+	go func() {
+		defer close(commitGroups)
+		defer func() {
+			err := cmd.Wait()
+			if err != nil {
+				ctx.Logger().Error(err, "git log exited with error", "stderr", cmd.Stderr)
+			}
+		}()
+
+		s := bufio.NewScanner(stdOut)
+		commitGroup := make([]string, 0, showGroupSize)
+
+		var err error
+		for s.Scan() && !common.IsDone(ctx) {
+			commitGroup = append(commitGroup, s.Text())
+
+			if len(commitGroup) == showGroupSize {
+				err = common.CancellableWrite(ctx, commitGroups, commitGroup)
+				if err != nil {
+					ctx.Logger().Error(err, "git log stopping early")
+					return
+				}
+				commitGroup = make([]string, 0, showGroupSize)
+			}
+		}
+		if len(commitGroup) != 0 {
+			err = common.CancellableWrite(ctx, commitGroups, commitGroup)
+			if err != nil {
+				ctx.Logger().Error(err, "failed to flush last git log group")
+			}
+
+		}
+
+		if err := s.Err(); err != nil {
+			ctx.Logger().Error(err, "error reading git log")
+		}
+	}()
+
+	return commitGroups, nil
 }
 
 func (c *Parser) prepGitArgs(source string, head string, abbreviatedLog bool, excludedGlobs []string, isBare bool) gitArgs {

--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -35,6 +35,14 @@ const (
 
 	// defaultWaitDelay is the default time to wait after context cancellation before forcefully killing git processes.
 	defaultWaitDelay = 5 * time.Second
+
+	// abbrevCommit is the git sha abbreviation length to use for `git show` invocations in the lower-memory scan mode.
+	abbrevCommit = 20
+
+	// showGroupSize is the number of commits per `git show` in the lower-memory scan mode.
+	//
+	// Windows has a command length limit of 32767, so at these values we should only be using a tiny part of of that for the commit list ((abbrevCommit + 1) * showGroupSize).  We don't target any platforms with shorter limits.
+	showGroupSize = 75
 )
 
 // contentWriter defines a common interface for writing, reading, and managing diff content.
@@ -132,6 +140,7 @@ type Parser struct {
 	waitDelay     time.Duration
 
 	useCustomContentWriter bool
+	lowMemoryScan          bool
 }
 
 type ParseState int
@@ -191,6 +200,13 @@ func (state ParseState) String() string {
 // UseCustomContentWriter sets useCustomContentWriter option.
 func UseCustomContentWriter() Option {
 	return func(parser *Parser) { parser.useCustomContentWriter = true }
+}
+
+// UseLowMemoryScan sets the scan to optimize for limited memory at the cost of speed (currently up to 9%)
+func UseLowMemoryScan() Option {
+	return func(parser *Parser) {
+		parser.lowMemoryScan = true
+	}
 }
 
 // WithMaxDiffSize sets maxDiffSize option. Diffs larger than maxDiffSize will
@@ -254,16 +270,23 @@ func (c *Parser) RepoPath(
 	excludedGlobs []string,
 	isBare bool,
 ) (chan *Diff, error) {
-	const abbrevCommit = 20
-	const showGroupSize = 75
-	// Windows has a command length limit of 32767, so at these values we
-	// should only be using a tiny part of of that for the commit list
-	// ((abbrevCommit + 1) * showGroupSize).  We don't target any platforms
-	// with shorter limits.
+	args := c.prepGitArgs(source, head, abbreviatedLog, excludedGlobs, isBare)
 
-	args := c.prepGitArgs(source, abbrevCommit, head, abbreviatedLog, excludedGlobs, isBare)
+	if c.lowMemoryScan {
+		return c.repoPathLowMemory(ctx, args)
+	}
 
-	commitGroups, err := c.gatherGitLog(ctx, args, showGroupSize)
+	showCmd := exec.CommandContext(ctx,
+		"git",
+		slices.Concat(args.global, []string{"log"}, args.show, args.log, args.paths)...,
+	)
+	showCmd.Env = args.env
+
+	return c.executeCommand(ctx, showCmd, false)
+}
+
+func (c *Parser) repoPathLowMemory(ctx context.Context, args gitArgs) (chan *Diff, error) {
+	commitGroups, err := c.gatherGitLog(ctx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -327,8 +350,18 @@ func (c *Parser) RepoPath(
 // on the work of linearizing history for us, then we work through the commit
 // list.  Returns a channel of groups of commit IDs, so scanning can start asap
 // even if git log is taking a bit for large repos.
-func (c *Parser) gatherGitLog(ctx context.Context, args gitArgs, showGroupSize int) (chan []string, error) {
-	cmd := exec.CommandContext(ctx, "git", slices.Concat(args.global, []string{"log"}, args.log)...)
+func (c *Parser) gatherGitLog(ctx context.Context, args gitArgs) (chan []string, error) {
+	cmd := exec.CommandContext(ctx,
+		"git", slices.Concat(
+			args.global, []string{"log"},
+			args.log, []string{
+				// https://git-scm.com/docs/git-log#_pretty_formats
+				"--pretty=format:%h",
+				// https://git-scm.com/docs/git-log#Documentation/git-log.txt---abbrevn
+				fmt.Sprintf("--abbrev=%d", abbrevCommit),
+			},
+			args.paths,
+		)...)
 	cmd.WaitDelay = c.waitDelay
 	cmd.Env = args.env
 
@@ -392,10 +425,6 @@ func (c *Parser) prepGitArgs(source string, head string, abbreviatedLog bool, ex
 		log: []string{
 			// https://git-scm.com/docs/git-log#Documentation/git-log.txt---full-history
 			"--full-history",
-			// https://git-scm.com/docs/git-log#_pretty_formats
-			"--pretty=format:%h",
-			// https://git-scm.com/docs/git-log#Documentation/git-log.txt---abbrevn
-			fmt.Sprintf("--abbrev=%d", abbrevCommit),
 		},
 		show: []string{
 			// https://git-scm.com/docs/git-show#Documentation/git-show.txt---patch

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -27,7 +27,6 @@ func TestPrepGitArgs(t *testing.T) {
 
 	args := p.prepGitArgs(repopath, "", false, nil, false)
 	assert.Equal(t, []string{"-C", repopath}, args.global)
-	assert.Contains(t, args.log, "--abbrev=12")
 	assert.Contains(t, args.log, "--all")
 	assert.NotContains(t, args.log, "--diff-filter=AM")
 	assert.Equal(t, []string{"GIT_DIR=" + filepath.Join(repopath, ".git")}, args.env)

--- a/pkg/gitparse/gitparse_test.go
+++ b/pkg/gitparse/gitparse_test.go
@@ -2,6 +2,7 @@ package gitparse
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,46 @@ import (
 	bufferwriter "github.com/trufflesecurity/trufflehog/v3/pkg/writers/buffer_writer"
 	bufferedfilewriter "github.com/trufflesecurity/trufflehog/v3/pkg/writers/buffered_file_writer"
 )
+
+func TestPrepGitArgs(t *testing.T) {
+	t.Setenv("GIT_OBJECT_DIRECTORY", "")
+	t.Setenv("GIT_ALTERNATE_OBJECT_DIRECTORIES", "")
+	repopath := t.TempDir()
+
+	p := Parser{}
+
+	args := p.prepGitArgs(repopath, "", false, nil, false)
+	assert.Equal(t, []string{"-C", repopath}, args.global)
+	assert.Contains(t, args.log, "--abbrev=12")
+	assert.Contains(t, args.log, "--all")
+	assert.NotContains(t, args.log, "--diff-filter=AM")
+	assert.Equal(t, []string{"GIT_DIR=" + filepath.Join(repopath, ".git")}, args.env)
+	assert.Empty(t, args.paths)
+
+	args = p.prepGitArgs(repopath, "branchname", true, []string{"some/file.txt", "bloated.dat"}, true)
+	// head
+	assert.Contains(t, args.log, "branchname")
+	assert.NotContains(t, args.log, "--all")
+	// abbreviatedLog
+	assert.Contains(t, args.log, "--diff-filter=AM")
+	assert.Contains(t, args.show, "--diff-filter=AM")
+	// excludedGlobs
+	assert.Contains(t, args.paths, "--")
+	assert.Contains(t, args.paths, ":(exclude)bloated.dat")
+	// isBare
+	assert.Equal(t, []string{"GIT_DIR=" + repopath}, args.env)
+
+	// test env passthrough used for pre-receive
+	t.Setenv("GIT_OBJECT_DIRECTORY", "foo")
+	t.Setenv("GIT_ALTERNATE_OBJECT_DIRECTORIES", "bar")
+
+	args = p.prepGitArgs(repopath, "", false, nil, true)
+	assert.Equal(t, []string{
+		"GIT_DIR=" + repopath,
+		"GIT_OBJECT_DIRECTORY=foo",
+		"GIT_ALTERNATE_OBJECT_DIRECTORIES=bar",
+	}, args.env)
+}
 
 type testCaseLine struct {
 	latestState ParseState
@@ -750,7 +791,6 @@ func TestToFileLinePathParse(t *testing.T) {
 // `asserts` on `Diff`'s _structure_, giving better test output than just comparing two
 // diffs.
 func assertDiffEqualToExpected(t *testing.T, expected *Diff, actual *Diff) {
-
 	// Use `cmp.Diff` to automatically compare all the exported fields.  This allows this test to grow automatically if
 	// new exported fields are added to these structs.  However, the most important field we want to test is unexpected
 	// (i.e. contentWriter) which is where the actual content of the diff is stored.  We break this out next.
@@ -1476,8 +1516,8 @@ func TestMaxCommitSize(t *testing.T) {
 	if diffCount != 2 {
 		t.Errorf("Commit count does not match. Got: %d, expected: %d", diffCount, 2)
 	}
-
 }
+
 func TestWaitDelay(t *testing.T) {
 	// Test that WithWaitDelay sets the waitDelay correctly
 	customDelay := 10 * time.Second

--- a/pkg/sources/git/git.go
+++ b/pkg/sources/git/git.go
@@ -127,11 +127,12 @@ type Config struct {
 // NewGit creates a new Git instance with the provided configuration. The Git instance is used to interact with
 // Git repositories.
 func NewGit(config *Config) *Git {
-	var parser *gitparse.Parser
+	parserOpts := []gitparse.Option{}
 	if config.UseCustomContentWriter {
-		parser = gitparse.NewParser(gitparse.UseCustomContentWriter())
-	} else {
-		parser = gitparse.NewParser()
+		parserOpts = append(parserOpts, gitparse.UseCustomContentWriter())
+	}
+	if feature.UseGitLowMemoryScan.Load() {
+		parserOpts = append(parserOpts, gitparse.UseLowMemoryScan())
 	}
 
 	return &Git{
@@ -145,7 +146,7 @@ func NewGit(config *Config) *Git {
 		concurrency:        semaphore.NewWeighted(int64(config.Concurrency)),
 		skipBinaries:       config.SkipBinaries,
 		skipArchives:       config.SkipArchives,
-		parser:             parser,
+		parser:             gitparse.NewParser(parserOpts...),
 	}
 }
 

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -1545,3 +1545,49 @@ func TestGitChunk_LongLine(t *testing.T) {
 	// one chunk for the commit/file metadata, and at least one chunk for the file content
 	assert.Equal(t, 2, count, "expected two chunks from a file with a 100 KB line")
 }
+
+func TestGitLowMemoryScan(t *testing.T) {
+	feature.UseGitLowMemoryScan.Store(true)
+	t.Cleanup(func() { feature.UseGitLowMemoryScan.Store(false) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	thisrepo := &sourcespb.Git{
+		Directories: []string{"../../../"},
+		Credential: &sourcespb.Git_Unauthenticated{
+			Unauthenticated: &credentialspb.Unauthenticated{},
+		},
+	}
+	wantChunk := &sources.Chunk{
+		SourceType:   sourcespb.SourceType_SOURCE_TYPE_GIT,
+		SourceName:   "this repo, low memory",
+		SourceVerify: false,
+	}
+
+	s := Source{}
+	conn, err := anypb.New(thisrepo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = s.Init(ctx, "this repo, low memory", 0, 0, false, conn, 1)
+	if err != nil {
+		t.Errorf("Source.Init() error = %v", err)
+		return
+	}
+
+	chunksCh := make(chan *sources.Chunk, 1)
+	go func() {
+		assert.NoError(t, s.Chunks(ctx, chunksCh))
+	}()
+
+	gotChunk := <-chunksCh
+	gotChunk.Data = nil
+	// Commits don't come in a deterministic order, so remove metadata comparison
+	gotChunk.SourceMetadata = nil
+	if diff := pretty.Compare(gotChunk, wantChunk); diff != "" {
+		t.Errorf("Source.Chunks() UseGitLowMemoryScan diff: (-got +want)\n%s", diff)
+		t.Errorf("Data: %s", string(gotChunk.Data))
+	}
+}


### PR DESCRIPTION
### Description:
This PR adds an alternate mode to git scanning which significantly reduces the peak memory usage for a given repo, for a small trade in speed.  Currently a single `git log` command is run on a repo, listing all history and patches, and this git process's peak RSS always increases with repo size, so very large repos can reach high peak memory use that is hard to plan for in containers and quotas, especially with concurrency and with other repos of different sizes.

Instead, with this mode, we'd still lean on git to deal with the repo, but we split into a `git log` that orders the commit graph and returns only IDs, and then we use `git show` to get those in patch form, in batches.  Peak memory usage with this change will still depend a bit on the specific repo, but it is more tied to the size of the largest commit in the repo rather than that _and_ the total length of the commit history.

I ran a series of tests on repos of different sizes to 1) ensure there's no loss of coverage and 2) gather time and memory numbers to judge a good batch size.

I can share full data but this is the short version.  The repos listed are ~2k, ~12k, ~250k, and ~1M commits in size. 

Max RSS (mb)
|           | base   | branch | change  | %    |
|-----------|-------:|-------:|--------:|-----:|
| watchexec | 54.4   | 25.8   | -28.6   | -53% |
| thog      | 1292.0 | 416.6  | -875.3  | -68% |
| rust      | 2346.7 | 688.0  | -1658.7 | -71% |
| firefox   | 7438.2 | 1431.9 | -6006.2 | -80% |

Total Run Time (s)
|           | base   | branch | change | %
|-----------|-------:|-------:|-------:|-----:|
| watchexec | 1.1    | 1.2    | 0.1    | 9%   | 
| thog      | 30.1   | 32.9   | 2.8    | 9%   |
| rust      | 352.4  | 327.1  | -25.3  | -7%  |
| firefox   | 2855.2 | 3029.2 | 174.0  | 6%   |

So, peak memory use is always smaller, but there's generally a slowdown, though it's not guaranteed.  The rust repo consistently ran faster with this branch, and at all reasonable batch sizes.

There may also may be some time that can be won back by changing the channel pattern here but I did test a few other options already.  I can also confirm there doesn't seem to be much value in parallelizing the `git show` commands (they are intentionally slightly _pipelined_ but not remarkably parallel here) - as you'd lose some of the memory benefit and the reader consuming `*Diff`s becomes a bottleneck.  If it can be improved enough later, maybe it doesn't need to be an alternate mode.

This mode is currently controlled by a hidden feature flag so we can give it further exercise or optimization.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how git history is fetched and parsed on an opt-in path; bugs could affect scan completeness or ordering, though default behavior is unchanged.
> 
> **Overview**
> Adds an optional **low-memory git scan** path controlled by the hidden `--git-low-memory-scan` flag (wired to `feature.UseGitLowMemoryScan`).
> 
> When enabled, repo history is no longer streamed from a single `git log --patch`. The parser first runs `git log` for commit hashes only, batches them (75 commits per group), then fetches patches with grouped `git show` calls and merges the results back into one diff channel—aiming to cap peak memory closer to large commits than total history length, at some runtime cost.
> 
> Git argument construction is centralized in `prepGitArgs`, and `RepoPath`/`executeCommand` are refactored accordingly (including using the parser’s `waitDelay` and returning errors on pipe setup failures). The git source enables `gitparse.UseLowMemoryScan()` when the feature flag is on. Tests cover `prepGitArgs` and an integration-style low-memory scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bee83532499af21f3dd6d47151f12666aa6ea390. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->