### PR TITLE
Int 595 verify asymmetry

### DIFF
--- a/pkg/detectors/algoliaadminkey/algoliaadminkey.go
+++ b/pkg/detectors/algoliaadminkey/algoliaadminkey.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"slices"
 	"strings"
@@ -68,12 +69,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 	// Test matches.
 	for key := range keyMatches {
 		for id := range idMatches {
-			if invalidHosts.Exists(id) {
-				logger.V(3).Info("Skipping application id: no such host", "host", id)
-				delete(idMatches, id)
-				continue
-			}
-
 			r := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_AlgoliaAdminKey,
 				Raw:          []byte(key),
@@ -85,17 +80,26 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				// Verify if the key is a valid Algolia Admin Key.
-				isVerified, extraData, verificationErr := verifyMatch(ctx, id, key)
-				r.Verified = isVerified
-				r.ExtraData = extraData
-				if verificationErr != nil {
-					if errors.Is(verificationErr, errNoHost) {
-						invalidHosts.Set(id, struct{}{})
-						continue
-					}
+				if invalidHosts.Exists(id) {
+					// An earlier candidate already proved this host does not resolve, so the lookup is
+					// skipped. The finding is still reported: dropping it here would make the reported
+					// secrets depend on whether verification was requested, and on the order in which
+					// candidates happened to be processed.
+					logger.V(3).Info("Skipping application id: no such host", "host", id)
+					r.SetVerificationError(errNoHost, key)
+				} else {
+					// Verify if the key is a valid Algolia Admin Key.
+					isVerified, extraData, verificationErr := verifyMatch(ctx, id, key)
+					r.Verified = isVerified
+					r.ExtraData = extraData
+					if verificationErr != nil {
+						var dnsErr *net.DNSError
+						if errors.As(verificationErr, &dnsErr) && dnsErr.IsNotFound {
+							invalidHosts.Set(id, struct{}{})
+						}
 
-					r.SetVerificationError(verificationErr, key)
+						r.SetVerificationError(verificationErr, key)
+					}
 				}
 			}
 
@@ -127,11 +131,6 @@ func verifyMatch(ctx context.Context, appId, apiKey string) (bool, map[string]st
 
 	res, err := client.Do(req)
 	if err != nil {
-		// lookup xyz.algolia.net: no such host
-		if strings.Contains(err.Error(), "no such host") {
-			return false, nil, errNoHost
-		}
-
 		return false, nil, err
 	}
 	defer func() {

--- a/pkg/detectors/artifactory/artifactory.go
+++ b/pkg/detectors/artifactory/artifactory.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 
@@ -77,11 +78,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for token := range uniqueTokens {
 		for url := range uniqueUrls {
-			if invalidHosts.Exists(url) {
-				delete(uniqueUrls, url)
-				continue
-			}
-
 			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_ArtifactoryAccessToken,
 				Raw:          []byte(token),
@@ -93,15 +89,23 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 			}
 
 			if verify {
-				isVerified, verificationErr := verifyArtifactory(ctx, s.getClient(), url, token)
-				s1.Verified = isVerified
-				if verificationErr != nil {
-					if errors.Is(verificationErr, errNoHost) {
-						invalidHosts.Set(url, struct{}{})
-						continue
-					}
+				if invalidHosts.Exists(url) {
+					// An earlier candidate already proved this host does not resolve, so the lookup is
+					// skipped. The finding is still reported: dropping it here would make the reported
+					// secrets depend on whether verification was requested, and on the order in which
+					// candidates happened to be processed.
+					s1.SetVerificationError(errNoHost, token)
+				} else {
+					isVerified, verificationErr := verifyArtifactory(ctx, s.getClient(), url, token)
+					s1.Verified = isVerified
+					if verificationErr != nil {
+						var dnsErr *net.DNSError
+						if errors.As(verificationErr, &dnsErr) && dnsErr.IsNotFound {
+							invalidHosts.Set(url, struct{}{})
+						}
 
-					s1.SetVerificationError(verificationErr, token)
+						s1.SetVerificationError(verificationErr, token)
+					}
 				}
 			}
 
@@ -123,11 +127,6 @@ func verifyArtifactory(ctx context.Context, client *http.Client, resURLMatch, re
 
 	resp, err := client.Do(req)
 	if err != nil {
-		// lookup foo.jfrog.io: no such host
-		if strings.Contains(err.Error(), "no such host") {
-			return false, errNoHost
-		}
-
 		return false, err
 	}
 

--- a/pkg/detectors/azure_cosmosdb/azure_cosmosdb.go
+++ b/pkg/detectors/azure_cosmosdb/azure_cosmosdb.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -74,11 +75,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 	for key := range uniqueKeyMatches {
 		for accountUrl := range uniqueAccountMatches {
-			if invalidHosts.Exists(accountUrl) {
-				delete(uniqueAccountMatches, accountUrl)
-				continue
-			}
-
 			s1 := detectors.Result{
 				DetectorType: detector_typepb.DetectorType_AzureCosmosDBKeyIdentifiable,
 				Raw:          []byte(key),
@@ -90,30 +86,43 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 				ExtraData: map[string]string{},
 			}
 
+			// The database type follows from the account URL alone, so it is recorded for every
+			// finding rather than only for the ones that reach a verification request.
+			if strings.Contains(accountUrl, ".documents.azure.com") {
+				s1.ExtraData["DB Type"] = "Document"
+			} else if strings.Contains(accountUrl, ".table.cosmos.azure.com") {
+				s1.ExtraData["DB Type"] = "Table"
+			}
+
 			if verify {
-				var verified bool
-				var verificationErr error
+				if invalidHosts.Exists(accountUrl) {
+					// An earlier candidate already proved this host does not resolve, so the lookup is
+					// skipped. The finding is still reported: dropping it here would make the reported
+					// secrets depend on whether verification was requested, and on the order in which
+					// candidates happened to be processed.
+					s1.SetVerificationError(errNoHost)
+				} else {
+					var verified bool
+					var verificationErr error
 
-				client := s.getClient()
+					client := s.getClient()
 
-				// perform verification based on db type
-				if strings.Contains(accountUrl, ".documents.azure.com") {
-					verified, verificationErr = verifyCosmosDocumentDB(client, accountUrl, key)
-					s1.ExtraData["DB Type"] = "Document"
-
-				} else if strings.Contains(accountUrl, ".table.cosmos.azure.com") {
-					verified, verificationErr = verifyCosmosTableDB(client, accountUrl, key)
-					s1.ExtraData["DB Type"] = "Table"
-				}
-
-				s1.Verified = verified
-				if verificationErr != nil {
-					if errors.Is(verificationErr, errNoHost) {
-						invalidHosts.Set(accountUrl, struct{}{})
-						continue
+					// perform verification based on db type
+					if strings.Contains(accountUrl, ".documents.azure.com") {
+						verified, verificationErr = verifyCosmosDocumentDB(client, accountUrl, key)
+					} else if strings.Contains(accountUrl, ".table.cosmos.azure.com") {
+						verified, verificationErr = verifyCosmosTableDB(client, accountUrl, key)
 					}
 
-					s1.SetVerificationError(verificationErr)
+					s1.Verified = verified
+					if verificationErr != nil {
+						var dnsErr *net.DNSError
+						if errors.As(verificationErr, &dnsErr) && dnsErr.IsNotFound {
+							invalidHosts.Set(accountUrl, struct{}{})
+						}
+
+						s1.SetVerificationError(verificationErr)
+					}
 				}
 			}
 
@@ -148,11 +157,6 @@ func verifyCosmosDocumentDB(client *http.Client, accountUrl, key string) (bool, 
 
 	resp, err := client.Do(req)
 	if err != nil {
-		// lookup foo.documents.azure.com: no such host
-		if strings.Contains(err.Error(), "no such host") {
-			return false, errNoHost
-		}
-
 		return false, err
 	}
 	defer func() {

--- a/pkg/detectors/azure_cosmosdb/table.go
+++ b/pkg/detectors/azure_cosmosdb/table.go
@@ -38,11 +38,6 @@ func verifyCosmosTableDB(client *http.Client, accountUrl, key string) (bool, err
 
 	resp, err := client.Do(req)
 	if err != nil {
-		// lookup foo.table.cosmos.azure.com: no such host
-		if strings.Contains(err.Error(), "no such host") {
-			return false, errNoHost
-		}
-
 		return false, err
 	}
 	defer func() {

--- a/pkg/detectors/azureapimanagement/repositorykey/repositorykey.go
+++ b/pkg/detectors/azureapimanagement/repositorykey/repositorykey.go
@@ -30,7 +30,7 @@ var (
 	passwordPat = regexp.MustCompile(detectors.PrefixRegex([]string{"azure", "password"}) + `\b(git&[0-9]{12}&[a-zA-Z0-9\/+]{85}[a-zA-Z0-9]==)`)
 
 	invalidHosts  = simple.NewCache[struct{}]()
-	errNoSuchHost = errors.New("could not resolve host")
+	errNoSuchHost = errors.New("no such host")
 )
 
 const (
@@ -60,7 +60,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		uniquePasswordMatches[strings.TrimSpace(matches[1])] = struct{}{}
 	}
 
-EndpointLoop:
 	for urlMatch := range uniqueUrlsMatches {
 		for passwordMatch := range uniquePasswordMatches {
 			s1 := detectors.Result{
@@ -75,18 +74,21 @@ EndpointLoop:
 
 			if verify {
 				if invalidHosts.Exists(urlMatch) {
-					logger.V(3).Info("Skipping invalid registry", "url", urlMatch)
-					continue EndpointLoop
-				}
-
-				isVerified, err := verifyUrlPassword(ctx, urlMatch, azureGitUsername, passwordMatch)
-				s1.Verified = isVerified
-				if err != nil {
-					if errors.Is(err, errNoSuchHost) {
-						invalidHosts.Set(urlMatch, struct{}{})
-						continue EndpointLoop
+					// An earlier candidate already proved this host does not resolve, so the lookup is
+					// skipped. The finding is still reported: dropping it here would make the reported
+					// secrets depend on whether verification was requested, and on the order in which
+					// candidates happened to be processed.
+					logger.V(3).Info("Skipping verification: no such host", "url", urlMatch)
+					s1.SetVerificationError(errNoSuchHost, urlMatch)
+				} else {
+					isVerified, err := verifyUrlPassword(ctx, urlMatch, azureGitUsername, passwordMatch)
+					s1.Verified = isVerified
+					if err != nil {
+						if errors.Is(err, errNoSuchHost) {
+							invalidHosts.Set(urlMatch, struct{}{})
+						}
+						s1.SetVerificationError(err, urlMatch)
 					}
-					s1.SetVerificationError(err, urlMatch)
 				}
 			}
 			results = append(results, s1)

--- a/pkg/detectors/azureapimanagementsubscriptionkey/azureapimanagementsubscriptionkey.go
+++ b/pkg/detectors/azureapimanagementsubscriptionkey/azureapimanagementsubscriptionkey.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 
@@ -54,7 +55,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		keyMatchesUnique[strings.TrimSpace(keyMatch[1])] = struct{}{}
 	}
 
-EndpointLoop:
 	for baseUrl := range urlMatchesUnique {
 		for key := range keyMatchesUnique {
 			s1 := detectors.Result{
@@ -69,23 +69,27 @@ EndpointLoop:
 
 			if verify {
 				if invalidHosts.Exists(baseUrl) {
-					logger.V(3).Info("Skipping invalid registry", "baseUrl", baseUrl)
-					continue EndpointLoop
-				}
-
-				client := s.client
-				if client == nil {
-					client = defaultClient
-				}
-
-				isVerified, verificationErr := s.verifyMatch(ctx, client, baseUrl, key)
-				s1.Verified = isVerified
-				if verificationErr != nil {
-					if errors.Is(verificationErr, errNoSuchHost) {
-						invalidHosts.Set(baseUrl, struct{}{})
-						continue EndpointLoop
+					// An earlier candidate already proved this host does not resolve, so the lookup is
+					// skipped. The finding is still reported: dropping it here would make the reported
+					// secrets depend on whether verification was requested, and on the order in which
+					// candidates happened to be processed.
+					logger.V(3).Info("Skipping verification: no such host", "baseUrl", baseUrl)
+					s1.SetVerificationError(errNoSuchHost, baseUrl)
+				} else {
+					client := s.client
+					if client == nil {
+						client = defaultClient
 					}
-					s1.SetVerificationError(verificationErr, baseUrl)
+
+					isVerified, verificationErr := s.verifyMatch(ctx, client, baseUrl, key)
+					s1.Verified = isVerified
+					if verificationErr != nil {
+						var dnsErr *net.DNSError
+						if errors.As(verificationErr, &dnsErr) && dnsErr.IsNotFound {
+							invalidHosts.Set(baseUrl, struct{}{})
+						}
+						s1.SetVerificationError(verificationErr, baseUrl)
+					}
 				}
 			}
 
@@ -118,7 +122,9 @@ func (s Scanner) verifyMatch(ctx context.Context, client *http.Client, baseUrl, 
 	req.Header.Set("Ocp-Apim-Subscription-Key", key)
 	resp, err := client.Do(req)
 	if err != nil {
-		return false, nil
+		// A transport failure means the credential was never tested, so the result is
+		// indeterminate. Returning (false, nil) here would report it as a rejection.
+		return false, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/pkg/detectors/azurecontainerregistry/azurecontainerregistry.go
+++ b/pkg/detectors/azurecontainerregistry/azurecontainerregistry.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
-	"strings"
 
 	regexp "github.com/wasilibs/go-re2"
 
@@ -73,7 +73,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		passwordMatches[p] = struct{}{}
 	}
 
-EndpointLoop:
 	for username := range registryMatches {
 		for password := range passwordMatches {
 			r := detectors.Result{
@@ -89,26 +88,30 @@ EndpointLoop:
 
 			if verify {
 				if invalidHosts.Exists(username) {
-					logger.V(3).Info("Skipping invalid registry", "username", username)
-					continue EndpointLoop
-				}
-
-				client := s.client
-				if client == nil {
-					client = defaultClient
-				}
-
-				isVerified, verificationErr := verifyMatch(ctx, client, username, password)
-				if isVerified {
-					delete(passwordMatches, password)
-					r.Verified = true
-				}
-				if verificationErr != nil {
-					if errors.Is(verificationErr, errNoSuchHost) {
-						invalidHosts.Set(username, struct{}{})
-						continue EndpointLoop
+					// An earlier candidate already proved this host does not resolve, so the lookup is
+					// skipped. The finding is still reported: dropping it here would make the reported
+					// secrets depend on whether verification was requested, and on the order in which
+					// candidates happened to be processed.
+					logger.V(3).Info("Skipping verification: no such host", "username", username)
+					r.SetVerificationError(errNoSuchHost, password)
+				} else {
+					client := s.client
+					if client == nil {
+						client = defaultClient
 					}
-					r.SetVerificationError(verificationErr, password)
+
+					isVerified, verificationErr := verifyMatch(ctx, client, username, password)
+					if isVerified {
+						delete(passwordMatches, password)
+						r.Verified = true
+					}
+					if verificationErr != nil {
+						var dnsErr *net.DNSError
+						if errors.As(verificationErr, &dnsErr) && dnsErr.IsNotFound {
+							invalidHosts.Set(username, struct{}{})
+						}
+						r.SetVerificationError(verificationErr, password)
+					}
 				}
 			}
 
@@ -137,10 +140,6 @@ func verifyMatch(ctx context.Context, client *http.Client, username string, pass
 	req.SetBasicAuth(username, password)
 	res, err := client.Do(req)
 	if err != nil {
-		// lookup foo.azurecr.io: no such host
-		if strings.Contains(err.Error(), "no such host") {
-			return false, errNoSuchHost
-		}
 		return false, err
 	}
 	defer func() {

--- a/pkg/detectors/azuredirectmanagementkey/azuredirectmanagementkey.go
+++ b/pkg/detectors/azuredirectmanagementkey/azuredirectmanagementkey.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -60,7 +61,6 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 		keyMatchesUnique[strings.TrimSpace(keyMatch[1])] = struct{}{}
 	}
 
-EndpointLoop:
 	for baseUrl, serviceName := range urlMatchesUnique {
 		for key := range keyMatchesUnique {
 			s1 := detectors.Result{
@@ -75,23 +75,27 @@ EndpointLoop:
 
 			if verify {
 				if invalidHosts.Exists(baseUrl) {
-					logger.V(3).Info("Skipping invalid registry", "baseUrl", baseUrl)
-					continue EndpointLoop
-				}
-
-				client := s.client
-				if client == nil {
-					client = defaultClient
-				}
-
-				isVerified, verificationErr := s.verifyMatch(ctx, client, baseUrl, serviceName, key)
-				s1.Verified = isVerified
-				if verificationErr != nil {
-					if errors.Is(verificationErr, errNoSuchHost) {
-						invalidHosts.Set(baseUrl, struct{}{})
-						continue EndpointLoop
+					// An earlier candidate already proved this host does not resolve, so the lookup is
+					// skipped. The finding is still reported: dropping it here would make the reported
+					// secrets depend on whether verification was requested, and on the order in which
+					// candidates happened to be processed.
+					logger.V(3).Info("Skipping verification: no such host", "baseUrl", baseUrl)
+					s1.SetVerificationError(errNoSuchHost, baseUrl)
+				} else {
+					client := s.client
+					if client == nil {
+						client = defaultClient
 					}
-					s1.SetVerificationError(verificationErr, baseUrl)
+
+					isVerified, verificationErr := s.verifyMatch(ctx, client, baseUrl, serviceName, key)
+					s1.Verified = isVerified
+					if verificationErr != nil {
+						var dnsErr *net.DNSError
+						if errors.As(verificationErr, &dnsErr) && dnsErr.IsNotFound {
+							invalidHosts.Set(baseUrl, struct{}{})
+						}
+						s1.SetVerificationError(verificationErr, baseUrl)
+					}
 				}
 			}
 
@@ -131,7 +135,9 @@ func (s Scanner) verifyMatch(ctx context.Context, client *http.Client, baseUrl, 
 	req.Header.Set("Authorization", fmt.Sprintf("SharedAccessSignature %s", accessToken))
 	resp, err := client.Do(req)
 	if err != nil {
-		return false, nil
+		// A transport failure means the credential was never tested, so the result is
+		// indeterminate. Returning (false, nil) here would report it as a rejection.
+		return false, err
 	}
 	defer func() { _ = resp.Body.Close() }()
 


### PR DESCRIPTION
## Problem
Setting `verify: true` changed *which* findings were reported, not just their verification status. Seven detectors dropped a candidate entirely when its host didn't resolve, so `last_seen` never advanced and a revoked secret stayed looking live.

## Change
Verification now only decorates a finding, never decides whether it exists. The host cache still suppresses the DNS lookup; the result is reported with the error attached.

- **Dropped findings** (artifactory, algoliaadminkey, azure_cosmosdb, azurecontainerregistry, azureapimanagement/repositorykey): `continue` skipped the `append`.
- **Misclassified transport errors** (azureapimanagementsubscriptionkey, azuredirectmanagementkey): `client.Do` errors returned `(false, nil)`, a determinate rejection that sets `date_rotated` and marks a live secret dead. Now `(false, err)`.
- In artifactory, algoliaadminkey and azure_cosmosdb the cache guard sat outside the `verify` block, so a globally cached host also dropped findings in later `verify: false` runs. Moved inside.
- DNS detection switched to `errors.As(&net.DNSError{}) && IsNotFound`. repositorykey's sentinel retexted to `"no such host"` so it classifies as DNS.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret-detection and verification semantics across multiple detectors; fixes incorrect “dead secret” signals but may increase reported findings and alter downstream rotation tracking when verify is on.
> 
> **Overview**
> Fixes **verify asymmetry** across several Azure-, Artifactory-, and Algolia-related detectors: enabling verification no longer changes *which* secrets are emitted when a host does not resolve or a request never reaches the server.
> 
> For **Algolia, Artifactory, Cosmos DB, ACR, and Azure API Management** detectors, unresolved hosts used to **`continue`** (and sometimes ran the invalid-host guard even when `verify` was false), so candidates were dropped entirely. Those paths now **always append** the result; cached bad hosts only skip the HTTP/git check and attach a verification error via **`SetVerificationError`**. DNS failures are detected with **`errors.As` → `*net.DNSError` (`IsNotFound`)** instead of string-matching `"no such host"` or custom wrappers in `verifyMatch`.
> 
> **Azure APIM subscription** and **direct management** keys now return **`(false, err)`** from `client.Do` failures instead of **`(false, nil)`**, so network/DNS problems are indeterminate verification errors rather than looking like a rejected credential (which could incorrectly drive rotation/`last_seen` behavior).
> 
> **Cosmos DB** sets **`ExtraData["DB Type"]`** from the account URL for every match, not only when verification runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41ac72aec875c866d5bae27b1925e92d5608ae3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->