### PR TITLE
deps: bump x/oauth2 to v0.36.0 and pin the credential type at three call sites

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,7 +106,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/net v0.56.0
-	golang.org/x/oauth2 v0.34.0
+	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/text v0.39.0
 	golang.org/x/time v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -901,8 +901,8 @@ golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
-golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
-golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
+golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/pkg/detectors/gcp/gcp.go
+++ b/pkg/detectors/gcp/gcp.go
@@ -165,7 +165,10 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 }
 
 func verifyMatch(ctx context.Context, credBytes []byte) (bool, error) {
-	credentials, err := google.CredentialsFromJSON(ctx, credBytes, "https://www.googleapis.com/auth/cloud-platform")
+	// credBytes came out of a scanned repository, so it is attacker-controlled. Pinning the type
+	// keeps an external_account config — which can name arbitrary token and credential-source URLs
+	// — from being honoured during verification.
+	credentials, err := google.CredentialsFromJSONWithType(ctx, credBytes, google.ServiceAccount, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		return false, err
 	}

--- a/pkg/detectors/gcpapplicationdefaultcredentials/gcpapplicationdefaultcredentials.go
+++ b/pkg/detectors/gcpapplicationdefaultcredentials/gcpapplicationdefaultcredentials.go
@@ -111,7 +111,9 @@ func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (result
 
 func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, map[string]string, error) {
 	// First load the credential from the found key
-	credentials, err := google.CredentialsFromJSON(ctx, []byte(token), "https://www.googleapis.com/auth/cloud-platform")
+	// Same untrusted input as the gcp detector. keyPat matches on `client_secret`, which is the
+	// authorized_user shape — an ADC file — so that is the only type this verifier should honour.
+	credentials, err := google.CredentialsFromJSONWithType(ctx, []byte(token), google.AuthorizedUser, "https://www.googleapis.com/auth/cloud-platform")
 	if err != nil {
 		return false, nil, err
 	}

--- a/pkg/sources/gcs/gcs_manager.go
+++ b/pkg/sources/gcs/gcs_manager.go
@@ -144,7 +144,9 @@ func withAPIKey(ctx context.Context, apiKey string) gcsManagerOption {
 
 // withJSONServiceAccount uses the provided JSON service account when creating a new GCS client.
 func withJSONServiceAccount(ctx context.Context, jsonServiceAccount []byte) gcsManagerOption {
-	creds, err := google.CredentialsFromJSON(ctx, jsonServiceAccount, storage.ScopeReadOnly)
+	// Operator-supplied rather than scanned, so the exposure is not the detectors'; the type is
+	// pinned because the function's name says what this option accepts.
+	creds, err := google.CredentialsFromJSONWithType(ctx, jsonServiceAccount, google.ServiceAccount, storage.ScopeReadOnly)
 	if err != nil {
 		return func(m *gcsManager) error {
 			return fmt.Errorf("failed to load credentials: %w", err)


### PR DESCRIPTION
`golang.org/x/oauth2` v0.36.0 marks `google.CredentialsFromJSON` deprecated, and the deprecation names the exact situation two of these call sites are in:

> If you are loading your credential configuration from an untrusted source and have not mitigated the risks (e.g. by validating the configuration yourself), make these changes as soon as possible to prevent security risks to your environment.

The `gcp` and `gcpapplicationdefaultcredentials` detectors parse credential JSON **found in scanned repositories**. That input is attacker-controlled by construction — it is the whole job. An `external_account` configuration names its own token and credential-source URLs, and `x/oauth2` flags that type in its own docs as "a security risk occurs when a credential configuration configured with malicious urls is used". [gcp.go](https://github.com/trufflesecurity/trufflehog/blob/main/pkg/detectors/gcp/gcp.go#L151) records `creds.Type` as metadata but never gates on it.

`CredentialsFromJSONWithType` pins each site to the type that detector actually matches:

| site | input | type |
|---|---|---|
| `pkg/detectors/gcp` | scanned repo content | `ServiceAccount` |
| `pkg/detectors/gcpapplicationdefaultcredentials` | scanned repo content; `keyPat` matches `client_secret`, the ADC shape | `AuthorizedUser` |
| `pkg/sources/gcs` | operator-supplied config | `ServiceAccount` |

### This also unblocks the lint failure on #5237 and #5238, and that failure is ours

I first read it as pre-existing, on the strength of two unrelated dependency bumps producing byte-identical findings. That was wrong — both bump `x/oauth2` transitively, so identical findings is what you would expect. Measured properly:

| | golangci-lint |
|---|---|
| clean `main` @ oauth2 v0.34.0 | **0 issues** |
| #5237 / #5238 @ oauth2 v0.36.0 | 3 × SA1019 |
| this branch @ v0.36.0 | **0 issues** |

(golangci-lint 2.13.2, go1.27.0, darwin/arm64, run over the three affected packages.)

### The behaviour change, which is yours to rule on

Pinning the type means trufflehog **stops verifying `external_account` credentials it currently verifies**. That is the point of the deprecation, but it is a detector behaviour change on a security tool and I would rather flag it than slip it past you. If you would prefer "detect, but mark unverified with a reason" over narrowing what gets honoured, say so and I will rework it that way — the current shape simply lets the error from the typed constructor become the verification error.

### Tests

`pkg/detectors/gcp` and `pkg/detectors/gcpapplicationdefaultcredentials` pass.

`pkg/sources/gcs` fails four tests — `TestNewGcsManager`, `TestGCSManagerStats`, `TestGCSManagerStats_Time`, `TestGCSManagerListObjects` — and **the same four fail on clean `main`** in a separate worktree at `cc1fe98` with `oauth2 v0.34.0` and nothing modified. They appear to want GCP credentials this machine does not have. Not introduced here, and I checked rather than assumed: my first attempt at that control used `git stash push -- <paths>`, which failed on syntax and silently re-ran the branch against itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches secret verification on attacker-controlled JSON and changes which GCP credential shapes can be verified, but the change is a deliberate hardening aligned with oauth2 v0.36 guidance.
> 
> **Overview**
> Upgrades **`golang.org/x/oauth2`** to **v0.36.0**, which deprecates untyped **`google.CredentialsFromJSON`** for configs from untrusted sources.
> 
> Verification and GCS client setup now use **`google.CredentialsFromJSONWithType`** so only the expected JSON **`type`** is honored: **`ServiceAccount`** in the GCP detector and GCS service-account option (scanned vs operator JSON), and **`AuthorizedUser`** in the GCP ADC detector (matches **`client_secret`** / ADC shape). This blocks **`external_account`** configs that could drive token or credential-source URLs during verification of repo-found secrets.
> 
> **Detector behavior:** credentials that are not the pinned type (including **`external_account`**) no longer verify successfully; errors from the typed constructor surface as verification failures rather than attempting network calls with attacker-chosen endpoints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a1060f98ee56f019f629f2e7a6c0529d3927e5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->