### PR TITLE
ci: avoid Node 20 BuildPulse action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
         if: ${{ success() || failure() }} # always run this step, even if there were previous errors
       - name: Upload test results to BuildPulse for flaky test detection
         if: ${{ !cancelled() }} # Run this step even when the tests fail. Skip if the workflow is cancelled.
-        uses: buildpulse/buildpulse-action@0b048a4942e59de0796568d1035946e283be6b3a # main
+        uses: buildpulse/buildpulse-action@d4d8e00c645a2e3db0419a43664bbcf868080234 # v0.12.0
         with:
           account: 79229934
           repository: 77726177


### PR DESCRIPTION
### Description:
Use BuildPulse’s official composite v0.12.0 release instead of the Node.js 20 action on main. The workflow retains its existing inputs and uses an immutable SHA.

### Checklist:
* [x] Verified the replacement supports the existing action inputs.
* [x] `git diff --check`
* [ ] `make test-community` (not run; workflow-only action pin change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only third-party action pin with the same inputs; no application or auth logic changes.
> 
> **Overview**
> Updates the **Test** workflow’s BuildPulse upload step to use the **v0.12.0** composite action (immutable SHA) instead of tracking **`main`**, so CI no longer pulls the Node 20–based action from the default branch.
> 
> **Account, repository, JUnit paths, secrets, and `integration` tags are unchanged**—only the action ref changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a1b658d9cd093f4cf402f094be7996bf677b412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->