### PR TITLE
Make Transport Errors indeterminate for Twilio secrets and twilioapikeys

### DIFF
--- a/pkg/detectors/twilio/twilio.go
+++ b/pkg/detectors/twilio/twilio.go
@@ -106,7 +106,7 @@ func (s Scanner) Description() string {
 func verifyTwilio(ctx context.Context, client *http.Client, key, sid string) (map[string]string, bool, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", "https://verify.twilio.com/v2/Services", nil)
 	if err != nil {
-		return nil, false, nil
+		return nil, false, err
 	}
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
@@ -114,7 +114,7 @@ func verifyTwilio(ctx context.Context, client *http.Client, key, sid string) (ma
 	req.SetBasicAuth(sid, key)
 	resp, err := detectors.DoWithDedup(client, detector_typepb.DetectorType_Twilio, sid+key, req)
 	if err != nil {
-		return nil, false, nil
+		return nil, false, err
 	}
 	defer func() {
 		_, _ = io.Copy(io.Discard, resp.Body)

--- a/pkg/detectors/twilioapikey/twilioapikey.go
+++ b/pkg/detectors/twilioapikey/twilioapikey.go
@@ -101,7 +101,7 @@ func (s Scanner) Description() string {
 func verifyTwilioAPIKey(ctx context.Context, client *http.Client, apiKey, secret string) (map[string]string, bool, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", "https://verify.twilio.com/v2/Services", nil)
 	if err != nil {
-		return nil, false, nil
+		return nil, false, err
 	}
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
@@ -110,7 +110,7 @@ func verifyTwilioAPIKey(ctx context.Context, client *http.Client, apiKey, secret
 
 	resp, err := detectors.DoWithDedup(client, detector_typepb.DetectorType_TwilioApiKey, apiKey+secret, req)
 	if err != nil {
-		return nil, false, nil
+		return nil, false, err
 	}
 	defer func() {
 		_, _ = io.Copy(io.Discard, resp.Body)


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
pkg/detectors/twilio/twilio.go — verifyTwilio now returns the error from both http.NewRequestWithContext and detectors.DoWithDedup instead of discarding it, so retry exhaustion on 429/5xx, timeouts, resets, and dial failures produce a verification error and land in the indeterminate branch of ApplySecretUpdate rather than writing date_rotated.
pkg/detectors/twilioapikey/twilioapikey.go — the same two-line change, covering the transport failures that affect it despite having no retry wrapper.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change in Twilio secret verification error propagation only; no auth or data-model changes beyond more accurate indeterminate outcomes.
> 
> **Overview**
> **Twilio** and **Twilio API key** detectors no longer swallow errors when building the verify request or performing the HTTP call. `verifyTwilio` and `verifyTwilioAPIKey` now return those errors instead of `(nil, false, nil)`.
> 
> That lets retry exhaustion (429/5xx), timeouts, and connection failures surface as verification errors on the scan result. Downstream handling can treat the secret as **indeterminate** rather than incorrectly recording it as rotated when the API was never reached successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e898d40f318934b8ab5402c15be74325308d806. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->