### PR TITLE
Revert "[INT-933] De-base64 SourceUnit.UnitData in the GitHub Source"

### DIFF
--- a/pkg/sources/github/github.go
+++ b/pkg/sources/github/github.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -130,12 +129,6 @@ type unitEnvelope struct {
 func (u unitEnvelope) SourceUnitID() (string, sources.SourceUnitKind) { return u.ID, u.Kind }
 func (u unitEnvelope) Display() string                                { return u.Name }
 
-func decodeBase64(data []byte) ([]byte, error) {
-	out := make([]byte, base64.StdEncoding.DecodedLen(len(data)))
-	n, err := base64.StdEncoding.Decode(out, data)
-	return out[:n], err
-}
-
 func unmarshalSourceUnit[unitType sources.SourceUnit](data []byte) (unitType, error) {
 	u := new(unitType)
 
@@ -171,20 +164,12 @@ func (s *Source) UnmarshalSourceUnit(data []byte) (sources.SourceUnit, error) {
 		return env, nil
 	case "repo":
 		if len(env.UnitData) > 0 {
-			decodedData, err := decodeBase64(env.UnitData)
-			if err != nil {
-				return nil, fmt.Errorf("error decoding repo unit data: %w", err)
-			}
-			return unmarshalSourceUnit[RepoUnit](decodedData)
+			return unmarshalSourceUnit[RepoUnit](env.UnitData)
 		}
 		return RepoUnit{Name: env.Name, URL: env.ID}, nil
 	case "gist":
-		decodedData, err := decodeBase64(env.UnitData)
-		if err != nil {
-			return nil, fmt.Errorf("error decoding gist unit data: %w", err)
-		}
 		if len(env.UnitData) > 0 {
-			return unmarshalSourceUnit[GistUnit](decodedData)
+			return unmarshalSourceUnit[GistUnit](env.UnitData)
 		}
 		return GistUnit{Name: env.Name, URL: env.ID}, nil
 	default:

--- a/pkg/sources/github/map_installations_test.go
+++ b/pkg/sources/github/map_installations_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"testing"
 
@@ -24,9 +23,6 @@ func newMarshalledRepoUnit(t *testing.T, su sources.SourceUnit) []byte {
 
 	unitData, err := json.Marshal(su)
 	require.NoError(t, err)
-
-	// [CG] This additional base64 encoding mimics the pipeline's behavior
-	unitData = []byte(base64.StdEncoding.EncodeToString(unitData))
 
 	out, err := json.Marshal(map[string]any{
 		"id":        id,


### PR DESCRIPTION
Reverts trufflesecurity/trufflehog#5248

We're seeing the issue brought up by the bot on this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how GitHub repo/gist units are parsed on the scan path; encoding mismatch with the pipeline can break unit metadata (e.g. installation IDs) without failing loudly everywhere.
> 
> **Overview**
> **Reverts #5248** and puts GitHub source unit handling back in line with how the scanner pipeline serializes enumerated units.
> 
> `UnmarshalSourceUnit` again **base64-decodes** `unit_data` before JSON-unmarshaling **repo** and **gist** units (via a restored `decodeBase64` helper). The test helper `newMarshalledRepoUnit` again **base64-encodes** marshaled unit JSON in `unit_data`, matching pipeline behavior.
> 
> This addresses the regression from treating `unit_data` as raw JSON when the pipeline still delivers an extra base64 layer—e.g. losing fields like `installation_id` on `RepoUnit` during chunked scans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 130f3993e1dca8bc5c35401e0c105713ade5cff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->