### PR TITLE
Twilio detector tests

### DIFF
--- a/pkg/detectors/twilio/twilio.go
+++ b/pkg/detectors/twilio/twilio.go
@@ -106,7 +106,7 @@ func (s Scanner) Description() string {
 func verifyTwilio(ctx context.Context, client *http.Client, key, sid string) (map[string]string, bool, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", "https://verify.twilio.com/v2/Services", nil)
 	if err != nil {
-		return nil, false, nil
+		return nil, false, err
 	}
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
@@ -114,7 +114,7 @@ func verifyTwilio(ctx context.Context, client *http.Client, key, sid string) (ma
 	req.SetBasicAuth(sid, key)
 	resp, err := detectors.DoWithDedup(client, detector_typepb.DetectorType_Twilio, sid+key, req)
 	if err != nil {
-		return nil, false, nil
+		return nil, false, err
 	}
 	defer func() {
 		_, _ = io.Copy(io.Discard, resp.Body)

--- a/pkg/detectors/twilio/twilio_test.go
+++ b/pkg/detectors/twilio/twilio_test.go
@@ -2,11 +2,19 @@ package twilio
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/hashicorp/go-retryablehttp"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 )
@@ -79,5 +87,119 @@ func TestTwilio_Pattern(t *testing.T) {
 				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
 			}
 		})
+	}
+}
+type errorTransport struct{ err error }
+
+func (t errorTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, t.err }
+
+func TestTwilio_VerificationDeterminacy(t *testing.T) {
+	data := []byte(fmt.Sprintf("twilio sid %s key %s", validSid, validKey))
+
+	tests := []struct {
+		name                string
+		client              *http.Client
+		wantVerified        bool
+		wantVerificationErr bool
+	}{
+		{
+			name:                "authenticated rejection is determinate",
+			client:              common.ConstantResponseHttpClient(http.StatusUnauthorized, ""),
+			wantVerified:        false,
+			wantVerificationErr: false,
+		},
+		{
+			name:                "success is determinate",
+			client:              common.ConstantResponseHttpClient(http.StatusOK, `{"services":[{"friendly_name":"n","sid":"s","account_sid":"a"}]}`),
+			wantVerified:        true,
+			wantVerificationErr: false,
+		},
+		{
+			name:                "connection reset is indeterminate",
+			client:              &http.Client{Transport: errorTransport{err: errors.New("read: connection reset by peer")}},
+			wantVerified:        false,
+			wantVerificationErr: true,
+		},
+		{
+			name:                "timeout is indeterminate",
+			client:              &http.Client{Transport: errorTransport{err: context.DeadlineExceeded}},
+			wantVerified:        false,
+			wantVerificationErr: true,
+		},
+		{
+			name:                "rate limit reaching the switch is indeterminate",
+			client:              common.ConstantResponseHttpClient(http.StatusTooManyRequests, ""),
+			wantVerified:        false,
+			wantVerificationErr: true,
+		},
+		{
+			name:                "server error is indeterminate",
+			client:              common.ConstantResponseHttpClient(http.StatusInternalServerError, "{}"),
+			wantVerified:        false,
+			wantVerificationErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results, err := Scanner{client: test.client}.FromData(context.Background(), true, data)
+			if err != nil {
+				t.Fatalf("FromData() error = %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(results))
+			}
+
+			got := results[0]
+			if got.Verified != test.wantVerified {
+				t.Errorf("Verified = %v, want %v", got.Verified, test.wantVerified)
+			}
+			if (got.VerificationError() != nil) != test.wantVerificationErr {
+				t.Errorf("VerificationError() = %v, want error presence %v",
+					got.VerificationError(), test.wantVerificationErr)
+			}
+			if e := got.VerificationError(); e != nil && strings.Contains(e.Error(), validKey) {
+				t.Errorf("verification error leaks the credential: %v", e)
+			}
+		})
+	}
+}
+
+func TestTwilio_RetryExhaustionIsIndeterminate(t *testing.T) {
+	var attempts int32
+
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = 3
+	retryClient.Logger = nil
+	retryClient.RetryWaitMin = time.Millisecond
+	retryClient.RetryWaitMax = 2 * time.Millisecond
+	retryClient.HTTPClient.Transport = common.FakeTransport{
+		CreateResponse: func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&attempts, 1)
+			return &http.Response{
+				Request:    req,
+				StatusCode: http.StatusTooManyRequests,
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		},
+	}
+
+	data := []byte(fmt.Sprintf("twilio sid %s key %s", validSid, validKey))
+	results, err := Scanner{client: retryClient.StandardClient()}.FromData(context.Background(), true, data)
+	if err != nil {
+		t.Fatalf("FromData() error = %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	if got := atomic.LoadInt32(&attempts); got != 4 {
+		t.Errorf("expected 4 attempts (initial + RetryMax), got %d", got)
+	}
+	if results[0].Verified {
+		t.Error("Verified = true, want false")
+	}
+	if results[0].VerificationError() == nil {
+		t.Error("VerificationError() = nil; a throttled credential would be recorded as rotated")
 	}
 }

--- a/pkg/detectors/twilioapikey/twilioapikey.go
+++ b/pkg/detectors/twilioapikey/twilioapikey.go
@@ -101,7 +101,7 @@ func (s Scanner) Description() string {
 func verifyTwilioAPIKey(ctx context.Context, client *http.Client, apiKey, secret string) (map[string]string, bool, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", "https://verify.twilio.com/v2/Services", nil)
 	if err != nil {
-		return nil, false, nil
+		return nil, false, err
 	}
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
@@ -110,7 +110,7 @@ func verifyTwilioAPIKey(ctx context.Context, client *http.Client, apiKey, secret
 
 	resp, err := detectors.DoWithDedup(client, detector_typepb.DetectorType_TwilioApiKey, apiKey+secret, req)
 	if err != nil {
-		return nil, false, nil
+		return nil, false, err
 	}
 	defer func() {
 		_, _ = io.Copy(io.Discard, resp.Body)

--- a/pkg/detectors/twilioapikey/twilioapikey_test.go
+++ b/pkg/detectors/twilioapikey/twilioapikey_test.go
@@ -2,11 +2,15 @@ package twilioapikey
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
 )
@@ -100,5 +104,80 @@ func TestTwilioAPIKey_SecretRedacted(t *testing.T) {
 
 	if results[0].Redacted != validSecret[:5]+"..." {
 		t.Errorf("expected redacted secret to be '%s', got '%s'", validSecret[:5]+"...", results[0].Redacted)
+	}
+}
+type errorTransport struct{ err error }
+
+func (t errorTransport) RoundTrip(*http.Request) (*http.Response, error) { return nil, t.err }
+
+func TestTwilioAPIKey_VerificationDeterminacy(t *testing.T) {
+	data := []byte(fmt.Sprintf("twilio %s %s", validAPIKey, validSecret))
+
+	tests := []struct {
+		name                string
+		client              *http.Client
+		wantVerified        bool
+		wantVerificationErr bool
+	}{
+		{
+			name:                "authenticated rejection is determinate",
+			client:              common.ConstantResponseHttpClient(http.StatusUnauthorized, ""),
+			wantVerified:        false,
+			wantVerificationErr: false,
+		},
+		{
+			name:                "success is determinate",
+			client:              common.ConstantResponseHttpClient(http.StatusOK, `{"services":[{"friendly_name":"n","sid":"s","account_sid":"a"}]}`),
+			wantVerified:        true,
+			wantVerificationErr: false,
+		},
+		{
+			name:                "rate limit is indeterminate",
+			client:              common.ConstantResponseHttpClient(http.StatusTooManyRequests, ""),
+			wantVerified:        false,
+			wantVerificationErr: true,
+		},
+		{
+			name:                "connection reset is indeterminate",
+			client:              &http.Client{Transport: errorTransport{err: errors.New("read: connection reset by peer")}},
+			wantVerified:        false,
+			wantVerificationErr: true,
+		},
+		{
+			name:                "timeout is indeterminate",
+			client:              &http.Client{Transport: errorTransport{err: context.DeadlineExceeded}},
+			wantVerified:        false,
+			wantVerificationErr: true,
+		},
+		{
+			name:                "server error is indeterminate",
+			client:              common.ConstantResponseHttpClient(http.StatusInternalServerError, "{}"),
+			wantVerified:        false,
+			wantVerificationErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			results, err := Scanner{client: test.client}.FromData(context.Background(), true, data)
+			if err != nil {
+				t.Fatalf("FromData() error = %v", err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(results))
+			}
+
+			got := results[0]
+			if got.Verified != test.wantVerified {
+				t.Errorf("Verified = %v, want %v", got.Verified, test.wantVerified)
+			}
+			if (got.VerificationError() != nil) != test.wantVerificationErr {
+				t.Errorf("VerificationError() = %v, want error presence %v",
+					got.VerificationError(), test.wantVerificationErr)
+			}
+			if e := got.VerificationError(); e != nil && strings.Contains(e.Error(), validSecret) {
+				t.Errorf("verification error leaks the credential: %v", e)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Added tests for https://github.com/trufflesecurity/trufflehog/pull/5267, to ensure fix behaves as expected

### Checklist:
* [ ] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live credential verification semantics for Twilio detectors when HTTP calls fail, which can affect how scan results are classified downstream; scope is limited to two detectors and is covered by new tests.
> 
> **Overview**
> **Twilio** and **Twilio API key** verifiers now **return real errors** from request construction and `DoWithDedup` instead of swallowing them as `(nil, false, nil)`, so transport/retry failures surface as **indeterminate** verification via `VerificationError()` rather than looking like a clean “not verified” outcome.
> 
> Adds **verification determinacy** tests for both detectors: **401** and **200** are treated as definite outcomes; **429**, **5xx**, timeouts, and connection errors stay **unverified** with a verification error. The Twilio package also adds a **retry-exhaustion** test (persistent **429**) to ensure throttled credentials are not misclassified as rotated, plus checks that errors do not leak secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa85b7fdde258c715d70e5beddd81409f8ffa237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->