### PR TITLE
Implement wakatime detector

### DIFF
--- a/pkg/detectors/wakatime/wakatime.go
+++ b/pkg/detectors/wakatime/wakatime.go
@@ -1,0 +1,104 @@
+package wakatime
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	regexp "github.com/wasilibs/go-re2"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+type Scanner struct {
+	client *http.Client
+}
+
+// Ensure the Scanner satisfies the interface at compile time.
+var _ detectors.Detector = (*Scanner)(nil)
+
+var (
+	defaultClient = common.SaneHttpClient()
+	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
+	keyPat = regexp.MustCompile(`\b(waka_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\b`)
+)
+
+// Keywords are used for efficiently pre-filtering chunks.
+// Use identifiers in the secret preferably, or the provider name.
+func (s Scanner) Keywords() []string {
+	return []string{"waka_"}
+}
+
+// FromData will find and optionally verify Wakatime secrets in a given set of bytes.
+func (s Scanner) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
+	dataStr := string(data)
+
+	uniqueMatches := make(map[string]struct{})
+	for _, match := range keyPat.FindAllStringSubmatch(dataStr, -1) {
+		uniqueMatches[match[1]] = struct{}{}
+	}
+
+	for match := range uniqueMatches {
+		s1 := detectors.Result{
+			DetectorType: detector_typepb.DetectorType_Wakatime,
+			Raw:          []byte(match),
+			SecretParts:  map[string]string{"key": match},
+		}
+
+		if verify {
+			client := s.client
+			if client == nil {
+				client = defaultClient
+			}
+
+			isVerified, extraData, verificationErr := verifyMatch(ctx, client, match)
+			s1.Verified = isVerified
+			s1.ExtraData = extraData
+			s1.SetVerificationError(verificationErr, match)
+		}
+
+		results = append(results, s1)
+	}
+
+	return
+}
+
+func verifyMatch(ctx context.Context, client *http.Client, token string) (bool, map[string]string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://wakatime.com/api/v1/users/current", nil)
+	if err != nil {
+		return false, nil, err
+	}
+
+	req.SetBasicAuth(token, "")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return false, nil, err
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, res.Body)
+		_ = res.Body.Close()
+	}()
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		// If the endpoint returns useful information, we can return it as a map.
+		return true, nil, nil
+	case http.StatusUnauthorized:
+		// The secret is determinately not verified (nothing to do)
+		return false, nil, nil
+	default:
+		return false, nil, fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
+	}
+}
+
+func (s Scanner) Type() detector_typepb.DetectorType {
+	return detector_typepb.DetectorType_Wakatime
+}
+
+func (s Scanner) Description() string {
+	return "WakaTime is an automated time-tracking and metrics platform designed for software developers."
+}

--- a/pkg/detectors/wakatime/wakatime_integration_test.go
+++ b/pkg/detectors/wakatime/wakatime_integration_test.go
@@ -1,0 +1,168 @@
+//go:build detectors
+// +build detectors
+
+package wakatime
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
+)
+
+func TestWakatime_FromChunk(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+	testSecrets, err := common.GetSecret(ctx, "trufflehog-testing", "detectors5")
+	if err != nil {
+		t.Fatalf("could not get test secrets from GCP: %s", err)
+	}
+	secret := testSecrets.MustGetField("WAKATIME")
+	inactiveSecret := testSecrets.MustGetField("WAKATIME_INACTIVE")
+
+	type args struct {
+		ctx    context.Context
+		data   []byte
+		verify bool
+	}
+	tests := []struct {
+		name                string
+		s                   Scanner
+		args                args
+		want                []detectors.Result
+		wantErr             bool
+		wantVerificationErr bool
+	}{
+		{
+			name: "found, verified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a wakatime secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_Wakatime,
+					Verified:     true,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "found, unverified",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a wakatime secret %s within but not valid", inactiveSecret)), // the secret would satisfy the regex but not pass validation
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_Wakatime,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "not found",
+			s:    Scanner{},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte("You cannot find the secret within"),
+				verify: true,
+			},
+			want:                nil,
+			wantErr:             false,
+			wantVerificationErr: false,
+		},
+		{
+			name: "found, would be verified if not for timeout",
+			s:    Scanner{client: common.SaneHttpClientTimeOut(1 * time.Microsecond)},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a wakatime secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_Wakatime,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+		{
+			name: "found, verified but unexpected api surface",
+			s:    Scanner{client: common.ConstantResponseHttpClient(404, "")},
+			args: args{
+				ctx:    context.Background(),
+				data:   []byte(fmt.Sprintf("You can find a wakatime secret %s within", secret)),
+				verify: true,
+			},
+			want: []detectors.Result{
+				{
+					DetectorType: detector_typepb.DetectorType_Wakatime,
+					Verified:     false,
+				},
+			},
+			wantErr:             false,
+			wantVerificationErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.s.FromData(tt.args.ctx, tt.args.verify, tt.args.data)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Wakatime.FromData() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			for i := range got {
+				if len(got[i].Raw) == 0 {
+					t.Fatalf("no raw secret present: \n %+v", got[i])
+				}
+				if (got[i].VerificationError() != nil) != tt.wantVerificationErr {
+					t.Fatalf("wantVerificationError = %v, verification error = %v", tt.wantVerificationErr, got[i].VerificationError())
+				}
+			}
+			ignoreOpts := cmpopts.IgnoreFields(detectors.Result{},
+				"Raw",
+				"verificationError",
+				"primarySecret",
+				"SecretParts",
+				"chunkOffset",
+				"chunkOffsetSet",
+			)
+			if diff := cmp.Diff(got, tt.want, ignoreOpts); diff != "" {
+				t.Errorf("Wakatime.FromData() %s diff: (-got +want)\n%s", tt.name, diff)
+			}
+		})
+	}
+}
+
+func BenchmarkFromData(benchmark *testing.B) {
+	ctx := context.Background()
+	s := Scanner{}
+	for name, data := range detectors.MustGetBenchmarkData() {
+		benchmark.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				_, err := s.FromData(ctx, false, data)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/detectors/wakatime/wakatime_test.go
+++ b/pkg/detectors/wakatime/wakatime_test.go
@@ -1,0 +1,106 @@
+package wakatime
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
+)
+
+func TestWakatime_Pattern(t *testing.T) {
+	d := Scanner{}
+	ahoCorasickCore := ahocorasick.NewAhoCorasickCore([]detectors.Detector{d})
+	key1 := "waka_" + "cd1ff59d-4108-4b5f-bdb8-46da1d95c3d5"
+	key2 := "waka_" + "cd1ff59c-4108-4b5f-bdb8-46da1d95c3d5"
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name: "valid pattern",
+			input: fmt.Sprintf(`
+				[INFO] Sending request to the wakatime API
+				[DEBUG] Using Key=%s
+				[INFO] Response received: 200 OK
+			`, key1),
+			want: []string{key1},
+		},
+		{
+			name: "valid pattern - xml",
+			input: fmt.Sprintf(`
+				<com.cloudbees.plugins.credentials.impl.StringCredentialsImpl>
+					<scope>GLOBAL</scope>
+					<id>{wakatime}</id>
+					<secret>{%s}</secret>
+					<description>configuration for production</description>
+					<creationDate>2023-05-18T14:32:10Z</creationDate>
+					<owner>jenkins-admin</owner>
+				</com.cloudbees.plugins.credentials.impl.StringCredentialsImpl>
+			`, key1),
+			want: []string{key1},
+		},
+		{
+			name: "finds all matches",
+			input: fmt.Sprintf(`
+				[INFO] Sending request to the wakatime API
+				[DEBUG] Using Key=%s
+				[ERROR] Response received 401 UnAuthorized
+				[DEBUG] Using wakatime Key=%s
+				[INFO] Response received: 200 OK
+			`, key1, key2),
+			want: []string{key1, key2},
+		},
+		{
+			name: "invalid pattern",
+			input: `
+				[INFO] Sending request to the wakatime API
+				[DEBUG] Using Key=waka_cd1ff59d-4108-4b5f-bb8-46da1d95c3d5
+				[ERROR] Response received: 401 UnAuthorized
+			`,
+			want: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			matchedDetectors := ahoCorasickCore.FindDetectorMatches([]byte(test.input))
+			if len(matchedDetectors) == 0 {
+				t.Errorf("test %q failed: expected keywords %v to be found in the input", test.name, d.Keywords())
+				return
+			}
+
+			results, err := d.FromData(context.Background(), false, []byte(test.input))
+			require.NoError(t, err)
+
+			if len(results) != len(test.want) {
+				t.Errorf("mismatch in result count: expected %d, got %d", len(test.want), len(results))
+				return
+			}
+
+			actual := make(map[string]struct{}, len(results))
+			for _, r := range results {
+				if len(r.RawV2) > 0 {
+					actual[string(r.RawV2)] = struct{}{}
+				} else {
+					actual[string(r.Raw)] = struct{}{}
+				}
+			}
+
+			expected := make(map[string]struct{}, len(test.want))
+			for _, v := range test.want {
+				expected[v] = struct{}{}
+			}
+
+			if diff := cmp.Diff(expected, actual); diff != "" {
+				t.Errorf("%s diff: (-want +got)\n%s", test.name, diff)
+			}
+		})
+	}
+}

--- a/pkg/engine/defaults/defaults.go
+++ b/pkg/engine/defaults/defaults.go
@@ -854,6 +854,7 @@ import (
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/vpnapi"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/vultrapikey"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/vyte"
+	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/wakatime"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/walkscore"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/weatherbit"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors/weatherstack"
@@ -1781,6 +1782,7 @@ func buildDetectorList() []detectors.Detector {
 		&vultrapikey.Scanner{},
 		&vyte.Scanner{},
 		&walkscore.Scanner{},
+		&wakatime.Scanner{},
 		&weatherbit.Scanner{},
 		&weatherstack.Scanner{},
 		&web3storage.Scanner{},

--- a/pkg/engine/defaults/defaults_test.go
+++ b/pkg/engine/defaults/defaults_test.go
@@ -351,7 +351,6 @@ var excludedFromDefaultList = map[detector_typepb.DetectorType]struct{}{
 	detector_typepb.DetectorType_Uproc:                                   {},
 	detector_typepb.DetectorType_Veevavault:                              {},
 	detector_typepb.DetectorType_Vonage:                                  {},
-	detector_typepb.DetectorType_Wakatime:                                {},
 	detector_typepb.DetectorType_Webengage:                               {},
 	detector_typepb.DetectorType_WeChatAppKey:                            {},
 	detector_typepb.DetectorType_Woopra:                                  {},

--- a/pkg/pb/detector_typepb/detector_type.pb.go
+++ b/pkg/pb/detector_typepb/detector_type.pb.go
@@ -164,7 +164,7 @@ const (
 	DetectorType_D7Network                     DetectorType = 138
 	DetectorType_ScrapingBee                   DetectorType = 139
 	DetectorType_KeenIO                        DetectorType = 140
-	DetectorType_Wakatime                      DetectorType = 141 // Not yet implemented
+	DetectorType_Wakatime                      DetectorType = 141
 	DetectorType_Buildkite                     DetectorType = 142
 	DetectorType_Verimail                      DetectorType = 143
 	DetectorType_Zerobounce                    DetectorType = 144

--- a/proto/detector_type.proto
+++ b/proto/detector_type.proto
@@ -143,7 +143,7 @@ enum DetectorType {
   D7Network = 138;
   ScrapingBee = 139;
   KeenIO = 140;
-  Wakatime = 141; // Not yet implemented
+  Wakatime = 141;
   Buildkite = 142;
   Verimail = 143;
   Zerobounce = 144;


### PR DESCRIPTION
### Description:
Implement wakatime previously unimplemented as part of a POC for learning.

### Checklist:
* [ X] Tests passing (`make test-community`)?
* [ X] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated new detector following existing TruffleHog patterns; verification only performs outbound HTTP when scanning with verify enabled.
> 
> **Overview**
> Adds a **WakaTime** secret scanner for the existing `DetectorType_Wakatime` enum entry, which was previously marked as not implemented.
> 
> The detector finds `waka_`-prefixed UUID v4 keys via regex (keyword prefilter `waka_`), deduplicates matches, and optionally verifies them with HTTP basic auth against `GET /api/v1/users/current` (200 = verified, 401 = invalid). It is registered in the default detector list, and WakaTime is removed from the engine’s “not yet implemented” test set. Proto comments are updated to reflect that the type is implemented.
> 
> Unit tests cover regex/Aho–Corasick matching; integration tests (build tag `detectors`) cover live verification, inactive keys, timeouts, and unexpected API responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb0c00c1f2946eb3652bc9af3e6976a5679ef1e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->