### PR TITLE
fix(mongodb): anchor placeholder password regex to the whole string

### DIFF
--- a/pkg/detectors/mongodb/mongodb.go
+++ b/pkg/detectors/mongodb/mongodb.go
@@ -31,7 +31,7 @@ var (
 	// Make sure that your group is surrounded in boundary characters such as below to reduce false positives.
 	connStrPat = regexp.MustCompile(`\b(mongodb(?:\+srv)?://(?P<username>\S{3,50}):(?P<password>\S{3,88})@(?P<host>[-.%\w]+(?::\d{1,5})?(?:,[-.%\w]+(?::\d{1,5})?)*)(?:/(?P<authdb>[\w-]+)?(?P<options>\?\w+=[\w@/.$-]+(?:&(?:amp;)?\w+=[\w@/.$-]+)*)?)?)(?:\b|$)`)
 	// TODO: Add support for sharded cluster, replica set and Atlas Deployment.
-	placeholderPasswordPat = regexp.MustCompile(`^[xX]+|\*+$`)
+	placeholderPasswordPat = regexp.MustCompile(`^(?:[xX]+|\*+)$`)
 )
 
 // Keywords are used for efficiently pre-filtering chunks.

--- a/pkg/detectors/mongodb/mongodb_test.go
+++ b/pkg/detectors/mongodb/mongodb_test.go
@@ -144,6 +144,17 @@ func TestMongoDB_Pattern(t *testing.T) {
 			data:        `mongodb://prisma:risima@srv1.bu2lt.mongodb.net:27017,srv2.bu2lt.mongodb.net:27017,srv3.bu2lt.mongodb.net:27017/test?retryWrites=true&w=majority`,
 			shouldMatch: true,
 		},
+		{
+			name:        "password_starting_with_x",
+			data:        `mongodb://myDBReader:xK9mP2vL8qZ@mongodb0.example.com:27017`,
+			shouldMatch: true,
+		},
+		{
+			name:        "password_ending_with_asterisk",
+			data:        `mongodb://myDBReader:pass123*@mongodb0.example.com:27017`,
+			shouldMatch: true,
+			match:       `mongodb://myDBReader:pass123%2A@mongodb0.example.com:27017`,
+		},
 		// TODO: These fail because the Go driver doesn't explicitly support `authMechanism=DEFAULT`[1].
 		// However, this seems like a valid option[2] and I'm going to try to get that behaviour changed.
 		//


### PR DESCRIPTION
# fix(mongodb): anchor placeholder password regex to the whole string

## What this fixes

The MongoDB detector silently discards valid secrets whose password
starts with `x`/`X` or ends with `*` (#5276):

```go
// before
placeholderPasswordPat = regexp.MustCompile(`^[xX]+|\*+$`)
```

Because `|` binds looser than the anchors, this reads as
`(^ contains xX) OR (ends with *)` — so `xSecret123` and `pass123*` are
treated as placeholders and dropped at the `continue` in `FromData`,
with no result and no log.

## The fix

```go
placeholderPasswordPat = regexp.MustCompile(`^(?:[xX]+|\*+)$`)
```

A non-capturing group shares the anchors across both alternatives, so a
password is a placeholder only when it is *entirely* `xX` (e.g.
`xxxxxx`) or entirely `*` (e.g. `****`) — the intended semantics.
Equivalent to the regex suggested in the issue, but with one set of
anchors so a single-sided anchor can't regress. The existing
false-positive cases (`xxxx:xxxxx@xxxxxxx`) are still filtered.

## Tests

Two new cases in `mongodb_test.go`:

- `password_starting_with_x`: `mongodb://myDBReader:xK9mP2vL8qZ@...` now
  matches (red before the fix — the password was swallowed as a
  placeholder).
- `password_ending_with_asterisk`: `mongodb://myDBReader:pass123*@...`
  now matches; the expected match accounts for the `*` being
  URL-escaped to `%2A` in the raw credential.

Both existing placeholder false-positive cases still pass. Repo-wide
grep confirms this `^[xX]+|` pattern exists only in the MongoDB
detector.

`go test ./pkg/detectors/mongodb/...` all pass, build and `go vet` clean.

Fixes #5276

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow detector false-negative fix with no auth or data-path changes; placeholder filtering behavior is tightened, not broadened.
> 
> **Overview**
> Fixes a bug where the MongoDB detector dropped real connection strings when the password **started with `x`/`X`** or **ended with `*`** because `placeholderPasswordPat` was parsed as “starts with x/X” OR “ends with `*`” instead of “whole password is only placeholders.”
> 
> The regex is now **`^(?:[xX]+|\*+)$`**, so only passwords that are entirely `x`/`X` or entirely `*` are skipped; all-`xxxx` example credentials still do not match.
> 
> Tests add **`password_starting_with_x`** and **`password_ending_with_asterisk`** (including URL-encoded `%2A` in the expected raw match).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df350f92cecf80cd837c72aa4a2b636844b8032d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->