### PR TITLE
fix(install.sh): retry release asset downloads on 404

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -43,15 +43,15 @@ parse_args() {
 execute() {
   tmpdir=$(mktemp -d)
   log_debug "downloading files into ${tmpdir}"
-  http_download "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
-  
+  http_download_with_retry "${tmpdir}/${CHECKSUM}" "${CHECKSUM_URL}"
+
   if [ "$VERIFY_SIGN" = true ]; then
-    http_download "${tmpdir}/${CHECKSUM}.${CERT_FORMAT}" "${CHECKSUM_URL}.${CERT_FORMAT}"
-    http_download "${tmpdir}/${CHECKSUM}.${SIG_FORMAT}" "${CHECKSUM_URL}.${SIG_FORMAT}"
+    http_download_with_retry "${tmpdir}/${CHECKSUM}.${CERT_FORMAT}" "${CHECKSUM_URL}.${CERT_FORMAT}"
+    http_download_with_retry "${tmpdir}/${CHECKSUM}.${SIG_FORMAT}" "${CHECKSUM_URL}.${SIG_FORMAT}"
     verify_sign "${tmpdir}/${CHECKSUM}" "${tmpdir}/${CHECKSUM}.${CERT_FORMAT}" "${tmpdir}/${CHECKSUM}.${SIG_FORMAT}"
   fi
 
-  http_download "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
+  http_download_with_retry "${tmpdir}/${TARBALL}" "${TARBALL_URL}"
   hash_sha256_verify "${tmpdir}/${TARBALL}" "${tmpdir}/${CHECKSUM}"
   srcdir="${tmpdir}"
   (cd "${tmpdir}" && untar "${TARBALL}")
@@ -275,6 +275,31 @@ http_download() {
   return 1
 }
 
+# GitHub occasionally marks a release "latest" (or lets a user tag/publish
+# one) before all of its platform archives have finished uploading, so a
+# release asset can 404 for a few minutes right after it's tagged even
+# though the release itself definitely exists (we already resolved TAG from
+# real release metadata by this point). Retry with a short delay to ride out
+# that window instead of failing immediately.
+http_download_with_retry() {
+  local_file=$1
+  source_url=$2
+  header=$3
+  attempt=1
+  while [ "$attempt" -le "$RETRY_MAX_ATTEMPTS" ]; do
+    if http_download "$local_file" "$source_url" "$header"; then
+      return 0
+    fi
+    if [ "$attempt" -lt "$RETRY_MAX_ATTEMPTS" ]; then
+      log_info "asset not available yet for release '${TAG}' (attempt ${attempt}/${RETRY_MAX_ATTEMPTS}); it may still be uploading, retrying in ${RETRY_DELAY_SECONDS}s..."
+      sleep "$RETRY_DELAY_SECONDS"
+    fi
+    attempt=$((attempt + 1))
+  done
+  log_crit "release '${TAG}' still doesn't have '${source_url}' available after $((RETRY_MAX_ATTEMPTS * RETRY_DELAY_SECONDS))s -- it may still be building. Try again in a few minutes, or pin an earlier version, e.g.: sh -s -- -b ${BINDIR} <tag>. See https://github.com/${PREFIX}/releases for available tags."
+  return 1
+}
+
 http_copy() {
   tmp=$(mktemp)
   http_download "${tmp}" "$1" "$2" || return 1
@@ -372,6 +397,11 @@ COSIGN_BINARY=cosign
 VERIFY_SIGN=false
 CERT_FORMAT=pem
 SIG_FORMAT=sig
+# how many times (and how long to wait between) to retry a release asset
+# download that 404s, to ride out the window where a release is tagged but
+# its artifacts haven't finished uploading yet
+RETRY_MAX_ATTEMPTS=${RETRY_MAX_ATTEMPTS:-8}
+RETRY_DELAY_SECONDS=${RETRY_DELAY_SECONDS:-15}
 
 # use in logging routines
 log_prefix() {


### PR DESCRIPTION
## Summary

- `scripts/install.sh` fails with a bare `http_download_curl received HTTP status 404` when it's run against a release whose tag/metadata already exists but whose platform archives haven't finished uploading yet (goreleaser publishes the release object before all matrix jobs finish uploading assets). This has recurred multiple times (#4750, #4904) even after a prior fix to the release-marking logic (#4766) — this PR doesn't touch the release pipeline, it just makes the client resilient to that window.
- By the time `execute()` downloads the checksum/cert/sig/tarball, `TAG` has already been resolved from real GitHub release metadata in `tag_to_version()`, so a 404 at that point can only mean the assets aren't uploaded yet — not that the tag is invalid. That makes it safe to retry.
- Adds `http_download_with_retry`, used for all four asset downloads in `execute()`. Retries up to `RETRY_MAX_ATTEMPTS` (default 8) with a `RETRY_DELAY_SECONDS` delay (default 15s, ~2 minutes total), both overridable via env var for CI environments that want a different budget. If it still fails, the final error is actionable — points at the releases page and the "pin an earlier tag" workaround already circulating in the linked issues — instead of a bare HTTP status code.
- Tag resolution itself (`tag_to_version`) is untouched: a request for a genuinely nonexistent tag still fails immediately with today's clear message, no retries.

## Test plan

- [x] `dash -n scripts/install.sh` and `sh -n scripts/install.sh` — syntax checks pass.
- [x] Extracted the script's functions into a stub and ran `http_download_with_retry` against a local flaky HTTP server that 404s twice then returns 200: recovers and installs correctly after 2 logged retries.
- [x] Same setup with a server that always 404s (`RETRY_MAX_ATTEMPTS=3`): exhausts retries and exits with the new actionable error message instead of hanging or a bare 404.
- [x] Ran the full, unmodified-elsewhere script end-to-end against a real published release (`v3.88.0`) on macOS/arm64 — installs correctly with zero retries needed, confirming no regression on the normal path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the shell install script’s download retry behavior with no impact on runtime auth, data handling, or application logic.
> 
> **Overview**
> The install script now **retries release asset downloads** when checksum, signature, or tarball fetches fail (e.g. transient 404s right after a GitHub release is tagged but before all artifacts finish uploading).
> 
> `execute()` routes those four downloads through a new **`http_download_with_retry`** helper instead of calling **`http_download`** directly. It retries up to **`RETRY_MAX_ATTEMPTS`** (default **8**) with **`RETRY_DELAY_SECONDS`** between tries (default **15s**), both overridable via environment variables. Failed attempts log an informational message; after exhaustion, a **critical error** suggests waiting, pinning an older tag, or checking the releases page.
> 
> **Tag resolution** (`tag_to_version` / GitHub metadata) is unchanged and still fails immediately on invalid tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8318ba555e6b290fc51808367aa0a93eb537355. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->