### PR TITLE
Use internal HTTP clients instead of a global in custom detectors

### DIFF
--- a/pkg/custom_detectors/custom_detectors.go
+++ b/pkg/custom_detectors/custom_detectors.go
@@ -30,6 +30,7 @@ const maxTotalMatches = 100
 // initialization).
 type CustomRegexWebhook struct {
 	*custom_detectorspb.CustomRegex
+	httpClient *http.Client
 }
 
 // Ensure the Scanner satisfies the interface at compile time.
@@ -77,10 +78,11 @@ func NewWebhookCustomRegex(pb *custom_detectorspb.CustomRegex) (*CustomRegexWebh
 	ensurePrimaryRegexNameSet(pb)
 
 	// TODO: Copy only necessary data out of pb.
-	return &CustomRegexWebhook{pb}, nil
+	return &CustomRegexWebhook{
+		CustomRegex: pb,
+		httpClient:  common.SaneHttpClient(),
+	}, nil
 }
-
-var httpClient = common.SaneHttpClient()
 
 func (c *CustomRegexWebhook) FromData(ctx context.Context, verify bool, data []byte) (results []detectors.Result, err error) {
 	dataStr := string(data)
@@ -307,7 +309,7 @@ func (c *CustomRegexWebhook) createResults(ctx context.Context, match map[string
 		if req.Header.Get("Content-Type") == "" {
 			req.Header.Set("Content-Type", "application/json")
 		}
-		resp, err := httpClient.Do(req)
+		resp, err := c.httpClient.Do(req)
 		if err != nil {
 			continue
 		}

--- a/pkg/custom_detectors/custom_detectors_test.go
+++ b/pkg/custom_detectors/custom_detectors_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/trufflesecurity/trufflehog/v3/pkg/common"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/custom_detectorspb"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/pb/detector_typepb"
@@ -137,13 +138,14 @@ func TestCustomDetectorsParsing(t *testing.T) {
 
 func TestFromData_InvalidRegEx(t *testing.T) {
 	c := &CustomRegexWebhook{
-		&custom_detectorspb.CustomRegex{
+		CustomRegex: &custom_detectorspb.CustomRegex{
 			Name:     "Internal bi tool",
 			Keywords: []string{"secret_v1_", "pat_v2_"},
 			Regex: map[string]string{
 				"test": "!!?(?:?)[a-zA-Z0-9]{32}", // invalid regex
 			},
 		},
+		httpClient: common.SaneHttpClient(),
 	}
 
 	_, err := c.FromData(context.Background(), false, []byte("test"))
@@ -832,12 +834,12 @@ func TestVerificationWithConfigurableRanges(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name              string
-		serverStatus      int
-		successRanges     []string
-		rotatedRanges     []string
-		wantVerified      bool
-		wantVerifyErr     bool
+		name          string
+		serverStatus  int
+		successRanges []string
+		rotatedRanges []string
+		wantVerified  bool
+		wantVerifyErr bool
 	}{
 		{
 			name:          "backward compat: no ranges, 200 -> verified",


### PR DESCRIPTION
### Description:

All custom detectors share a single global HTTP client. This moves the global client into `CustomRegexWebhook` so each custom detector now has its own HTTP client it can configure separately, which we need in order to support authentication in custom detectors.