### PR TITLE
make 401s for Basic auth verified false.

### DIFF
--- a/pkg/detectors/docker/docker_auth_config.go
+++ b/pkg/detectors/docker/docker_auth_config.go
@@ -188,6 +188,10 @@ func verifyMatch(ctx logContext.Context, client *http.Client, registry string, u
 			return false, nil
 		}
 
+		if strings.HasPrefix(h, "Basic") {
+			return false, nil
+		}
+
 		if !strings.HasPrefix(h, "Bearer") {
 			return false, fmt.Errorf("unsupported WWW-Authenticate auth scheme: %s", h)
 		}

--- a/pkg/detectors/docker/docker_auth_config_test.go
+++ b/pkg/detectors/docker/docker_auth_config_test.go
@@ -1,11 +1,14 @@
 package docker
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/context"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/detectors"
 	"github.com/trufflesecurity/trufflehog/v3/pkg/engine/ahocorasick"
-	"testing"
 )
 
 func TestDocker_Pattern(t *testing.T) {
@@ -297,5 +300,104 @@ func Test_ParseAuthenticateHeader(t *testing.T) {
 		if diff := cmp.Diff(expected, actual); diff != "" {
 			t.Errorf("%s diff: (-want +got)\n%s", input, diff)
 		}
+	}
+}
+
+func Test_VerifyMatch(t *testing.T) {
+	// base64 of "user:pass"
+	const basicAuth = "dXNlcjpwYXNz"
+
+	// bearerChallenge points the token realm back at the test server so the follow-up
+	// request stays in-process.
+	bearerChallenge := func(host string) string {
+		return `Bearer realm="http://` + host + `/token",service="registry"`
+	}
+
+	tests := []struct {
+		name         string
+		handler      http.HandlerFunc
+		wantVerified bool
+		wantErr      bool
+	}{
+		{
+			name: "harbor rejects basic auth",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Www-Authenticate", `Basic realm="harbor"`)
+				w.WriteHeader(http.StatusUnauthorized)
+			},
+			wantVerified: false,
+			wantErr:      false,
+		},
+		{
+			name: "unauthorized without a challenge",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusUnauthorized)
+			},
+			wantVerified: false,
+			wantErr:      false,
+		},
+		{
+			name: "unsupported scheme is still indeterminate",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Www-Authenticate", `Digest realm="registry"`)
+				w.WriteHeader(http.StatusUnauthorized)
+			},
+			wantVerified: false,
+			wantErr:      true,
+		},
+		{
+			name: "bearer token exchange rejects credentials",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/token" {
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				w.Header().Set("Www-Authenticate", bearerChallenge(r.Host))
+				w.WriteHeader(http.StatusUnauthorized)
+			},
+			wantVerified: false,
+			wantErr:      false,
+		},
+		{
+			name: "bearer token exchange accepts credentials",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/token" {
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+				w.Header().Set("Www-Authenticate", bearerChallenge(r.Host))
+				w.WriteHeader(http.StatusUnauthorized)
+			},
+			wantVerified: true,
+			wantErr:      false,
+		},
+		{
+			name: "registry accepts basic auth",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{}`))
+			},
+			wantVerified: true,
+			wantErr:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(tc.handler)
+			defer server.Close()
+
+			verified, err := verifyMatch(context.Background(), server.Client(), server.URL, "user", basicAuth)
+
+			if tc.wantErr && err == nil {
+				t.Errorf("expected a verification error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("expected no verification error, got %v", err)
+			}
+			if verified != tc.wantVerified {
+				t.Errorf("verified = %v, want %v", verified, tc.wantVerified)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Docker registries that use basic auth (e.g. Harbor) answer `/v2/` with
`401` and `WWW-Authenticate: Basic realm="..."` when the credentials are
rejected. `verifyMatch` only knew how to handle a `Bearer` challenge, so
a `Basic` challenge fell through to `unsupported WWW-Authenticate auth
scheme` and was recorded as a verification error.
Changes:
- Treat a `Basic` challenge on `401` as a definitive verification failure.
- Add `Test_VerifyMatch` covering the new case plus existing behavior
  (no challenge header, unsupported scheme, both bearer token-exchange
  outcomes, and a successful `200`).

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to how 401 + Basic challenges are classified during optional verification; behavior is more accurate and covered by new unit tests.
> 
> **Overview**
> Fixes Docker registry credential verification when a registry responds to `/v2/` with **401** and **`WWW-Authenticate: Basic`** (e.g. Harbor rejecting bad credentials). **`verifyMatch`** previously treated non-**Bearer** challenges as unsupported and returned a verification **error**; it now returns **`verified: false`** with **no error**, matching other definitive auth failures.
> 
> Adds **`Test_VerifyMatch`** using **`httptest`** to cover the Harbor/Basic case plus existing paths: empty challenge, unsupported **Digest** scheme (still errors), bearer token exchange success/failure, and **200** success.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdfdb44c039186590997e7443393c840171c5415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->