### PR TITLE
feat: add --no-ignore-tag to report secrets on trufflehog:ignore lines

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,6 +65,7 @@ var (
 
 	allowVerificationOverlap   = cli.Flag("allow-verification-overlap", "Allow verification of similar credentials across detectors").Bool()
 	filterUnverified           = cli.Flag("filter-unverified", "Only output first unverified result per chunk per detector if there are more than one results.").Bool()
+	noIgnoreTag                = cli.Flag("no-ignore-tag", "Do not suppress results on lines containing a 'trufflehog:ignore' comment.").Bool()
 	filterEntropy              = cli.Flag("filter-entropy", "Filter unverified results with Shannon entropy. Start with 3.0.").Float64()
 	scanEntireChunk            = cli.Flag("scan-entire-chunk", "Scan the entire chunk for secrets.").Hidden().Default("false").Bool()
 	maxDecodeDepth             = cli.Flag("max-decode-depth", "Maximum depth of iterative decoding. Each decoder's output is fed back through all decoders, up to this limit. 1 = single pass, 2+ = chained decoding (e.g., base64 inside utf16).").Default("5").Int()
@@ -654,6 +655,7 @@ func run(state overseer.State, logSync func() error) {
 		VerifierEndpoints:        *verifiers,
 		Dispatcher:               engine.NewPrinterDispatcher(printer),
 		FilterUnverified:         *filterUnverified,
+		NoIgnoreTag:              *noIgnoreTag,
 		FilterEntropy:            *filterEntropy,
 		VerificationOverlap:      *allowVerificationOverlap,
 		Results:                  parsedResults,

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -123,7 +123,10 @@ type Config struct {
 	FilterEntropy float64
 	// FilterUnverified sets the filterUnverified flag on the engine. If set to
 	// true, the engine will only return the first unverified result for a chunk for a detector.
-	FilterUnverified      bool
+	FilterUnverified bool
+	// NoIgnoreTag, when true, disables the default behavior of dropping results
+	// whose line contains a "trufflehog:ignore" comment.
+	NoIgnoreTag           bool
 	ShouldScanEntireChunk bool
 
 	Dispatcher ResultsDispatcher
@@ -184,6 +187,9 @@ type Engine struct {
 	// If there are multiple unverified results for the same chunk for the same detector,
 	// only the first one will be kept.
 	filterUnverified bool
+	// noIgnoreTag disables suppression of results on lines containing the
+	// "trufflehog:ignore" comment tag.
+	noIgnoreTag bool
 	// entropyFilter is used to filter out unverified results using Shannon entropy.
 	filterEntropy           float64
 	notifyVerifiedResults   bool
@@ -253,6 +259,7 @@ func NewEngine(ctx context.Context, cfg *Config) (*Engine, error) {
 		dispatcher:                          cfg.Dispatcher,
 		verify:                              cfg.Verify,
 		filterUnverified:                    cfg.FilterUnverified,
+		noIgnoreTag:                         cfg.NoIgnoreTag,
 		filterEntropy:                       cfg.FilterEntropy,
 		printAvgDetectorTime:                cfg.PrintAvgDetectorTime,
 		retainFalsePositives:                cfg.LogFilteredUnverified,
@@ -1290,7 +1297,7 @@ func (e *Engine) processResult(
 		}
 		chunk = copyChunk
 	}
-	if ignoreLinePresent {
+	if ignoreLinePresent && !e.noIgnoreTag {
 		resultsDropped.WithLabelValues("process_result", "ignore_line_tag", res.DetectorType.String()).Inc()
 		return
 	}


### PR DESCRIPTION
Adds a CLI flag that disables the default suppression of results whose line contains a `trufflehog:ignore` comment. Detection is unchanged; only the post-detection drop in processResult is bypassed.

<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
 So CI can enforce that no verified secret reaches main — even one hidden behind a trufflehog:ignore / false-positive annotation.
### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in CLI flag that only changes post-detection filtering in processResult; default behavior is unchanged.
> 
> **Overview**
> Adds an opt-in **`--no-ignore-tag`** flag so scans can still **report findings on lines marked with `trufflehog:ignore`**, instead of dropping them in post-processing.
> 
> The flag is wired from `main.go` into `engine.Config` / `Engine.noIgnoreTag`. In **`processResult`**, the existing ignore-line check still runs for line numbers and links, but results are only suppressed when the tag is present **and** the flag is off (`ignoreLinePresent && !e.noIgnoreTag`). **Detection and verification are unchanged**—only the ignore-tag filter is bypassed when the flag is set, which supports CI policies that must not allow verified secrets to hide behind ignore comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2feb5d27f51d5c3fdf20b1cc82084bc43727dbc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->