### PR TITLE
remove pre-commit env awareness with hardcoded params

### DIFF
--- a/main.go
+++ b/main.go
@@ -882,24 +882,7 @@ func runSingleScan(ctx context.Context, cmd string, cfg engine.Config) (metrics,
 			ClonePath:           *gitClonePath,
 			NoCleanup:           *gitNoCleanup,
 			PrintLegacyJSON:     *jsonLegacy,
-			TrustLocalGitConfig: *gitTrustLocalGitConfig,
-		}
-
-		// detect if trufflehog is running git source as a pre-commit hook
-		if isPreCommitHook() {
-			ctx.Logger().Info("Running as a pre-commit hook, overriding default flags for hook context")
-
-			// Override git configuration for pre-commit hook context
-			gitCfg.TrustLocalGitConfig = true
-			gitCfg.BaseRef = "HEAD" // Only scan staged changes
-
-			// Override result filters for pre-commit hook context
-			// In hook mode, we only want to show verified secrets and unknown findings
-			*results = "verified,unknown"
-
-			// Override failure behavior for pre-commit hook context
-			// In hook mode, we want to fail the commit if any secrets are found
-			*fail = true
+			TrustLocalGitConfig: *gitTrustLocalGitConfig || isPreCommitHook(),
 		}
 
 		if ref, err := eng.ScanGit(ctx, gitCfg); err != nil {


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
Remove legacy hardcoded params, when pre-commit frameworks are used. Delegate configuration options to user.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for pre-commit integrations that relied on implicit scan scope, result filtering, and exit-on-find behavior without documenting those flags in hook configs.
> 
> **Overview**
> Removes automatic **pre-commit hook** behavior that rewrote scan settings when `isPreCommitHook()` detected frameworks like pre-commit.com or Husky.
> 
> Previously, hook runs forced **`BaseRef` to `HEAD`**, narrowed **`--results`** to `verified,unknown`, and enabled **`--fail`**, in addition to trusting local git config. Those overrides are gone; hook authors must pass flags explicitly (e.g. `--since-commit`, `--results`, `--fail`) in their hook configuration.
> 
> The only remaining hook-specific default is **`TrustLocalGitConfig`**, which is now set inline as `*gitTrustLocalGitConfig || isPreCommitHook()` instead of being applied in a separate block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b88eff8a63c15c6a369c0bdb1611e5c9727dfc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->