### PR TITLE
Clarify security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,22 +1,68 @@
-Please report security issues to security@trufflesec.com and include `trufflehog` in the subject line. If your vulnerability involves SSRF or outbound requests, please see our policy for that specific class of vulnerability below.
+Please report security issues to security@trufflesec.com and include
+`trufflehog` in the subject line. If your vulnerability involves SSRF or
+outbound requests, please see our policy for that specific class of
+vulnerability below.
+
 
 ## Blind SSRF & Outbound Request Policy
-Truffle Security treats blind SSRF (the ability to induce outbound requests without data retrieval) as a hardening opportunity rather than a vulnerability. We do not issue CVEs or formal advisories for reports showing outbound interactions unless they demonstrate a tangible security risk to users.
 
-#### Policy Criteria
-**Vulnerability (CVE Issued):** We will issue a CVE if a researcher demonstrates a clear exploit chain. For example:
-- Credential Exfiltration: Forcing TruffleHog to send third-party secrets (discovered during a scan) or the host's own environment credentials (e.g., IAM metadata) to an attacker-controlled endpoint.
-- Internal Exploitation: Using a blind request to trigger secondary vulnerabilities (e.g. RCE) on restricted internal services configured for defense-in-depth.
+As part of its intended operation, TruffleHog makes network requests to
+upstream secret providers in order to verify liveness of each secret.
 
-**Hardening (No CVE):** We generally will not issue a CVE for:
-- Reflected Payloads: Inducing a request to an attacker-controlled URL by inserting a URL into the scan input (i.e., the attacker receiving data back that they already had access to).
-- Basic Outbound Control: Demonstrating control over the request URL, Path, or Body, without demonstrating a path to credential leakage or internal system exploitation.
-- Service Probing: Simple open/closed port verification or basic interaction with internal services (e.g., triggering a GET request to a local web server) without a demonstrated compromise of data or system integrity.
-- Secondary Vulnerability Dependencies: Where the impact relies entirely on the pre-existing lack of authentication, misconfiguration, or known vulnerabilities of a third-party internal service.
+Truffle Security treats blind SSRF (i.e., the ability to induce outbound
+requests without data retrieval) as a hardening opportunity rather than
+a vulnerability.
+
+We do not issue CVEs or formal advisories for reports showing outbound
+interactions unless they demonstrate a tangible security risk to users.
+
+### Policy Criteria
+
+#### Vulnerability (CVE Issued):
+We will issue a CVE if a researcher demonstrates a clear exploit chain.
+For example:
+
+- Credential Exfiltration: Forcing TruffleHog to send third-party
+  secrets (discovered during a scan) or the host's own environment
+  credentials (e.g., IAM metadata) to an attacker-controlled endpoint.
+
+- Internal Exploitation: Using a blind request to trigger secondary
+  vulnerabilities (e.g. RCE) on restricted internal services configured
+  for defense-in-depth.
+
+#### Hardening Opportunity (No CVE):
+We will not issue a CVE for:
+
+- **Reflected Payloads:** Inducing a request to an attacker-controlled endpoint
+  that requires the attacker to have write access to the scan input (i.e., the
+  attacker receiving data back that they already had access to).
+
+- **Basic Outbound Control:** Demonstrating control over the request
+  URL, Path, or Body, without demonstrating a path to credential leakage
+  or internal system exploitation.
+
+- **Service Probing:** Simple open/closed port verification or basic
+  interaction with internal services (e.g., triggering a GET request to
+  a local web server) without a demonstrated compromise of data or
+  system integrity.
+
+- **Secondary Vulnerability Dependencies:** Where the impact relies
+  entirely on the pre-existing lack of authentication, misconfiguration,
+  or known vulnerabilities of a third-party internal service.
 
 ### Submission Guidelines
+
 To help us evaluate your report, please specify:
-- Level of Control: Which request components are controllable (Method, Host, Path, Headers, or Body)?
-- Secret Context: Can you prove that a legitimate secret (not the attacker's payload) is attached to or contained within the outbound request?
-- Target Reach: Can the request reach restricted internal IPs (e.g., 127.0.0.1 or 169.254.169.254)?
-- Demonstrated Impact: What is the specific risk to a user or environment beyond a simple DNS/HTTP interaction?
+
+- **Level of Control:** Which request components are controllable (Method,
+  Host, Path, Headers, or Body)?
+
+- **Secret Context:** Can you prove that a legitimate secret that the attacker
+  did not already have access to (i.e., not the attacker's payload) is attached
+  to or contained within the outbound request?
+
+- **Target Reach:** Can the request reach restricted internal IPs (e.g.,
+  127.0.0.1 or 169.254.169.254)?
+
+- **Demonstrated Impact:** What is the specific risk to a user or environment
+  beyond a simple DNS/HTTP interaction?


### PR DESCRIPTION
- wrap text for plain-text legibility
- fix heading nesting
- expand SSRF policy and submission guidelines for clarity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to security disclosure policy; no code or configuration is modified.
> 
> **Overview**
> Updates **`SECURITY.md`** to make the blind SSRF / outbound-request policy easier to read and more explicit for researchers—no product or runtime behavior changes.
> 
> The intro and policy sections are **line-wrapped** for plain-text viewing, and **heading levels** are corrected (`Policy Criteria` and separate **Vulnerability** vs **Hardening Opportunity** subsections). A new paragraph states that **outbound requests to secret providers are expected** during liveness verification.
> 
> Substantive wording tweaks: **reflected payloads** now require **write access to scan input** and refer to an attacker-controlled **endpoint**; **Secret Context** in submission guidelines now requires proof of a secret the attacker **did not already possess** (not just “not the attacker’s payload”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e74cd03016412413e6c7faf333c59f0480542449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->