### PR TITLE
Postgres: drop non-connection URI params before verifying

### DIFF
--- a/pkg/detectors/postgres/postgres.go
+++ b/pkg/detectors/postgres/postgres.go
@@ -38,6 +38,24 @@ const (
 	pgDbType         = "db_type"
 )
 
+// nonConnectionParams are query-string arguments that ORMs append to
+// Postgres connection URIs but that are not libpq connection keywords. lib/pq and pgx
+// forward any key they don't recognize to the server as a startup runtime parameter,
+// which the server rejects with 42704. Exluding them prevents this
+var nonConnectionParams = map[string]struct{}{
+	"schema":           {}, // Prisma: search_path selector
+	"connection_limit": {}, // Prisma: client-side pool size
+	"pool_timeout":     {}, // Prisma: pool-acquisition wait
+	"socket_timeout":   {}, // Prisma: per-query timeout
+	"pgbouncer":        {}, // Prisma: PgBouncer compatibility mode
+	"sslidentity":      {}, // Prisma: PKCS12 certificate path
+}
+
+func isNonConnectionParam(key string) bool {
+	_, ok := nonConnectionParams[key]
+	return ok
+}
+
 // This detector currently only finds Postgres connection string URIs
 // (https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS) When it finds one, it uses
 // pq.ParseURI to normalize this into space-separated key-value pair Postgres connection string, and then uses a regular
@@ -320,7 +338,7 @@ func verifyPostgresPgx(ctx context.Context, params map[string]string) (bool, err
 func pgxConnString(params map[string]string) string {
 	var connStr strings.Builder
 	for key, value := range params {
-		if key == pgDbType || key == pgRequiressl {
+		if key == pgDbType || key == pgRequiressl || isNonConnectionParam(key) {
 			continue
 		}
 		fmt.Fprintf(&connStr, "%s='%s'", key, value)
@@ -370,6 +388,9 @@ func verifyPostgresPq(params map[string]string) (bool, error) {
 
 	var connStr string
 	for key, value := range params {
+		if isNonConnectionParam(key) {
+			continue
+		}
 		connStr += fmt.Sprintf("%s='%s'", key, value)
 	}
 

--- a/pkg/detectors/postgres/postgres.go
+++ b/pkg/detectors/postgres/postgres.go
@@ -67,9 +67,9 @@ func isNonConnectionParam(key string) bool {
 // Multi-host connection string URIs are currently not supported because pq.ParseURI doesn't parse them correctly. If we
 // happen to run into a case where this matters we can address it then.
 var (
-	_                  detectors.Detector = (*Scanner)(nil)
-	uriPattern                            = regexp.MustCompile(`\b(?i)(postgres(?:ql)?)://\S+\b`)
-	connStrPartPattern                    = regexp.MustCompile(`([[:alpha:]]+)='(.+?)' ?`)
+	_          detectors.Detector = (*Scanner)(nil)
+	uriPattern                    = regexp.MustCompile(`\b(?i)(postgres(?:ql)?)://\S+\b`)
+	connStrPartPattern = regexp.MustCompile(`([[:alpha:]_]+)='(.+?)' ?`)
 )
 
 type Scanner struct {

--- a/pkg/detectors/postgres/postgres_test.go
+++ b/pkg/detectors/postgres/postgres_test.go
@@ -253,3 +253,50 @@ func TestPostgres_RawVsPrimarySecret(t *testing.T) {
 	assert.Equal(t, expectedRaw, string(res.RawV2))
 	assert.Equal(t, input, res.GetPrimarySecretValue())
 }
+
+// TestPgxConnString_FiltersNonConnectionParams verifies that ORM query-string arguments
+// which are not libpq connection keywords are dropped from the verification connection
+// string
+func TestPgxConnString_FiltersNonConnectionParams(t *testing.T) {
+	params := map[string]string{
+		pgUser:             "u",
+		pgPassword:         "p",
+		pgHost:             "h",
+		pgPort:             "5432",
+		pgDbname:           "d",
+		pgSslmode:          "require",    // libpq keyword, also a Prisma arg — must be kept
+		pgConnectTimeout:   "5",          // libpq keyword, also a Prisma arg — must be kept
+		"sslcert":          "/tmp/c.pem", // libpq keyword — must be kept
+		pgDbType:           "postgresql", // detector-internal — must be dropped
+		pgRequiressl:       "1",          // pgx does not recognize — must be dropped
+		"schema":           "public",     // Prisma — must be dropped
+		"connection_limit": "5",          // Prisma — must be dropped
+		"pool_timeout":     "10",         // Prisma — must be dropped
+		"socket_timeout":   "30",         // Prisma — must be dropped
+		"pgbouncer":        "true",       // Prisma — must be dropped
+		"sslidentity":      "/tmp/i.p12", // Prisma — must be dropped
+	}
+
+	got := pgxConnString(params)
+
+	kept := []string{pgUser, pgPassword, pgHost, pgPort, pgDbname, pgSslmode, pgConnectTimeout, "sslcert"}
+	for _, key := range kept {
+		assert.Containsf(t, got, key+"=", "expected connection param %q to be preserved", key)
+	}
+
+	dropped := []string{pgDbType, pgRequiressl, "schema", "connection_limit", "pool_timeout", "socket_timeout", "pgbouncer", "sslidentity"}
+	for _, key := range dropped {
+		assert.NotContainsf(t, got, key+"=", "expected non-connection param %q to be filtered out", key)
+	}
+}
+
+func TestIsNonConnectionParam(t *testing.T) {
+	// ORM arguments that are not libpq keywords.
+	for _, key := range []string{"schema", "connection_limit", "pool_timeout", "socket_timeout", "pgbouncer", "sslidentity"} {
+		assert.Truef(t, isNonConnectionParam(key), "%q should be treated as a non-connection param", key)
+	}
+	// Real libpq keywords that ORMs also use — must not be filtered.
+	for _, key := range []string{pgConnectTimeout, pgSslmode, "sslcert", pgUser, pgPassword, pgHost, pgPort, pgDbname} {
+		assert.Falsef(t, isNonConnectionParam(key), "%q is a real connection parameter and must not be filtered", key)
+	}
+}

--- a/pkg/detectors/postgres/postgres_test.go
+++ b/pkg/detectors/postgres/postgres_test.go
@@ -254,39 +254,25 @@ func TestPostgres_RawVsPrimarySecret(t *testing.T) {
 	assert.Equal(t, input, res.GetPrimarySecretValue())
 }
 
-// TestPgxConnString_FiltersNonConnectionParams verifies that ORM query-string arguments
-// which are not libpq connection keywords are dropped from the verification connection
-// string
-func TestPgxConnString_FiltersNonConnectionParams(t *testing.T) {
-	params := map[string]string{
-		pgUser:             "u",
-		pgPassword:         "p",
-		pgHost:             "h",
-		pgPort:             "5432",
-		pgDbname:           "d",
-		pgSslmode:          "require",    // libpq keyword, also a Prisma arg — must be kept
-		pgConnectTimeout:   "5",          // libpq keyword, also a Prisma arg — must be kept
-		"sslcert":          "/tmp/c.pem", // libpq keyword — must be kept
-		pgDbType:           "postgresql", // detector-internal — must be dropped
-		pgRequiressl:       "1",          // pgx does not recognize — must be dropped
-		"schema":           "public",     // Prisma — must be dropped
-		"connection_limit": "5",          // Prisma — must be dropped
-		"pool_timeout":     "10",         // Prisma — must be dropped
-		"socket_timeout":   "30",         // Prisma — must be dropped
-		"pgbouncer":        "true",       // Prisma — must be dropped
-		"sslidentity":      "/tmp/i.p12", // Prisma — must be dropped
-	}
+// TestVerifyConnString_FiltersNonConnectionParams verifies that ORM query-string
+// arguments which are not libpq connection keywords are dropped from the verification
+// connection string.
+func TestVerifyConnString_FiltersNonConnectionParams(t *testing.T) {
+	uri := `postgresql://u:p@h:5432/db?sslmode=require&schema=public&connection_limit=5&pool_timeout=10&socket_timeout=30&pgbouncer=true&sslidentity=/tmp/i.p12&connect_timeout=7`
 
-	got := pgxConnString(params)
+	matches := findUriMatches([]byte(uri), nil)
+	require.Len(t, matches, 1)
+	got := pgxConnString(matches[0].params)
 
-	kept := []string{pgUser, pgPassword, pgHost, pgPort, pgDbname, pgSslmode, pgConnectTimeout, "sslcert"}
-	for _, key := range kept {
+
+	for _, key := range []string{pgUser, pgPassword, pgHost, pgPort, pgDbname, pgSslmode, pgConnectTimeout} {
 		assert.Containsf(t, got, key+"=", "expected connection param %q to be preserved", key)
 	}
-
-	dropped := []string{pgDbType, pgRequiressl, "schema", "connection_limit", "pool_timeout", "socket_timeout", "pgbouncer", "sslidentity"}
-	for _, key := range dropped {
+	for _, key := range []string{pgDbType, "schema", "connection_limit", "pool_timeout", "socket_timeout", "pgbouncer", "sslidentity"} {
 		assert.NotContainsf(t, got, key+"=", "expected non-connection param %q to be filtered out", key)
+	}
+	for _, mangled := range []string{"limit=", "identity="} {
+		assert.NotContainsf(t, got, mangled, "found truncated key fragment %q — connStrPartPattern lost the underscore", mangled)
 	}
 }
 


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
For Postgres, drop non-connection URI params before verifying
Prisma and other ORMs append query-string arguments such as `schema`,
`connection_limit`, and `pgbouncer` to Postgres connection URIs. These
are not libpq connection keywords, so lib/pq and pgx forward them to the
server as startup runtime parameters, which the server rejects with
42704 ("unrecognized configuration parameter") before authentication can
resolve. This trapped valid credentials in indeterminate verification.
This change adds a denylist of known non-connection params out of the connection
string on both the lib/pq and pgx (Neon) paths. Each entry was diffed
against the libpq keyword list; params that ORMs share with libpq
(connect_timeout, sslmode, sslcert) are intentionally kept. 
### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to Postgres verification string assembly with denylist filtering and unit tests; no auth logic changes beyond avoiding bogus server GUC errors.
> 
> **Overview**
> Fixes **indeterminate Postgres verification** when connection URIs include ORM-specific query arguments (e.g. Prisma’s `schema`, `connection_limit`, `pgbouncer`). Those keys are not libpq keywords; **lib/pq** and **pgx** would forward them as server startup parameters and the server returns **42704** before auth completes, so valid secrets could not be classified.
> 
> The detector now maintains a **denylist** of known non-connection params and **drops them** when building strings for both the **pgx (Neon)** path (`pgxConnString`) and the **lib/pq** path (`verifyPostgresPq`). Real shared keywords like `connect_timeout` and `sslmode` stay.
> 
> **`connStrPartPattern`** is updated to allow **underscores** in parameter names so keys like `connection_limit` parse fully instead of being truncated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e830e8b62d3af08db5c168b71426677a9a2d4e14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->