### PR TITLE
Include merge diffs in git scanning

### DIFF
--- a/pkg/gitparse/gitparse.go
+++ b/pkg/gitparse/gitparse.go
@@ -429,6 +429,8 @@ func (c *Parser) prepGitArgs(source string, head string, abbreviatedLog bool, ex
 		show: []string{
 			// https://git-scm.com/docs/git-show#Documentation/git-show.txt---patch
 			"--patch",
+			// https://git-scm.com/docs/git-log#Documentation/git-log.txt-first-parent
+			"--diff-merges=first-parent",
 			// https://git-scm.com/docs/git-log#Documentation/git-log.txt---dateformat
 			"--date=iso-strict",
 			// https://git-scm.com/docs/git-show#_pretty_formats

--- a/pkg/sources/git/git_test.go
+++ b/pkg/sources/git/git_test.go
@@ -508,6 +508,8 @@ func TestSource_Chunks_Integration(t *testing.T) {
 				"8fe6f04ef1839e3fc54b5147e3d0e0b7ab971bd5-aws":   {B: []byte("blah blaj\n\nthis is the secret: AKIA2E0A8F3B244C9986\n\nokay thank you bye\n"), Multi: true},
 				"84e9c75e388ae3e866e121087ea2dd45a71068f2-":      {B: []byte("Dylan Ayrey <dxa4481@rit.edu>\nGitHub <noreply@github.com>\nUpdate aws\n")},
 				"84e9c75e388ae3e866e121087ea2dd45a71068f2-aws":   {B: []byte("\n\nthis is the secret: [Default]\nAccess key Id: AKIAILE3JG6KMS3HZGCA\nSecret Access Key: 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\n\nokay thank you bye\n"), Multi: false},
+				"90c75f884c65dc3638ca1610bd9844e668f213c2-":      {B: []byte("Dustin Decker <dustindecker@protonmail.com>\nGitHub <noreply@github.com>\nMerge pull request #1 from dxa4481/patch-1\n\nUpdate aws\n")},
+				"90c75f884c65dc3638ca1610bd9844e668f213c2-aws":   {B: []byte("\n\nthis is the secret: [Default]\nAccess key Id: AKIAILE3JG6KMS3HZGCA\nSecret Access Key: 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\n\nokay thank you bye\n"), Multi: false},
 			},
 		},
 		{
@@ -532,6 +534,23 @@ func TestSource_Chunks_Integration(t *testing.T) {
 			scanOptions: ScanOptions{
 				HeadHash: "some_branch",
 				BaseHash: "master",
+			},
+		},
+		{
+			name:    "remote repo, secret only present in merge",
+			repoURL: "https://github.com/mariduv/git-merge-leak.git",
+			expectedChunkData: map[string]*byteCompare{
+				"c68b1b9f952e5bd6e69aaaabea79ae28fcc0d53d-":           {B: []byte("Meredith Howard <meredith.howard@trufflesec.com>\nMeredith Howard <meredith.howard@trufflesec.com>\nMerge branch 'some-branch'\n")},
+				"c68b1b9f952e5bd6e69aaaabea79ae28fcc0d53d-blah.txt":   {B: []byte("\n\nWed Jul 15 10:00:58 CDT 2026\n")},
+				"c68b1b9f952e5bd6e69aaaabea79ae28fcc0d53d-blah2.txt":  {B: []byte("Wed Jul 15 10:00:58 CDT 2026\n")},
+				"c68b1b9f952e5bd6e69aaaabea79ae28fcc0d53d-secret.aws": {B: []byte("[default]\naws_access_key_id = AKIAXYZDQCEN4B6JSJQI\naws_secret_access_key = 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\noutput = json\nregion = us-east-2\n")},
+				"be526890e9cbdf98233f2332c3617d13a26a8c32-":           {B: []byte("Meredith Howard <meredith.howard@trufflesec.com>\nMeredith Howard <meredith.howard@trufflesec.com>\nUpdates\n")},
+				"be526890e9cbdf98233f2332c3617d13a26a8c32-blah.txt":   {B: []byte("\nWed Jul 15 10:00:58 CDT 2026\n")},
+				"be526890e9cbdf98233f2332c3617d13a26a8c32-blah2.txt":  {B: []byte("Wed Jul 15 10:00:58 CDT 2026\n")},
+			},
+			scanOptions: ScanOptions{
+				HeadHash: "c68b1b9f952e5bd6e69aaaabea79ae28fcc0d53d",
+				BaseHash: "c48635b82f3a203fee843cdc915abca1876e026b",
 			},
 		},
 	}


### PR DESCRIPTION
Merge commits can include novel changes not present in any parent, and should be scanned.  The git log command with -p shows merge commits, commits but without any diffs, so we were not scanning that content.

The "low memory" mode does get merge diffs in git show, but they're in a format the parser isn't prepared to handle, and changes would need careful testing.

There are a few ways to show the merge diffs, some make it easier to show any novel changes, but require some parser/test adjustment or version checks.  "first-parent" is the simplest "what did this merge introduce" diff, meaning we double scan content from other parents, but also include changes that are only in the merge.

### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core git diff extraction for all repo scans; behavior shifts on merge commits and may increase scanned content, though tests lock expected chunk output.
> 
> **Overview**
> Git scans previously walked merge commits but **`git log`/`git show` with `-p` often produced no patch for merges**, so secrets introduced only in a merge could be missed.
> 
> This adds **`--diff-merges=first-parent`** to the shared `git show` arguments in `prepGitArgs`, so merge commits emit a first-parent diff the existing parser can consume (with some duplicate scanning of parent content, as noted in the PR).
> 
> Integration expectations are updated for a GitHub merge PR on `secretsandstuff`, and a new case scans **`git-merge-leak`** where the AWS credential appears only on the merge commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 295d2f3760cd7b6343ba45a7d143fc3756623edb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->