### PR TITLE
return error body for fetchBearerToken

### DIFF
--- a/pkg/detectors/twitterconsumerkey/twitterconsumerkey.go
+++ b/pkg/detectors/twitterconsumerkey/twitterconsumerkey.go
@@ -5,6 +5,7 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
@@ -142,6 +143,10 @@ func fetchBearerToken(ctx context.Context, client *http.Client, key, secret stri
 		}
 		return token.AccessToken, nil
 	default:
+		body, _ := io.ReadAll(io.LimitReader(res.Body, 1024))
+		if len(body) > 0 {
+			return "", fmt.Errorf("unexpected HTTP response status %d: %s", res.StatusCode, strings.TrimSpace(string(body)))
+		}
 		return "", fmt.Errorf("unexpected HTTP response status %d", res.StatusCode)
 	}
 }


### PR DESCRIPTION
<!--
Please create an issue to collect feedback prior to feature additions. Please also reference that issue in any PRs.
If possible try to keep PRs scoped to one feature, and add tests for new features.
-->

### Description:
For twitterconsumerkey detector, surface token-endpoint error body in verification errors
### Checklist:
* [x] Tests passing (`make test-community`)?
* [x] Lint passing (`make lint` this requires [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation))?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only enriches error strings on failed token requests; success path and credential handling are unchanged.
> 
> **Overview**
> When **Twitter consumer key** verification fails at the OAuth2 token endpoint, errors now include a trimmed snippet of the HTTP response body (up to 1024 bytes) instead of only the status code.
> 
> This makes `fetchBearerToken` failures easier to debug (e.g. invalid credentials vs rate limits) when results are marked with `SetVerificationError` during verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adca0ebd6373730868572843cab1041867664748. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->