### PR TITLE
Recognize a missing Postgres database by SQLSTATE

### DIFF
--- a/pkg/detectors/postgres/postgres.go
+++ b/pkg/detectors/postgres/postgres.go
@@ -275,13 +275,31 @@ func getDeadlineInSeconds(ctx context.Context) (int, bool) {
 	return int(duration.Seconds()), true
 }
 
-func isErrorDatabaseNotFound(err error, dbName string) bool {
-	if dbName == "" {
-		dbName = "postgres"
-	}
-	missingDbErrorText := fmt.Sprintf("database \"%s\" does not exist", dbName)
+// The server looks the database up only after authenticating, so this confirms the credentials.
+const invalidCatalogName = "3D000"
 
-	return strings.Contains(err.Error(), missingDbErrorText)
+// Message text is only a fallback, for proxies that relay a failure without a SQLSTATE; the server
+// translates messages per lc_messages. Postgres substitutes the user name, not "postgres", when a
+// connection string names no database (src/backend/tcop/backend_startup.c).
+func isErrorDatabaseNotFound(err error, params map[string]string) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) && pqErr.Code == invalidCatalogName {
+		return true
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == invalidCatalogName {
+		return true
+	}
+
+	dbName := params[pgDbname]
+	if dbName == "" {
+		dbName = params[pgUser]
+	}
+	if dbName == "" {
+		return false
+	}
+
+	return strings.Contains(err.Error(), fmt.Sprintf("database %q does not exist", dbName))
 }
 
 func verifyPostgres(ctx context.Context, params map[string]string) (bool, error) {
@@ -299,7 +317,7 @@ func verifyPostgres(ctx context.Context, params map[string]string) (bool, error)
 func verifyPostgresPgx(ctx context.Context, params map[string]string) (bool, error) {
 	conn, err := pgx.Connect(ctx, pgxConnString(params))
 	if err != nil {
-		return classifyPostgresVerifyError(err, params[pgDbname])
+		return classifyPostgresVerifyError(err, params)
 	}
 	defer func() {
 		// Best-effort close after verification; the verify outcome is already decided.
@@ -309,7 +327,7 @@ func verifyPostgresPgx(ctx context.Context, params map[string]string) (bool, err
 	}()
 
 	if err := conn.Ping(ctx); err != nil {
-		return classifyPostgresVerifyError(err, params[pgDbname])
+		return classifyPostgresVerifyError(err, params)
 	}
 	return true, nil
 }
@@ -328,7 +346,7 @@ func pgxConnString(params map[string]string) string {
 	return connStr.String()
 }
 
-func classifyPostgresVerifyError(err error, dbName string) (bool, error) {
+func classifyPostgresVerifyError(err error, params map[string]string) (bool, error) {
 	var pgErr *pgconn.PgError
 	if errors.As(err, &pgErr) {
 		switch pgErr.Code {
@@ -341,7 +359,7 @@ func classifyPostgresVerifyError(err error, dbName string) (bool, error) {
 	if strings.Contains(err.Error(), "password authentication failed") {
 		return false, nil
 	}
-	if isErrorDatabaseNotFound(err, dbName) {
+	if isErrorDatabaseNotFound(err, params) {
 		return true, nil
 	}
 	return false, err
@@ -392,7 +410,7 @@ func verifyPostgresPq(params map[string]string) (bool, error) {
 		params[pgSslmode] = pgSslmodeDisable
 		defer delete(params, pgSslmode) // We want to return with the original params map intact (for ExtraData)
 		return verifyPostgresPq(params)
-	case isErrorDatabaseNotFound(err, params[pgDbname]):
+	case isErrorDatabaseNotFound(err, params):
 		return true, nil // If we know this, we were able to authenticate
 	default:
 		return false, err

--- a/pkg/detectors/postgres/postgres_test.go
+++ b/pkg/detectors/postgres/postgres_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -179,7 +180,7 @@ func TestClassifyPostgresVerifyError(t *testing.T) {
 	tests := []struct {
 		name         string
 		err          error
-		dbName       string
+		params       map[string]string
 		wantVerified bool
 		wantErr      bool
 	}{
@@ -192,7 +193,19 @@ func TestClassifyPostgresVerifyError(t *testing.T) {
 		{
 			name:         "missing database code",
 			err:          &pgconn.PgError{Code: "3D000", Message: `database "app" does not exist`},
-			dbName:       "app",
+			params:       map[string]string{pgDbname: "app"},
+			wantVerified: true,
+			wantErr:      false,
+		},
+		{
+			name:         "missing database code needs no parameters",
+			err:          &pgconn.PgError{Code: "3D000", Message: "la base de données n'existe pas"},
+			wantVerified: true,
+			wantErr:      false,
+		},
+		{
+			name:         "missing database code from lib/pq",
+			err:          &pq.Error{Code: "3D000", Message: `database "app" does not exist`},
 			wantVerified: true,
 			wantErr:      false,
 		},
@@ -203,8 +216,30 @@ func TestClassifyPostgresVerifyError(t *testing.T) {
 			wantErr:      false,
 		},
 		{
-			name:         "missing database by message",
+			name:         "missing database by message names the given database",
+			err:          errors.New(`database "app" does not exist`),
+			params:       map[string]string{pgDbname: "app"},
+			wantVerified: true,
+			wantErr:      false,
+		},
+		{
+			name:         "missing database by message names the user when no database is given",
+			err:          errors.New(`database "svc_reports" does not exist`),
+			params:       map[string]string{pgUser: "svc_reports"},
+			wantVerified: true,
+			wantErr:      false,
+		},
+		{
+			name:         "missing database by message for a database nobody asked for",
 			err:          errors.New(`database "postgres" does not exist`),
+			params:       map[string]string{pgUser: "svc_reports"},
+			wantVerified: false,
+			wantErr:      true,
+		},
+		{
+			name:         "proxy relays the failure without a sqlstate",
+			err:          errors.New(`server login has been failing, cached error: database "svc_reports" does not exist`),
+			params:       map[string]string{pgUser: "svc_reports"},
 			wantVerified: true,
 			wantErr:      false,
 		},
@@ -219,7 +254,7 @@ func TestClassifyPostgresVerifyError(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			verified, err := classifyPostgresVerifyError(tc.err, tc.dbName)
+			verified, err := classifyPostgresVerifyError(tc.err, tc.params)
 			assert.Equal(t, tc.wantVerified, verified)
 			if tc.wantErr {
 				assert.Error(t, err)


### PR DESCRIPTION
A Postgres URI that names no database gets reported as a verification error even when the credentials are good.

The detector already treats "database does not exist" as proof of a working credential, since the server only looks the database up once authentication has passed. The check builds that message from a database name, and when the connection string supplies none it assumes the default is `postgres`. Here is the exchange, credential masked. Note the trailing slash: the string names no database.

```text
  dialled   postgresql://svc_reports:••••••••@db-prod-07.internal:5432/
                                                                      ↑ no database given
  libpq     omits the parameter, so the server fills it in
  server    pq: database "svc_reports" does not exist
                          ↑ the user name, not "postgres"
  check     looks for: database "postgres" does not exist   →   no match
```

Postgres defaults the database to the user name: `port->database_name = pstrdup(port->user_name)` in [backend_startup.c](https://github.com/postgres/postgres/blob/master/src/backend/tcop/backend_startup.c#L870-L873), under the comment "The database defaults to the user name", matching the StartupMessage description in [the protocol documentation](https://www.postgresql.org/docs/current/protocol-message-formats.html). The driver plays no part in it: lib/pq copies the options it was given into the startup packet and [leaves an absent database absent](https://github.com/lib/pq/blob/v1.10.9/conn.go#L1176-L1179), with no default of its own anywhere in the package.

Ordering is what makes the reply safe to read as success. [`PerformAuthentication`](https://github.com/postgres/postgres/blob/master/src/backend/utils/init/postinit.c#L949) runs before the lookup that raises [`database "%s" does not exist`](https://github.com/postgres/postgres/blob/master/src/backend/utils/init/postinit.c#L1064-L1068), so reaching that error means the credentials were accepted. That is the same conclusion the existing code states in [its own comment](https://github.com/trufflesecurity/trufflehog/blob/main/pkg/detectors/postgres/postgres.go#L395-L396).

SQLSTATE settles this without guessing a name. `3D000` is `invalid_catalog_name`, both drivers expose it, [lib/pq](https://github.com/lib/pq/blob/v1.10.9/error.go#L231) by name and [pgx](https://github.com/jackc/pgx/blob/v5.9.2/pgconn/errors.go#L32-L35) on its error type, and it carries the same meaning whatever the database was called. It also holds on a server running a non-English `lc_messages`, where comparing message text cannot work at all.

Message matching stays as a fallback, since a connection pooler can relay the failure without a SQLSTATE, and it now expects the name the server would have used. That closes a second gap in the same helper: an error naming some other missing database used to satisfy the check and mark the credential verified.

The `postgres` default dates from [#2314](https://github.com/trufflesecurity/trufflehog/pull/2314) in January 2024 and reached the pgx path through [#5217](https://github.com/trufflesecurity/trufflehog/pull/5217). Anyone scanning connection strings written without an explicit database loses those verifications today, which is how this surfaced: a corpus of 170 Postgres credentials where 139 omit the database reported every one of them as unverifiable.
